### PR TITLE
Move security gating from preview to GA 2026-04-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -3251,7 +3251,7 @@ model ManagedClusterSecurityProfileDefender {
   /**
    * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
    */
-  @added(Versions.v2026_04_02_preview)
+  @added(Versions.v2026_04_01)
   securityGating?: ManagedClusterSecurityProfileDefenderSecurityGating;
 }
 
@@ -3268,7 +3268,7 @@ model ManagedClusterSecurityProfileDefenderSecurityMonitoring {
 /**
  * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
  */
-@added(Versions.v2026_04_02_preview)
+@added(Versions.v2026_04_01)
 model ManagedClusterSecurityProfileDefenderSecurityGating {
   /**
    * Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules.
@@ -3288,7 +3288,7 @@ model ManagedClusterSecurityProfileDefenderSecurityGating {
 }
 
 /** Identity information used by Defender security gating to access container registries. */
-@added(Versions.v2026_04_02_preview)
+@added(Versions.v2026_04_01)
 model ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem {
   /**
    * The container registry for which the identity will be used; the identity specified here should have a federated identity credential attached to it.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
@@ -8260,6 +8260,46 @@
         "securityMonitoring": {
           "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityMonitoring",
           "description": "Microsoft Defender threat detection for Cloud settings for the security profile."
+        },
+        "securityGating": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGating",
+          "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityGating": {
+      "type": "object",
+      "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules."
+        },
+        "identities": {
+          "type": "array",
+          "description": "List of identities that the admission controller will make use of in order to pull security artifacts from the registry. These are the same identities used by the cluster to pull container images. Each identity provided should have federated identity credential attached to it.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "allowSecretAccess": {
+          "type": "boolean",
+          "description": "In use only while registry access granted by secret rather than managed identity. Set whether to grant the Defender gating agent access to the cluster's secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform any image validation. Default value is false."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem": {
+      "type": "object",
+      "description": "Identity information used by Defender security gating to access container registries.",
+      "properties": {
+        "azureContainerRegistry": {
+          "type": "string",
+          "description": "The container registry for which the identity will be used; the identity specified here should have a federated identity credential attached to it."
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentity",
+          "description": "The identity object used to access the registry"
         }
       }
     },


### PR DESCRIPTION
Promote securityGating feature from v2026_04_02_preview to v2026_04_01 stable:
- ManagedClusterSecurityProfileDefender.securityGating
- ManagedClusterSecurityProfileDefenderSecurityGating model
- ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem model

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
