### PR TITLE
Add external agent kind for third-party agent registration

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14208,12 +14208,6 @@
               "external"
             ]
           },
-          "agent_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.",
-            "example": "https://example-agent.contoso.com/agent"
-          },
           "otel_agent_id": {
             "type": "string",
             "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -135,7 +135,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -576,7 +577,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -9166,6 +9168,7 @@
           "mapping": {
             "prompt": "#/components/schemas/PromptAgentDefinition",
             "workflow": "#/components/schemas/WorkflowAgentDefinition",
+            "external": "#/components/schemas/ExternalAgentDefinition",
             "hosted": "#/components/schemas/HostedAgentDefinition"
           }
         },
@@ -9173,7 +9176,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -9181,7 +9185,8 @@
         "type": "string",
         "enum": [
           "HostedAgents=V1Preview",
-          "WorkflowAgents=V1Preview"
+          "WorkflowAgents=V1Preview",
+          "ExternalAgents=V1Preview"
         ],
         "description": "Opt-in keys for defining preview Hosted or Workflow Agents."
       },
@@ -9195,7 +9200,8 @@
             "enum": [
               "prompt",
               "hosted",
-              "workflow"
+              "workflow",
+              "external"
             ]
           }
         ]
@@ -11824,7 +11830,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           }
@@ -11833,7 +11840,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -11898,7 +11906,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           }
@@ -11907,7 +11916,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -14185,6 +14195,42 @@
           }
         },
         "description": "Evaluator Definition"
+      },
+      "ExternalAgentDefinition": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "external"
+            ]
+          },
+          "agent_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.",
+            "example": "https://example-agent.contoso.com/agent"
+          },
+          "otel_agent_id": {
+            "type": "string",
+            "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",
+            "example": "gcp-travel-planner-agent"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentDefinition"
+          }
+        ],
+        "description": "The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).\nRegistration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)\nover customer-emitted OpenTelemetry data.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "ExternalAgents=V1Preview"
+          ]
+        }
       },
       "FabricDataAgentToolCall": {
         "type": "object",
@@ -37680,7 +37726,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -18399,12 +18399,6 @@
               "external"
             ]
           },
-          "agent_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.",
-            "example": "https://example-agent.contoso.com/agent"
-          },
           "otel_agent_id": {
             "type": "string",
             "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -144,7 +144,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -1943,7 +1944,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -12251,6 +12253,7 @@
           "mapping": {
             "prompt": "#/components/schemas/PromptAgentDefinition",
             "workflow": "#/components/schemas/WorkflowAgentDefinition",
+            "external": "#/components/schemas/ExternalAgentDefinition",
             "hosted": "#/components/schemas/HostedAgentDefinition",
             "container_app": "#/components/schemas/ContainerAppAgentDefinition"
           }
@@ -12259,7 +12262,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -12268,6 +12272,7 @@
         "enum": [
           "HostedAgents=V1Preview",
           "WorkflowAgents=V1Preview",
+          "ExternalAgents=V1Preview",
           "ContainerAgents=V1Preview"
         ],
         "description": "Opt-in keys for defining preview Hosted or Workflow Agents."
@@ -12621,6 +12626,7 @@
               "prompt",
               "hosted",
               "workflow",
+              "external",
               "container_app"
             ]
           }
@@ -15694,7 +15700,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           },
@@ -15742,7 +15749,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -15833,7 +15841,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           },
@@ -15855,7 +15864,8 @@
           "conditional_previews": [
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
-            "WorkflowAgents=V1Preview"
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         }
       },
@@ -18376,6 +18386,42 @@
           }
         },
         "description": "Evaluator Definition"
