### PR TITLE
Add Foundry-Features preview opt-in header to Models operations

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6788,7 +6788,12 @@
         },
         "tags": [
           "Models"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
       },
       "delete": {
         "operationId": "Models_deleteVersion",
@@ -6854,7 +6859,12 @@
         },
         "tags": [
           "Models"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "Models_updateVersion",
@@ -6948,6 +6958,11 @@
             }
           },
           "description": "The UpdateModelVersionRequest to create or update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -7036,6 +7051,11 @@
             }
           },
           "description": "Model version to create."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -7121,6 +7141,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -7206,6 +7231,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6600,6 +6600,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           }
         ],
         "responses": {
@@ -6654,6 +6666,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           }
         ],
         "responses": {
@@ -6707,6 +6731,18 @@
             "description": "The name of the resource",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
             }
           },
           {
@@ -6771,6 +6807,18 @@
             }
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "version",
             "in": "path",
             "required": true,
@@ -6831,6 +6879,18 @@
             "description": "The specific version id of the UpdateModelVersionRequest to create or update.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
             }
           }
         ],
@@ -6898,6 +6958,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           },
           {
             "name": "name",
@@ -6976,6 +7048,18 @@
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "name",
             "in": "path",
             "required": true,
@@ -7047,6 +7131,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           },
           {
             "name": "name",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4480,6 +4480,9 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
       tags:
         - Models
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     delete:
       operationId: Models_deleteVersion
       description: Delete the specific version of the ModelVersion. The service returns 204 No Content if the ModelVersion was deleted successfully or if the ModelVersion does not exist.
@@ -4522,6 +4525,9 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
       tags:
         - Models
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     patch:
       operationId: Models_updateVersion
       description: Update an existing ModelVersion with the given version id
@@ -4581,6 +4587,9 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateModelVersionRequest'
         description: The UpdateModelVersionRequest to create or update.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/createAsync:
     post:
       operationId: Models_createAsync
@@ -4637,6 +4646,9 @@ paths:
             schema:
               $ref: '#/components/schemas/ModelVersion'
         description: Model version to create.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/credentials:
     post:
       operationId: Models_getCredentials
@@ -4690,6 +4702,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ModelCredentialRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Models_startPendingUpload
@@ -4743,6 +4758,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PendingUploadRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /openai/v1/conversations:
     post:
       operationId: createConversation

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4363,6 +4363,14 @@ paths:
       description: List the latest version of each ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -4396,6 +4404,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -4429,6 +4445,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: version
           in: path
           required: true
@@ -4467,6 +4491,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: version
           in: path
           required: true
@@ -4507,6 +4539,14 @@ paths:
           description: The specific version id of the UpdateModelVersionRequest to create or update.
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -4547,6 +4587,14 @@ paths:
       description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true
@@ -4595,6 +4643,14 @@ paths:
       description: Get credentials for a model version asset.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true
@@ -4640,6 +4696,14 @@ paths:
       description: Start or retrieve a pending upload for a model version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -8321,6 +8321,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           }
         ],
         "responses": {
@@ -8375,6 +8387,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           }
         ],
         "responses": {
@@ -8428,6 +8452,18 @@
             "description": "The name of the resource",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
             }
           },
           {
@@ -8492,6 +8528,18 @@
             }
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "version",
             "in": "path",
             "required": true,
@@ -8552,6 +8600,18 @@
             "description": "The specific version id of the UpdateModelVersionRequest to create or update.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
             }
           }
         ],
@@ -8619,6 +8679,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           },
           {
             "name": "name",
@@ -8697,6 +8769,18 @@
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
+          },
+          {
             "name": "name",
             "in": "path",
             "required": true,
@@ -8768,6 +8852,18 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": true,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Models=V1Preview"
+              ]
+            }
           },
           {
             "name": "name",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -8509,7 +8509,12 @@
         },
         "tags": [
           "Models"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
       },
       "delete": {
         "operationId": "Models_deleteVersion",
@@ -8575,7 +8580,12 @@
         },
         "tags": [
           "Models"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
+        }
       },
       "patch": {
         "operationId": "Models_updateVersion",
@@ -8669,6 +8679,11 @@
             }
           },
           "description": "The UpdateModelVersionRequest to create or update."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -8757,6 +8772,11 @@
             }
           },
           "description": "Model version to create."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -8842,6 +8862,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },
