### PR TITLE
Added rust to schemas used in status check

### DIFF
--- a/.github/shared/src/sdk-types.js
+++ b/.github/shared/src/sdk-types.js
@@ -4,7 +4,7 @@ import * as z from "zod";
  * Represents supported SDK language identifiers.
  *
  * @readonly
- * @enum {"azure-sdk-for-go" | "azure-sdk-for-java" | "azure-sdk-for-js" | "azure-sdk-for-net" | "azure-sdk-for-python"}
+ * @enum {"azure-sdk-for-go" | "azure-sdk-for-java" | "azure-sdk-for-js" | "azure-sdk-for-net" | "azure-sdk-for-python" | "azure-sdk-for-rust"}
  */
 export const SdkName = Object.freeze({
   Go: "azure-sdk-for-go",
@@ -12,6 +12,7 @@ export const SdkName = Object.freeze({
   Js: "azure-sdk-for-js",
   Net: "azure-sdk-for-net",
   Python: "azure-sdk-for-python",
+  Rust: "azure-sdk-for-rust",
 });
 /** @type {import("zod").ZodType<SdkName>} */
 export const SdkNameSchema = z.enum(Object.values(SdkName));
@@ -87,5 +88,11 @@ export const sdkLabels = {
     breakingChangeApproved: "BreakingChange-Python-Sdk-Approved",
     breakingChangeSuppression: "BreakingChange-Python-Sdk-Suppression",
     breakingChangeSuppressionApproved: "BreakingChange-Python-Sdk-Suppression-Approved",
+  },
+  "azure-sdk-for-rust": {
+    breakingChange: undefined,
+    breakingChangeApproved: undefined,
+    breakingChangeSuppression: undefined,
+    breakingChangeSuppressionApproved: undefined,
   },
 };


### PR DESCRIPTION
**SDK support expansion:**

* Added `"azure-sdk-for-rust"` to the `SdkName` enum and included it in the `SdkNameSchema` to recognize Rust as a supported SDK language. (.github/shared/src/sdk-types.js)