### PR TITLE
Add force query parameter to DeleteAgent and DeleteAgentVersion APIs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -434,7 +434,7 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgent",
-        "description": "Deletes an agent.",
+        "description": "Deletes an agent. For hosted agents, if any version has active sessions, the request\nis rejected with HTTP 409 unless `force` is set to true. When force is true, all\nassociated sessions are cascade-deleted along with the agent and its versions.",
         "parameters": [
           {
             "name": "agent_name",
@@ -443,6 +443,15 @@
             "description": "The name of the agent to delete.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
+            "schema": {
+              "type": "boolean"
             }
           },
           {
@@ -2044,7 +2053,7 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgentVersion",
-        "description": "Deletes a specific version of an agent.",
+        "description": "Deletes a specific version of an agent. For hosted agents, if the version has active\nsessions, the request is rejected with HTTP 409 unless `force` is set to true. When\nforce is true, all sessions associated with this version are cascade-deleted.",
         "parameters": [
           {
             "name": "agent_name",
@@ -2062,6 +2071,15 @@
             "description": "The version of the agent to delete",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
+            "schema": {
+              "type": "boolean"
             }
           },
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -451,7 +451,8 @@
             "required": false,
             "description": "If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
@@ -2079,7 +2080,8 @@
             "required": false,
             "description": "If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -300,6 +300,7 @@ paths:
           description: If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
           schema:
             type: boolean
+            default: false
         - name: api-version
           in: query
           required: true
@@ -1414,6 +1415,7 @@ paths:
           description: If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
           schema:
             type: boolean
+            default: false
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -283,7 +283,10 @@ paths:
                 contentType: application/json
     delete:
       operationId: Agents_deleteAgent
-      description: Deletes an agent.
+      description: |-
+        Deletes an agent. For hosted agents, if any version has active sessions, the request
+        is rejected with HTTP 409 unless `force` is set to true. When force is true, all
+        associated sessions are cascade-deleted along with the agent and its versions.
       parameters:
         - name: agent_name
           in: path
@@ -291,6 +294,12 @@ paths:
           description: The name of the agent to delete.
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
+          schema:
+            type: boolean
         - name: api-version
           in: query
           required: true
@@ -1382,7 +1391,10 @@ paths:
         - Agents
     delete:
       operationId: Agents_deleteAgentVersion
-      description: Deletes a specific version of an agent.
+      description: |-
+        Deletes a specific version of an agent. For hosted agents, if the version has active
+        sessions, the request is rejected with HTTP 409 unless `force` is set to true. When
+        force is true, all sessions associated with this version are cascade-deleted.
       parameters:
         - name: agent_name
           in: path
@@ -1396,6 +1408,12 @@ paths:
           description: The version of the agent to delete
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
+          schema:
+            type: boolean
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -437,7 +437,7 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgent",
-        "description": "Deletes an agent.",
+        "description": "Deletes an agent. For hosted agents, if any version has active sessions, the request\nis rejected with HTTP 409 unless `force` is set to true. When force is true, all\nassociated sessions are cascade-deleted along with the agent and its versions.",
         "parameters": [
           {
             "name": "agent_name",
@@ -446,6 +446,15 @@
             "description": "The name of the agent to delete.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
+            "schema": {
+              "type": "boolean"
             }
           },
           {
@@ -2262,7 +2271,7 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgentVersion",
-        "description": "Deletes a specific version of an agent.",
+        "description": "Deletes a specific version of an agent. For hosted agents, if the version has active\nsessions, the request is rejected with HTTP 409 unless `force` is set to true. When\nforce is true, all sessions associated with this version are cascade-deleted.",
         "parameters": [
           {
             "name": "agent_name",
@@ -2280,6 +2289,15 @@
             "description": "The version of the agent to delete",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
+            "schema": {
+              "type": "boolean"
             }
           },
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -454,7 +454,8 @@
             "required": false,
             "description": "If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
@@ -2297,7 +2298,8 @@
             "required": false,
             "description": "If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -284,7 +284,10 @@ paths:
                 contentType: application/json
     delete:
       operationId: Agents_deleteAgent
-      description: Deletes an agent.
+      description: |-
+        Deletes an agent. For hosted agents, if any version has active sessions, the request
+        is rejected with HTTP 409 unless `force` is set to true. When force is true, all
+        associated sessions are cascade-deleted along with the agent and its versions.
       parameters:
         - name: agent_name
           in: path
@@ -292,6 +295,12 @@ paths:
           description: The name of the agent to delete.
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
+          schema:
+            type: boolean
         - name: api-version
           in: query
           required: true
@@ -1536,7 +1545,10 @@ paths:
         - Agents
     delete:
       operationId: Agents_deleteAgentVersion
-      description: Deletes a specific version of an agent.
+      description: |-
+        Deletes a specific version of an agent. For hosted agents, if the version has active
+        sessions, the request is rejected with HTTP 409 unless `force` is set to true. When
+        force is true, all sessions associated with this version are cascade-deleted.
       parameters:
         - name: agent_name
           in: path
@@ -1550,6 +1562,12 @@ paths:
           description: The version of the agent to delete
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
+          schema:
+            type: boolean
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -301,6 +301,7 @@ paths:
           description: If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
           schema:
             type: boolean
+            default: false
         - name: api-version
           in: query
           required: true
@@ -1568,6 +1569,7 @@ paths:
           description: If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false.
           schema:
             type: boolean
+            default: false
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -165,7 +165,7 @@ interface Agents {
       @path agent_name: string;
 
       /** If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
-      @query force?: boolean;
+      @query force?: boolean = false;
     },
     DeleteAgentResponse
   >;
@@ -261,7 +261,7 @@ interface Agents {
       @path agent_version: string;
 
       /** If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
-      @query force?: boolean;
+      @query force?: boolean = false;
     },
     DeleteAgentVersionResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -153,7 +153,9 @@ interface Agents {
   >;
 
   /**
-   * Deletes an agent.
+   * Deletes an agent. For hosted agents, if any version has active sessions, the request
+   * is rejected with HTTP 409 unless `force` is set to true. When force is true, all
+   * associated sessions are cascade-deleted along with the agent and its versions.
    */
   @delete
   @route("/agents/{agent_name}")
@@ -161,6 +163,9 @@ interface Agents {
     {
       /** The name of the agent to delete. */
       @path agent_name: string;
+
+      /** If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
+      @query force?: boolean;
     },
     DeleteAgentResponse
   >;
@@ -241,7 +246,9 @@ interface Agents {
   >;
 
   /**
-   * Deletes a specific version of an agent.
+   * Deletes a specific version of an agent. For hosted agents, if the version has active
+   * sessions, the request is rejected with HTTP 409 unless `force` is set to true. When
+   * force is true, all sessions associated with this version are cascade-deleted.
    */
   @delete
   @route("/agents/{agent_name}/versions/{agent_version}")
@@ -252,6 +259,9 @@ interface Agents {
 
       /** The version of the agent to delete */
       @path agent_version: string;
+
+      /** If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
+      @query force?: boolean;
     },
     DeleteAgentVersionResponse
   >;


### PR DESCRIPTION
## Summary

Adds an optional `force` boolean query parameter to both `deleteAgent` and `deleteAgentVersion` operations for hosted agents with active sessions.

## Behavior

| Scenario | `force` omitted / false | `force=true` |
|----------|--------------------------|----------------|
| No active sessions | Deletes normally | Deletes normally |
| Active sessions exist (hosted agents) | **HTTP 409 Conflict** | Cascade-deletes all associated sessions, then deletes |

## Changes

- `agents/routes.tsp`: Added `@query force?: boolean` to `deleteAgent` and `deleteAgentVersion`
- Updated doc comments documenting the 409 behavior and cascade semantics for hosted agents

## Gating

No preview gating (`@removed` or `required_previews`) is applied because:
- `force` is a plain optional parameter on existing non-preview operations
- It defaults to `false` (backward-compatible, no behavioral change for existing callers)
- There is no TypeSpec mechanism to gate a single parameter behind a preview header
- For non-hosted agents (no sessions), the parameter is a no-op

SDK exposure is controlled separately via `Access.internal` shims in `sdk-agents/client.tsp` (both `deleteAgent` and `deleteAgentVersion` are already internal with void-returning public wrappers).

## Design References

- `06-key-decisions.md`: "Agent version deletion is blocked if active sessions exist, unless a force flag is used"
- `w1_adc_integration_runtime_detailed_design_plan.md` §3.2.3: `DELETE /agents/{name}/versions/{version}?force={true|false}`
- AWS Bedrock precedent: `skipResourceInUseCheck` parameter
