### PR TITLE
Rename Cost Management reason model for C#

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -239,6 +239,7 @@ op GetGenerateDetailedCostReportOperationStatusCustomized(
   "csharp"
 );
 @@clientName(Status, "ReportOperationStatus", "csharp");
+@@clientName(Reason, "CostManagementReason", "csharp");
 
 @@clientName(CostAllocationRuleDefinition, "CostAllocationRule", "csharp");
 @@clientName(GenerateCostDetailsReportRequestDefinition,

--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -239,7 +239,7 @@ op GetGenerateDetailedCostReportOperationStatusCustomized(
   "csharp"
 );
 @@clientName(Status, "ReportOperationStatus", "csharp");
-@@clientName(Reason, "CostManagementReason", "csharp");
+@@clientName(Reason, "CostAllocationRuleCheckNameAvailabilityReason", "csharp");
 
 @@clientName(CostAllocationRuleDefinition, "CostAllocationRule", "csharp");
 @@clientName(GenerateCostDetailsReportRequestDefinition,


### PR DESCRIPTION
## Summary
- Rename Cost Management TypeSpec union `Reason` to `CostManagementReason` for C# using `@@clientName`

## Context
Addresses Azure SDK for .NET PR review feedback: https://github.com/Azure/azure-sdk-for-net/pull/59088#discussion_r3206520589

## Validation
- Regenerated Azure.ResourceManager.CostManagement locally from this spec change
- Exported .NET API listings and confirmed `Models.Reason` is replaced by `Models.CostManagementReason`
