### PR TITLE
Relocate new agents operations to the agents beta sub-client, since they are in preview

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -296,8 +296,8 @@ using Azure.AI.Projects;
 @@usage(SessionFileWriteResponse, Usage.output);
 @@access(SessionFileWriteResponse, Access.public);
 
-// Exclude these operations entirely from emitted SDKs
-@@scope(Agents.createAgentFromCode, "!(python, javascript)");
+// Exclude these operations entirely from emitted Python SDK
+@@scope(Agents.createAgentFromCode, "!(python)");
 
 // --------------------------------------------------------------------------------
 // To support custom client-side handling of "opt-in" to preview features.

--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -296,6 +296,9 @@ using Azure.AI.Projects;
 @@usage(SessionFileWriteResponse, Usage.output);
 @@access(SessionFileWriteResponse, Access.public);
 
+// Exclude these operations entirely from emitted SDKs
+@@scope(Agents.createAgentFromCode, "!(python, javascript)");
+
 // --------------------------------------------------------------------------------
 // To support custom client-side handling of "opt-in" to preview features.
 // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -299,6 +299,8 @@ using Azure.AI.Projects;
 // Exclude these operations entirely from emitted Python SDK
 @@scope(Agents.createAgentFromCode, "!(python)");
 
+@@clientName(DownloadAgentCodeResponse, "DownloadAgentCodeResult", "python");
+
 // --------------------------------------------------------------------------------
 // To support custom client-side handling of "opt-in" to preview features.
 // --------------------------------------------------------------------------------

--- a/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
@@ -108,6 +108,12 @@ interface Agents {}
 @@clientLocation(Azure.AI.Projects.Agents.deleteSession, Agents);
 @@clientLocation(Azure.AI.Projects.Agents.listSessions, Agents);
 @@clientLocation(Azure.AI.Projects.Agents.getSessionLogStream, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.createAgentFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.updateAgentFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.createAgentVersionFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.downloadAgentCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.downloadAgentVersionCode, Agents);
+
 
 interface Datasets {}
 


### PR DESCRIPTION
Also for Python:
-  Do not emit `createAgentFromCode` from Python (for the same reason we do not emit `createAgent`). Customers should use the `createAgentVersionFromCode` (and `createAgentVersion`) methods instead. 
- Rename class `DownloadAgentCodeResponse` to `DownloadAgentCodeResult`. This is similar to what we've done for other classes with a name ending in `Response`  -- replace `Response` with `Result`.