### PR TITLE
Remove EvaluationTarget customization

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/client.csharp.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/client.csharp.tsp
@@ -141,9 +141,6 @@ namespace Azure.AI.Projects;
 // --------------------------------------------------------------------------------
 @@access(EvaluatorDefinitionType, Access.public);
 
-// Hide classes not currently used
-@@clientName(EvaluationTarget, "InternalEvaluationTarget", "csharp");
-@@access(EvaluationTarget, Access.internal);
 // Rename Target from openai-evaluations to EvaluationTarget.
 @@clientName(Target, "EvaluationTarget", "csharp");
 

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Create_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Create_MaximumSet_Gen.json
@@ -20,7 +20,7 @@
         "key9280": "fwzjtipl"
       },
       "target": {
-        "type": "TargetConfig"
+        "type": "RedTeamTargetConfig"
       }
     }
   },
@@ -45,7 +45,7 @@
         },
         "status": "owgxaiudnkkeqwlnhtmihvhdkbgd",
         "target": {
-          "type": "TargetConfig"
+          "type": "RedTeamTargetConfig"
         }
       }
     }

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Create_MinimumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Create_MinimumSet_Gen.json
@@ -13,7 +13,7 @@
         "HateUnfairness"
       ],
       "target": {
-        "type": "TargetConfig"
+        "type": "RedTeamTargetConfig"
       }
     }
   },
@@ -30,7 +30,7 @@
           "HateUnfairness"
         ],
         "target": {
-          "type": "TargetConfig"
+          "type": "RedTeamTargetConfig"
         }
       }
     }

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Get_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_Get_MaximumSet_Gen.json
@@ -27,7 +27,7 @@
         },
         "status": "owgxaiudnkkeqwlnhtmihvhdkbgd",
         "target": {
-          "type": "TargetConfig"
+          "type": "RedTeamTargetConfig"
         }
       }
     }

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_List_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/RedTeams_List_MaximumSet_Gen.json
@@ -31,7 +31,7 @@
             },
             "status": "owgxaiudnkkeqwlnhtmihvhdkbgd",
             "target": {
-              "type": "TargetConfig"
+              "type": "RedTeamTargetConfig"
             }
           }
         ],

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -13557,7 +13557,7 @@
         },
         "allOf": [
           {
-            "$ref": "#/components/schemas/TargetConfig"
+            "$ref": "#/components/schemas/RedTeamTargetConfig"
           }
         ],
         "description": "Azure OpenAI model configuration. The API version would be selected by the service for querying the model."
@@ -40660,7 +40660,7 @@
           "target": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/TargetConfig"
+                "$ref": "#/components/schemas/RedTeamTargetConfig"
               }
             ],
             "description": "Target configuration for the red-team run."
@@ -40787,6 +40787,25 @@
           }
         ],
         "description": "Represents the parameters for red team seed prompts item generation."
+      },
+      "RedTeamTargetConfig": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of the model configuration."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "AzureOpenAIModel": "#/components/schemas/AzureOpenAIModelConfiguration"
+          }
+        },
+        "description": "Abstract class for target configuration."
       },
       "RedTeamTaxonomyItemGenerationParams": {
         "type": "object",
@@ -41821,25 +41840,6 @@
           }
         ],
         "description": "Represents a data source for target-based completion evaluation configuration."
-      },
-      "TargetConfig": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Type of the model configuration."
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "AzureOpenAIModel": "#/components/schemas/AzureOpenAIModelConfiguration"
-          }
-        },
-        "description": "Abstract class for target configuration."
       },
       "TargetUpdate": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9008,7 +9008,7 @@ components:
           type: string
           description: 'Deployment name for AOAI model. Example: gpt-4o if in AIServices or connection based `connection_name/deployment_name` (e.g. `my-aoai-connection/gpt-4o`).'
       allOf:
-        - $ref: '#/components/schemas/TargetConfig'
+        - $ref: '#/components/schemas/RedTeamTargetConfig'
       description: Azure OpenAI model configuration. The API version would be selected by the service for querying the model.
     BaseCredentials:
       type: object
@@ -28972,7 +28972,7 @@ components:
           readOnly: true
         target:
           allOf:
-            - $ref: '#/components/schemas/TargetConfig'
+            - $ref: '#/components/schemas/RedTeamTargetConfig'
           description: Target configuration for the red-team run.
       description: Red team details.
     RedTeamEvalRunDataSource:
@@ -29053,6 +29053,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team seed prompts item generation.
+    RedTeamTargetConfig:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: Type of the model configuration.
+      discriminator:
+        propertyName: type
+        mapping:
+          AzureOpenAIModel: '#/components/schemas/AzureOpenAIModelConfiguration'
+      description: Abstract class for target configuration.
     RedTeamTaxonomyItemGenerationParams:
       type: object
       required:
