### PR TITLE
Fix csharp clientName decorators that conflict with mgmt generator auto-rename

### DIFF
--- a/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/client.tsp
+++ b/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/client.tsp
@@ -117,7 +117,6 @@ using Azure.Core;
   "CloudHsmClusterPrivateEndpointServiceConnectionStatus",
   "csharp"
 );
-@@clientName(CloudHsmClusterPatchParameters, "DedicatedHsmPatch", "csharp");
 @@alternateType(PrivateEndpointConnection.etag, eTag, "csharp");
 @@usage(Azure.ResourceManager.PrivateLinkResource, Usage.input, "csharp");
 @@clientName(Azure.ResourceManager.PrivateLinkResource,

--- a/specification/maintenance/resource-manager/Microsoft.Maintenance/Maintenance/back-compatible.tsp
+++ b/specification/maintenance/resource-manager/Microsoft.Maintenance/Maintenance/back-compatible.tsp
@@ -82,7 +82,8 @@ using Microsoft.Maintenance;
   MaintenanceConfigurations
 );
 @@clientName(MaintenanceConfigurationOperationGroup.maintenanceConfigurationsList,
-  "List"
+  "List",
+  "!csharp"
 );
 @@clientLocation(ApplyUpdateOperationGroup.get, ApplyUpdates);
 @@clientLocation(ApplyUpdateOperationGroup.createOrUpdateOrCancel,

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/client.tsp
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/client.tsp
@@ -65,7 +65,6 @@ using Microsoft.DBforMySQL;
   "MySqlFlexibleServerHighAvailabilityState",
   "csharp"
 );
-@@clientName(ServerForUpdate, "MySqlFlexibleServerForUpdate", "csharp");
 @@alternateType(ServerForUpdate.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -39,7 +39,6 @@ using Microsoft.Cache;
   "RedisEnterpriseCustomerManagedKeyEncryptionKeyIdentity",
   "csharp"
 );
-@@clientName(ClusterUpdate, "RedisEnterpriseClusterUpdate", "csharp");
 @@clientName(CmkIdentityType,
   "RedisEnterpriseCustomerManagedKeyIdentityType",
   "csharp"

--- a/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
+++ b/specification/relay/resource-manager/Microsoft.Relay/Relay/client.tsp
@@ -119,10 +119,7 @@ model RelayUpdateParametersReplacement
   "csharp"
 );
 @@clientName(RelayUpdateParameters, "RelayUpdateParametersTemp", "csharp");
-@@clientName(RelayUpdateParametersReplacement,
-  "RelayUpdateParameters",
-  "csharp"
-);
+@@clientName(RelayUpdateParametersReplacement, "RelayNamespacePatch", "csharp");
 
 // Back-compat: operation was named CheckRelayNamespaceNameAvailability in the old SDK
 @@clientName(NamespacesOperationGroup.checkNameAvailability,

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/back-compatible.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/back-compatible.tsp
@@ -77,22 +77,28 @@ using Microsoft.SignalRService;
   "WebPubSub",
   "!csharp"
 );
-@@clientName(WebPubSubResources.listByResourceGroup, "ListByResourceGroup");
+@@clientName(WebPubSubResources.listByResourceGroup,
+  "ListByResourceGroup",
+  "!csharp"
+);
 @@clientLocation(WebPubSubResources.listBySubscription, "WebPubSub", "!csharp");
-@@clientName(WebPubSubResources.listBySubscription, "ListBySubscription");
+@@clientName(WebPubSubResources.listBySubscription,
+  "ListBySubscription",
+  "!csharp"
+);
 @@clientLocation(WebPubSubResources.listKeys, "WebPubSub", "!csharp");
