### PR TITLE
Refactor evaluation-suites CRUD to VersionedCrud pattern (asset-versioning guideline)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
@@ -49,6 +49,25 @@ interface Evaluators {}
 @@clientLocation(Azure.AI.Projects.EvaluatorGenerationJobs.cancel, Evaluators);
 @@clientLocation(Azure.AI.Projects.EvaluatorGenerationJobs.delete, Evaluators);
 
+interface EvaluationSuites {}
+// Evaluation suite CRUD + versioning operations
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.createOrUpdate, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.get, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.list, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.delete, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.snapshotVersion, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.createVersion, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.getVersion, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.listVersions, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.run, EvaluationSuites);
+
+// Evaluation suite generation jobs → nested under EvaluationSuites sub-client
+@@clientLocation(Azure.AI.Projects.EvaluationSuiteGenerationJobs.create, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuiteGenerationJobs.get, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuiteGenerationJobs.list, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuiteGenerationJobs.cancel, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuiteGenerationJobs.delete, EvaluationSuites);
+
 interface Schedules {}
 @@clientLocation(Azure.AI.Projects.Schedules.delete, Schedules);
 @@clientLocation(Azure.AI.Projects.Schedules.get, Schedules);

--- a/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
@@ -55,7 +55,7 @@ interface EvaluationSuites {}
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.get, EvaluationSuites);
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.list, EvaluationSuites);
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.delete, EvaluationSuites);
-@@clientLocation(Azure.AI.Projects.EvaluationSuites.snapshotVersion, EvaluationSuites);
+@@clientLocation(Azure.AI.Projects.EvaluationSuites.publishVersion, EvaluationSuites);
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.createVersion, EvaluationSuites);
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.getVersion, EvaluationSuites);
 @@clientLocation(Azure.AI.Projects.EvaluationSuites.listVersions, EvaluationSuites);

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -1,0 +1,346 @@
+import "@typespec/openapi";
+
+import "../common/models.tsp";
+import "../servicepatterns.tsp";
+import "../openai-evaluations/models.tsp";
+import "../evaluations/models.tsp";
+
+using TypeSpec.Rest;
+using OpenAPI;
+
+namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+@doc("The subtype of an evaluation suite.")
+union EvaluationSuiteSubtype {
+  string,
+
+  @doc("Default suite type.")
+  default: "default",
+
+  @doc("Benchmark suite.")
+  benchmark: "benchmark",
+}
+
+@doc("The category of evaluator generation.")
+union EvaluationSuiteGenerationCategory {
+  string,
+
+  @doc("Quality-focused rubric criteria.")
+  quality: "quality",
+
+  @doc("Safety-focused policy criteria.")
+  safety: "safety",
+}
+
+@doc("The data generation type.")
+union EvaluationDataGenerationType {
+  string,
+
+  @doc("Simple question and answer generation.")
+  simple_qna: "simple_qna",
+
+  @doc("Traces-based generation.")
+  traces: "traces",
+
+  @doc("Tool use generation.")
+  tool_use: "tool_use",
+
+  @doc("Task-based generation.")
+  task: "task",
+}
+
+// ---------------------------------------------------------------------------
+// Child models
+// ---------------------------------------------------------------------------
+
+@doc("""
+  Reference to a dataset by name and version.
+  """)
+model EvaluationDatasetReference {
+  @doc("Dataset name.")
+  name: string;
+
+  @doc("Dataset version. If not provided, resolves to the latest version.")
+  version?: string;
+
+  @doc("""
+    Name of the schema file within the dataset's blob folder (e.g., "a3f2b1c4_schema.json").
+    Optional — if not provided, schema is inferred at runtime from the data.
+    Only applicable for uri_folder datasets.
+    """)
+  schema_file_name?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path parameters
+// ---------------------------------------------------------------------------
+
+@doc("Path properties for identifying an evaluation suite.")
+model EvaluationSuitePath {
+  @doc("The evaluation suite name.")
+  @path
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Version envelope
+// ---------------------------------------------------------------------------
+
+@doc("Version metadata for an evaluation suite.")
+model EvaluationSuiteVersionProperties {
+  @doc("The version identifier (server-assigned, monotonically increasing).")
+  version: string;
+}
+
+// ---------------------------------------------------------------------------
+// CRUD Resource model ($latest working state)
+// ---------------------------------------------------------------------------
+
+@doc("""
+  An evaluation suite bundles testing criteria — an optional dataset, one or more
+  evaluator configs with thresholds and init params — into a reusable, named artifact that
+  can gate agent changes across batch, scheduled, continuous, and CI/CD evals.
+  """)
+model EvaluationSuite {
+  @doc("The name of the evaluation suite.")
+  @visibility(Lifecycle.Read)
+  name: string;
+
+  @doc("""
+    Human-readable display name.
+    Does not need to be unique. Shown in Foundry portal list views and eval reports.
+    """)
+  display_name?: string;
+
+  @doc("The asset description text.")
+  description?: string;
+
+  @doc("""
+    Subtype of the evaluation suite.
+    """)
+  subtype?: EvaluationSuiteSubtype;
+
+  @doc("""
+    Dataset reference for evaluation.
+    Optional — omit for evaluator-only suites where data comes from
+    live production traces or is provided at run time.
+    The referenced dataset must exist in the project's dataset registry.
+    """)
+  dataset?: EvaluationDatasetReference;
+
+  @doc("""
+    Testing criteria — the evaluator configurations for this suite.
+    Supports all grader types: azure_ai_evaluator, string_check, label_model,
+    score_model, text_similarity, python, etc.
+    At least one entry is required.
+    """)
+  @minItems(1)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Matching eval group testing_criteria pattern"
+  testing_criteria: (
+    | OpenAI.EvalGraderLabelModel
+    | OpenAI.EvalGraderStringCheck
+    | OpenAI.EvalGraderTextSimilarity
+    | OpenAI.EvalGraderPython
+    | OpenAI.EvalGraderScoreModel
+    | TestingCriterionAzureAIEvaluator
+  )[];
+
+  @doc("""
+    Target for this evaluation suite. Uses the existing Target discriminated type
+    from eval runs. Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
+    Optional — allows suites to exist without a target.
+    """)
+  target?: Target;
+
+  @doc("""
+    How to send dataset rows to the target (agent or model).
+    Supports template type (prompt with column placeholders) and
+    item_reference type (column containing pre-built messages).
+    """)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Supporting both input message types"
+  input_messages?: OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate
+    | OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference;
+
+  @doc("""
+    Default evaluation level for this suite. Can be overridden at run time.
+    """)
+  evaluation_level?: EvaluationLevel;
+
+  @doc("Tag dictionary. Tags can be added, removed, and updated.")
+  tags?: Record<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Versioned response envelope
+// ---------------------------------------------------------------------------
+
+@doc("An evaluation suite with version metadata.")
+model VersionedEvaluationSuite {
+  ...EvaluationSuite;
+
+  @doc("Version metadata for this snapshot.")
+  version: EvaluationSuiteVersionProperties;
+}
+
+// ---------------------------------------------------------------------------
+// Run API models
+// ---------------------------------------------------------------------------
+
+@doc("Request body for running an evaluation from a suite.")
+model EvaluationSuiteRunRequest {
+  @doc("Name for the evaluation. Default: '{suiteName}-runs'.")
+  evaluation_name?: string;
+
+  @doc("Evaluation suite version to run. Default: latest.")
+  evaluation_suite_version?: string;
+
+  @doc("Overrides the suite's default evaluation level. If omitted, uses the level from the suite.")
+  evaluation_level?: EvaluationLevel;
+}
+
+@doc("Response from running an evaluation suite.")
+model EvaluationSuiteRunResponse {
+  @doc("The evaluation suite name used.")
+  evaluation_suite_name: string;
+
+  @doc("The evaluation suite version resolved.")
+  evaluation_suite_version: string;
+
+  @doc("The run results. Currently a single-element array; will support multiple runs in the future.")
+  results: EvaluationSuiteRunResult[];
+}
+
+@doc("Result of a single evaluation run within a suite execution.")
+model EvaluationSuiteRunResult {
+  @doc("The evaluation ID created.")
+  eval_id: string;
+
+  @doc("The eval run ID created.")
+  run_id: string;
+
+  @doc("Status of the run.")
+  status: JobStatus;
+
+  @doc("Timestamp when the run was created.")
+  created_at: FoundryTimestamp;
+}
+
+// ---------------------------------------------------------------------------
+// Generate API (LRO) models
+// ---------------------------------------------------------------------------
+
+@doc("The supported source types for evaluation suite generation jobs.")
+union EvaluationSuiteJobSourceType {
+  string,
+
+  @doc("Prompt source — inline text provided by the user.")
+  prompt: "prompt",
+
+  @doc("Agent source — references an agent.")
+  agent: "agent",
+
+  @doc("Traces source — conversation traces from Application Insights.")
+  traces: "traces",
+
+  @doc("Dataset source — reference to a dataset.")
+  dataset: "dataset",
+}
+
+@doc("The base source model for evaluation suite generation jobs. Polymorphic over `type`.")
+@discriminator("type")
+model EvaluationSuiteJobSource {
+  @doc("The type of source.")
+  type: EvaluationSuiteJobSourceType;
+
+  ...JobSourceDescription;
+}
+
+@doc("Prompt source for evaluation suite generation jobs — inline text provided by the user.")
+model PromptEvaluationSuiteJobSource extends EvaluationSuiteJobSource {
+  ...PromptJobSource;
+}
+
+@doc("Agent source for evaluation suite generation jobs — references an agent to fetch instructions and metadata from.")
+model AgentEvaluationSuiteJobSource extends EvaluationSuiteJobSource {
+  ...AgentJobSource;
+}
+
+@doc("Traces source for evaluation suite generation jobs — conversation traces from Application Insights.")
+model TracesEvaluationSuiteJobSource extends EvaluationSuiteJobSource {
+  ...TracesJobSource;
+}
+
+@doc("Dataset source for evaluation suite generation jobs — reference to a dataset.")
+model DatasetEvaluationSuiteJobSource extends EvaluationSuiteJobSource {
+  ...DatasetJobSource;
+}
+
+@doc("Caller-supplied inputs for an evaluation suite generation job.")
+model EvaluationSuiteGenerationJobInputs {
+  @doc("The evaluation suite name to create.")
+  evaluation_suite_name: string;
+
+  @doc("Source materials for generation — agent context, prompts, traces, or datasets.")
+  sources: EvaluationSuiteJobSource[];
+
+  @doc("The LLM model to use for rubric and data generation (e.g., 'gpt-4o').")
+  generation_model: string;
+
+  @doc("Category determines the generation focus. Default: quality.")
+  category?: EvaluationSuiteGenerationCategory = EvaluationSuiteGenerationCategory.quality;
+
+  @doc("""
+    Optional initialization parameters applied to all generated evaluators.
+    For example, deployment_name for LLM judge model, default threshold.
+    """)
+  initialization_parameters?: Record<unknown>;
+
+  @doc("""
+    Data generation options. Controls how the evaluation dataset is generated.
+    If omitted, defaults are used (simple_qna, 100 max_samples).
+    """)
+  data_generation_options?: EvaluationSuiteDataGenerationOptions;
+}
+
+@doc("Options for dataset generation within an evaluation suite generation job.")
+model EvaluationSuiteDataGenerationOptions {
+  @doc("The data generation type. Defaults to 'simple_qna' if not specified.")
+  type?: EvaluationDataGenerationType;
+
+  @doc("Maximum number of samples to generate. Valid range: 15-1000.")
+  @minValue(15)
+  @maxValue(1000)
+  max_samples?: int32;
+}
+
+@doc("Evaluation suite generation job resource — a long-running job that generates testing criteria and optionally a dataset from source materials. On success, the result is a new versioned EvaluationSuite.")
+model EvaluationSuiteGenerationJob
+  is JobLike<VersionedEvaluationSuite, EvaluationSuiteGenerationJobInputs> {
+  @doc("The timestamp when the job was created, represented in Unix time.")
+  @visibility(Lifecycle.Read)
+  created_at: FoundryTimestamp;
+
+  @doc("The timestamp when the job finished, represented in Unix time.")
+  @visibility(Lifecycle.Read)
+  finished_at?: FoundryTimestamp;
+
+  @doc("Token consumption summary. Populated on terminal states.")
+  @visibility(Lifecycle.Read)
+  usage?: EvaluationSuiteGenerationTokenUsage;
+}
+
+@doc("Token usage summary for an evaluation suite generation job.")
+model EvaluationSuiteGenerationTokenUsage {
+  @doc("Number of input tokens consumed.")
+  input_tokens?: int64;
+
+  @doc("Number of output tokens consumed.")
+  output_tokens?: int64;
+
+  @doc("Total tokens consumed.")
+  total_tokens?: int64;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -182,7 +182,7 @@ model EvaluationSuite {
 model VersionedEvaluationSuite {
   ...EvaluationSuite;
 
-  @doc("Version metadata for this snapshot.")
+  @doc("Version metadata for this published version.")
   version: EvaluationSuiteVersionProperties;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
@@ -1,0 +1,178 @@
+import "../common/models.tsp";
+import "../servicepatterns.tsp";
+import "./models.tsp";
+
+namespace Azure.AI.Projects;
+using Http;
+using OpenAPI;
+using Rest;
+using TypeSpec.Versioning;
+
+alias EvaluationSuiteFilterQueryParams = {
+  @query("agent_name")
+  @doc("Filter by associated Foundry agent name (from target).")
+  agent_name?: string;
+};
+
+// ---------------------------------------------------------------------------
+// CRUD + Versioning operations (VersionedCrud pattern)
+// ---------------------------------------------------------------------------
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Using VersionedCrud pattern from asset-versioning guideline"
+@route("evaluation_suites")
+interface EvaluationSuites {
+  // ── $latest CRUD ──────────────────────────────────────────────────
+
+  @put
+  @route("{name}")
+  @summary("Create or update an evaluation suite ($latest).")
+  @doc("Creates a new evaluation suite or replaces the current $latest state. The name in the path identifies the suite.")
+  createOrUpdate is FoundryDataPlaneOperation<
+    {
+      ...EvaluationSuitePath;
+      @body body: EvaluationSuite;
+    },
+    EvaluationSuite
+  >;
+
+  @get
+  @route("{name}")
+  @summary("Get the current $latest state of an evaluation suite.")
+  @doc("Returns the mutable $latest working state of the evaluation suite.")
+  get is FoundryDataPlaneOperation<EvaluationSuitePath, EvaluationSuite>;
+
+  @get
+  @summary("List all evaluation suites.")
+  @doc("Returns a paginated list of evaluation suites. Supports filtering by agent name.")
+  list is FoundryDataPlaneOperation<
+    {
+      ...CommonPageQueryParameters;
+      ...EvaluationSuiteFilterQueryParams;
+    },
+    AgentsPagedResult<EvaluationSuite>
+  >;
+
+  @delete
+  @route("{name}")
+  @summary("Delete an evaluation suite and all its snapped versions.")
+  @doc("Permanently deletes the evaluation suite identified by name, including all snapped versions.")
+  delete is FoundryDataPlaneOperation<EvaluationSuitePath, void>;
+
+  // ── Versioning operations (VersionedCrud) ─────────────────────────
+
+  @post
+  @route("{name}:snapshot_version")
+  @summary("Snap the current $latest state as a new immutable version.")
+  @doc("Creates a new immutable version by snapshotting the current $latest state. The version number is server-assigned and monotonically increasing.")
+  snapshotVersion is FoundryDataPlaneOperation<
+    EvaluationSuitePath,
+    VersionedEvaluationSuite
+  >;
+
+  @post
+  @route("{name}/versions")
+  @summary("Create a version directly — updates $latest and snaps a new immutable version.")
+  @doc("Updates the $latest state with the provided body and immediately snaps it as a new immutable version in one atomic operation.")
+  createVersion is FoundryDataPlaneOperation<
+    {
+      ...EvaluationSuitePath;
+      @body body: EvaluationSuite;
+    },
+    VersionedEvaluationSuite
+  >;
+
+  @get
+  @route("{name}/versions/{version}")
+  @summary("Get a specific snapped version of an evaluation suite.")
+  @doc("Returns the immutable snapped version identified by version number.")
+  getVersion is FoundryDataPlaneOperation<
+    {
+      ...EvaluationSuitePath;
+      @doc("The version identifier.")
+      @path version: string;
+    },
+    VersionedEvaluationSuite
+  >;
+
+  @get
+  @route("{name}/versions")
+  @summary("List all snapped versions of an evaluation suite.")
+  @doc("Returns a paginated list of all immutable snapped versions for the specified evaluation suite.")
+  listVersions is FoundryDataPlaneOperation<
+    {
+      ...EvaluationSuitePath;
+      ...CommonPageQueryParameters;
+    },
+    AgentsPagedResult<VersionedEvaluationSuite>
+  >;
+
+  // ── Action ────────────────────────────────────────────────────────
+
+  @post
+  @route("{name}:run")
+  @summary("Run an evaluation using the suite's testing criteria and dataset.")
+  @doc("Triggers an evaluation run using the suite's testing criteria, dataset, and target. Returns the eval and run IDs for tracking.")
+  run is FoundryDataPlaneOperation<
+    {
+      ...EvaluationSuitePath;
+      @body body: EvaluationSuiteRunRequest;
+    },
+    EvaluationSuiteRunResponse
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Generate API (LRO jobs pattern — follows evaluator_generation_jobs)
+// ---------------------------------------------------------------------------
+
+const EvaluationSuiteGenerationJobsRequiredPreviews = #{
+  conditional_previews: #[
+    FoundryFeaturesOptInKeys.evaluations_v1_preview
+  ],
+};
+
+@removed(Versions.v1)
+#suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "OpenAI-based operations are not conventionally versioned"
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
+#suppress "@azure-tools/typespec-azure-core/long-running-polling-operation-required" "LRO polling is handled by the client via Operation-Location"
+@tag("EvaluationSuiteGenerationJobs")
+interface EvaluationSuiteGenerationJobs {
+  @summary("Creates an evaluation suite generation job.")
+  @route("evaluation_suite_generation_jobs")
+  @extension("x-ms-foundry-meta", EvaluationSuiteGenerationJobsRequiredPreviews)
+  create is postJobPreview<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
+    EvaluationSuiteGenerationJob
+  >;
+
+  @summary("Get info about an evaluation suite generation job.")
+  @route("evaluation_suite_generation_jobs/{jobId}")
+  @extension("x-ms-foundry-meta", EvaluationSuiteGenerationJobsRequiredPreviews)
+  get is queryJobStatusPreview<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
+    EvaluationSuiteGenerationJob
+  >;
+
+  @summary("Returns a list of evaluation suite generation jobs.")
+  @route("evaluation_suite_generation_jobs")
+  @extension("x-ms-foundry-meta", EvaluationSuiteGenerationJobsRequiredPreviews)
+  list is listJobsPreview<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
+    EvaluationSuiteGenerationJob
+  >;
+
+  @summary("Cancels an evaluation suite generation job.")
+  @route("evaluation_suite_generation_jobs/{jobId}:cancel")
+  @extension("x-ms-foundry-meta", EvaluationSuiteGenerationJobsRequiredPreviews)
+  cancel is cancelJobPreview<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
+    EvaluationSuiteGenerationJob
+  >;
+
+  @summary("Deletes an evaluation suite generation job.")
+  @route("evaluation_suite_generation_jobs/{jobId}")
+  @extension("x-ms-foundry-meta", EvaluationSuiteGenerationJobsRequiredPreviews)
+  delete is deleteJobPreview<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
@@ -54,25 +54,25 @@ interface EvaluationSuites {
 
   @delete
   @route("{name}")
-  @summary("Delete an evaluation suite and all its snapped versions.")
-  @doc("Permanently deletes the evaluation suite identified by name, including all snapped versions.")
+  @summary("Delete an evaluation suite and all its published versions.")
+  @doc("Permanently deletes the evaluation suite identified by name, including all published versions.")
   delete is FoundryDataPlaneOperation<EvaluationSuitePath, void>;
 
   // ── Versioning operations (VersionedCrud) ─────────────────────────
 
   @post
-  @route("{name}:snapshot_version")
-  @summary("Snap the current $latest state as a new immutable version.")
-  @doc("Creates a new immutable version by snapshotting the current $latest state. The version number is server-assigned and monotonically increasing.")
-  snapshotVersion is FoundryDataPlaneOperation<
+  @route("{name}:publish_version")
+  @summary("Publish the current $latest state as a new immutable version.")
+  @doc("Creates a new immutable version by publishing the current $latest state. The version number is server-assigned and monotonically increasing.")
+  publishVersion is FoundryDataPlaneOperation<
     EvaluationSuitePath,
     VersionedEvaluationSuite
   >;
 
   @post
   @route("{name}/versions")
-  @summary("Create a version directly — updates $latest and snaps a new immutable version.")
-  @doc("Updates the $latest state with the provided body and immediately snaps it as a new immutable version in one atomic operation.")
+  @summary("Create a version directly — updates $latest and publishes a new immutable version.")
+  @doc("Updates the $latest state with the provided body and immediately publishes it as a new immutable version in one atomic operation.")
   createVersion is FoundryDataPlaneOperation<
     {
       ...EvaluationSuitePath;
@@ -83,8 +83,8 @@ interface EvaluationSuites {
 
   @get
   @route("{name}/versions/{version}")
-  @summary("Get a specific snapped version of an evaluation suite.")
-  @doc("Returns the immutable snapped version identified by version number.")
+  @summary("Get a specific published version of an evaluation suite.")
+  @doc("Returns the immutable published version identified by version number.")
   getVersion is FoundryDataPlaneOperation<
     {
       ...EvaluationSuitePath;
@@ -96,8 +96,8 @@ interface EvaluationSuites {
 
   @get
   @route("{name}/versions")
-  @summary("List all snapped versions of an evaluation suite.")
-  @doc("Returns a paginated list of all immutable snapped versions for the specified evaluation suite.")
+  @summary("List all published versions of an evaluation suite.")
+  @doc("Returns a paginated list of all immutable published versions for the specified evaluation suite.")
   listVersions is FoundryDataPlaneOperation<
     {
       ...EvaluationSuitePath;


### PR DESCRIPTION
## Summary

Refactors the Evaluation Suite CRUD API to follow the **VersionedCrud** pattern proposed in the [asset-versioning guideline](https://github.com/coreai-microsoft/foundrysdk_specs/pull/55). This replaces the old `VersionedOperations` mixin with explicit `$latest` + snap-version operations.

## Source

- Conceptual spec: https://github.com/coreai-microsoft/foundrysdk_specs/pull/70
- Versioning guideline: https://github.com/coreai-microsoft/foundrysdk_specs/pull/55
- Original TypeSpec PR: https://github.com/Azure/azure-rest-api-specs/pull/42424

## Key Changes

### Pattern shift: `VersionedOperations` → `VersionedCrud`

| Before (old pattern) | After (new pattern) |
|---|---|
| `PATCH /evaluation_suites/{name}/versions/{version}` | `PUT /evaluation_suites/{name}` (create/update `$latest`) |
| `GET /evaluation_suites/{name}/versions/{version}` (only) | `GET /evaluation_suites/{name}` (`$latest`) + `GET .../versions/{version}` |
| Flat `version: "1"` in response | Nested `version: { version: "1" }` envelope |
| Mutable versions via PATCH | Immutable snapped versions |

### New route structure

| Method | Route | Description |
|---|---|---|
| `PUT` | `/evaluation_suites/{name}` | Create or update `$latest` |
| `GET` | `/evaluation_suites/{name}` | Get `$latest` |
| `GET` | `/evaluation_suites` | List all suites |
| `DELETE` | `/evaluation_suites/{name}` | Delete suite + all versions |
| `POST` | `/evaluation_suites/{name}:snapshot_version` | Snap `$latest` as immutable version |
| `POST` | `/evaluation_suites/{name}/versions` | Create version directly (update `$latest` + snap) |
| `GET` | `/evaluation_suites/{name}/versions/{version}` | Get specific version |
| `GET` | `/evaluation_suites/{name}/versions` | List all versions |
| `POST` | `/evaluation_suites/{name}:run` | Run evaluation from suite |

### Changes by file

- **models.tsp**: Renamed `EvaluationSuiteVersion` → `EvaluationSuite` ($latest resource body). Added `EvaluationSuitePath`, `EvaluationSuiteVersionProperties`, and `VersionedEvaluationSuite` (response envelope). Removed `@resource`/`@key` decorators and `version` field from base model. Updated `EvaluationSuiteGenerationJob` TResult to `VersionedEvaluationSuite`.
- **routes.tsp**: Replaced `VersionedOperations` extension with explicit operations using `FoundryDataPlaneOperation`. All CRUD + versioning operations defined manually following the VersionedCrud route structure.
- **relocate-beta-operations.tsp**: Added `EvaluationSuites` interface in Beta namespace with `@@clientLocation` for all 9 CRUD/versioning operations. Moved generation job relocations from `Evaluators` → `EvaluationSuites`.

### Follow-up needed
- `@@clientName` entries in `client.tsp` for evaluation suite operations (deferred to follow-up PR)
- Wire format change: `version` field is now nested `{ version: { version: "1" } }` — SDK codegen and examples need updating

## Validation
- [ ] TypeSpec compiles with zero errors
- [ ] OpenAPI3 output reviewed and matches spec intent
- [ ] Team guidelines checked (asset-versioning, naming-conventions)

---
> ⚠️ This PR was AI-authored. Please review carefully before merging.
