### PR TITLE
[CosmosDB] Address Ravimeda soft-delete review feedback (PR #41475 C3-C6)

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -169,7 +169,7 @@ model SoftDeletedSqlDatabaseGetResult
     Resource = SoftDeletedSqlDatabaseGetResult,
     KeyName = "databaseName",
     SegmentName = "softDeletedSqlDatabases",
-    NamePattern = "^[^/\\\\#?]+$"
+    NamePattern = ""
   >;
 }
 
@@ -235,7 +235,7 @@ model SoftDeletedSqlContainerGetResult
     Resource = SoftDeletedSqlContainerGetResult,
     KeyName = "containerName",
     SegmentName = "softDeletedSqlContainers",
-    NamePattern = "^[^/\\\\#?]+$"
+    NamePattern = ""
   >;
 }
 
@@ -395,7 +395,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlDatabaseGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -447,7 +446,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -484,7 +482,6 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -529,14 +526,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
   ): ArmResponse<SoftDeletedSqlContainerGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -566,7 +561,6 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -595,14 +589,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 
@@ -639,14 +631,12 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
-    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -169,7 +169,7 @@ model SoftDeletedSqlDatabaseGetResult
     Resource = SoftDeletedSqlDatabaseGetResult,
     KeyName = "databaseName",
     SegmentName = "softDeletedSqlDatabases",
-    NamePattern = ""
+    NamePattern = "^[^/\\\\#?]+$"
   >;
 }
 
@@ -235,7 +235,7 @@ model SoftDeletedSqlContainerGetResult
     Resource = SoftDeletedSqlContainerGetResult,
     KeyName = "containerName",
     SegmentName = "softDeletedSqlContainers",
-    NamePattern = ""
+    NamePattern = "^[^/\\\\#?]+$"
   >;
 }
 
@@ -395,6 +395,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlDatabaseGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -446,6 +447,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -482,6 +484,7 @@ interface SoftDeletedSqlDatabases {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
@@ -526,12 +529,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
   ): ArmResponse<SoftDeletedSqlContainerGetResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -561,6 +566,7 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
   ): ArmResponse<SoftDeletedSqlContainersListResult> | Azure.ResourceManager.CommonTypes.ErrorResponse;