+      },
+      "ExternalAgentDefinition": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "external"
+            ]
+          },
+          "agent_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.",
+            "example": "https://example-agent.contoso.com/agent"
+          },
+          "otel_agent_id": {
+            "type": "string",
+            "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",
+            "example": "gcp-travel-planner-agent"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentDefinition"
+          }
+        ],
+        "description": "The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).\nRegistration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)\nover customer-emitted OpenTelemetry data.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "ExternalAgents=V1Preview"
+          ]
+        }
       },
       "FabricDataAgentToolCall": {
         "type": "object",
@@ -42669,7 +42715,8 @@
               "conditional_previews": [
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
-                "WorkflowAgents=V1Preview"
+                "WorkflowAgents=V1Preview",
+                "ExternalAgents=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -422,12 +422,6 @@ model ExternalAgentDefinition extends AgentDefinition {
   kind: AgentKind.external;
 
   @doc("""
-    The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.
-    """)
-  @example("https://example-agent.contoso.com/agent")
-  agent_url?: url;
-
-  @doc("""
     The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.
     Spans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.
     Defaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios
@@ -1025,9 +1019,7 @@ model AgentCard {
 /** The status of an agent session. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 union AgentSessionStatus {
@@ -1063,9 +1055,7 @@ union AgentSessionStatus {
 /** The type of version indicator used to determine the agent version backing a session. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 union VersionIndicatorType {
@@ -1079,9 +1069,7 @@ union VersionIndicatorType {
 @doc("Version indicator determining which agent version backs the session.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 @discriminator("type")
@@ -1093,9 +1081,7 @@ model VersionIndicator {
 /** Version indicator that references a specific agent version by name. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model VersionRefIndicator extends VersionIndicator {
@@ -1112,9 +1098,7 @@ model VersionRefIndicator extends VersionIndicator {
 @doc("An agent session providing a long-lived compute sandbox for hosted agent invocations.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model AgentSessionResource {
@@ -1149,9 +1133,7 @@ model AgentSessionResource {
 @doc("Request to create a new agent session.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model CreateAgentSessionRequest {
@@ -1168,9 +1150,7 @@ model CreateAgentSessionRequest {
 @doc("Paged result for session list operations.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model SessionListResult {

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -10,7 +10,8 @@ const AllConditionalAgentDefinitionPreviews = #{
   conditional_previews: #[
     AgentDefinitionOptInKeys.hosted_agents_v1_preview,
     AgentDefinitionOptInKeys.container_agents_v1_preview,
-    AgentDefinitionOptInKeys.workflow_agents_v1_preview
+    AgentDefinitionOptInKeys.workflow_agents_v1_preview,
+    AgentDefinitionOptInKeys.external_agents_v1_preview
   ],
 };
 
@@ -314,6 +315,7 @@ union AgentKind {
   prompt: "prompt",
   hosted: "hosted",
   workflow: "workflow",
+  external: "external",
 
   @removed(Versions.v1)
   container_app: "container_app",
@@ -405,6 +407,35 @@ model WorkflowAgentDefinition extends AgentDefinition {
 
   @doc("The CSDL YAML definition of the workflow.")
   workflow?: string;
+}
+
+@doc("""
+  The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).
+  Registration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)
+  over customer-emitted OpenTelemetry data.
+  """)
+@extension(
+  "x-ms-foundry-meta",
+  #{ required_previews: #[AgentDefinitionOptInKeys.external_agents_v1_preview] }
+)
+model ExternalAgentDefinition extends AgentDefinition {
+  kind: AgentKind.external;
+
+  @doc("""
+    The URL of the externally-hosted agent. Recorded as identity/discoverability metadata.
+    """)
+  @example("https://example-agent.contoso.com/agent")
+  agent_url?: url;
+
+  @doc("""
+    The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.
+    Spans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.
+    Defaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios
+    where the running external agent already emits a stable id that differs from the Foundry agent name.
+    The resolved value is always echoed on read.
+    """)
+  @example("gcp-travel-planner-agent")
+  otel_agent_id?: string;
 }
 
 @doc("The hosted agent definition.")

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -53,6 +53,7 @@ op FoundryDataPlaneOperation<
 union AgentDefinitionOptInKeys {
   hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
+  external_agents_v1_preview: "ExternalAgents=V1Preview",
 
   @removed(Versions.v1)
   container_agents_v1_preview: "ContainerAgents=V1Preview",


### PR DESCRIPTION
Introduces a new `external` agent kind for registering third-party agents hosted outside Foundry (e.g. on GCP/AWS).

Design: observation-only registration. Foundry records the agent definition to light up trace and evaluation experiences over customer-emitted OpenTelemetry data. The MVP does not invoke the agent endpoint.

### TypeSpec changes
- Added `external_agents_v1_preview: ExternalAgents=V1Preview` to `AgentDefinitionOptInKeys`.
- Added `external: external` to `AgentKind`.
- Added new `ExternalAgentDefinition` model with:
  - `agent_url` (optional url) – identity/discoverability metadata, not invoked in MVP.
  - `otel_agent_id` (optional string) – attributes customer-emitted spans (`gen_ai.agent.id`) to this Foundry agent. Defaults to the top-level agent name; an explicit value is for migration scenarios.
- Wired the new opt-in into `AllConditionalAgentDefinitionPreviews` so the existing `CreateAgentRequest` / `CreateAgentVersionRequest` envelopes accept it.

OpenAPI3 outputs regenerated. `npx tsp compile .` passes (only pre-existing warnings).