### PR TITLE
Additional input argument and class renames

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -142,6 +142,8 @@ using Azure.AI.Projects;
 // Rename models ending with 'Object' to end with 'Details' for Python
 @@clientName(MemoryStoreObject, "MemoryStoreDetails", "python");
 
+@@clientName(PendingUploadResponse, "PendingUploadResult", "python");
+
 // Remove 'Object' suffix for JS client
 @@clientName(MemoryStoreObject, "MemoryStore", "javascript");
 
@@ -271,6 +273,8 @@ using Azure.AI.Projects;
 @@clientName(Skills.updateSkill, "update");
 @@clientName(Skills.deleteSkill, "delete");
 
+@@clientName(DeleteSkillResponse, "DeleteSkillResult", "python");
+
 // --------------------------------------------------------------------------------
 // Connections sub‐client
 // --------------------------------------------------------------------------------
@@ -300,6 +304,8 @@ using Azure.AI.Projects;
 @@scope(Agents.createAgentFromCode, "!(python)");
 
 @@clientName(DownloadAgentCodeResponse, "DownloadAgentCodeResult", "python");
+@@clientName(SessionDirectoryListResponse, "SessionDirectoryListResult", "python");
+@@clientName(SessionFileWriteResponse, "SessionFileWriteResult", "python");
 
 // --------------------------------------------------------------------------------
 // To support custom client-side handling of "opt-in" to preview features.

--- a/specification/ai-foundry/data-plane/Foundry/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.tsp
@@ -273,7 +273,9 @@ using Azure.AI.Projects;
 @@clientName(Skills.updateSkill, "update");
 @@clientName(Skills.deleteSkill, "delete");
 
+@@clientName(SkillObject, "SkillDetails", "python");
 @@clientName(DeleteSkillResponse, "DeleteSkillResult", "python");
+@@clientName(DownloadSkillResponse, "DownloadSkillResult", "python"); 
 
 // --------------------------------------------------------------------------------
 // Connections sub‐client

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -29,7 +29,7 @@ alias CreateSkillFromPackageRequest = {
 
   @doc("The zip package used to create the skill.")
   @body
-  body: bytes;
+  content: bytes;
 };
 
 alias UpdateSkillRequest = {
@@ -106,5 +106,5 @@ model DownloadSkillResponse {
 
   @doc("The zip skill package content.")
   @body
-  body: bytes;
+  content: bytes;
 }


### PR DESCRIPTION
For all languages:
- Do not use "body" as input argument for public methods. Here we use "content" instead. The same thing was done in previous PR related to creating Agent from Code (zip content).
For Python:
- Do not use class named "SomethingObject". Use "SomethingDetails" instead. Here I renamed "SkillObject" to "SkillDetails". The same was done in previous release with "AgentDetails".
- Do not use class names that end with "Response". They should end with "Result" instead. Here I do this for several classes. Already plenty of examples of those. 
