### PR TITLE
Add csharp customizations for RedHatOpenShift migration

### DIFF
--- a/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/client.tsp
+++ b/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/client.tsp
@@ -24,3 +24,71 @@ using Azure.ClientGenerator.Core;
   "preconfiguredNsg",
   "java"
 );
+
+// ---- C# rename mappings (preserve names from previous AutoRest-based SDK) ----
+@@clientName(Microsoft.RedHatOpenShift, "RedHatOpenShiftManagementClient", "csharp");
+
+@@clientName(Microsoft.RedHatOpenShift.APIServerProfile, "OpenShiftApiServerProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.ProvisioningState, "OpenShiftClusterProvisioningState", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.Visibility, "OpenShiftVisibility", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.NetworkProfile, "OpenShiftNetworkProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.ClusterProfile, "OpenShiftClusterProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.MasterProfile, "OpenShiftMasterProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.WorkerProfile, "OpenShiftWorkerProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.IngressProfile, "OpenShiftIngressProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.LoadBalancerProfile, "OpenShiftLoadBalancerProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.ServicePrincipalProfile, "OpenShiftServicePrincipalProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.OutboundType, "OpenShiftOutboundType", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.OutboundType.Loadbalancer, "LoadBalancer", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.EncryptionAtHost, "OpenShiftEncryptionAtHost", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.FipsValidatedModules, "OpenShiftFipsValidatedModules", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.PreconfiguredNSG, "OpenShiftPreconfiguredNsg", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentity, "OpenShiftPlatformWorkloadIdentity", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityProfile, "OpenShiftPlatformWorkloadIdentityProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityRole, "OpenShiftPlatformWorkloadIdentityRole", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.ConsoleProfile, "OpenShiftConsoleProfile", "csharp");
+@@clientName(Microsoft.RedHatOpenShift.ManagedOutboundIPs, "OpenShiftManagedOutboundIPs", "csharp");
+
+// Property casing fixes for C#
+@@clientName(Microsoft.RedHatOpenShift.OpenShiftClusterProperties.apiserverProfile,
+  "apiServerProfile",
+  "csharp"
+);
+@@clientName(Microsoft.RedHatOpenShift.NetworkProfile.preconfiguredNSG,
+  "preconfiguredNsg",
+  "csharp"
+);
+
+// arm-id formatted properties (mirrors autorest format-by-name-rules)
+@@alternateType(Microsoft.RedHatOpenShift.MasterProfile.subnetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.MasterProfile.diskEncryptionSetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.WorkerProfile.subnetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.WorkerProfile.diskEncryptionSetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.ClusterProfile.resourceGroupId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.PlatformWorkloadIdentity.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityRole.roleDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(Microsoft.RedHatOpenShift.EffectiveOutboundIP.id,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);

--- a/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/client.tsp
+++ b/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/client.tsp
@@ -2,93 +2,96 @@ import "@azure-tools/typespec-client-generator-core";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Azure.Core;
+using Microsoft.RedHatOpenShift;
 
 @@clientName(Microsoft.RedHatOpenShift,
   "AzureRedHatOpenShiftClient",
   "javascript,python"
 );
 
-@@clientName(Microsoft.RedHatOpenShift.APIServerProfile,
+@@clientName(APIServerProfile, "ApiServerProfile", "java");
+@@clientName(EffectiveOutboundIP, "EffectiveOutboundIp", "java");
+@@clientName(PreconfiguredNSG, "PreconfiguredNsg", "java");
+@@clientName(NetworkProfile.preconfiguredNSG, "preconfiguredNsg", "java");
+
+//@@clientName(Microsoft.RedHatOpenShift, "RedHatOpenShiftManagementClient", "csharp");
+@@clientName(APIServerProfile, "OpenShiftApiServerProfile", "csharp");
+@@clientName(ProvisioningState, "OpenShiftClusterProvisioningState", "csharp");
+@@clientName(Visibility, "OpenShiftVisibility", "csharp");
+@@clientName(NetworkProfile, "OpenShiftNetworkProfile", "csharp");
+@@clientName(ClusterProfile, "OpenShiftClusterProfile", "csharp");
+@@clientName(MasterProfile, "OpenShiftMasterProfile", "csharp");
+@@clientName(WorkerProfile, "OpenShiftWorkerProfile", "csharp");
+@@clientName(IngressProfile, "OpenShiftIngressProfile", "csharp");
+@@clientName(LoadBalancerProfile, "OpenShiftLoadBalancerProfile", "csharp");
+@@clientName(ServicePrincipalProfile,
+  "OpenShiftServicePrincipalProfile",
+  "csharp"
+);
+@@clientName(OutboundType, "OpenShiftOutboundType", "csharp");
+@@clientName(OutboundType.Loadbalancer, "LoadBalancer", "csharp");
+@@clientName(EncryptionAtHost, "OpenShiftEncryptionAtHost", "csharp");
+@@clientName(FipsValidatedModules, "OpenShiftFipsValidatedModule", "csharp");
+@@clientName(PreconfiguredNSG, "OpenShiftPreconfiguredNsg", "csharp");
+@@clientName(PlatformWorkloadIdentity,
+  "OpenShiftPlatformWorkloadIdentity",
+  "csharp"
+);
+@@clientName(PlatformWorkloadIdentityProfile,
+  "OpenShiftPlatformWorkloadIdentityProfile",
+  "csharp"
+);
+@@clientName(PlatformWorkloadIdentityRole,
+  "OpenShiftPlatformWorkloadIdentityRole",
+  "csharp"
+);
+@@clientName(ConsoleProfile, "OpenShiftConsoleProfile", "csharp");
+@@clientName(ManagedOutboundIPs, "OpenShiftManagedOutboundIPs", "csharp");
+@@clientName(OpenShiftClusterProperties.apiserverProfile,
   "ApiServerProfile",
-  "java"
-);
-@@clientName(Microsoft.RedHatOpenShift.EffectiveOutboundIP,
-  "EffectiveOutboundIp",
-  "java"
-);
-@@clientName(Microsoft.RedHatOpenShift.PreconfiguredNSG,
-  "PreconfiguredNsg",
-  "java"
-);
-@@clientName(Microsoft.RedHatOpenShift.NetworkProfile.preconfiguredNSG,
-  "preconfiguredNsg",
-  "java"
-);
-
-// ---- C# rename mappings (preserve names from previous AutoRest-based SDK) ----
-@@clientName(Microsoft.RedHatOpenShift, "RedHatOpenShiftManagementClient", "csharp");
-
-@@clientName(Microsoft.RedHatOpenShift.APIServerProfile, "OpenShiftApiServerProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.ProvisioningState, "OpenShiftClusterProvisioningState", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.Visibility, "OpenShiftVisibility", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.NetworkProfile, "OpenShiftNetworkProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.ClusterProfile, "OpenShiftClusterProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.MasterProfile, "OpenShiftMasterProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.WorkerProfile, "OpenShiftWorkerProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.IngressProfile, "OpenShiftIngressProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.LoadBalancerProfile, "OpenShiftLoadBalancerProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.ServicePrincipalProfile, "OpenShiftServicePrincipalProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.OutboundType, "OpenShiftOutboundType", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.OutboundType.Loadbalancer, "LoadBalancer", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.EncryptionAtHost, "OpenShiftEncryptionAtHost", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.FipsValidatedModules, "OpenShiftFipsValidatedModules", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.PreconfiguredNSG, "OpenShiftPreconfiguredNsg", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentity, "OpenShiftPlatformWorkloadIdentity", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityProfile, "OpenShiftPlatformWorkloadIdentityProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityRole, "OpenShiftPlatformWorkloadIdentityRole", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.ConsoleProfile, "OpenShiftConsoleProfile", "csharp");
-@@clientName(Microsoft.RedHatOpenShift.ManagedOutboundIPs, "OpenShiftManagedOutboundIPs", "csharp");
-
-// Property casing fixes for C#
-@@clientName(Microsoft.RedHatOpenShift.OpenShiftClusterProperties.apiserverProfile,
-  "apiServerProfile",
   "csharp"
 );
-@@clientName(Microsoft.RedHatOpenShift.NetworkProfile.preconfiguredNSG,
-  "preconfiguredNsg",
+@@clientName(NetworkProfile.preconfiguredNSG, "PreconfiguredNsg", "csharp");
+@@clientName(NetworkProfile.preconfiguredNSG, "PreconfiguredNsg", "csharp");
+@@clientName(PlatformWorkloadIdentityRoleSet,
+  "OpenShiftPlatformWorkloadIdentityRoleSet",
   "csharp"
 );
 
-// arm-id formatted properties (mirrors autorest format-by-name-rules)
-@@alternateType(Microsoft.RedHatOpenShift.MasterProfile.subnetId,
+@@alternateType(MasterProfile.subnetId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.MasterProfile.diskEncryptionSetId,
+@@alternateType(MasterProfile.diskEncryptionSetId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.WorkerProfile.subnetId,
+@@alternateType(WorkerProfile.subnetId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.WorkerProfile.diskEncryptionSetId,
+@@alternateType(WorkerProfile.diskEncryptionSetId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.ClusterProfile.resourceGroupId,
+@@alternateType(ClusterProfile.resourceGroupId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.PlatformWorkloadIdentity.resourceId,
+@@alternateType(PlatformWorkloadIdentity.resourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.PlatformWorkloadIdentityRole.roleDefinitionId,
+@@alternateType(PlatformWorkloadIdentityRole.roleDefinitionId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(Microsoft.RedHatOpenShift.EffectiveOutboundIP.id,
+@@alternateType(EffectiveOutboundIP.id,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
+@@alternateType(APIServerProfile.url, url, "csharp");
+@@alternateType(APIServerProfile.ip, ipV4Address, "csharp");
+@@alternateType(ConsoleProfile.url, url, "csharp");
+@@alternateType(IngressProfile.ip, ipV4Address, "csharp");

--- a/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/tspconfig.yaml
+++ b/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/OpenShiftClusters/tspconfig.yaml
@@ -44,6 +44,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.RedHatOpenShift"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Adds the C# emitter and csharp-scoped client customizations for migrating `Azure.ResourceManager.RedHatOpenShift` from AutoRest/Swagger to TypeSpec.

## Spec changes

- `tspconfig.yaml`: register `@azure-typespec/http-client-csharp-mgmt` with namespace `Azure.ResourceManager.RedHatOpenShift`.
- `client.tsp`:
  - `@@clientName(Microsoft.RedHatOpenShift, "RedHatOpenShiftManagementClient", "csharp")`
  - `OpenShift*` rename mapping for the data-plane-style model names that the existing AutoRest config used (`APIServerProfile`, `NetworkProfile`, `ClusterProfile`, `MasterProfile`, `WorkerProfile`, `IngressProfile`, `LoadBalancerProfile`, `ServicePrincipalProfile`, `OutboundType`, `EncryptionAtHost`, `FipsValidatedModules`, `PreconfiguredNSG`, `PlatformWorkloadIdentity`/`Profile`/`Role`, `ConsoleProfile`, `ManagedOutboundIPs`, `ProvisioningState`, `Visibility`).
  - `@@clientName` for the `OutboundType.Loadbalancer` enum value to keep the existing `LoadBalancer` casing.
  - Property-name fixes for C#: `apiserverProfile` → `apiServerProfile` and `preconfiguredNSG` → `preconfiguredNsg`.
  - `@@alternateType` to `Azure.Core.armResourceIdentifier` for the arm-id formatted properties that AutoRest's `format-by-name-rules` previously typed as `ResourceIdentifier` (`subnetId`, `diskEncryptionSetId`, `resourceGroupId`, `resourceId`, `roleDefinitionId`, `EffectiveOutboundIP.id`).

These customizations are scoped to `"csharp"` so other languages are unaffected.

Companion SDK PR: Azure/azure-sdk-for-net#<TBD>