### PR TITLE
Transfer CODEOWNERS for /specification/authorization/ to active maintainers (v2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /specification/asazure/ @athipp
 
 # PRLabel: %Authorization
-/specification/authorization/ @darshanhs90
+/specification/authorization/ @jruttle @abaccin @chocomochiko
 
 # PRLabel: %Automation
 /specification/automation/ @vrdmr


### PR DESCRIPTION
## Purpose

Update CODEOWNERS for `/specification/authorization/` to transfer ownership from a former employee to active maintainers.

  - [x] Other, please clarify:
    - Update CODEOWNERS

## Context

Fresh PR after #43014 hit a stale `user-org-visibility-blob` cache issue (codeowners-linter saw `@jruttle` as a private member even though live GitHub had me set to public for hours).

Per investigation in the Azure SDK > API Spec Review Teams thread (7-8 May 2026):

- Current CODEOWNER `@darshanhs90` is no longer employed at Microsoft (verified by @MikeHarder, Azure SDK EngSys). Last activity in this repo was January 2021.
- Previous co-owner `@stankovski` was already removed via #41839.
- This has left the spec effectively unowned, blocking PRs like #42261 (waiting on review for 3+ weeks).

## Change

Replace the abandoned CODEOWNER with active owners from the two teams that maintain `Microsoft.Authorization` specifications:

- **PAS team** (owns the `Microsoft.Authorization` service: RBAC, deny assignments, role definitions): `@jruttle`, `@abaccin`
- `@chocomochiko` (Sherry Yang — owns the attribute-namespaces sub-area; PR #40393)

@chocomochiko, please follow up with a small PR to add any teammates from your team who should also be CODEOWNERS. `@avurganov` to be added once his Azure org membership is publicized.

## Approval

@MikeHarder offered to approve this transfer in the API Spec Review Teams thread. Tagging @MikeHarder for review/approval.

## Unblocks

- #42261 — `.NET emitter addition` to Authorization tspconfig.yaml (the last blocker for the .NET SDK in our Deny Assignment GA release; Java + Python SDKs already shipped 7 May)