-@@clientName(WebPubSubResources.listKeys, "ListKeys");
+@@clientName(WebPubSubResources.listKeys, "ListKeys", "!csharp");
 @@clientLocation(WebPubSubResources.regenerateKey, "WebPubSub", "!csharp");
 @@clientName(WebPubSubResources.regenerateKey, "RegenerateKey");
 @@clientLocation(WebPubSubResources.restart, "WebPubSub", "!csharp");
 @@clientName(WebPubSubResources.restart, "Restart");
 @@clientLocation(WebPubSubResources.listSkus, "WebPubSub", "!csharp");
-@@clientName(WebPubSubResources.listSkus, "ListSkus");
+@@clientName(WebPubSubResources.listSkus, "ListSkus", "!csharp");
 @@clientLocation(WebPubSubResources.list,
   "WebPubSubPrivateLinkResources",
   "!csharp"
 );
-@@clientName(WebPubSubResources.list, "List");
+@@clientName(WebPubSubResources.list, "List", "!csharp");
 
 // Replicas interface operations with WebPubSubReplicas_ prefix
 @@clientLocation(Replicas.get, "WebPubSubReplicas", "!csharp");
@@ -104,9 +110,9 @@ using Microsoft.SignalRService;
 @@clientLocation(Replicas.delete, "WebPubSubReplicas", "!csharp");
 @@clientName(Replicas.delete, "Delete");
 @@clientLocation(Replicas.list, "WebPubSubReplicas", "!csharp");
-@@clientName(Replicas.list, "List");
+@@clientName(Replicas.list, "List", "!csharp");
 @@clientLocation(Replicas.listReplicaSkus, "WebPubSub", "!csharp");
-@@clientName(Replicas.listReplicaSkus, "ListReplicaSkus");
+@@clientName(Replicas.listReplicaSkus, "ListReplicaSkus", "!csharp");
 @@clientLocation(Replicas.restart, "WebPubSubReplicas", "!csharp");
 @@clientName(Replicas.restart, "Restart");
 
@@ -130,7 +136,7 @@ using Microsoft.SignalRService;
   "WebPubSubCustomCertificates",
   "!csharp"
 );
-@@clientName(CustomCertificates.list, "List");
+@@clientName(CustomCertificates.list, "List", "!csharp");
 
 // CustomDomains interface operations with WebPubSubCustomDomains_ prefix
 @@clientLocation(CustomDomains.get, "WebPubSubCustomDomains", "!csharp");
@@ -143,7 +149,7 @@ using Microsoft.SignalRService;
 @@clientLocation(CustomDomains.delete, "WebPubSubCustomDomains", "!csharp");
 @@clientName(CustomDomains.delete, "Delete");
 @@clientLocation(CustomDomains.list, "WebPubSubCustomDomains", "!csharp");
-@@clientName(CustomDomains.list, "List");
+@@clientName(CustomDomains.list, "List", "!csharp");
 
 // PrivateEndpointConnections interface operations with WebPubSubPrivateEndpointConnections_ prefix
 @@clientLocation(PrivateEndpointConnections.get,
@@ -165,7 +171,7 @@ using Microsoft.SignalRService;
   "WebPubSubPrivateEndpointConnections",
   "!csharp"
 );
-@@clientName(PrivateEndpointConnections.list, "List");
+@@clientName(PrivateEndpointConnections.list, "List", "!csharp");
 
 // SharedPrivateLinkResources interface operations with WebPubSubReplicaSharedPrivateLinkResources_ prefix
 @@clientLocation(SharedPrivateLinkResources.get,
@@ -182,7 +188,7 @@ using Microsoft.SignalRService;
   "WebPubSubReplicaSharedPrivateLinkResources",
   "!csharp"
 );
-@@clientName(SharedPrivateLinkResources.list, "List");
+@@clientName(SharedPrivateLinkResources.list, "List", "!csharp");
 
 // WebPubSubSharedPrivateLinkResources interface operations with WebPubSubSharedPrivateLinkResources_ prefix
 @@clientName(WebPubSubSharedPrivateLinkResources.delete, "Delete");
