### PR TITLE
Add Java backward compatibility for OperationalInsights ProvisioningStateEnum and etag

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -31,8 +31,7 @@ using Microsoft.OperationalInsights;
 );
 
 /**
- * Compatible provisioning state enum for backward compatibility, merging values from
- * OperationalInsightsTableProvisioningState and ProvisioningStateEnum.
+ * Table's current provisioning state. If set to 'updating', indicates a resource lock due to ongoing operation, forbidding any update to the table until the ongoing operation is concluded.
  */
 union CompatibleProvisioningStateEnum {
   string,

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -23,3 +23,38 @@ using Microsoft.OperationalInsights;
   global.AccessRulePropertiesSubscriptionsItem[],
   "java"
 );
+
+// Rename existing ProvisioningStateEnum to ProvisioningState for Java to deduplicate
+@@clientName(Microsoft.OperationalInsights.ProvisioningStateEnum,
+  "ProvisioningState",
+  "java"
+);
+
+// Create compatible ProvisioningStateEnum for backward compatibility
+#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compatibility for Java SDK by merging provisioning state values"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Mirror enum for backward compatibility"
+enum CompatibleProvisioningStateEnum {
+  Updating: "Updating",
+  InProgress: "InProgress",
+  Succeeded: "Succeeded",
+  Deleting: "Deleting",
+  Failed: "Failed",
+  Canceled: "Canceled",
+}
+@@clientName(CompatibleProvisioningStateEnum, "ProvisioningStateEnum", "java");
+
+@@alternateType(Microsoft.OperationalInsights.TableProperties.provisioningState,
+  CompatibleProvisioningStateEnum,
+  "java"
+);
+@@alternateType(Microsoft.OperationalInsights.SummaryLogsProperties.provisioningState,
+  CompatibleProvisioningStateEnum,
+  "java"
+);
+
+// Fix etag casing for backward compatibility
+@@clientName(Microsoft.OperationalInsights.SearchMetadata.eTag, "etag", "java");
+@@clientName(Microsoft.OperationalInsights.AzureEntityResource.etag,
+  "etag",
+  "java"
+);

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -28,7 +28,10 @@ using Microsoft.OperationalInsights;
   "SummaryLogsProvisioningState",
   "java"
 );
-@@clientName(OperationalInsightsTableProvisioningState, "ProvisioningStateEnum", "java");
+@@clientName(OperationalInsightsTableProvisioningState,
+  "ProvisioningStateEnum",
+  "java"
+);
 
 // Fix etag casing for backward compatibility
 @@clientName(Microsoft.OperationalInsights.SearchMetadata.eTag, "etag", "java");

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -24,58 +24,11 @@ using Microsoft.OperationalInsights;
   "java"
 );
 
-// Rename existing ProvisioningStateEnum to ProvisioningState for Java to deduplicate
 @@clientName(Microsoft.OperationalInsights.ProvisioningStateEnum,
-  "ProvisioningState",
+  "SummaryLogsProvisioningState",
   "java"
 );
-
-/**
- * Table's current provisioning state. If set to 'updating', indicates a resource lock due to ongoing operation, forbidding any update to the table until the ongoing operation is concluded.
- */
-union CompatibleProvisioningStateEnum {
-  string,
-
-  /**
-   * Table schema is still being built and updated, table is currently locked for any changes till the procedure is done.
-   */
-  Updating: "Updating",
-
-  /**
-   * Table schema is stable and without changes, table data is being updated.
-   */
-  InProgress: "InProgress",
-
-  /**
-   * Table state is stable and without changes, table is unlocked and open for new updates.
-   */
-  Succeeded: "Succeeded",
-
-  /**
-   * Table state is deleting.
-   */
-  Deleting: "Deleting",
-
-  /**
-   * Table state is failed.
-   */
-  Failed: "Failed",
-
-  /**
-   * Table state is canceled.
-   */
-  Canceled: "Canceled",
-}
-@@clientName(CompatibleProvisioningStateEnum, "ProvisioningStateEnum", "java");
-
-@@alternateType(Microsoft.OperationalInsights.TableProperties.provisioningState,
-  CompatibleProvisioningStateEnum,
-  "java"
-);
-@@alternateType(Microsoft.OperationalInsights.SummaryLogsProperties.provisioningState,
-  CompatibleProvisioningStateEnum,
-  "java"
-);
+@@clientName(OperationalInsightsTableProvisioningState, "ProvisioningStateEnum", "java");
 
 // Fix etag casing for backward compatibility
 @@clientName(Microsoft.OperationalInsights.SearchMetadata.eTag, "etag", "java");

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -54,7 +54,3 @@ enum CompatibleProvisioningStateEnum {
 
 // Fix etag casing for backward compatibility
 @@clientName(Microsoft.OperationalInsights.SearchMetadata.eTag, "etag", "java");
-@@clientName(Microsoft.OperationalInsights.AzureEntityResource.etag,
-  "etag",
-  "java"
-);

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -31,9 +31,9 @@ using Microsoft.OperationalInsights;
 );
 
 // Create compatible ProvisioningStateEnum for backward compatibility
-#suppress "@azure-tools/typespec-azure-core/no-enum" "Backward compatibility for Java SDK by merging provisioning state values"
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Mirror enum for backward compatibility"
-enum CompatibleProvisioningStateEnum {
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "Mirror union for backward compatibility"
+union CompatibleProvisioningStateEnum {
+  string,
   Updating: "Updating",
   InProgress: "InProgress",
   Succeeded: "Succeeded",

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -30,15 +30,41 @@ using Microsoft.OperationalInsights;
   "java"
 );
 
-// Create compatible ProvisioningStateEnum for backward compatibility
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "Mirror union for backward compatibility"
+/**
+ * Compatible provisioning state enum for backward compatibility, merging values from
+ * OperationalInsightsTableProvisioningState and ProvisioningStateEnum.
+ */
 union CompatibleProvisioningStateEnum {
   string,
+
+  /**
+   * Table schema is still being built and updated, table is currently locked for any changes till the procedure is done.
+   */
   Updating: "Updating",
+
+  /**
+   * Table schema is stable and without changes, table data is being updated.
+   */
   InProgress: "InProgress",
+
+  /**
+   * Table state is stable and without changes, table is unlocked and open for new updates.
+   */
   Succeeded: "Succeeded",
+
+  /**
+   * Table state is deleting.
+   */
   Deleting: "Deleting",
+
+  /**
+   * Table state is failed.
+   */
   Failed: "Failed",
+
+  /**
+   * Table state is canceled.
+   */
   Canceled: "Canceled",
 }
 @@clientName(CompatibleProvisioningStateEnum, "ProvisioningStateEnum", "java");


### PR DESCRIPTION
Add alternateType and clientName customizations for Java SDK backward compatibility:
- Create compatible ProvisioningStateEnum enum merging both provisioning state unions
- Use alternateType to redirect Table and SummaryLogs provisioningState properties
- Fix etag casing for SearchMetadata and AzureEntityResource