### PR TITLE
Follow-up cleanup of csharp @@clientName overrides for new mgmt generator behavior

### DIFF
--- a/specification/billingbenefits/BillingBenefits.Management/client.tsp
+++ b/specification/billingbenefits/BillingBenefits.Management/client.tsp
@@ -94,7 +94,6 @@ using Microsoft.BillingBenefits;
 @@clientName(Price, "BillingBenefitsPrice", "csharp");
 @@clientName(PaymentDetail, "SavingsPlanOrderPaymentDetail", "csharp");
 @@clientName(PaymentStatus, "BillingBenefitsPaymentStatus", "csharp");
-@@clientName(SavingsPlanUpdateRequest, "SavingsPlanUpdateContent", "csharp");
 @@clientName(SavingsPlanUpdateValidateRequest,
   "SavingsPlanUpdateValidateContent",
   "csharp"
@@ -107,7 +106,6 @@ using Microsoft.BillingBenefits;
   "ReservationOrderAliasContent",
   "csharp"
 );
-@@clientName(DiscountPatchRequest, "DiscountPatchContent", "csharp");
 @@clientName(SavingsPlanUpdateRequestProperties,
   "BillingBenefitsSavingsPlanPatchProperties",
   "csharp"

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -325,10 +325,6 @@ using Azure.ResourceManager;
 @@clientName(EdgeAction, "CdnEdgeAction", "csharp");
 @@clientName(GroupByVariable, "RateLimitGroupByVariable", "csharp");
 @@clientName(InvocationPoint, "EdgeActionInvocationPoint", "csharp");
-@@clientName(KnowledgeSourceUpdateParameters,
-  "WebAgentKnowledgeSourcePatch",
-  "csharp"
-);
 @@clientName(KnowledgeSourceProvisioningState,
   "CdnWebAgentKnowledgeSourceProvisioningState",
   "csharp"
@@ -577,10 +573,6 @@ using Azure.ResourceManager;
   "FrontDoorCustomDomainHttpsContent",
   "csharp"
 );
-@@clientName(AFDDomainUpdateParameters,
-  "FrontDoorCustomDomainUpdateParameters",
-  "csharp"
-);
 @@clientName(AFDDomainUpdatePropertiesParameters,
   "FrontDoorCustomDomainUpdatePropertiesParameters",
   "csharp"
@@ -597,20 +589,12 @@ using Azure.ResourceManager;
 @@clientName(AFDEndpoints.listResourceUsage, "GetResourceUsages", "csharp");
 @@clientName(AFDOriginGroups.listResourceUsage, "GetResourceUsages", "csharp");
 @@clientName(AFDEndpointProperties, "FrontDoorEndpointProperties", "csharp");
-@@clientName(AFDEndpointUpdateParameters,
-  "FrontDoorEndpointUpdateParameters",
-  "csharp"
-);
 @@clientName(AFDEndpointPropertiesUpdateParameters,
   "FrontDoorEndpointPropertiesUpdateParameters",
   "csharp"
 );
 @@clientName(AFDOrigin, "FrontDoorOrigin", "csharp");
 @@clientName(AFDOriginProperties, "FrontDoorOriginProperties", "csharp");
-@@clientName(AFDOriginUpdateParameters,
-  "FrontDoorOriginUpdateParameters",
-  "csharp"
-);
 @@clientName(AFDOriginUpdatePropertiesParameters,
   "FrontDoorOriginUpdatePropertiesParameters",
   "csharp"
@@ -618,10 +602,6 @@ using Azure.ResourceManager;
 @@clientName(AFDOriginGroup, "FrontDoorOriginGroup", "csharp");
 @@clientName(AFDOriginGroupProperties,
   "FrontDoorOriginGroupProperties",
-  "csharp"
-);
-@@clientName(AFDOriginGroupUpdateParameters,
-  "FrontDoorOriginGroupUpdateParameters",
   "csharp"
 );
 @@clientName(AFDOriginGroupUpdatePropertiesParameters,

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
@@ -35,7 +35,7 @@ using Microsoft.Chaos;
   "ExecutionDetails",
   "csharp"
 );
-@@clientName(Microsoft.Chaos.Experiments.listAll, "getExperiments", "csharp");
+@@clientName(Microsoft.Chaos.Experiments.listAll, "getExperiments", "!csharp");
 @@clientName(Microsoft.Chaos.PrivateAccesses.listAll,
   "getPrivateAccesses",
   "csharp"

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/client.tsp
@@ -35,7 +35,6 @@ using Microsoft.Chaos;
   "ExecutionDetails",
   "csharp"
 );
-@@clientName(Microsoft.Chaos.Experiments.listAll, "getExperiments", "!csharp");
 @@clientName(Microsoft.Chaos.PrivateAccesses.listAll,
   "getPrivateAccesses",
   "csharp"

--- a/specification/networkfunction/resource-manager/Microsoft.NetworkFunction/TrafficCollector/back-compatible.tsp
+++ b/specification/networkfunction/resource-manager/Microsoft.NetworkFunction/TrafficCollector/back-compatible.tsp
@@ -16,7 +16,8 @@ using Microsoft.NetworkFunction;
   "AzureTrafficCollectorsBySubscription"
 );
 @@clientName(AzureTrafficCollectors.azureTrafficCollectorsBySubscriptionList,
-  "List"
+  "List",
+  "!csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(AzureTrafficCollector.properties);

--- a/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/client.tsp
+++ b/specification/servicenetworking/resource-manager/Microsoft.ServiceNetworking/ServiceNetworking/client.tsp
@@ -56,7 +56,6 @@ using Microsoft.ServiceNetworking;
   "csharp"
 );
 @@clientName(Association, "TrafficControllerAssociation", "csharp");
-@@clientName(AssociationUpdate, "TrafficControllerAssociationUpdate", "csharp");
 @@clientName(AssociationType, "TrafficControllerAssociationType", "csharp");
 @@clientName(Frontend, "TrafficControllerFrontend", "csharp");
 @@clientName(PolicyType,


### PR DESCRIPTION
Follow-up cleanup of csharp-scoped @@clientName overrides that conflict with the new behavior introduced in azure-typespec/http-client-csharp-mgmt (Azure/azure-sdk-for-net#59096), where csharp-scoped @@clientName on resource update models and list service methods now wins over the generator's auto-derived default.

In each case below, the shipped C# SDK name matched the new default, so the override was causing unintended model / method renames in the version bump PR (Azure/azure-sdk-for-net#59170).

Companion to #43050.

### Changes

- **cdn**: removed 5 `*UpdateParameters` -> * overrides (`FrontDoorCustomDomain/Endpoint/Origin/OriginGroup` and `WebAgentKnowledgeSource`)
- **chaos**: scoped `Experiments.listAll -> `getExperiments` ` from `csharp` to `!csharp`
- **networkfunction**: scoped `azureTrafficCollectorsBySubscriptionList -> List ` to `!csharp`
- **servicenetworking**: removed `AssociationUpdate -> TrafficControllerAssociationUpdate ` override
- **billingbenefits**: removed `SavingsPlanUpdateRequest -> SavingsPlanUpdateContent ` and `DiscountPatchRequest -> DiscountPatchContent ` overrides