@@ -589,12 +595,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 
@@ -631,12 +639,14 @@ interface SoftDeletedSqlContainers {
     /**
      * Cosmos DB SQL database name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     databaseName: string,
 
     /**
      * Cosmos DB SQL container name.
      */
+    @pattern("^[^/\\\\#?]+$")
     @path
     containerName: string,
 

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/SoftDeletedResources.tsp
@@ -79,6 +79,7 @@ model SoftDeletedDatabaseAccountResource {
 /**
  * The properties of a soft-deleted database account.
  */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Soft-deleted resources are read-only views of previously-deleted resources; they have no provisioning lifecycle and provisioningState is not applicable."
 @added(Versions.v2026_04_01_preview)
 model SoftDeletedDatabaseAccountProperties {
   /**
@@ -106,56 +107,22 @@ model SoftDeletedDatabaseAccountProperties {
  * A Azure Cosmos DB soft-deleted database account.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedDatabaseAccountGetResult {
-  /**
-   * The properties of a soft-deleted database account.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
-  @extension("x-ms-client-flatten", true)
-  properties?: SoftDeletedDatabaseAccountProperties;
-
-  /**
-   * The unique resource identifier of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of Azure resource.
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * The location of the resource group to which the resource belongs.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
-  @extension("x-ms-mutability", #["read", "create"])
-  location?: string;
+model SoftDeletedDatabaseAccountGetResult
+  is Azure.ResourceManager.ProxyResource<SoftDeletedDatabaseAccountProperties> {
+  ...ResourceNameParameter<
+    Resource = SoftDeletedDatabaseAccountGetResult,
+    KeyName = "accountName",
+    SegmentName = "softDeletedDatabaseAccounts",
+    NamePattern = "^[a-z0-9]+(-[a-z0-9]+)*"
+  >;
 }
 
 /**
  * The List operation response, that contains the soft-deleted database accounts and their properties.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedDatabaseAccountsListResult {
-  /**
-   * List of soft-deleted database accounts and their properties.
-   */
-  @visibility(Lifecycle.Read)
-  value?: SoftDeletedDatabaseAccountGetResult[];
-
-  /**
-   * The URL to get the next set of results.
-   */
-  nextLink?: string;
-}
+model SoftDeletedDatabaseAccountsListResult
+  is Azure.Core.Page<SoftDeletedDatabaseAccountGetResult>;
 
 /**
  * Cosmos DB SQL database resource object
@@ -178,6 +145,7 @@ model SoftDeletedSqlDatabaseResource {
 /**
  * The properties of a soft-deleted SQL database.
  */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Soft-deleted resources are read-only views of previously-deleted resources; they have no provisioning lifecycle and provisioningState is not applicable."
 @added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlDatabaseProperties {
   /**
@@ -195,56 +163,22 @@ model SoftDeletedSqlDatabaseProperties {
  * An Azure Cosmos DB soft-deleted SQL database.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedSqlDatabaseGetResult {
-  /**
-   * The properties of a soft-deleted SQL database.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
-  @extension("x-ms-client-flatten", true)
-  properties?: SoftDeletedSqlDatabaseProperties;
-
-  /**
-   * The unique resource identifier of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of Azure resource.
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * The location of the resource group to which the resource belongs.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
-  @extension("x-ms-mutability", #["read", "create"])
-  location?: string;
+model SoftDeletedSqlDatabaseGetResult
+  is Azure.ResourceManager.ProxyResource<SoftDeletedSqlDatabaseProperties> {
+  ...ResourceNameParameter<
+    Resource = SoftDeletedSqlDatabaseGetResult,
+    KeyName = "databaseName",
+    SegmentName = "softDeletedSqlDatabases",
+    NamePattern = "^[^/\\\\#?]+$"
+  >;
 }
 
 /**
  * The List operation response, that contains the soft-deleted SQL databases and their properties.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedSqlDatabasesListResult {
-  /**
-   * List of soft-deleted SQL databases and their properties.
-   */
-  @visibility(Lifecycle.Read)
-  value?: SoftDeletedSqlDatabaseGetResult[];
-
-  /**
-   * The URL to get the next set of results.
-   */
-  nextLink?: string;
-}
+model SoftDeletedSqlDatabasesListResult
+  is Azure.Core.Page<SoftDeletedSqlDatabaseGetResult>;
 
 /**
  * Cosmos DB SQL container resource object
@@ -277,6 +211,7 @@ model SoftDeletedSqlContainerResource {
 /**
  * The properties of a soft-deleted SQL container.
  */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Soft-deleted resources are read-only views of previously-deleted resources; they have no provisioning lifecycle and provisioningState is not applicable."
 @added(Versions.v2026_04_01_preview)
 model SoftDeletedSqlContainerProperties {
   /**
@@ -294,56 +229,22 @@ model SoftDeletedSqlContainerProperties {
  * An Azure Cosmos DB soft-deleted SQL container.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedSqlContainerGetResult {
-  /**
-   * The properties of a soft-deleted SQL container.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-client-flatten is required for swagger compatibility"
-  @extension("x-ms-client-flatten", true)
-  properties?: SoftDeletedSqlContainerProperties;
-
-  /**
-   * The unique resource identifier of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the ARM resource.
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of Azure resource.
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * The location of the resource group to which the resource belongs.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-openapi" "x-ms-mutability is required for ARM location property"
-  @extension("x-ms-mutability", #["read", "create"])
-  location?: string;
+model SoftDeletedSqlContainerGetResult
+  is Azure.ResourceManager.ProxyResource<SoftDeletedSqlContainerProperties> {
+  ...ResourceNameParameter<
+    Resource = SoftDeletedSqlContainerGetResult,
+    KeyName = "containerName",
+    SegmentName = "softDeletedSqlContainers",
+    NamePattern = "^[^/\\\\#?]+$"
+  >;
 }
 
 /**
  * The List operation response, that contains the soft-deleted SQL containers and their properties.
  */
 @added(Versions.v2026_04_01_preview)
-model SoftDeletedSqlContainersListResult {
-  /**
-   * List of soft-deleted SQL containers and their properties.
-   */
-  @visibility(Lifecycle.Read)
-  value?: SoftDeletedSqlContainerGetResult[];
-
-  /**
-   * The URL to get the next set of results.
-   */
-  nextLink?: string;
-}
+model SoftDeletedSqlContainersListResult
+  is Azure.Core.Page<SoftDeletedSqlContainerGetResult>;
 
 // ──────────────────────────────────────────────
 //  Soft-Deleted Database Account Operations

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
         "name": "softdeleted-cosmosdb-1",
         "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
         "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
         "name": "softdeleted-cosmosdb-1",
         "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
         "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -9,7 +9,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {
@@ -22,7 +22,7 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
             "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -9,7 +9,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {
@@ -22,7 +22,7 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
             "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -9,8 +9,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -9,8 +9,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -11,8 +11,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -11,8 +11,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
         "name": "softdeleted-cosmosdb-1",
         "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
         "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountGet.json
@@ -9,7 +9,7 @@
   "responses": {
     "200": {
       "body": {
-        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/softdeleted-cosmosdb-1",
         "name": "softdeleted-cosmosdb-1",
         "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
         "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -9,7 +9,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {
@@ -22,7 +22,7 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
             "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountListByLocation.json
@@ -9,7 +9,7 @@
       "body": {
         "value": [
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "name": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {
@@ -22,7 +22,7 @@
             }
           },
           {
-            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/locations/westus/softDeletedDatabaseAccounts/b2c3d4e5-6789-01bc-def2-234567890abc",
             "name": "b2c3d4e5-6789-01bc-def2-234567890abc",
             "type": "Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts",
             "properties": {

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountPurge.json
@@ -9,8 +9,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedDatabaseAccountRestore.json
@@ -9,8 +9,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerPurge.json
@@ -11,8 +11,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-container-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlContainerRestore.json
@@ -11,8 +11,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-container-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabasePurge.json
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/purge-database-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {},

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/CosmosDBSoftDeletedSqlDatabaseRestore.json
@@ -10,8 +10,8 @@
   "responses": {
     "202": {
       "headers": {
-        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
-        "location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/restore-operation-id?api-version=2026-04-01-preview"
       }
     },
     "204": {}

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -19951,8 +19951,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20008,8 +20007,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20068,16 +20066,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           }
         ],
         "responses": {
@@ -20872,8 +20868,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -20971,8 +20966,7 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21070,16 +21064,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21177,16 +21169,14 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string",
-            "pattern": "^[^/\\\\#?]+$"
+            "type": "string"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -31518,33 +31518,14 @@
       "properties": {
         "properties": {
           "$ref": "#/definitions/SoftDeletedDatabaseAccountProperties",
-          "description": "The properties of a soft-deleted database account.",
-          "x-ms-client-flatten": true
-        },
-        "id": {
-          "type": "string",
-          "description": "The unique resource identifier of the ARM resource.",
-          "readOnly": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the ARM resource.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of Azure resource.",
-          "readOnly": true
-        },
-        "location": {
-          "type": "string",
-          "description": "The location of the resource group to which the resource belongs.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
+          "description": "The resource-specific properties for this resource."
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
     },
     "SoftDeletedDatabaseAccountProperties": {
       "type": "object",
@@ -31604,17 +31585,20 @@
       "properties": {
         "value": {
           "type": "array",
-          "description": "List of soft-deleted database accounts and their properties.",
+          "description": "The SoftDeletedDatabaseAccountGetResult items on this page",
           "items": {
             "$ref": "#/definitions/SoftDeletedDatabaseAccountGetResult"
-          },
-          "readOnly": true
+          }
         },
         "nextLink": {
           "type": "string",
-          "description": "The URL to get the next set of results."
+          "format": "uri",
+          "description": "The link to the next page of items"
         }
-      }
+      },
+      "required": [
+        "value"
+      ]
     },
     "SoftDeletedSqlContainerGetResult": {
       "type": "object",
@@ -31622,33 +31606,14 @@
       "properties": {
         "properties": {
           "$ref": "#/definitions/SoftDeletedSqlContainerProperties",
-          "description": "The properties of a soft-deleted SQL container.",
-          "x-ms-client-flatten": true
-        },
-        "id": {
-          "type": "string",
-          "description": "The unique resource identifier of the ARM resource.",
-          "readOnly": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the ARM resource.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of Azure resource.",
-          "readOnly": true
-        },
-        "location": {
-          "type": "string",
-          "description": "The location of the resource group to which the resource belongs.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
+          "description": "The resource-specific properties for this resource."
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
     },
     "SoftDeletedSqlContainerProperties": {
       "type": "object",
@@ -31697,17 +31662,20 @@
       "properties": {
         "value": {
           "type": "array",
-          "description": "List of soft-deleted SQL containers and their properties.",
+          "description": "The SoftDeletedSqlContainerGetResult items on this page",
           "items": {
             "$ref": "#/definitions/SoftDeletedSqlContainerGetResult"
-          },
-          "readOnly": true
+          }
         },
         "nextLink": {
           "type": "string",
-          "description": "The URL to get the next set of results."
+          "format": "uri",
+          "description": "The link to the next page of items"
         }
-      }
+      },
+      "required": [
+        "value"
+      ]
     },
     "SoftDeletedSqlDatabaseGetResult": {
       "type": "object",
@@ -31715,33 +31683,14 @@
       "properties": {
         "properties": {
           "$ref": "#/definitions/SoftDeletedSqlDatabaseProperties",
-          "description": "The properties of a soft-deleted SQL database.",
-          "x-ms-client-flatten": true
-        },
-        "id": {
-          "type": "string",
-          "description": "The unique resource identifier of the ARM resource.",
-          "readOnly": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the ARM resource.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of Azure resource.",
-          "readOnly": true
-        },
-        "location": {
-          "type": "string",
-          "description": "The location of the resource group to which the resource belongs.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
+          "description": "The resource-specific properties for this resource."
         }
-      }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
     },
     "SoftDeletedSqlDatabaseProperties": {
       "type": "object",
@@ -31781,17 +31730,20 @@
       "properties": {
         "value": {
           "type": "array",
-          "description": "List of soft-deleted SQL databases and their properties.",
+          "description": "The SoftDeletedSqlDatabaseGetResult items on this page",
           "items": {
             "$ref": "#/definitions/SoftDeletedSqlDatabaseGetResult"
-          },
-          "readOnly": true
+          }
         },
         "nextLink": {
           "type": "string",
-          "description": "The URL to get the next set of results."
+          "format": "uri",
+          "description": "The link to the next page of items"
         }
-      }
+      },
+      "required": [
+        "value"
+      ]
     },
     "SoftDeletionMetadata": {
       "type": "object",

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -19951,7 +19951,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -20007,7 +20008,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -20066,14 +20068,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           }
         ],
         "responses": {
@@ -20868,7 +20872,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -20966,7 +20971,8 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21064,14 +21070,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -21169,14 +21177,16 @@
             "in": "path",
             "description": "Cosmos DB SQL database name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "name": "containerName",
             "in": "path",
             "description": "Cosmos DB SQL container name.",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "pattern": "^[^/\\\\#?]+$"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"


### PR DESCRIPTION
Addresses Ravimeda's six review comments (submitted 2026-05-05) on the soft-delete portion of [PR #41475](https://github.com/Azure/azure-rest-api-specs/pull/41475). Targets `cdb03150401p` (the PR head branch), not `main`.

## Comment-by-comment status

| # | Comment | Verdict | Where addressed |
|---|---------|---------|-----------------|
| C1 | [r3189874700](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189874700) — RPC-Uri-V1-01 (query strings in `@route`) | ❌ **Reject** | See thread reply. Reviewer agent invoked the wrong rule code. The actual [`RPC-Uri-V1-01` rule docs](https://github.com/Azure/azure-openapi-validator/blob/main/docs/path-contains-subscription-id.md) (PathContainsSubscriptionId) are about ensuring `subscriptionId` is in the path — not about query strings in path keys. Soft-delete paths already contain `subscriptionId`. The current `@route("...?softDeleteActionKind=...")` correctly emits to Azure's documented [`x-ms-paths` extension](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md#x-ms-paths) (verified — see `preview/2026-04-01-preview/openapi.json` `"x-ms-paths"` block). Removing the query string would either collide two `@delete` ops on the same path key or force consolidation that loses the team's intentional separate `SoftDeletedDatabaseAccounts_Restore`/`SoftDeletedDatabaseAccounts_Purge` operationIds. |
| C2 | [r3189876375](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189876375) — RPC-Delete-V1-01 (`@delete` for restore) | ❌ **Reject** | See thread reply. `@delete` semantics for restore/purge are intentional per team design. |
| C3 | [r3189877759](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189877759) — ARM Resource Pattern | ✅ **Fixed** | Commit 153e0dc — soft-delete result models now extend `Azure.ResourceManager.ProxyResource&lt;T&gt;`. ARM envelope (`id`, `name`, `type`, `systemData`) comes from the standard template; `ResourceNameParameter` mixin supplies the required `name` matching existing route segments. |
| C4 | [r3189880218](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189880218) — EX-DESCRIPTIVE-VALUES (response id missing `resourceGroups`) | ✅ **Fixed** | Commits 275220a + 9dde6fa — added `/resourceGroups/{rg}/` segment (`rg1` for these examples) to response body `id` fields in `CosmosDBSoftDeletedDatabaseAccountGet.json` and `CosmosDBSoftDeletedDatabaseAccountListByLocation.json` (and their `preview/` mirrors). Verified against `ResourceProviderHttpRuntime.cs` L1024-1027: the Get/Restore/Purge handlers bind to `RPPaths.SoftDeletedDatabaseAccountRoot` which includes `/resourceGroups/`. Sibling `ListByResourceGroupAndLocation`, `Get` (Sql Database/Container) examples already had correct ids. (Note: commit 332582f temporarily reverted this on the assumption that soft-delete was subscription+location-scoped, but cross-check against the RP routing showed that was incorrect for CosmosDB — re-applied in commit 9dde6fa.) |
| C5 | [r3189881950](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189881950) — LRO Header Casing | ✅ **Fixed** | Commit 275220a — replaced lowercase `azure-asyncoperation`/`location` with PascalCase `Azure-AsyncOperation`/`Location` in 12 soft-delete restore/purge example files (6 distinct × 2 mirror locations). LRO header URL **values** intentionally remain subscription+location-scoped without `/resourceGroups/` to match the operation return contract. |
| C6 | [r3189883653](https://github.com/Azure/azure-rest-api-specs/pull/41475#discussion_r3189883653) — Pagination Pattern | ✅ **Fixed** | Commit 153e0dc — list result models now use `is Azure.Core.Page&lt;T&gt;`. Matches the standard pattern used elsewhere in the spec (e.g., `chaosFaultListResponse`). |

## Validation

- `npx tsp compile .` exits 0 with no errors and no warnings on the modified spec.
- Re-emit produces no further diff (committed `openapi.json` is up to date).
- Generated swagger correctly emits `allOf` references to common-types `ProxyResource` for the three result models, and standard paginated list shape for the three list models.
- Cross-checked each of the 6 review comment URLs against the diff at HEAD; see status table above.

## Scope

All changes are limited to soft-delete files (the portion the CosmosDB team owns in PR #41475). No edits to other parts of the spec.
