### PR TITLE
[monitoringservice] Remove readOnly from AzureMonitorWorkspace metrics property

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-05-03-preview/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-05-03-preview/azuremonitorworkspace.json
@@ -3141,25 +3141,6 @@
       "format": "uuid",
       "description": "Universally Unique Identifier"
     },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "Azure.ResourceManager.ResourceProvisioningState": {
       "type": "string",
       "description": "The provisioning state of a resource type.",
@@ -3328,18 +3309,20 @@
     },
     "AzureMonitorWorkspaceResourceUpdate": {
       "type": "object",
-      "description": "An Azure Monitor Workspace definition",
+      "description": "The type used for updating an Azure Monitor Workspace",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/AzureMonitorWorkspace",
           "description": "Resource properties"
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "AzureMonitorWorkspaceSignalGroup": {
       "type": "object",
@@ -4313,7 +4296,7 @@
     },
     "IssuePropertiesUpdate": {
       "type": "object",
-      "description": "The issue properties",
+      "description": "The issue properties for update",
       "properties": {
         "title": {
           "type": "string",
@@ -4372,18 +4355,13 @@
     },
     "IssueResourceUpdate": {
       "type": "object",
-      "description": "The Issue resource",
+      "description": "The Issue resource update",
       "properties": {
         "properties": {
           "$ref": "#/definitions/IssuePropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "ListParameter": {
       "type": "object",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-05-03-preview/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-05-03-preview/azuremonitorworkspace.json
@@ -3183,8 +3183,7 @@
         },
         "metrics": {
           "$ref": "#/definitions/AzureMonitorWorkspaceMetrics",
-          "description": "Properties related to the metrics container in the Azure Monitor Workspace",
-          "readOnly": true
+          "description": "Properties related to the metrics container in the Azure Monitor Workspace"
         },
         "provisioningState": {
           "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-10-03-preview/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-10-03-preview/azuremonitorworkspace.json
@@ -1390,25 +1390,6 @@
       "format": "uuid",
       "description": "Universally Unique Identifier"
     },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "Azure.ResourceManager.ResourceProvisioningState": {
       "type": "string",
       "description": "The provisioning state of a resource type.",
@@ -1565,18 +1546,20 @@
     },
     "AzureMonitorWorkspaceResourceUpdate": {
       "type": "object",
-      "description": "An Azure Monitor Workspace definition",
+      "description": "The type used for updating an Azure Monitor Workspace",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/AzureMonitorWorkspace",
           "description": "Resource properties"
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "Background": {
       "type": "object",
@@ -1767,7 +1750,7 @@
     },
     "IssuePropertiesUpdate": {
       "type": "object",
-      "description": "The issue properties",
+      "description": "The issue properties for update",
       "properties": {
         "title": {
           "type": "string",
@@ -1830,18 +1813,13 @@
     },
     "IssueResourceUpdate": {
       "type": "object",
-      "description": "The Issue resource",
+      "description": "The Issue resource update",
       "properties": {
         "properties": {
           "$ref": "#/definitions/IssuePropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "ListParameter": {
       "type": "object",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-10-03-preview/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/preview/2025-10-03-preview/azuremonitorworkspace.json
@@ -1432,8 +1432,7 @@
         },
         "metrics": {
           "$ref": "#/definitions/AzureMonitorWorkspaceMetrics",
-          "description": "Properties related to the metrics container in the Azure Monitor Workspace",
-          "readOnly": true
+          "description": "Properties related to the metrics container in the Azure Monitor Workspace"
         },
         "provisioningState": {
           "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/stable/2025-10-03/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/stable/2025-10-03/azuremonitorworkspace.json
@@ -1390,43 +1390,6 @@
       "format": "uuid",
       "description": "Universally Unique Identifier"
     },
-    "Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "type": {
-          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
-          "description": "The type of managed identity assigned to this resource."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The identities assigned to this resource by the user.",
-          "additionalProperties": {
-            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
-            "x-nullable": true
-          }
-        }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "Azure.ResourceManager.ResourceProvisioningState": {
       "type": "string",
       "description": "The provisioning state of a resource type.",
@@ -1587,22 +1550,24 @@
     },
     "AzureMonitorWorkspaceResourceUpdate": {
       "type": "object",
-      "description": "An Azure Monitor Workspace definition",
+      "description": "The type used for updating an Azure Monitor Workspace",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
         "properties": {
           "$ref": "#/definitions/AzureMonitorWorkspace",
           "description": "Resource properties"
-        },
-        "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
-          "description": "The managed service identities assigned to this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "Background": {
       "type": "object",
@@ -1821,7 +1786,7 @@
     },
     "IssuePropertiesUpdate": {
       "type": "object",
-      "description": "The issue properties",
+      "description": "The issue properties for update",
       "properties": {
         "title": {
           "type": "string",
@@ -1888,18 +1853,13 @@
     },
     "IssueResourceUpdate": {
       "type": "object",
-      "description": "The Issue resource",
+      "description": "The Issue resource update",
       "properties": {
         "properties": {
           "$ref": "#/definitions/IssuePropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "ListParameter": {
       "type": "object",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/stable/2025-10-03/azuremonitorworkspace.json
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/stable/2025-10-03/azuremonitorworkspace.json
@@ -1432,8 +1432,7 @@
         },
         "metrics": {
           "$ref": "#/definitions/AzureMonitorWorkspaceMetrics",
-          "description": "Properties related to the metrics container in the Azure Monitor Workspace",
-          "readOnly": true
+          "description": "Properties related to the metrics container in the Azure Monitor Workspace"
         },
         "provisioningState": {
           "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/AzureMonitorWorkspace.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/AzureMonitorWorkspace.tsp
@@ -25,9 +25,9 @@ namespace Microsoft.Monitor {
     /**
      * Updates part of an Azure Monitor Workspace
      */
-    update is ArmResourcePatchSync<
+    update is ArmCustomPatchSync<
       AzureMonitorWorkspaceResource,
-      AzureMonitorWorkspace
+      AzureMonitorWorkspaceResourceUpdate
     >;
 
     /**

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/issues/issues.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/issues/issues.tsp
@@ -55,7 +55,7 @@ interface Issue {
   >;
 
   @doc("Update an issue")
-  update is ArmResourcePatchSync<IssueResource, IssueProperties>;
+  update is ArmCustomPatchSync<IssueResource, IssueResourceUpdate>;
 
   @doc("Get issue properties")
   get is ArmResourceRead<IssueResource>;

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/issues/models.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/issues/models.tsp
@@ -367,6 +367,35 @@ model RelatedResources {
   value: RelatedResource[];
 }
 
+@doc("The issue properties for update")
+model IssuePropertiesUpdate {
+  @doc("The issue title")
+  title?: string;
+
+  @doc("The issue status")
+  status?: Status;
+
+  @doc("The issue severity")
+  severity?: string;
+
+  @doc("The issue impact time (in UTC)")
+  impactTime?: utcDateTime;
+
+  @added(Versions.v2025_10_03)
+  @doc("The issue background information")
+  background?: Background;
+
+  @added(Versions.v2025_10_03_stable)
+  @doc("The issue notification settings")
+  notifications?: Notifications;
+}
+
+@doc("The Issue resource update")
+model IssueResourceUpdate {
+  @doc("The resource-specific properties for this resource.")
+  properties?: IssuePropertiesUpdate;
+}
+
 @@clientName(ListParameter, "ListParameterContent", "csharp");
 @doc("Parameters for listing related entities")
 model ListParameter {

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/models.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/models.tsp
@@ -148,3 +148,30 @@ namespace Microsoft.Monitor {
 @@TypeSpec.Versioning.added(Microsoft.Monitor.AzureMonitorWorkspaceResource.identity,
   Microsoft.Monitor.Versions.v2025_10_03_stable
 );
+
+namespace Microsoft.Monitor {
+  /**
+   * The type used for updating an Azure Monitor Workspace
+   */
+  model AzureMonitorWorkspaceResourceUpdate {
+    /**
+     * Resource tags.
+     */
+    #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "tags is a standard ARM update pattern"
+    tags?: Record<string>;
+
+    /**
+     * The managed service identities assigned to this resource.
+     */
+    identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
+
+    /**
+     * Resource properties
+     */
+    properties?: AzureMonitorWorkspace;
+  }
+}
+
+@@TypeSpec.Versioning.added(Microsoft.Monitor.AzureMonitorWorkspaceResourceUpdate.identity,
+  Microsoft.Monitor.Versions.v2025_10_03_stable
+);

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/models.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/typespec/models.tsp
@@ -40,7 +40,6 @@ namespace Microsoft.Monitor {
     /**
      * Properties related to the metrics container in the Azure Monitor Workspace
      */
-    @visibility(Lifecycle.Read)
     metrics?: AzureMonitorWorkspaceMetrics;
 
     /**


### PR DESCRIPTION
The metrics property on AzureMonitorWorkspace was incorrectly marked as readOnly at the object level. This removes that flag so that enableAccessUsingResourcePermissions is accessible as a writable CLI argument.