### PR TITLE
CP: Add Microsoft.Network/InterconnectGroups TypeSpec for 2025-07-01. Original PR: https://github.com/Azure/azure-rest-api-specs/pull/42331/

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -90,6 +90,10 @@ enum Features {
   serviceGateway,
   #suppress "@azure-tools/typespec-azure-core/documentation-required"
   virtualNetworkAppliance,
+
+  /** Interconnect group resource type for managing interconnect groups. */
+  @added(Versions.v2025_07_01)
+  interconnectGroup,
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
@@ -1,0 +1,158 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "../Common/main.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+using Common;
+using Azure.ClientGenerator.Core;
+
+namespace Microsoft.Network;
+
+/**
+ * An interconnect group resource.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Common.Resource references internal types from the legacy Network RP base model"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Network RP uses its own legacy Common.Resource base type for all resources for backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending Common.Resource via inheritance is the standard pattern for all Network RP resources"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy operations and types are required for backward compatibility with the existing Network RP SDK"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@Http.Private.includeInapplicableMetadataInPayload(false)
+model InterconnectGroup extends Common.Resource {
+  /** Properties of the interconnect group. */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for backward compatibility with existing Network SDKs"
+  @extension("x-ms-client-flatten", true)
+  properties?: InterconnectGroupPropertiesFormat;
+
+  /** The name of the interconnect group. */
+  @visibility(Lifecycle.Read)
+  @path
+  @key("interconnectGroupName")
+  @segment("interconnectGroups")
+  @pattern("^[^_\\W][\\w-._]{0,79}(?<![-.])$")
+  name: string;
+
+  /** A unique read-only string that changes whenever the resource is updated. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "etag is a standard envelope property on Network RP resources for optimistic concurrency"
+  @visibility(Lifecycle.Read)
+  etag?: string;
+}
+
+/**
+ * A subgroup in an interconnect group.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "Common.SubResourceModel references internal types from the legacy Network RP base model"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Network RP uses its own legacy Common.SubResourceModel base type for all child resources for backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Extending Common.SubResourceModel via inheritance is the standard pattern for all Network RP child resources"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy operations and types are required for backward compatibility with the existing Network RP SDK"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@Http.Private.includeInapplicableMetadataInPayload(false)
+@parentResource(InterconnectGroup)
+model Subgroup extends Common.SubResourceModel {
+  /** Properties of the subgroup. */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for backward compatibility with existing Network SDKs"
+  @extension("x-ms-client-flatten", true)
+  properties?: SubgroupProperties;
+
+  /** The name of the subgroup. */
+  @visibility(Lifecycle.Read)
+  @path
+  @key("subgroupName")
+  @segment("subgroups")
+  name: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy operations and types are required for backward compatibility with the existing Network RP SDK"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@armResourceOperations
+interface InterconnectGroups {
+  /**
+   * Gets information about the specified interconnect group.
+   */
+  get is ArmResourceRead<InterconnectGroup, Error = CloudError>;
+
+  /**
+   * Creates or updates an interconnect group.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceSync<
+    InterconnectGroup,
+    Error = CloudError
+  >;
+
+  /**
+   * Updates interconnect group tags.
+   */
+  @patch(#{ implicitOptionality: false })
+  updateTags is ArmCustomPatchSync<
+    InterconnectGroup,
+    PatchModel = TagsObject,
+    Error = CloudError
+  >;
+
+  /**
+   * Deletes the specified interconnect group.
+   */
+  delete is ArmResourceDeleteSync<InterconnectGroup, Error = CloudError>;
+
+  /**
+   * Gets all interconnect groups in a resource group.
+   */
+  list is ArmResourceListByParent<InterconnectGroup, Error = CloudError>;
+
+  /**
+   * Gets all interconnect groups in a subscription.
+   */
+  listAll is ArmListBySubscription<InterconnectGroup, Error = CloudError>;
+
+  /**
+   * Gets node availability for all subgroups in the specified interconnect group.
+   */
+  @action("nodeAvailability")
+  getNodeAvailability is ArmResourceActionAsync<
+    InterconnectGroup,
+    void,
+    InterconnectGroupNodeAvailability,
+    Error = CloudError
+  >;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy operations and types are required for backward compatibility with the existing Network RP SDK"
+@added(Versions.v2025_07_01)
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@armResourceOperations
+interface Subgroups {
+  /**
+   * Gets the specified subgroup in an interconnect group.
+   */
+  get is ArmResourceRead<Subgroup, Error = CloudError>;
+
+  /**
+   * Gets all subgroups in an interconnect group.
+   */
+  list is ArmResourceListByParent<Subgroup, Error = CloudError>;
+}
+
+@@doc(InterconnectGroup.name, "The name of the interconnect group.");
+@@doc(InterconnectGroup.properties, "Properties of the interconnect group.");
+@@doc(InterconnectGroups.createOrUpdate::parameters.resource,
+  "Parameters supplied to the create or update interconnect group operation."
+);
+@@doc(InterconnectGroups.updateTags::parameters.properties,
+  "Parameters supplied to update interconnect group tags."
+);
+@@clientName(InterconnectGroups.createOrUpdate::parameters.resource,
+  "parameters"
+);
+@@clientName(InterconnectGroups.updateTags::parameters.properties,
+  "parameters"
+);

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupCreate.json
@@ -1,0 +1,57 @@
+{
+  "title": "Create interconnect group",
+  "operationId": "InterconnectGroups_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "parameters": {
+      "properties": {
+        "scope": "InfiniBand",
+        "subgroupProfile": {
+          "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+          "scope": "VerticalConnect",
+          "size": 18
+        }
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupDelete.json
@@ -1,0 +1,14 @@
+{
+  "title": "Delete interconnect group",
+  "operationId": "InterconnectGroups_Delete",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupGet.json
@@ -1,0 +1,48 @@
+{
+  "title": "Get interconnect group",
+  "operationId": "InterconnectGroups_Get",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          },
+          "subgroups": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+              "name": "subgroup0",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+                "interconnectBlock": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+                },
+                "virtualMachines": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupGetNodeAvailability.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupGetNodeAvailability.json
@@ -1,0 +1,37 @@
+{
+  "title": "Get interconnect group node availability",
+  "operationId": "InterconnectGroups_GetNodeAvailability",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "subgroupsNodeAvailability": [
+          {
+            "name": "subgroup0",
+            "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+            "inServiceNodeCount": 16,
+            "inUseNodeCount": 12,
+            "count": 18
+          },
+          {
+            "name": "subgroup1",
+            "internalSubgroupId": "00000000-0000-0000-0000-000000000002",
+            "inServiceNodeCount": 18,
+            "inUseNodeCount": 5,
+            "count": 18
+          }
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupList.json
@@ -1,0 +1,32 @@
+{
+  "title": "List interconnect groups in resource group",
+  "operationId": "InterconnectGroups_List",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-ig",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+            "type": "Microsoft.Network/interconnectGroups",
+            "location": "eastus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "scope": "InfiniBand",
+              "subgroupProfile": {
+                "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+                "scope": "VerticalConnect",
+                "size": 18
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupListAll.json
@@ -1,0 +1,31 @@
+{
+  "title": "List all interconnect groups",
+  "operationId": "InterconnectGroups_ListAll",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-ig",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+            "type": "Microsoft.Network/interconnectGroups",
+            "location": "eastus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "scope": "InfiniBand",
+              "subgroupProfile": {
+                "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+                "scope": "VerticalConnect",
+                "size": 18
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/InterconnectGroupUpdateTags.json
@@ -1,0 +1,39 @@
+{
+  "title": "Update interconnect group tags",
+  "operationId": "InterconnectGroups_UpdateTags",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/SubgroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/SubgroupGet.json
@@ -1,0 +1,31 @@
+{
+  "title": "Get subgroup",
+  "operationId": "Subgroups_Get",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "subgroupName": "subgroup0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+        "name": "subgroup0",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+          "interconnectBlock": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+          },
+          "virtualMachines": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/SubgroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-07-01/SubgroupList.json
@@ -1,0 +1,34 @@
+{
+  "title": "List subgroups",
+  "operationId": "Subgroups_List",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+            "name": "subgroup0",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+              "interconnectBlock": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+              },
+              "virtualMachines": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -135,6 +135,7 @@ import "./WebApplicationFirewallPolicy.tsp";
 import "./routes.tsp";
 import "./VirtualNetworkAppliance.tsp";
 import "./ServiceGateway.tsp";
+import "./InterconnectGroup.tsp";
 import "../Common/main.tsp";
 
 using TypeSpec.Rest;

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -26530,3 +26530,137 @@ model VirtualNetworkApplianceIpConfigurationProperties {
 @@identifiers(GetServiceGatewayServicesResult.value, #["name"]);
 @@added(DisablePeeringRoute, Versions.v2025_07_01);
 @@added(RouteTablePropertiesFormat.disablePeeringRoute, Versions.v2025_07_01);
+
+/**
+ * Scope of an interconnect group resource.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+union InterconnectGroupScope {
+  string,
+
+  /** No interconnect group scope. */
+  None: "None",
+
+  /** InfiniBand interconnect group scope. */
+  InfiniBand: "InfiniBand",
+}
+
+/**
+ * Scope of the subgroup profile.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+union SubgroupProfileScope {
+  string,
+
+  /** No subgroup profile scope. */
+  None: "None",
+
+  /** VerticalConnect subgroup profile scope. */
+  VerticalConnect: "VerticalConnect",
+}
+
+/**
+ * Subgroup profile of the interconnect group resource.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+model SubgroupProfile {
+  /** VM size of the subgroup profile. */
+  vmSize: string;
+
+  /** Scope of the subgroup profile. */
+  scope?: SubgroupProfileScope;
+
+  /** Size of the subgroup profile. */
+  @minValue(0)
+  size?: int32;
+}
+
+/**
+ * Interconnect group properties.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+model InterconnectGroupPropertiesFormat {
+  /** Scope of interconnect group resource. */
+  scope?: InterconnectGroupScope;
+
+  /** A list of subgroups of the interconnect group. */
+  @visibility(Lifecycle.Read)
+  subgroups?: Subgroup[];
+
+  /** The provisioning state of the interconnect group resource. */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+
+  /** The resource GUID property of the interconnect group resource. */
+  @visibility(Lifecycle.Read)
+  resourceGuid?: string;
+
+  /** The subgroup profile of the interconnect group resource. */
+  subgroupProfile: SubgroupProfile;
+}
+
+/**
+ * Properties of subgroup.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+model SubgroupProperties {
+  /** The unique identifier of the subgroup. */
+  @visibility(Lifecycle.Read)
+  internalSubgroupId?: string;
+
+  /** The reference to an interconnect block resource. */
+  @visibility(Lifecycle.Read)
+  interconnectBlock?: SubResource;
+
+  /** A list of virtual machine references. */
+  @visibility(Lifecycle.Read)
+  virtualMachines?: SubResource[];
+
+  /** The provisioning state of the subgroup. */
+  @visibility(Lifecycle.Read)
+  provisioningState?: ProvisioningState;
+}
+
+/**
+ * Represents node availability information for subgroups within an interconnect group.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+model InterconnectGroupNodeAvailability {
+  /** The list of subgroup node availability entries. */
+  subgroupsNodeAvailability?: SubgroupNodeAvailabilityEntry[];
+}
+
+/**
+ * Represents the node availability information for a single subgroup.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Legacy types are required for backward compatibility with the existing Network RP SDK"
+@Azure.ResourceManager.Legacy.feature(Features.interconnectGroup)
+@added(Versions.v2025_07_01)
+model SubgroupNodeAvailabilityEntry {
+  /** The subgroup name. */
+  name?: string;
+
+  /** The unique identifier of the subgroup. */
+  internalSubgroupId?: string;
+
+  /** The number of nodes that are in service. */
+  inServiceNodeCount?: int32;
+
+  /** The number of nodes that are currently in use. */
+  inUseNodeCount?: int32;
+
+  /** The total node count for the subgroup. */
+  count?: int32;
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/readme.md
+++ b/specification/network/resource-manager/Microsoft.Network/Network/readme.md
@@ -43,6 +43,7 @@ input-file:
   - stable/2025-07-01/expressRoute.json
   - stable/2025-07-01/firewall.json
   - stable/2025-07-01/firewallPolicy.json
+  - stable/2025-07-01/interconnectGroup.json
   - stable/2025-07-01/loadBalancer.json
   - stable/2025-07-01/networkGateway.json
   - stable/2025-07-01/networkingOperations.json
@@ -78,6 +79,28 @@ suppressions:
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkReferences/{linkReferenceName}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}"].delete
       - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}"].delete
+  - code: ProvisioningStateMustBeReadOnly
+    from: interconnectGroup.json
+    reason: provisioningState is correctly marked readOnly in the referenced schema. The linter does not follow $ref chains to verify readOnly.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}"].get.responses["200"].schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}"].put.responses["200"].schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}"].put.responses["201"].schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}"].patch.responses["200"].schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups/{subgroupName}"].get.responses["200"].schema
+  - code: ResourceNameRestriction
+    from: interconnectGroup.json
+    reason: Subgroup is a read-only child resource with no PUT operation. Pattern restriction is not applicable.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups/{subgroupName}"]
+  - code: RequiredPropertiesMissingInResourceModel
+    from: interconnectGroup.json
+    reason: name, id and type properties are inherited from the upper level
+    where:
+      - $.definitions.InterconnectGroup
+      - $.definitions.InterconnectGroupListResult
+      - $.definitions.Subgroup
+      - $.definitions.SubgroupListResult
   - code: PatchIdentityProperty
     reason: False alarm.
     where:

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/common.json
@@ -5826,6 +5826,30 @@
         ]
       }
     },
