### PR TITLE
Spec: merge code download endpoints into a single operation

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_MaximumSet_Gen.json
@@ -9,7 +9,8 @@
   "responses": {
     "200": {
       "headers": {
-        "Content-Type": "application/zip"
+        "Content-Type": "application/zip",
+        "x-ms-agent-version": "3"
       },
       "body": "<binary zip content>"
     }

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_WithVersion_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_WithVersion_Gen.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "Agents_downloadAgentVersionCode",
-  "title": "Agents_DownloadAgentVersionCode",
+  "operationId": "Agents_downloadAgentCode",
+  "title": "Agents_DownloadAgentCode_WithVersion",
   "parameters": {
     "api-version": "2025-11-15-preview",
     "agent_name": "my-code-agent",

--- a/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_WithVersion_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/2025-11-15-preview/Agents_DownloadAgentCode_WithVersion_Gen.json
@@ -10,7 +10,8 @@
   "responses": {
     "200": {
       "headers": {
-        "Content-Type": "application/zip"
+        "Content-Type": "application/zip",
+        "x-ms-agent-version": "1"
       },
       "body": "<binary zip content>"
     }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -566,7 +566,7 @@
     "/agents/{agent_name}/code:download": {
       "get": {
         "operationId": "Agents_downloadAgentCode",
-        "description": "Download the code zip for the latest version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.",
+        "description": "Download the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -584,10 +584,20 @@
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "description": "The name of the agent whose latest-version code zip should be downloaded.",
+            "description": "The name of the agent.",
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "agent_version",
+            "in": "query",
+            "required": false,
+            "description": "The version of the agent whose code zip should be downloaded.\nIf omitted, the latest version's code zip is returned.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2103,85 +2113,6 @@
         "tags": [
           "Agents"
         ]
-      }
-    },
-    "/agents/{agent_name}/versions/{agent_version}/code:download": {
-      "get": {
-        "operationId": "Agents_downloadAgentVersionCode",
-        "description": "Download the code zip for a specific version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.",
-        "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "CodeAgents=V1Preview"
-              ]
-            }
-          },
-          {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "agent_version",
-            "in": "path",
-            "required": true,
-            "description": "The version of the agent whose code zip should be downloaded.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "description": "The API version to use for this operation.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Agents"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
       }
     },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -613,6 +613,15 @@
         "responses": {
           "200": {
             "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
+            "headers": {
+              "x-ms-agent-version": {
+                "required": true,
+                "description": "The version of the agent whose code zip is returned in the response body.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/zip": {
                 "schema": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -413,6 +413,12 @@ paths:
             Body is the raw zip bytes; `Content-Type` declares `application/zip` so clients
             can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
             of the content-type label.
+          headers:
+            x-ms-agent-version:
+              required: true
+              description: The version of the agent whose code zip is returned in the response body.
+              schema:
+                type: string
           content:
             application/zip:
               schema:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -367,9 +367,14 @@ paths:
     get:
       operationId: Agents_downloadAgentCode
       description: |-
-        Download the code zip for the latest version of a code-based hosted agent.
+        Download the code zip for a code-based hosted agent.
         Returns the previously-uploaded zip (`application/zip`).
-        The SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.
+
+        If `agent_version` is supplied, returns that version's code zip; otherwise
+        returns the latest version's code zip.
+
+        The SHA-256 digest of the returned bytes matches the `content_hash` on the
+        resolved version's `code_configuration`.
       parameters:
         - name: Foundry-Features
           in: header
@@ -382,9 +387,18 @@ paths:
         - name: agent_name
           in: path
           required: true
-          description: The name of the agent whose latest-version code zip should be downloaded.
+          description: The name of the agent.
           schema:
             type: string
+        - name: agent_version
+          in: query
+          required: false
+          description: |-
+            The version of the agent whose code zip should be downloaded.
+            If omitted, the latest version's code zip is returned.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1419,64 +1433,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agents
-  /agents/{agent_name}/versions/{agent_version}/code:download:
-    get:
-      operationId: Agents_downloadAgentVersionCode
-      description: |-
-        Download the code zip for a specific version of a code-based hosted agent.
-        Returns the previously-uploaded zip (`application/zip`).
-        The SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.
-      parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - CodeAgents=V1Preview
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_version
-          in: path
-          required: true
-          description: The version of the agent whose code zip should be downloaded.
-          schema:
-            type: string
-        - name: api-version
-          in: query
-          required: true
-          description: The API version to use for this operation.
-          schema:
-            type: string
-          explode: false
-      responses:
-        '200':
-          description: |-
-            Response body for downloading a hosted agent's code zip.
-            Body is the raw zip bytes; `Content-Type` declares `application/zip` so clients
-            can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
-            of the content-type label.
-          content:
-            application/zip:
-              schema:
-                type: string
-                format: binary
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      tags:
-        - Agents
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -616,6 +616,15 @@
         "responses": {
           "200": {
             "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
+            "headers": {
+              "x-ms-agent-version": {
+                "required": true,
+                "description": "The version of the agent whose code zip is returned in the response body.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/zip": {
                 "schema": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -569,7 +569,7 @@
     "/agents/{agent_name}/code:download": {
       "get": {
         "operationId": "Agents_downloadAgentCode",
-        "description": "Download the code zip for the latest version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.",
+        "description": "Download the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -587,10 +587,20 @@
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "description": "The name of the agent whose latest-version code zip should be downloaded.",
+            "description": "The name of the agent.",
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "agent_version",
+            "in": "query",
+            "required": false,
+            "description": "The version of the agent whose code zip should be downloaded.\nIf omitted, the latest version's code zip is returned.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2321,85 +2331,6 @@
         "tags": [
           "Agents"
         ]
-      }
-    },
-    "/agents/{agent_name}/versions/{agent_version}/code:download": {
-      "get": {
-        "operationId": "Agents_downloadAgentVersionCode",
-        "description": "Download the code zip for a specific version of a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.",
-        "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "CodeAgents=V1Preview"
-              ]
-            }
-          },
-          {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "agent_version",
-            "in": "path",
-            "required": true,
-            "description": "The version of the agent whose code zip should be downloaded.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "description": "The API version to use for this operation.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Response body for downloading a hosted agent's code zip.\nBody is the raw zip bytes; `Content-Type` declares `application/zip` so clients\ncan route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless\nof the content-type label.",
-            "content": {
-              "application/zip": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Agents"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
       }
     },
     "/agents/{agent_name}/versions/{agent_version}/containers/default": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -368,9 +368,14 @@ paths:
     get:
       operationId: Agents_downloadAgentCode
       description: |-
-        Download the code zip for the latest version of a code-based hosted agent.
+        Download the code zip for a code-based hosted agent.
         Returns the previously-uploaded zip (`application/zip`).
-        The SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.
+
+        If `agent_version` is supplied, returns that version's code zip; otherwise
+        returns the latest version's code zip.
+
+        The SHA-256 digest of the returned bytes matches the `content_hash` on the
+        resolved version's `code_configuration`.
       parameters:
         - name: Foundry-Features
           in: header
@@ -383,9 +388,18 @@ paths:
         - name: agent_name
           in: path
           required: true
-          description: The name of the agent whose latest-version code zip should be downloaded.
+          description: The name of the agent.
           schema:
             type: string
+        - name: agent_version
+          in: query
+          required: false
+          description: |-
+            The version of the agent whose code zip should be downloaded.
+            If omitted, the latest version's code zip is returned.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1573,64 +1587,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agents
-  /agents/{agent_name}/versions/{agent_version}/code:download:
-    get:
-      operationId: Agents_downloadAgentVersionCode
-      description: |-
-        Download the code zip for a specific version of a code-based hosted agent.
-        Returns the previously-uploaded zip (`application/zip`).
-        The SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.
-      parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - CodeAgents=V1Preview
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_version
-          in: path
-          required: true
-          description: The version of the agent whose code zip should be downloaded.
-          schema:
-            type: string
-        - name: api-version
-          in: query
-          required: true
-          description: The API version to use for this operation.
-          schema:
-            type: string
-          explode: false
-      responses:
-        '200':
-          description: |-
-            Response body for downloading a hosted agent's code zip.
-            Body is the raw zip bytes; `Content-Type` declares `application/zip` so clients
-            can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
-            of the content-type label.
-          content:
-            application/zip:
-              schema:
-                type: string
-                format: binary
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      tags:
-        - Agents
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
   /agents/{agent_name}/versions/{agent_version}/containers/default:
     get:
       operationId: AgentContainers_getAgentContainer

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -414,6 +414,12 @@ paths:
             Body is the raw zip bytes; `Content-Type` declares `application/zip` so clients
             can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
             of the content-type label.
+          headers:
+            x-ms-agent-version:
+              required: true
+              description: The version of the agent whose code zip is returned in the response body.
+              schema:
+                type: string
           content:
             application/zip:
               schema:

--- a/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/relocate-beta-operations.tsp
@@ -122,7 +122,6 @@ interface Agents {}
 @@clientLocation(Azure.AI.Projects.Agents.updateAgentFromCode, Agents);
 @@clientLocation(Azure.AI.Projects.Agents.createAgentVersionFromCode, Agents);
 @@clientLocation(Azure.AI.Projects.Agents.downloadAgentCode, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.downloadAgentVersionCode, Agents);
 
 
 interface Datasets {}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -919,6 +919,10 @@ model DownloadAgentCodeResponse {
   @header("Content-Type")
   content_type: "application/zip";
 
+  @doc("The version of the agent whose code zip is returned in the response body.")
+  @header("x-ms-agent-version")
+  agent_version: string;
+
   @doc("The zip code package content.")
   @body
   content: bytes;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -336,32 +336,14 @@ interface Agents {
   >;
 
   /**
-   * Download the code zip for a specific version of a code-based hosted agent.
+   * Download the code zip for a code-based hosted agent.
    * Returns the previously-uploaded zip (`application/zip`).
-   * The SHA-256 digest of the returned bytes matches the `content_hash` on the agent version's `code_configuration`.
-   */
-  @get
-  @route("/agents/{agent_name}/versions/{agent_version}/code:download")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
-  downloadAgentVersionCode is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.code_agents_v1_preview,
-    {
-      /** The name of the agent. */
-      @path agent_name: string;
-
-      /** The version of the agent whose code zip should be downloaded. */
-      @path agent_version: string;
-    },
-    DownloadAgentCodeResponse
-  >;
-
-  /**
-   * Download the code zip for the latest version of a code-based hosted agent.
-   * Returns the previously-uploaded zip (`application/zip`).
-   * The SHA-256 digest of the returned bytes matches the `content_hash` on the latest version's `code_configuration`.
+   *
+   * If `agent_version` is supplied, returns that version's code zip; otherwise
+   * returns the latest version's code zip.
+   *
+   * The SHA-256 digest of the returned bytes matches the `content_hash` on the
+   * resolved version's `code_configuration`.
    */
   @get
   @route("/agents/{agent_name}/code:download")
@@ -372,8 +354,14 @@ interface Agents {
   downloadAgentCode is FoundryDataPlanePreviewOperation<
     AgentDefinitionOptInKeys.code_agents_v1_preview,
     {
-      /** The name of the agent whose latest-version code zip should be downloaded. */
+      /** The name of the agent. */
       @path agent_name: string;
+
+      /**
+       * The version of the agent whose code zip should be downloaded.
+       * If omitted, the latest version's code zip is returned.
+       */
+      @query agent_version?: string;
     },
     DownloadAgentCodeResponse
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-projects-agents/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-projects-agents/client.tsp
@@ -221,7 +221,6 @@ namespace Azure.AI.Projects {
   // Hide Agent administration opertaions, containing the foundry features
   // --------------------------------------------------------------------------------
   @@access(Agents.createAgentVersionFromCode, Access.internal);
-  @@access(Agents.downloadAgentVersionCode, Access.internal);
   @@access(Agents.downloadAgentCode, Access.internal);
 
   // --------------------------------------------------------------------------------


### PR DESCRIPTION
Replaces the two preview-only download operations:
  - GET /agents/{agent_name}/versions/{agent_version}/code:download (downloadAgentVersionCode)
  - GET /agents/{agent_name}/code:download (downloadAgentCode)

with a single operation:
  - GET /agents/{agent_name}/code:download?agent_version=<x> (downloadAgentCode)

When `agent_version` is omitted, the service returns the latest version's code zip; otherwise the specified version's code zip is returned. 

