### PR TITLE
Add McpToolConfig model and tool_configs field to MCPTool

### DIFF
--- a/agency.toml
+++ b/agency.toml
@@ -1,2 +1,0 @@
-[mcps.servers]
-azure-sdk-mcp = { args = ["./eng/common/mcp/azure-sdk-mcp.ps1", "-Run"], command = "pwsh", tools = ["*"], type = "stdio" }

--- a/agency.toml
+++ b/agency.toml
@@ -1,0 +1,2 @@
+[mcps.servers]
+azure-sdk-mcp = { args = ["./eng/common/mcp/azure-sdk-mcp.ps1", "-Run"], command = "pwsh", tools = ["*"], type = "stdio" }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -42438,13 +42438,6 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
-          },
-          "tool_configs": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -11627,20 +11627,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "base_url": {
             "type": "string",
@@ -13360,20 +13352,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "azure_ai_search": {
             "allOf": [
@@ -13633,20 +13617,12 @@
             ],
             "description": "The Azure Function Tool definition."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -13858,20 +13834,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -14056,20 +14024,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_grounding": {
             "allOf": [
@@ -14266,20 +14226,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -14430,20 +14382,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "outputs": {
             "allOf": [
@@ -18218,20 +18162,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -19466,20 +19402,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "memory_store_name": {
             "type": "string",
@@ -20025,20 +19953,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -21116,20 +21036,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "container": {
             "anyOf": [
@@ -25472,20 +25384,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -26921,20 +26825,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -27628,20 +27524,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -33392,20 +33280,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -33610,20 +33490,12 @@
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -39894,20 +39766,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -40182,20 +40046,12 @@
             ],
             "description": "The openapi function definition."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -41765,20 +41621,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -42591,20 +42439,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -43266,20 +43106,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -11627,6 +11627,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -13345,6 +13360,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -13602,6 +13632,21 @@
               }
             ],
             "description": "The Azure Function Tool definition."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -13813,6 +13858,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -13995,6 +14055,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_grounding": {
             "allOf": [
@@ -14191,6 +14266,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -14339,6 +14429,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "outputs": {
             "allOf": [
@@ -18112,6 +18217,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -19346,6 +19466,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -19889,6 +20024,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -20965,6 +21115,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "container": {
             "anyOf": [
@@ -25306,6 +25471,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -26740,6 +26920,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -27432,6 +27627,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -33181,6 +33391,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -33384,6 +33609,21 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -39654,6 +39894,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -39926,6 +40181,21 @@
               }
             ],
             "description": "The openapi function definition."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -41495,6 +41765,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -42205,6 +42490,21 @@
         ],
         "description": "The status of a tool call."
       },
+      "ToolConfig": {
+        "type": "object",
+        "properties": {
+          "pin": {
+            "type": "boolean",
+            "description": "When true, the tool is always included in agent context and visible in `tools/list`.\nWhen false (default), the tool is hidden from `tools/list` and only discoverable via `tool_search`."
+          },
+          "additional_search_text": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Additional text indexed for tool_search. Supplements the native tool description\nto improve discoverability. Does not alter `tools/list` output."
+          }
+        },
+        "description": "Per-tool configuration that controls tool visibility and search behavior."
+      },
       "ToolDescription": {
         "type": "object",
         "properties": {
@@ -42290,6 +42590,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -42950,6 +43265,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -7678,19 +7678,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         base_url:
           type: string
@@ -8829,19 +8823,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         azure_ai_search:
           allOf:
@@ -9008,19 +8996,13 @@ components:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
           description: The Azure Function Tool definition.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -9162,19 +9144,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         bing_custom_search_preview:
           allOf:
@@ -9300,19 +9276,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         bing_grounding:
           allOf:
@@ -9435,19 +9405,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         browser_automation_preview:
           allOf:
@@ -9542,19 +9506,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         outputs:
           allOf:
@@ -12410,19 +12368,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -13219,19 +13171,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
@@ -13588,19 +13534,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         fabric_dataagent_preview:
           allOf:
@@ -14363,19 +14303,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         container:
           anyOf:
@@ -17449,19 +17383,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -18454,19 +18382,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -19091,19 +19013,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -23286,19 +23202,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -23453,19 +23363,13 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -28468,19 +28372,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         custom_search_configuration:
           allOf:
@@ -28666,19 +28564,13 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
           description: The openapi function definition.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -29767,19 +29659,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         sharepoint_grounding_preview:
           allOf:
@@ -30328,19 +30214,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -30799,19 +30679,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -7678,6 +7678,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         base_url:
           type: string
           format: uri
@@ -8815,6 +8829,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -8980,6 +9008,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
           description: The Azure Function Tool definition.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for an Azure Function Tool, as used to configure an Agent.
@@ -9120,6 +9162,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -9244,6 +9300,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -9365,6 +9435,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -9458,6 +9542,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -12312,6 +12410,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -13107,6 +13219,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -13462,6 +13588,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -14223,6 +14363,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         container:
           anyOf:
             - type: string
@@ -17295,6 +17449,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -18286,6 +18454,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -18909,6 +19091,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -23090,6 +23286,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -23243,6 +23453,20 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -28244,6 +28468,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -28428,6 +28666,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
           description: The openapi function definition.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for an OpenAPI tool as used to configure an agent.
@@ -29515,6 +29767,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -29986,6 +30252,21 @@ components:
         - incomplete
         - failed
       description: The status of a tool call.
+    ToolConfig:
+      type: object
+      properties:
+        pin:
+          type: boolean
+          description: |-
+            When true, the tool is always included in agent context and visible in `tools/list`.
+            When false (default), the tool is hidden from `tools/list` and only discoverable via `tool_search`.
+        additional_search_text:
+          type: string
+          maxLength: 1000
+          description: |-
+            Additional text indexed for tool_search. Supplements the native tool description
+            to improve discoverability. Does not alter `tools/list` output.
+      description: Per-tool configuration that controls tool visibility and search behavior.
     ToolDescription:
       type: object
       properties:
@@ -30047,6 +30328,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -30504,6 +30799,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -30214,14 +30214,6 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        tool_configs:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14718,6 +14718,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "base_url": {
             "type": "string",
             "format": "uri",
@@ -16965,6 +16980,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -17222,6 +17252,21 @@
               }
             ],
             "description": "The Azure Function Tool definition."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -17433,6 +17478,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -17615,6 +17675,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_grounding": {
             "allOf": [
@@ -17811,6 +17886,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -17959,6 +18049,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "outputs": {
             "allOf": [
@@ -23161,6 +23266,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -24539,6 +24659,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -24591,6 +24726,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "memory_store_name": {
             "type": "string",
@@ -25170,6 +25320,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -26246,6 +26411,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           },
           "container": {
             "anyOf": [
@@ -30587,6 +30767,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -32021,6 +32216,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -32713,6 +32923,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -38462,6 +38687,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -38665,6 +38905,21 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -44960,6 +45215,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -45232,6 +45502,21 @@
               }
             ],
             "description": "The openapi function definition."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -46969,6 +47254,21 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -47748,6 +48048,21 @@
         ],
         "description": "The status of a tool call."
       },
+      "ToolConfig": {
+        "type": "object",
+        "properties": {
+          "pin": {
+            "type": "boolean",
+            "description": "When true, the tool is always included in agent context and visible in `tools/list`.\nWhen false (default), the tool is hidden from `tools/list` and only discoverable via `tool_search`."
+          },
+          "additional_search_text": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "Additional text indexed for tool_search. Supplements the native tool description\nto improve discoverability. Does not alter `tools/list` output."
+          }
+        },
+        "description": "Per-tool configuration that controls tool visibility and search behavior."
+      },
       "ToolDescription": {
         "type": "object",
         "properties": {
@@ -47854,6 +48169,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -48723,6 +49053,21 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
+          },
+          "default_tool_config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolConfig"
+              }
+            ],
+            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
+          },
+          "tool_configs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -48009,13 +48009,6 @@
           "description": {
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
-          },
-          "tool_configs": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ToolConfig"
-            },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14718,20 +14718,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "base_url": {
             "type": "string",
@@ -16980,20 +16972,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "azure_ai_search": {
             "allOf": [
@@ -17253,20 +17237,12 @@
             ],
             "description": "The Azure Function Tool definition."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -17478,20 +17454,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -17676,20 +17644,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "bing_grounding": {
             "allOf": [
@@ -17886,20 +17846,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -18050,20 +18002,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "outputs": {
             "allOf": [
@@ -23267,20 +23211,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -24659,20 +24595,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "memory_store_name": {
             "type": "string",
@@ -24727,20 +24655,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "memory_store_name": {
             "type": "string",
@@ -25321,20 +25241,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -26412,20 +26324,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "container": {
             "anyOf": [
@@ -30768,20 +30672,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -32217,20 +32113,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -32924,20 +32812,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -38688,20 +38568,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -38906,20 +38778,12 @@
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -45215,20 +45079,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -45503,20 +45359,12 @@
             ],
             "description": "The openapi function definition."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -47254,20 +47102,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -48170,20 +48010,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [
@@ -49054,20 +48886,12 @@
             "type": "string",
             "description": "Optional user-defined description for this tool or configuration."
           },
-          "default_tool_config": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ToolConfig"
-              }
-            ],
-            "description": "Default configuration applied to all tools unless\noverridden by a tool-specific entry in `tool_configs`."
-          },
           "tool_configs": {
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names.\nEntries here override `default_tool_config` for the matching tool.\nUnknown tool names are silently ignored at runtime."
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -33985,14 +33985,6 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        tool_configs:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9780,6 +9780,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         base_url:
           type: string
           format: uri
@@ -11284,6 +11298,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -11449,6 +11477,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
           description: The Azure Function Tool definition.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for an Azure Function Tool, as used to configure an Agent.
@@ -11589,6 +11631,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -11713,6 +11769,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -11834,6 +11904,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -11927,6 +12011,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -15728,6 +15826,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -16617,6 +16729,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -16656,6 +16782,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -17034,6 +17174,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -17795,6 +17949,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         container:
           anyOf:
             - type: string
@@ -20867,6 +21035,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -21858,6 +22040,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -22481,6 +22677,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -26662,6 +26872,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -26815,6 +27039,20 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -31836,6 +32074,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -32020,6 +32272,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
           description: The openapi function definition.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for an OpenAPI tool as used to configure an agent.
@@ -33222,6 +33488,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -33736,6 +34016,21 @@ components:
         - incomplete
         - failed
       description: The status of a tool call.
+    ToolConfig:
+      type: object
+      properties:
+        pin:
+          type: boolean
+          description: |-
+            When true, the tool is always included in agent context and visible in `tools/list`.
+            When false (default), the tool is hidden from `tools/list` and only discoverable via `tool_search`.
+        additional_search_text:
+          type: string
+          maxLength: 1000
+          description: |-
+            Additional text indexed for tool_search. Supplements the native tool description
+            to improve discoverability. Does not alter `tools/list` output.
+      description: Per-tool configuration that controls tool visibility and search behavior.
     ToolDescription:
       type: object
       properties:
@@ -33810,6 +34105,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -34399,6 +34708,20 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+        default_tool_config:
+          allOf:
+            - $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Default configuration applied to all tools unless
+            overridden by a tool-specific entry in `tool_configs`.
+        tool_configs:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names.
+            Entries here override `default_tool_config` for the matching tool.
+            Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9780,19 +9780,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         base_url:
           type: string
@@ -11298,19 +11292,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         azure_ai_search:
           allOf:
@@ -11477,19 +11465,13 @@ components:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
           description: The Azure Function Tool definition.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -11631,19 +11613,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         bing_custom_search_preview:
           allOf:
@@ -11769,19 +11745,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         bing_grounding:
           allOf:
@@ -11904,19 +11874,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         browser_automation_preview:
           allOf:
@@ -12011,19 +11975,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         outputs:
           allOf:
@@ -15826,19 +15784,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -16729,19 +16681,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
@@ -16782,19 +16728,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         memory_store_name:
           type: string
@@ -17174,19 +17114,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         fabric_dataagent_preview:
           allOf:
@@ -17949,19 +17883,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         container:
           anyOf:
@@ -21035,19 +20963,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -22040,19 +21962,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -22677,19 +22593,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -26872,19 +26782,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -27039,19 +26943,13 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -32074,19 +31972,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         custom_search_configuration:
           allOf:
@@ -32272,19 +32164,13 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
           description: The openapi function definition.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -33488,19 +33374,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
         sharepoint_grounding_preview:
           allOf:
@@ -34105,19 +33985,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -34708,19 +34582,13 @@ components:
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
-        default_tool_config:
-          allOf:
-            - $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Default configuration applied to all tools unless
-            overridden by a tool-specific entry in `tool_configs`.
         tool_configs:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
-            Per-tool configuration map. Keys are tool names.
-            Entries here override `default_tool_config` for the matching tool.
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -952,6 +952,7 @@ namespace Azure.AI.Projects {
     type: "toolbox_search_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
   }
 
   alias MemorySearchToolCallItemBase = {

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -952,7 +952,6 @@ namespace Azure.AI.Projects {
     type: "toolbox_search_preview";
 
     ...ToolNameAndDescriptionExtension;
-    ...ToolConfigExtension;
   }
 
   alias MemorySearchToolCallItemBase = {

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -163,14 +163,8 @@ namespace Azure.AI.Projects {
    */
   alias ToolConfigExtension = {
     /**
-     * Default configuration applied to all tools unless
-     * overridden by a tool-specific entry in `tool_configs`.
-     */
-    default_tool_config?: ToolConfig;
-
-    /**
-     * Per-tool configuration map. Keys are tool names.
-     * Entries here override `default_tool_config` for the matching tool.
+     * Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+     * Resolution order: exact tool name match takes priority over `*`.
      * Unknown tool names are silently ignored at runtime.
      */
     tool_configs?: Record<ToolConfig>;

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -44,6 +44,24 @@ namespace Azure.AI.Projects {
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyVariants(OpenAI.IncludeEnum, Azure.AI.Projects._AgentIncludable);
 
+  /**
+   * Per-tool configuration that controls tool visibility and search behavior.
+   */
+  model ToolConfig {
+    /**
+     * When true, the tool is always included in agent context and visible in `tools/list`.
+     * When false (default), the tool is hidden from `tools/list` and only discoverable via `tool_search`.
+     */
+    pin?: boolean;
+
+    /**
+     * Additional text indexed for tool_search. Supplements the native tool description
+     * to improve discoverability. Does not alter `tools/list` output.
+     */
+    @maxLength(1000)
+    additional_search_text?: string;
+  }
+
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.MCPTool,
     {
@@ -51,6 +69,8 @@ namespace Azure.AI.Projects {
        * The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
        */
       project_connection_id?: string,
+
+      ...ToolConfigExtension,
     }
   );
 
@@ -58,6 +78,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.WebSearchTool,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
 
       /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
@@ -71,6 +92,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.CodeInterpreterTool,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
     }
   );
 
@@ -78,6 +100,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.ImageGenTool,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
     }
   );
 
@@ -85,6 +108,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.LocalShellToolParam,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
     }
   );
 
@@ -92,6 +116,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.FunctionShellToolParam,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
     }
   );
 
@@ -99,6 +124,7 @@ namespace Azure.AI.Projects {
   @@copyProperties(OpenAI.FileSearchTool,
     {
       ...ToolNameAndDescriptionExtension,
+      ...ToolConfigExtension,
     }
   );
 
@@ -133,6 +159,24 @@ namespace Azure.AI.Projects {
   };
 
   /**
+   * Optional tool configuration extension for controlling tool visibility and search behavior.
+   */
+  alias ToolConfigExtension = {
+    /**
+     * Default configuration applied to all tools unless
+     * overridden by a tool-specific entry in `tool_configs`.
+     */
+    default_tool_config?: ToolConfig;
+
+    /**
+     * Per-tool configuration map. Keys are tool names.
+     * Entries here override `default_tool_config` for the matching tool.
+     * Unknown tool names are silently ignored at runtime.
+     */
+    tool_configs?: Record<ToolConfig>;
+  };
+
+  /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
   model BingGroundingTool extends OpenAI.Tool {
@@ -142,6 +186,7 @@ namespace Azure.AI.Projects {
     type: "bing_grounding";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -171,6 +216,7 @@ namespace Azure.AI.Projects {
     type: "fabric_dataagent_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The fabric data agent tool parameters.
@@ -200,6 +246,7 @@ namespace Azure.AI.Projects {
     type: "sharepoint_grounding_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The sharepoint grounding tool parameters.
@@ -217,6 +264,7 @@ namespace Azure.AI.Projects {
     type: "azure_ai_search";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The azure ai search index resource.
@@ -311,6 +359,8 @@ namespace Azure.AI.Projects {
      * The openapi function definition.
      */
     openapi: OpenApiFunctionDefinition;
+
+    ...ToolConfigExtension;
   }
 
   /**
@@ -323,6 +373,7 @@ namespace Azure.AI.Projects {
     type: "bing_custom_search_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The bing custom search tool parameters.
@@ -340,6 +391,7 @@ namespace Azure.AI.Projects {
     type: "browser_automation_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The Browser Automation Tool parameters.
@@ -380,6 +432,8 @@ namespace Azure.AI.Projects {
      * The Azure Function Tool definition.
      */
     azure_function: AzureFunctionDefinition;
+
+    ...ToolConfigExtension;
   }
 
   /**
@@ -730,6 +784,7 @@ namespace Azure.AI.Projects {
     type: "capture_structured_outputs";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The structured outputs to capture from the model.
@@ -747,6 +802,7 @@ namespace Azure.AI.Projects {
     type: "a2a_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * Base URL of the agent.
@@ -781,6 +837,7 @@ namespace Azure.AI.Projects {
     project_connection_id: string;
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
   }
 
   /**
@@ -815,6 +872,7 @@ namespace Azure.AI.Projects {
     require_approval?: OpenAI.MCPToolRequireApproval | string | null = "always";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
   }
 
   /**
@@ -827,6 +885,7 @@ namespace Azure.AI.Projects {
     type: "memory_search_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The name of the memory store to use.
@@ -862,6 +921,7 @@ namespace Azure.AI.Projects {
     type: "memory_search";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
 
     /**
      * The name of the memory store to use.
@@ -898,6 +958,7 @@ namespace Azure.AI.Projects {
     type: "toolbox_search_preview";
 
     ...ToolNameAndDescriptionExtension;
+    ...ToolConfigExtension;
   }
 
   alias MemorySearchToolCallItemBase = {


### PR DESCRIPTION
## What this PR does

Adds per-tool configuration support for MCP tools within toolboxes, enabling toolbox owners to:

1. **Pin tools** into agent context (visible in `tools/list`) instead of being hidden and only discoverable via `tool_search`
2. **Add search text** to improve tool discoverability without modifying the MCP server

### Changes

- **New `McpToolConfig` model** in `tools/models.tsp`:
  - `pin?: boolean` — when `true`, tool is always in agent context and visible in `tools/list`; when `false` (default), hidden and only discoverable via `tool_search`
  - `additional_search_text?: string` (`@maxLength(1000)`) — supplements native MCP description for search indexing
- **New `tool_configs` field** on `OpenAI.MCPTool` via `@@copyProperties`:
  - `Record<McpToolConfig>` — keys are MCP tool names or `*` (catch-all)
  - Resolution: exact name match > `*`; unknown tool names silently ignored

### Wire format example

```json
{
  "type": "mcp",
  "mcp": {
    "server_label": "analytics",
    "server_url": "https://db-mcp.internal/sse",
    "allowed_tools": ["execute_query", "list_tables"],
    "tool_configs": {
      "execute_query": {
        "pin": true,
        "additional_search_text": "SQL database analytics"
      },
      "*": {
        "pin": false
      }
    }
  }
}
```

### Validation

- `tsp compile` passes with no errors or warnings
