### PR TITLE
Transfer CODEOWNERS for /specification/authorization/ to active maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /specification/asazure/ @athipp
 
 # PRLabel: %Authorization
-/specification/authorization/ @jruttle @abaccin @avurganov @chocomochiko
+/specification/authorization/ @jruttle @abaccin @chocomochiko
 
 # PRLabel: %Automation
 /specification/automation/ @vrdmr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /specification/asazure/ @athipp
 
 # PRLabel: %Authorization
-/specification/authorization/ @darshanhs90
+/specification/authorization/ @jruttle @abaccin @avurganov @chocomochiko
 
 # PRLabel: %Automation
 /specification/automation/ @vrdmr


### PR DESCRIPTION
## Purpose

Update CODEOWNERS for `/specification/authorization/` to transfer ownership from a former employee to active maintainers.

  - [x] Other, please clarify:
    - Update CODEOWNERS

## Context

Per investigation in the Azure SDK > API Spec Review Teams thread (7-8 May 2026):

- Current CODEOWNER `@darshanhs90` is no longer employed at Microsoft (verified by @MikeHarder, Azure SDK EngSys). Last activity in this repo was January 2021.
- Previous co-owner `@stankovski` was already removed via #41839.
- This has left the spec effectively unowned, blocking PRs like #42261 (`.NET emitter addition`) which has been waiting on review for 3+ weeks.

## Change

Replace the abandoned CODEOWNER with active owners from the two teams that maintain `Microsoft.Authorization` specifications:

- **PAS team** (owns the `Microsoft.Authorization` service: RBAC, deny assignments, role definitions): `@jruttle`, `@abaccin`, `@avurganov`
- `@chocomochiko` (Sherry Yang — owns the attribute-namespaces sub-area; PR #40393)

@chocomochiko, please follow up with a small PR to add any additional teammates from your team who should also be CODEOWNERS — happy to keep this PR scoped to the immediate transfer and let your team self-determine its own membership.

## Approval

@MikeHarder offered to approve this transfer in the API Spec Review Teams thread, since the previous CODEOWNER has left:

> *"please create a PR to specs/main updating CODEOWNERS as you see fit. since the previous CODEOWNER appears to be no longer employed here, I can approve."*

Tagging @MikeHarder for review/approval.

## Unblocks

- #42261 — `.NET emitter addition` to Authorization tspconfig.yaml (the last blocker for the .NET SDK in our Deny Assignment GA release; Java + Python SDKs already shipped 7 May)
