### PR TITLE
Revert no-op @@clientName(Slis.delete) override for Java SDK

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Slis/client.tsp
@@ -14,7 +14,3 @@ namespace Microsoft.Monitor;
 @@access(SloView.sliSignalPreview, Access.internal);
 
 @@clientName(Microsoft.Monitor, "MonitorSlisMgmtClient", "python");
-
-// Prevent Java SDK from renaming delete to deleteByResourceGroup.
-// The Sli resource is scoped by service group, not resource group.
-@@clientName(Slis.delete, "delete", "java");


### PR DESCRIPTION
## Summary

Reverts the `@@clientName(Slis.delete, "delete", "java")` override added in #43020.

## Why

The override was intended to prevent the Java SDK from generating `Slis.deleteByResourceGroup` (since the `Sli` resource is service-group scoped, not resource-group scoped). However, it had **zero effect** on the generated Java code:

- `@@clientName` only retargets TypeSpec-defined symbols. It renamed the inner-client method `SlisClient.delete` → `SlisClient.delete` (no change).
- The unwanted method `Slis.deleteByResourceGroup` is **synthesized by the Java fluent management overlay** based on the resource's structural type (`ProxyResource<SliResource>`). It is not a TypeSpec-defined symbol, so `@@clientName` cannot reach it.

## Evidence

The Java SDK auto-regen [Azure/azure-sdk-for-java#49130](https://github.com/Azure/azure-sdk-for-java/pull/49130), triggered against the spec commit that includes #43020, produced **zero code changes** in the generated SDK — only `CHANGELOG.md` / `README.md` / `tsp-location.yaml` bumps. This confirms the override is dead code.

## What's next

The actual fix for the Java (and .NET) SDK convenience-method naming will be tracked separately. Two viable approaches:

1. **Switch `Sli` from `ProxyResource<...>` to `ExtensionResource<...>`** so the fluent overlay picks an extension-scope template (no `*ByResourceGroup` methods).
2. **Add a Java post-codegen `Customization.java`** to rename the synthesized methods.

This PR only removes the misleading no-op so the spec reflects reality.