@@ -8927,6 +8952,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Models=V1Preview"
+          ]
         }
       }
     },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -5521,6 +5521,14 @@ paths:
       description: List the latest version of each ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -5554,6 +5562,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -5587,6 +5603,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: version
           in: path
           required: true
@@ -5625,6 +5649,14 @@ paths:
           description: The name of the resource
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: version
           in: path
           required: true
@@ -5665,6 +5697,14 @@ paths:
           description: The specific version id of the UpdateModelVersionRequest to create or update.
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
       responses:
         '200':
           description: The request has succeeded.
@@ -5705,6 +5745,14 @@ paths:
       description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true
@@ -5753,6 +5801,14 @@ paths:
       description: Get credentials for a model version asset.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true
@@ -5798,6 +5854,14 @@ paths:
       description: Start or retrieve a pending upload for a model version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
+        - name: Foundry-Features
+          in: header
+          required: true
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Models=V1Preview
         - name: name
           in: path
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -5638,6 +5638,9 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
       tags:
         - Models
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     delete:
       operationId: Models_deleteVersion
       description: Delete the specific version of the ModelVersion. The service returns 204 No Content if the ModelVersion was deleted successfully or if the ModelVersion does not exist.
@@ -5680,6 +5683,9 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
       tags:
         - Models
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
     patch:
       operationId: Models_updateVersion
       description: Update an existing ModelVersion with the given version id
@@ -5739,6 +5745,9 @@ paths:
             schema:
               $ref: '#/components/schemas/UpdateModelVersionRequest'
         description: The UpdateModelVersionRequest to create or update.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/createAsync:
     post:
       operationId: Models_createAsync
@@ -5795,6 +5804,9 @@ paths:
             schema:
               $ref: '#/components/schemas/ModelVersion'
         description: Model version to create.
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/credentials:
     post:
       operationId: Models_getCredentials
@@ -5848,6 +5860,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ModelCredentialRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /models/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Models_startPendingUpload
@@ -5901,6 +5916,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PendingUploadRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Models=V1Preview
   /openai/v1/conversations:
     post:
       operationId: createConversation

--- a/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
@@ -12,6 +12,12 @@ alias ModelsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptI
 
 alias ListModelVersionsParameters = {};
 
+const ModelsRequiredPreviews = #{
+  required_previews: #[
+    FoundryFeaturesOptInKeys.models_v1_preview
+  ],
+};
+
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We are using service specific operation templates"
 @tag("Models")
 interface Models