+    "InterconnectGroupScope": {
+      "type": "string",
+      "description": "Scope of an interconnect group resource.",
+      "enum": [
+        "None",
+        "InfiniBand"
+      ],
+      "x-ms-enum": {
+        "name": "InterconnectGroupScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No interconnect group scope."
+          },
+          {
+            "name": "InfiniBand",
+            "value": "InfiniBand",
+            "description": "InfiniBand interconnect group scope."
+          }
+        ]
+      }
+    },
     "IpAllocationType": {
       "type": "string",
       "description": "IpAllocation type.",
@@ -8100,6 +8124,30 @@
             "name": "Staging",
             "value": "Staging",
             "description": "Staging"
+          }
+        ]
+      }
+    },
+    "SubgroupProfileScope": {
+      "type": "string",
+      "description": "Scope of the subgroup profile.",
+      "enum": [
+        "None",
+        "VerticalConnect"
+      ],
+      "x-ms-enum": {
+        "name": "SubgroupProfileScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No subgroup profile scope."
+          },
+          {
+            "name": "VerticalConnect",
+            "value": "VerticalConnect",
+            "description": "VerticalConnect subgroup profile scope."
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupCreate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupCreate.json
@@ -1,0 +1,57 @@
+{
+  "title": "Create interconnect group",
+  "operationId": "InterconnectGroups_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "parameters": {
+      "properties": {
+        "scope": "InfiniBand",
+        "subgroupProfile": {
+          "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+          "scope": "VerticalConnect",
+          "size": 18
+        }
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupDelete.json
@@ -1,0 +1,14 @@
+{
+  "title": "Delete interconnect group",
+  "operationId": "InterconnectGroups_Delete",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupGet.json
@@ -1,0 +1,48 @@
+{
+  "title": "Get interconnect group",
+  "operationId": "InterconnectGroups_Get",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "resourceGuid": "00000000-0000-0000-0000-000000000000",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          },
+          "subgroups": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+              "name": "subgroup0",
+              "properties": {
+                "provisioningState": "Succeeded",
+                "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+                "interconnectBlock": {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+                },
+                "virtualMachines": [
+                  {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupGetNodeAvailability.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupGetNodeAvailability.json
@@ -1,0 +1,37 @@
+{
+  "title": "Get interconnect group node availability",
+  "operationId": "InterconnectGroups_GetNodeAvailability",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "subgroupsNodeAvailability": [
+          {
+            "name": "subgroup0",
+            "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+            "inServiceNodeCount": 16,
+            "inUseNodeCount": 12,
+            "count": 18
+          },
+          {
+            "name": "subgroup1",
+            "internalSubgroupId": "00000000-0000-0000-0000-000000000002",
+            "inServiceNodeCount": 18,
+            "inUseNodeCount": 5,
+            "count": 18
+          }
+        ]
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-07-01"
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupList.json
@@ -1,0 +1,32 @@
+{
+  "title": "List interconnect groups in resource group",
+  "operationId": "InterconnectGroups_List",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-ig",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+            "type": "Microsoft.Network/interconnectGroups",
+            "location": "eastus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "scope": "InfiniBand",
+              "subgroupProfile": {
+                "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+                "scope": "VerticalConnect",
+                "size": 18
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupListAll.json
@@ -1,0 +1,31 @@
+{
+  "title": "List all interconnect groups",
+  "operationId": "InterconnectGroups_ListAll",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test-ig",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+            "type": "Microsoft.Network/interconnectGroups",
+            "location": "eastus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "scope": "InfiniBand",
+              "subgroupProfile": {
+                "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+                "scope": "VerticalConnect",
+                "size": 18
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupUpdateTags.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/InterconnectGroupUpdateTags.json
@@ -1,0 +1,39 @@
+{
+  "title": "Update interconnect group tags",
+  "operationId": "InterconnectGroups_UpdateTags",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "parameters": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test-ig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig",
+        "type": "Microsoft.Network/interconnectGroups",
+        "location": "eastus",
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "scope": "InfiniBand",
+          "subgroupProfile": {
+            "vmSize": "Standard_ND128isr_NDR_GB200_v6",
+            "scope": "VerticalConnect",
+            "size": 18
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/SubgroupGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/SubgroupGet.json
@@ -1,0 +1,31 @@
+{
+  "title": "Get subgroup",
+  "operationId": "Subgroups_Get",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig",
+    "subgroupName": "subgroup0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+        "name": "subgroup0",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+          "interconnectBlock": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+          },
+          "virtualMachines": [
+            {
+              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/SubgroupList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/examples/SubgroupList.json
@@ -1,0 +1,34 @@
+{
+  "title": "List subgroups",
+  "operationId": "Subgroups_List",
+  "parameters": {
+    "api-version": "2025-07-01",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "interconnectGroupName": "test-ig"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/interconnectGroups/test-ig/subgroups/subgroup0",
+            "name": "subgroup0",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "internalSubgroupId": "00000000-0000-0000-0000-000000000001",
+              "interconnectBlock": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/interconnectBlocks/test-block"
+              },
+              "virtualMachines": [
+                {
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
@@ -1,0 +1,719 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2025-07-01",
+    "description": "APIs to manage web application firewall rules.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "InterconnectGroups"
+    },
+    {
+      "name": "Subgroups"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/interconnectGroups": {
+      "get": {
+        "operationId": "InterconnectGroups_ListAll",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets all interconnect groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all interconnect groups": {
+            "$ref": "./examples/InterconnectGroupListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups": {
+      "get": {
+        "operationId": "InterconnectGroups_List",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets all interconnect groups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List interconnect groups in resource group": {
+            "$ref": "./examples/InterconnectGroupList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}": {
+      "get": {
+        "operationId": "InterconnectGroups_Get",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets information about the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get interconnect group": {
+            "$ref": "./examples/InterconnectGroupGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "InterconnectGroups_CreateOrUpdate",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Creates or updates an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update interconnect group operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'InterconnectGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'InterconnectGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create interconnect group": {
+            "$ref": "./examples/InterconnectGroupCreate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "InterconnectGroups_UpdateTags",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Updates interconnect group tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update interconnect group tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update interconnect group tags": {
+            "$ref": "./examples/InterconnectGroupUpdateTags.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "InterconnectGroups_Delete",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Deletes the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete interconnect group": {
+            "$ref": "./examples/InterconnectGroupDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/nodeAvailability": {
+      "post": {
+        "operationId": "InterconnectGroups_GetNodeAvailability",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets node availability for all subgroups in the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupNodeAvailability"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get interconnect group node availability": {
+            "$ref": "./examples/InterconnectGroupGetNodeAvailability.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/InterconnectGroupNodeAvailability"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups": {
+      "get": {
+        "operationId": "Subgroups_List",
+        "tags": [
+          "Subgroups"
+        ],
+        "description": "Gets all subgroups in an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SubgroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List subgroups": {
+            "$ref": "./examples/SubgroupList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups/{subgroupName}": {
+      "get": {
+        "operationId": "Subgroups_Get",
+        "tags": [
+          "Subgroups"
+        ],
+        "description": "Gets the specified subgroup in an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "subgroupName",
+            "in": "path",
+            "description": "The name of the subgroup.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Subgroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Common.CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get subgroup": {
+            "$ref": "./examples/SubgroupGet.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "InterconnectGroup": {
+      "type": "object",
+      "description": "An interconnect group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InterconnectGroupPropertiesFormat",
+          "description": "Properties of the interconnect group.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Common.Resource"
+        }
+      ]
+    },
+    "InterconnectGroupListResult": {
+      "type": "object",
+      "description": "The response of a InterconnectGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The InterconnectGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/InterconnectGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InterconnectGroupNodeAvailability": {
+      "type": "object",
+      "description": "Represents node availability information for subgroups within an interconnect group.",
+      "properties": {
+        "subgroupsNodeAvailability": {
+          "type": "array",
+          "description": "The list of subgroup node availability entries.",
+          "items": {
+            "$ref": "#/definitions/SubgroupNodeAvailabilityEntry"
+          }
+        }
+      }
+    },
+    "InterconnectGroupPropertiesFormat": {
+      "type": "object",
+      "description": "Interconnect group properties.",
+      "properties": {
+        "scope": {
+          "$ref": "./common.json#/definitions/InterconnectGroupScope",
+          "description": "Scope of interconnect group resource."
+        },
+        "subgroups": {
+          "type": "array",
+          "description": "A list of subgroups of the interconnect group.",
+          "items": {
+            "$ref": "#/definitions/Subgroup"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/Common.ProvisioningState",
+          "description": "The provisioning state of the interconnect group resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the interconnect group resource.",
+          "readOnly": true
+        },
+        "subgroupProfile": {
+          "$ref": "#/definitions/SubgroupProfile",
+          "description": "The subgroup profile of the interconnect group resource."
+        }
+      },
+      "required": [
+        "subgroupProfile"
+      ]
+    },
+    "Subgroup": {
+      "type": "object",
+      "description": "A subgroup in an interconnect group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubgroupProperties",
+          "description": "Properties of the subgroup.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Common.SubResourceModel"
+        }
+      ]
+    },
+    "SubgroupListResult": {
+      "type": "object",
+      "description": "The response of a Subgroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Subgroup items on this page",
+          "items": {
+            "$ref": "#/definitions/Subgroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SubgroupNodeAvailabilityEntry": {
+      "type": "object",
+      "description": "Represents the node availability information for a single subgroup.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The subgroup name."
+        },
+        "internalSubgroupId": {
+          "type": "string",
+          "description": "The unique identifier of the subgroup."
+        },
+        "inServiceNodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes that are in service."
+        },
+        "inUseNodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes that are currently in use."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total node count for the subgroup."
+        }
+      }
+    },
+    "SubgroupProfile": {
+      "type": "object",
+      "description": "Subgroup profile of the interconnect group resource.",
+      "properties": {
+        "vmSize": {
+          "type": "string",
+          "description": "VM size of the subgroup profile."
+        },
+        "scope": {
+          "$ref": "./common.json#/definitions/SubgroupProfileScope",
+          "description": "Scope of the subgroup profile."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Size of the subgroup profile.",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "vmSize"
+      ]
+    },
+    "SubgroupProperties": {
+      "type": "object",
+      "description": "Properties of subgroup.",
+      "properties": {
+        "internalSubgroupId": {
+          "type": "string",
+          "description": "The unique identifier of the subgroup.",
+          "readOnly": true
+        },
+        "interconnectBlock": {
+          "$ref": "./common.json#/definitions/Common.SubResource",
+          "description": "The reference to an interconnect block resource.",
+          "readOnly": true
+        },
+        "virtualMachines": {
+          "type": "array",
+          "description": "A list of virtual machine references.",
+          "items": {
+            "$ref": "./common.json#/definitions/Common.SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/Common.ProvisioningState",
+          "description": "The provisioning state of the subgroup.",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
Cherry-pick of #42331 - adds InterconnectGroup and Subgroup ARM resources to Network TypeSpec for API version 2025-07-01.