### PR TITLE
Fix Java SDK delete rename for Slis service group scope

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -14,3 +14,7 @@ namespace Microsoft.Monitor;
 @@access(SloView.sliSignalPreview, Access.internal);
 
 @@clientName(Microsoft.Monitor, "MonitorSlisMgmtClient", "python");
+
+// Prevent Java SDK from renaming delete to deleteByResourceGroup.
+// The Sli resource is scoped by service group, not resource group.
+@@clientName(Slis.delete, "delete", "java");


### PR DESCRIPTION
The Java SDK generator renames `delete` to `deleteByResourceGroup` because it assumes a resource group scope. However, the Sli resource is scoped by service group, not resource group. This adds a `@@clientName` override in `client.tsp` to preserve the correct `delete` name in the Java SDK.