@@ -29773,19 +29786,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for target-based completion evaluation configuration.
-    TargetConfig:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          description: Type of the model configuration.
-      discriminator:
-        propertyName: type
-        mapping:
-          AzureOpenAIModel: '#/components/schemas/AzureOpenAIModelConfiguration'
-      description: Abstract class for target configuration.
     TargetUpdate:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15729,7 +15729,7 @@
         },
         "allOf": [
           {
-            "$ref": "#/components/schemas/TargetConfig"
+            "$ref": "#/components/schemas/RedTeamTargetConfig"
           }
         ],
         "description": "Azure OpenAI model configuration. The API version would be selected by the service for querying the model."
@@ -43423,7 +43423,7 @@
           "target": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/TargetConfig"
+                "$ref": "#/components/schemas/RedTeamTargetConfig"
               }
             ],
             "description": "Target configuration for the red-team run."
@@ -43550,6 +43550,25 @@
           }
         ],
         "description": "Represents the parameters for red team seed prompts item generation."
+      },
+      "RedTeamTargetConfig": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of the model configuration."
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "AzureOpenAIModel": "#/components/schemas/AzureOpenAIModelConfiguration"
+          }
+        },
+        "description": "Abstract class for target configuration."
       },
       "RedTeamTaxonomyItemGenerationParams": {
         "type": "object",
@@ -44610,25 +44629,6 @@
           }
         ],
         "description": "Represents a data source for target-based completion evaluation configuration."
-      },
-      "TargetConfig": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Type of the model configuration."
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "AzureOpenAIModel": "#/components/schemas/AzureOpenAIModelConfiguration"
-          }
-        },
-        "description": "Abstract class for target configuration."
       },
       "TargetUpdate": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -10488,7 +10488,7 @@ components:
           type: string
           description: 'Deployment name for AOAI model. Example: gpt-4o if in AIServices or connection based `connection_name/deployment_name` (e.g. `my-aoai-connection/gpt-4o`).'
       allOf:
-        - $ref: '#/components/schemas/TargetConfig'
+        - $ref: '#/components/schemas/RedTeamTargetConfig'
       description: Azure OpenAI model configuration. The API version would be selected by the service for querying the model.
     BaseCredentials:
       type: object
@@ -30859,7 +30859,7 @@ components:
           readOnly: true
         target:
           allOf:
-            - $ref: '#/components/schemas/TargetConfig'
+            - $ref: '#/components/schemas/RedTeamTargetConfig'
           description: Target configuration for the red-team run.
       description: Red team details.
     RedTeamEvalRunDataSource:
@@ -30940,6 +30940,19 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team seed prompts item generation.
+    RedTeamTargetConfig:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: Type of the model configuration.
+      discriminator:
+        propertyName: type
+        mapping:
+          AzureOpenAIModel: '#/components/schemas/AzureOpenAIModelConfiguration'
+      description: Abstract class for target configuration.
     RedTeamTaxonomyItemGenerationParams:
       type: object
       required:
@@ -31677,19 +31690,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for target-based completion evaluation configuration.
-    TargetConfig:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          description: Type of the model configuration.
-      discriminator:
-        propertyName: type
-        mapping:
-          AzureOpenAIModel: '#/components/schemas/AzureOpenAIModelConfiguration'
-      description: Abstract class for target configuration.
     TargetUpdate:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/red-teams/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/red-teams/models.tsp
@@ -129,7 +129,7 @@ union RiskCategory {
 }
 
 @doc("Azure OpenAI model configuration. The API version would be selected by the service for querying the model.")
-model AzureOpenAIModelConfiguration extends TargetConfig {
+model AzureOpenAIModelConfiguration extends RedTeamTargetConfig {
   type: "AzureOpenAIModel";
 
   @doc("Deployment name for AOAI model. Example: gpt-4o if in AIServices or connection based `connection_name/deployment_name` (e.g. `my-aoai-connection/gpt-4o`).")
@@ -138,7 +138,7 @@ model AzureOpenAIModelConfiguration extends TargetConfig {
 
 @doc("Abstract class for target configuration.")
 @discriminator("type")
-model TargetConfig {
+model RedTeamTargetConfig {
   @doc("Type of the model configuration.")
   type: string;
 }
@@ -181,5 +181,5 @@ model RedTeam {
   status?: string;
 
   @doc("Target configuration for the red-team run.")
-  target: TargetConfig;
+  target: RedTeamTargetConfig;
 }


### PR DESCRIPTION
`EvaluationTarget` was removed in the V1 version, so we need to avoid attempts to rename it.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