@@ -196,9 +202,10 @@ using Microsoft.SignalRService;
   "!csharp"
 );
 @@clientName(WebPubSubOperationGroup.checkNameAvailability,
-  "CheckNameAvailability"
+  "CheckNameAvailability",
+  "!csharp"
 );
 
 // UsagesOperationGroup interface operations with Usages_ prefix
 @@clientLocation(UsagesOperationGroup.list, "Usages", "!csharp");
-@@clientName(UsagesOperationGroup.list, "List");
+@@clientName(UsagesOperationGroup.list, "List", "!csharp");

--- a/specification/workloads/Workloads.SAPVirtualInstance.Management/client.tsp
+++ b/specification/workloads/Workloads.SAPVirtualInstance.Management/client.tsp
@@ -220,24 +220,8 @@ using Microsoft.Workloads;
 @@clientName(SAPCentralServerInstance, "SapCentralServerInstance", "csharp");
 @@clientName(SAPDatabaseInstance, "SapDatabaseInstance", "csharp");
 @@clientName(SAPVirtualInstance, "SapVirtualInstance", "csharp");
-@@clientName(UpdateSAPVirtualInstanceRequest,
-  "UpdateSapVirtualInstanceRequest",
-  "csharp"
-);
 @@clientName(UpdateSAPVirtualInstanceProperties,
   "UpdateSapVirtualInstanceProperties",
-  "csharp"
-);
-@@clientName(UpdateSAPCentralInstanceRequest,
-  "UpdateSapCentralInstanceRequest",
-  "csharp"
-);
-@@clientName(UpdateSAPDatabaseInstanceRequest,
-  "UpdateSapDatabaseInstanceRequest",
-  "csharp"
-);
-@@clientName(UpdateSAPApplicationInstanceRequest,
-  "UpdateSapApplicationInstanceRequest",
   "csharp"
 );
 @@alternateType(DeployerVmPackages.url, url, "csharp");


### PR DESCRIPTION
## Summary

Removes redundant or incorrect csharp-scoped `@@clientName` decorators on mgmt resource update models, and scopes back-compat `@@clientName` overrides to non-csharp emitters. The C# mgmt generator already auto-renames update bodies to `{Resource}Patch` and list operations correctly; the existing csharp overrides either duplicate the auto-renamed names, conflict with shipped GA names, or (in one case) cause a class-name collision.

## Per-service changes

| Service | Change |
|---|---|
| HSM | Remove `CloudHsmClusterPatchParameters -> ""DedicatedHsmPatch""` (typo causing collision with the unrelated DedicatedHsm resource) |
| Maintenance | Scope `maintenanceConfigurationsList` rename to `!csharp` |
| MySql | Remove `ServerForUpdate -> ""MySqlFlexibleServerForUpdate""` (auto-rename matches shipped `MySqlFlexibleServerPatch`) |
| RedisEnterprise | Remove `ClusterUpdate -> ""RedisEnterpriseClusterUpdate""` (auto-rename matches shipped `RedisEnterpriseClusterPatch`) |
| Relay | Change `RelayUpdateParametersReplacement` csharp name to shipped `RelayNamespacePatch` |
| WebPubSub | Scope 30 unscoped `@@clientName` overrides to `!csharp` (matching their adjacent `!csharp` `clientLocation`) |
| Workloads (SAP) | Remove four `UpdateSAP*Request -> ""UpdateSap*Request""` csharp renames (auto-rename matches shipped `Sap*Patch`) |

## Why now

These cleanups are prerequisites for the upcoming azure-sdk-for-net mgmt generator update that honors csharp-scoped `@@clientName` overrides on mgmt resource update models and list operations (Azure/azure-sdk-for-net#58210, PR Azure/azure-sdk-for-net#59096).

Without these fixes, the next regen of each affected SDK against the new generator would introduce public API breaking renames or, in the HSM case, a class-name conflict.

## Validation

For each affected SDK, regenerated locally with the updated mgmt generator and verified that the public `api/*.cs` baseline is unchanged.