@@ -26,6 +32,7 @@ interface Models
     "Get the specific version of the {name}. The service returns 404 Not Found error if the {name} does not exist.",
     ModelVersion
   )
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   getVersion is Azure.Core.Foundations.ResourceOperation<
     ModelVersion,
     {
@@ -45,6 +52,7 @@ interface Models
     ModelVersion
   )
   @delete
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   deleteVersion is Azure.Core.Foundations.ResourceOperation<
     ModelVersion,
     {
@@ -62,6 +70,7 @@ interface Models
   @doc("Update an existing ModelVersion with the given version id", ModelVersion)
   @operationId("Models_updateVersion")
   @patch
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   createOrUpdateVersion is Azure.Core.Foundations.ResourceOperation<
     ModelVersion,
     InputParameters<UpdateModelVersionRequest> & ModelsPreviewHeader,
@@ -72,6 +81,7 @@ interface Models
   @doc("Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.")
   @route("/models/{name}/versions/{version}/createAsync")
   @post
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   createAsync is Azure.Core.Foundations.Operation<
     {
       ...ModelsPreviewHeader;
@@ -95,6 +105,7 @@ interface Models
   @doc("Start or retrieve a pending upload for a model version.")
   @route("/models/{name}/versions/{version}/startPendingUpload")
   @post
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   startPendingUpload is Azure.Core.Foundations.Operation<
     {
       ...ModelsPreviewHeader;
@@ -117,6 +128,7 @@ interface Models
   @doc("Get credentials for a model version asset.")
   @route("/models/{name}/versions/{version}/credentials")
   @post
+  @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   getCredentials is Azure.Core.Foundations.Operation<
     {
       ...ModelsPreviewHeader;

--- a/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
@@ -8,6 +8,8 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
+alias ModelsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.models_v1_preview>;
+
 alias ListModelVersionsParameters = {};
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "We are using service specific operation templates"
@@ -16,16 +18,53 @@ interface Models
   extends VersionedOperations<
       ModelVersion,
       InputParameters<UpdateModelVersionRequest>,
-      ListModelVersionsParameters,
-      ListModelVersionsParameters
+      ListModelVersionsParameters & ModelsPreviewHeader,
+      ListModelVersionsParameters & ModelsPreviewHeader
     > {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Suppress `Operation should be defined using a signature from the Azure.Core namespace.`"
+  @doc(
+    "Get the specific version of the {name}. The service returns 404 Not Found error if the {name} does not exist.",
+    ModelVersion
+  )
+  getVersion is Azure.Core.Foundations.ResourceOperation<
+    ModelVersion,
+    {
+      ...ModelsPreviewHeader;
+
+      @doc("The specific version id of the {name} to retrieve.", ModelVersion)
+      @Rest.segment("versions")
+      @path
+      version: string;
+    },
+    Azure.Core.Foundations.ResourceOkResponse<ModelVersion>
+  >;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Suppress `Operation should be defined using a signature from the Azure.Core namespace.`"
+  @doc(
+    "Delete the specific version of the {name}. The service returns 204 No Content if the {name} was deleted successfully or if the {name} does not exist.",
+    ModelVersion
+  )
+  @delete
+  deleteVersion is Azure.Core.Foundations.ResourceOperation<
+    ModelVersion,
+    {
+      ...ModelsPreviewHeader;
+
+      @doc("The version of the {name} to delete.", ModelVersion)
+      @Rest.segment("versions")
+      @path
+      version: string;
+    },
+    NoContentResponse
+  >;
+
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Suppress `Operation should be defined using a signature from the Azure.Core namespace.`"
   @doc("Update an existing ModelVersion with the given version id", ModelVersion)
   @operationId("Models_updateVersion")
   @patch
   createOrUpdateVersion is Azure.Core.Foundations.ResourceOperation<
     ModelVersion,
-    InputParameters<UpdateModelVersionRequest>,
+    InputParameters<UpdateModelVersionRequest> & ModelsPreviewHeader,
     Azure.Core.Foundations.ResourceCreatedOrOkResponse<ModelVersion>
   >;
 
@@ -35,6 +74,8 @@ interface Models
   @post
   createAsync is Azure.Core.Foundations.Operation<
     {
+      ...ModelsPreviewHeader;
+
       @doc("Name of the model.")
       @path
       name: string;
@@ -56,6 +97,8 @@ interface Models
   @post
   startPendingUpload is Azure.Core.Foundations.Operation<
     {
+      ...ModelsPreviewHeader;
+
       @doc("Name of the model.")
       @path
       name: string;
@@ -76,6 +119,8 @@ interface Models
   @post
   getCredentials is Azure.Core.Foundations.Operation<
     {
+      ...ModelsPreviewHeader;
+
       @doc("Name of the model.")
       @path
       name: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -53,6 +53,7 @@ union FoundryFeaturesOptInKeys {
   memory_stores_v1_preview: "MemoryStores=V1Preview",
   toolboxes_v1_preview: "Toolboxes=V1Preview",
   data_generation_jobs_v1_preview: "DataGenerationJobs=V1Preview",
+  models_v1_preview: "Models=V1Preview",
 }
 
 alias WithRequiredFoundryPreviewHeader<RequiredPreviewOptInHeader extends FoundryFeaturesOptInKeys | AgentDefinitionOptInKeys> = {


### PR DESCRIPTION
This PR adds the required Foundry-Features: Models=V1Preview preview opt-in header to all Models operations in the Foundry SDK TypeSpec.

**Changes:**
- Added models_v1_preview to FoundryFeaturesOptInKeys union in servicepatterns.tsp
- Added ModelsPreviewHeader (WithRequiredFoundryPreviewHeader) to all Models interface operations:
  - listVersions, listLatest (via VersionedOperations template params)
  - getVersion, deleteVersion (overridden from VersionedOperations to include header)
  - createOrUpdateVersion (intersection with ModelsPreviewHeader)
  - createAsync, startPendingUpload, getCredentials (spread into param models)
- Regenerated openapi3 output for both v1 and virtual-public-preview

All changes are additive. No existing behavior is modified.