### PR TITLE
Better class & body names for Agent Code operations

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14752,7 +14752,7 @@
           "metadata": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeMetadata"
               }
             ],
             "description": "JSON metadata including description and hosted definition."
@@ -14927,7 +14927,7 @@
           "metadata": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeMetadata"
               }
             ],
             "description": "JSON metadata including description and hosted definition."
@@ -14943,7 +14943,7 @@
           "code"
         ]
       },
-      "CreateAgentVersionFromCodeRequest": {
+      "CreateAgentVersionFromCodeMetadata": {
         "type": "object",
         "required": [
           "definition"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9814,7 +9814,7 @@ components:
       properties:
         metadata:
           allOf:
-            - $ref: '#/components/schemas/CreateAgentVersionFromCodeRequest'
+            - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
           type: string
@@ -9949,7 +9949,7 @@ components:
       properties:
         metadata:
           allOf:
-            - $ref: '#/components/schemas/CreateAgentVersionFromCodeRequest'
+            - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
           type: string
@@ -9958,7 +9958,7 @@ components:
       required:
         - metadata
         - code
-    CreateAgentVersionFromCodeRequest:
+    CreateAgentVersionFromCodeMetadata:
       type: object
       required:
         - definition

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17065,7 +17065,7 @@
           "metadata": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeMetadata"
               }
             ],
             "description": "JSON metadata including description and hosted definition."
@@ -17240,7 +17240,7 @@
           "metadata": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/CreateAgentVersionFromCodeRequest"
+                "$ref": "#/components/schemas/CreateAgentVersionFromCodeMetadata"
               }
             ],
             "description": "JSON metadata including description and hosted definition."
@@ -17256,7 +17256,7 @@
           "code"
         ]
       },
-      "CreateAgentVersionFromCodeRequest": {
+      "CreateAgentVersionFromCodeMetadata": {
         "type": "object",
         "required": [
           "definition"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11392,7 +11392,7 @@ components:
       properties:
         metadata:
           allOf:
-            - $ref: '#/components/schemas/CreateAgentVersionFromCodeRequest'
+            - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
           type: string
@@ -11527,7 +11527,7 @@ components:
       properties:
         metadata:
           allOf:
-            - $ref: '#/components/schemas/CreateAgentVersionFromCodeRequest'
+            - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
           type: string
@@ -11536,7 +11536,7 @@ components:
       required:
         - metadata
         - code
-    CreateAgentVersionFromCodeRequest:
+    CreateAgentVersionFromCodeMetadata:
       type: object
       required:
         - definition

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -871,7 +871,7 @@ model AgentCard {
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
 )
-model CreateAgentVersionFromCodeRequest {
+model CreateAgentVersionFromCodeMetadata {
   @doc("A human-readable description of the agent.")
   @maxLength(512)
   description?: string;
@@ -889,7 +889,7 @@ model CreateAgentVersionFromCodeRequest {
 )
 model CreateAgentVersionFromCodeContent {
   /** JSON metadata including description and hosted definition. */
-  metadata: HttpPart<CreateAgentVersionFromCodeRequest>;
+  metadata: HttpPart<CreateAgentVersionFromCodeMetadata>;
 
   /** The code zip file (max 250 MB). */
   code: HttpPart<bytes>;
@@ -921,7 +921,7 @@ model DownloadAgentCodeResponse {
 
   @doc("The zip code package content.")
   @body
-  body: bytes;
+  content: bytes;
 }
 
 // ══════════════════════════════════════════════════════════

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -65,7 +65,7 @@ interface Agents {
       @header("x-ms-code-zip-sha256")
       codeZipSha256: string;
 
-      @multipartBody body: CreateAgentFromCodeContent;
+      @multipartBody content: CreateAgentFromCodeContent;
     },
     AgentObject
   >;
@@ -121,7 +121,7 @@ interface Agents {
       @header("x-ms-code-zip-sha256")
       codeZipSha256: string;
 
-      @multipartBody body: CreateAgentVersionFromCodeContent;
+      @multipartBody content: CreateAgentVersionFromCodeContent;
     },
     AgentObject
   >;
@@ -330,7 +330,7 @@ interface Agents {
       @header("x-ms-code-zip-sha256")
       codeZipSha256: string;
 
-      @multipartBody body: CreateAgentVersionFromCodeContent;
+      @multipartBody content: CreateAgentVersionFromCodeContent;
     },
     AgentVersionObject
   >;


### PR DESCRIPTION
This change only affects emitted SDKs. It does not affect service functionality (even though the OpenAPI3 files are updated). This is based on previous Python Arch board review comments on similar method signatures. I think it should apply to all programming langauges.