### PR TITLE
Add C# customizations for SecurityCenter SDK migration

### DIFF
--- a/specification/security/resource-manager/Microsoft.Security/Security/AlertsAPI/Alert.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/AlertsAPI/Alert.tsp
@@ -40,7 +40,7 @@ alias AlertOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the alert object */
@@ -128,7 +128,7 @@ alias AlertOperationGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the alert object */

--- a/specification/security/resource-manager/Microsoft.Security/Security/ApplicationsAPI/Application.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/ApplicationsAPI/Application.tsp
@@ -31,40 +31,56 @@ interface Applications {
   /**
    * Get a specific application for the requested scope by applicationId
    */
-  get is Azure.ResourceManager.Extension.Read<
-    Azure.ResourceManager.Extension.Subscription,
+  get is SubscriptionSecurityApplicationOps.Read<
     Application,
-    Error = CloudError
+    ErrorType = CloudError
   >;
 
   /**
    * Creates or update a security application on the given subscription.
    */
-  createOrUpdate is Azure.ResourceManager.Extension.CreateOrReplaceSync<
-    Azure.ResourceManager.Extension.Subscription,
+  createOrUpdate is SubscriptionSecurityApplicationOps.CreateOrUpdateSync<
     Application,
-    Error = CloudError
+    ErrorType = CloudError
   >;
 
   /**
    * Delete an Application over a given scope
    */
-  delete is Azure.ResourceManager.Extension.DeleteSync<
-    Azure.ResourceManager.Extension.Subscription,
+  delete is SubscriptionSecurityApplicationOps.DeleteSync<
     Application,
-    Error = CloudError
+    ErrorType = CloudError
   >;
 
   /**
    * Get a list of all relevant applications over a subscription level scope
    */
-  list is Azure.ResourceManager.Extension.ListByTarget<
-    Azure.ResourceManager.Extension.Subscription,
+  list is SubscriptionSecurityApplicationOps.List<
     Application,
     Response = ArmResponse<ApplicationsList>,
-    Error = CloudError
+    ErrorType = CloudError
   >;
 }
+alias SubscriptionSecurityApplicationOps = Azure.ResourceManager.Legacy.ExtensionOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+  },
+  {
+    ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<Application>;
+  },
+  {
+    ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<Application>;
+
+    /** The security Application key - unique key for the standard application */
+    @path
+    @segment("applications")
+    @key
+    applicationId: string;
+  },
+  "SubscriptionSecurityApplication"
+>;
+
 alias SecurityConnectorApplicationOps = Azure.ResourceManager.Legacy.ExtensionOperations<
   {
     ...ApiVersionParameter;
@@ -94,7 +110,8 @@ alias SecurityConnectorApplicationOps = Azure.ResourceManager.Legacy.ExtensionOp
     @segment("applications")
     @key
     applicationId: string;
-  }
+  },
+  "SecurityConnectorApplication"
 >;
 
 @armResourceOperations(#{ omitTags: true })

--- a/specification/security/resource-manager/Microsoft.Security/Security/AssessmentAPI/SecurityAssessmentMetadataResponse.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/AssessmentAPI/SecurityAssessmentMetadataResponse.tsp
@@ -44,7 +44,8 @@ alias SecurityAssessmentMetadataResponseOps = Azure.ResourceManager.Legacy.Exten
     @segment("assessmentMetadata")
     @key
     assessmentMetadataName: string;
-  }
+  },
+  ResourceName = "TenantAssessmentMetadata"
 >;
 
 @armResourceOperations(#{ omitTags: true })
@@ -86,7 +87,8 @@ alias AssessmentsMetadatumOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @key
     assessmentMetadataName: string;
   },
-  {}
+  {},
+  ResourceName = "SubscriptionAssessmentMetadata"
 >;
 
 @armResourceOperations(#{ omitTags: true })

--- a/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/AllowedConnectionsResource.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/AllowedConnectionsResource.tsp
@@ -46,7 +46,7 @@ model ArmLocationResource {
   @path
   @segment("locations")
   @key
-  ascLocation: string;
+  ascLocation: Azure.Core.azureLocation;
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/JitNetworkAccessPolicy.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/JitNetworkAccessPolicy.tsp
@@ -55,7 +55,7 @@ alias JitNetworkAccessPoliciesInitiateOps = Azure.ResourceManager.Legacy.RoutedO
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
 
     /** Name of a Just-in-Time access configuration policy. */
     @path

--- a/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/TopologyResource.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/TopologyResource.tsp
@@ -39,6 +39,15 @@ interface TopologyResources {
   /**
    * Gets a specific topology component.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserve existing stable swagger operationId."
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserve existing stable swagger example reference."
+  @operationId("Topology_Get")
+  @OpenAPI.extension(
+    "x-ms-examples",
+    #{
+      `Get topology`: #{ $ref: "./examples/Topology/GetTopology_example.json" },
+    }
+  )
   get is ArmResourceRead<
     TopologyResource,
     BaseParameters = {
@@ -56,6 +65,17 @@ interface TopologyResources {
   /**
    * Gets a list that allows to build a topology view of a subscription and location.
    */
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserve existing stable swagger operationId."
+  #suppress "@azure-tools/typespec-azure-core/no-openapi" "Preserve existing stable swagger example reference."
+  @operationId("Topology_ListByHomeRegion")
+  @OpenAPI.extension(
+    "x-ms-examples",
+    #{
+      `Get topology on a subscription from security data location`: #{
+        $ref: "./examples/Topology/GetTopologySubscriptionLocation_example.json",
+      },
+    }
+  )
   listByHomeRegion is Azure.ResourceManager.Extension.ListByTarget<
     Azure.ResourceManager.Extension.Subscription,
     TopologyResource,

--- a/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/back-compatible.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/SecuritySolutionsAPI/back-compatible.tsp
@@ -9,7 +9,7 @@ using Common;
 @@Legacy.flattenProperty(CloudError.error);
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@Legacy.flattenProperty(securitySolutionsReferenceData.properties);
+@@Legacy.flattenProperty(securitySolutionsReferenceData.properties, "!csharp");
 
 @@clientLocation(AllowedConnectionsResources.get, "AllowedConnections");
 @@clientLocation(
@@ -51,8 +51,14 @@ using Common;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(ServerVulnerabilityAssessment.properties);
 
-@@clientLocation(TopologyResources.get, "Topology");
-@@clientLocation(TopologyResources.listByHomeRegion, "Topology");
+@@clientLocation(TopologyResources.get, "TopologyResources", "csharp");
+@@clientLocation(
+  TopologyResources.listByHomeRegion,
+  "TopologyResources",
+  "csharp"
+);
+@@clientLocation(TopologyResources.get, "Topology", "javascript");
+@@clientLocation(TopologyResources.listByHomeRegion, "Topology", "javascript");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(TopologyResource.properties);
 
@@ -81,11 +87,13 @@ using Common;
 
 @@clientLocation(
   SecuritySolutionsReferenceDataOperationGroup.list,
-  "SecuritySolutionsReferenceData"
+  "SecuritySolutionsReferenceData",
+  "!csharp"
 );
 @@clientLocation(
   SecuritySolutionsReferenceDataOperationGroup.listByHomeRegion,
-  "SecuritySolutionsReferenceData"
+  "SecuritySolutionsReferenceData",
+  "!csharp"
 );
 
 @@clientLocation(TopologyOperationGroup.list, "Topology");

--- a/specification/security/resource-manager/Microsoft.Security/Security/TasksAPI/SecurityTask.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/TasksAPI/SecurityTask.tsp
@@ -41,7 +41,7 @@ alias SecurityTaskOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the task object, will be a GUID */
@@ -62,7 +62,7 @@ alias SecurityTaskBuildingOps = Azure.ResourceManager.Legacy.RoutedOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the task object, will be a GUID */
@@ -134,7 +134,7 @@ alias TaskOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the task object, will be a GUID */
@@ -155,7 +155,7 @@ alias TaskBuildingOps = Azure.ResourceManager.Legacy.RoutedOperations<
     @path
     @segment("locations")
     @key
-    ascLocation: string;
+    ascLocation: Azure.Core.azureLocation;
   },
   {
     /** Name of the task object, will be a GUID */

--- a/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/client.tsp
@@ -30,10 +30,13 @@ import "./SqlVulnerabilityAssessmentsAPI/main.tsp";
 import "./StandardsAPI/main.tsp";
 import "./SubAssessmentsAPI/main.tsp";
 import "./TasksAPI/main.tsp";
+import "./csharp-arm-models.tsp";
+import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-client-generator-core";
 import "@typespec/versioning";
 
 using Azure.ClientGenerator.Core;
+using Azure.ClientGenerator.Core.Legacy;
 using TypeSpec.Versioning;
 using TypeSpec.Http;
 using TypeSpec.Rest;
@@ -51,6 +54,9 @@ using LegacySettingsAPI;
 using SqlVulnerabilityAssessmentsAPI;
 using AlertsAPI;
 using ApiCollectionsAPI;
+using IoTSecurityAPI;
+using SecurityConnectorsAPI;
+using StandardsAPI;
 
 @client({
   name: "SecurityManagementClient",
@@ -92,9 +98,10 @@ using ApiCollectionsAPI;
 })
 namespace SecurityManagementClient;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-#suppress "@azure-tools/typespec-azure-core/casing-style" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-model `private-link-parameters` {
+/**
+ * A private link resource name parameter.
+ */
+model PrivateLinkNameParameter {
   /**
    * The name of the private link resource.
    */
@@ -112,10 +119,8 @@ op privateLinksGetCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
+  ...PrivateLinkNameParameter,
 ): ArmResponse<PrivateLinksAPI.PrivateLinkResource> | ErrorResponse;
 
 @@Azure.ClientGenerator.Core.override(
@@ -131,11 +136,8 @@ op privateLinksCreateCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   resource: PrivateLinksAPI.PrivateLinkResource,
 ):
   | ArmResourceUpdatedResponse<PrivateLinksAPI.PrivateLinkResource>
@@ -163,11 +165,8 @@ op privateLinksUpdateCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   properties: PrivateLinksAPI.PrivateLinkUpdate,
 ): ArmResponse<PrivateLinksAPI.PrivateLinkResource> | ErrorResponse;
 
@@ -189,10 +188,8 @@ op privateLinksDeleteCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
+  ...PrivateLinkNameParameter,
 ):
   | ArmDeleteAcceptedLroResponse<LroHeaders = ArmAsyncOperationHeader &
       Azure.Core.Foundations.RetryAfterHeader>
@@ -213,10 +210,8 @@ op privateLinksHeadCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
+  ...PrivateLinkNameParameter,
 ): OkResponse | ErrorResponse;
 
 @@Azure.ClientGenerator.Core.override(
@@ -225,6 +220,28 @@ op privateLinksHeadCustomization(
   "!python,!java,!javascript"
 );
 
+@@clientName(
+  defenderFoDatabasesAwsOffering,
+  "DefenderForDatabasesAwsOffering",
+  "csharp"
+);
+@@clientName(
+  DefenderFoDatabasesAwsOfferingArcAutoProvisioning,
+  "DefenderForDatabasesAwsOfferingArcAutoProvisioning",
+  "csharp"
+);
+@@clientName(
+  DefenderFoDatabasesAwsOfferingRds,
+  "DefenderForDatabasesAwsOfferingRds",
+  "csharp"
+);
+@@clientName(
+  DefenderFoDatabasesAwsOfferingDatabasesDspm,
+  "DefenderForDatabasesAwsOfferingDatabasesDspm",
+  "csharp"
+);
+@@access(DefenderFoDatabasesAwsOfferingDatabasesDspm, Access.public, "csharp");
+
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 op privateEndpointConnectionsListCustomization(
@@ -232,10 +249,8 @@ op privateEndpointConnectionsListCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
+  ...PrivateLinkNameParameter,
 ):
   | ArmResponse<ResourceListResult<PrivateLinksAPI.PrivateEndpointConnection>>
   | ErrorResponse;
@@ -253,11 +268,8 @@ op privateEndpointConnectionsGetCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   privateEndpointConnectionName: string,
 ): ArmResponse<Azure.ResourceManager.PrivateEndpointConnection> | ErrorResponse;
 
@@ -274,11 +286,8 @@ op privateEndpointConnectionsCreateOrUpdateCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   privateEndpointConnectionName: string,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -310,11 +319,8 @@ op privateEndpointConnectionsDeleteCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   privateEndpointConnectionName: string,
 ):
@@ -336,10 +342,8 @@ op privateLinkResourcesListCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
+  ...PrivateLinkNameParameter,
 ): ArmResponse<ResourceListResult<PrivateLinkGroupResource>> | ErrorResponse;
 
 @@Azure.ClientGenerator.Core.override(
@@ -355,11 +359,8 @@ op privateLinkResourcesGetCustomization(
   ...SubscriptionIdParameter,
   ...ResourceGroupParameter,
   ...Azure.ResourceManager.Legacy.Provider,
-
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-  @query
-  privateLinkName: `private-link-parameters`,
-
+  ...PrivateLinkNameParameter,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
   groupId: string,
 ): ArmResponse<PrivateLinkGroupResource> | ErrorResponse;
@@ -391,7 +392,7 @@ op privateLinkResourcesGetCustomization(
 @@usage(
   IoTSecurityAPI.CustomAlertRule,
   Usage.input | Usage.output,
-  "go,javascript"
+  "go,javascript,csharp"
 );
 
 @@clientName(
@@ -442,6 +443,1542 @@ op privateLinkResourcesGetCustomization(
 
 @@clientName(Common.ResourceDetails, "CommonResourceDetails", "python");
 @@clientName(HealthReportsAPI.status, "StatusAutoGenerated", "python");
+
+// C# compatibility customizations are grouped by purpose.
+
+// C# client names.
+@@clientName(
+  Azure.ResourceManager.CommonTypes.PrivateEndpointConnection,
+  "ArmPrivateEndpointConnection",
+  "csharp"
+);
+@@clientName(
+  Azure.ResourceManager.CommonTypes.ActionType,
+  "ArmActionType",
+  "csharp"
+);
+@@clientName(HealthReportsAPI.status, "HealthReportStatus", "csharp");
+@@clientName(AutomationsAPI.Operator.Equals, "EqualsValue", "csharp");
+@@clientName(LegacySettingsAPI.AutoProvision, "AutoProvisionState", "csharp");
+@@clientName(
+  AssessmentAPI.ExpandEnum,
+  "SecurityAssessmentODataExpand",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.MinimalSeverity,
+  "SecurityAlertMinimalSeverity",
+  "csharp"
+);
+@@clientName(
+  SecureScoreAPI.ExpandControlsEnum,
+  "SecurityScoreODataExpand",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.Type,
+  "VulnerabilityAssessmentAutoProvisioningType",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.ArcAutoProvisioningConfiguration,
+  "DefenderForDatabasesAwsOfferingArcAutoProvisioningConfiguration",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GcpOrganizationalDataMember,
+  "GcpMemberOrganizationalInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GcpOrganizationalDataOrganization,
+  "GcpParentOrganizationalInfo",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RuleType,
+  "VulnerabilityAssessmentRuleType",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.Remediation,
+  "SqlVulnerabilityAssessmentRemediation",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.VaRule,
+  "VulnerabilityAssessmentRule",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.QueryCheck,
+  "VulnerabilityAssessmentRuleQueryCheck",
+  "csharp"
+);
+@@usage(
+  SqlVulnerabilityAssessmentsAPI.ScanResultProperties,
+  Usage.input,
+  "csharp"
+);
+@@usage(SqlVulnerabilityAssessmentsAPI.Remediation, Usage.input, "csharp");
+@@usage(SqlVulnerabilityAssessmentsAPI.VaRule, Usage.input, "csharp");
+@@usage(SqlVulnerabilityAssessmentsAPI.QueryCheck, Usage.input, "csharp");
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RulesResultsInput,
+  "RulesResultsContent",
+  "csharp"
+);
+@@clientName(SecurityConnectorsAPI.SubPlan, "AvailableSubPlanType", "csharp");
+@@clientName(StandardsAPI.Assignment, "SecurityCenterAssignment", "csharp");
+@@clientName(StandardsAPI.Standard, "SecurityCenterStandard", "csharp");
+@@clientName(
+  PrivateLinksAPI.PrivateLinkGroupResource,
+  "PrivateLinkGroup",
+  "csharp"
+);
+@@clientName(
+  SubAssessmentsAPI.SecuritySubAssessmentProperties.id,
+  "VulnerabilityId",
+  "csharp"
+);
+
+@@clientName(
+  IoTSecurityAPI.IoTSecuritySolutionModel,
+  "IotSecuritySolution",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityAggregatedAlert,
+  "IotSecurityAggregatedAlert",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityAggregatedRecommendation,
+  "IotSecurityAggregatedRecommendation",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecuritySolutionAnalyticsModel,
+  "IotSecuritySolutionAnalyticsModel",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityAggregatedAlertPropertiesTopDevicesListItem,
+  "IotSecurityAggregatedAlertTopDevice",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.ExportData,
+  "IotSecuritySolutionExportOption",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.DataSource,
+  "IotSecuritySolutionDataSource",
+  "csharp"
+);
+@@clientName(IoTSecurityAPI.IoTSeverityMetrics, "IotSeverityMetrics", "csharp");
+@@clientName(
+  IoTSecurityAPI.IoTSecuritySolutionAnalyticsModelPropertiesDevicesMetricsItem,
+  "IotSecuritySolutionAnalyticsModelDevicesMetrics",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityAlertedDevice,
+  "IotSecurityAlertedDevice",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityDeviceAlert,
+  "IotSecurityDeviceAlert",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityDeviceRecommendation,
+  "IotSecurityDeviceRecommendation",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.ConnectionToIpNotAllowed,
+  "ConnectionToIPNotAllowed",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.ConnectionFromIpNotAllowed,
+  "ConnectionFromIPNotAllowed",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.UnmaskedIpLoggingStatus,
+  "UnmaskedIPLoggingStatus",
+  "csharp"
+);
+@@usage(
+  SecuritySolutionsAPI.ServerVulnerabilityAssessment,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  ComplianceResultsAPI.ComplianceResult,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  IoTSecurityAPI.IoTSecurityAggregatedAlert,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  IoTSecurityAPI.IoTSecurityAggregatedRecommendation,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  IoTSecurityAPI.IoTSecuritySolutionAnalyticsModel,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  RegulatoryComplianceAPI.RegulatoryComplianceAssessment,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  RegulatoryComplianceAPI.RegulatoryComplianceControl,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  RegulatoryComplianceAPI.RegulatoryComplianceStandard,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(SecureScoreAPI.SecureScoreItem, Usage.input | Usage.output, "csharp");
+@@usage(AlertsAPI.Alert, Usage.input | Usage.output, "csharp");
+@@usage(LocationsAPI.AscLocation, Usage.input | Usage.output, "csharp");
+@@usage(LegacySettingsAPI.Compliance, Usage.input | Usage.output, "csharp");
+@@usage(
+  SubAssessmentsAPI.SecuritySubAssessment,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(TasksAPI.SecurityTask, Usage.input | Usage.output, "csharp");
+@@clientName(AlertsAPI.Alert, "SecurityAlert", "csharp");
+@@clientName(
+  AlertsAPI.AlertSimulatorRequestBody,
+  "SecurityAlertSimulatorContent",
+  "csharp"
+);
+@@clientName(SecureScoreAPI.SecureScoreItem, "SecureScore", "csharp");
+@@clientName(
+  AlertsSuppressionRulesAPI.AlertsSuppressionRule,
+  "SecurityAlertsSuppressionRule",
+  "csharp"
+);
+@@clientName(
+  AlertsSuppressionRulesAPI.AlertsSuppressionRuleProperties.lastModifiedUtc,
+  "LastModifiedOn",
+  "csharp"
+);
+@@clientName(
+  AlertsSuppressionRulesAPI.AlertsSuppressionRuleProperties.expirationDateUtc,
+  "ExpireOn",
+  "csharp"
+);
+@@clientName(
+  AlertsSuppressionRulesAPI.RuleState,
+  "SecurityAlertsSuppressionRuleState",
+  "csharp"
+);
+@@clientName(
+  AlertsSuppressionRulesAPI.SuppressionAlertsScope.allOf,
+  "SuppressionAlertsScopeAllOf",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required to preserve the existing C# flattened SecurityAlertsSuppressionRule shape."
+@@flattenProperty(
+  AlertsSuppressionRulesAPI.AlertsSuppressionRuleProperties.suppressionAlertsScope,
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessment,
+  "SecurityAssessmentCreateOrUpdateContent",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentResponse,
+  "SecurityAssessment",
+  "csharp"
+);
+@@clientName(AutomationsAPI.Automation, "SecurityAutomation", "csharp");
+@@clientName(
+  AutomationsAPI.AutomationScope,
+  "SecurityAutomationScope",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationSource,
+  "SecurityAutomationSource",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationRuleSet,
+  "SecurityAutomationRuleSet",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationTriggeringRule,
+  "SecurityAutomationTriggeringRule",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationAction,
+  "SecurityAutomationAction",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationActionLogicApp,
+  "SecurityAutomationActionLogicApp",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationActionEventHub,
+  "SecurityAutomationActionEventHub",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationActionWorkspace,
+  "SecurityAutomationActionWorkspace",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.PropertyType,
+  "AutomationTriggeringRulePropertyType",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.Operator,
+  "AutomationTriggeringRuleOperator",
+  "csharp"
+);
+@@clientName(AutomationsAPI.EventSource, "SecurityEventSource", "csharp");
+@@clientName(LocationsAPI.AscLocation, "SecurityCenterLocation", "csharp");
+@@clientName(PricingsAPI.Pricing, "SecurityCenterPricing", "csharp");
+@@clientName(LegacySettingsAPI.Compliance, "SecurityCompliance", "csharp");
+@@clientName(LegacySettingsAPI.Rank, "SensitivityLabelRank", "csharp");
+@@clientName(ApplicationsAPI.Application, "SecurityApplication", "csharp");
+@@clientName(SettingsAPI.Setting, "SecuritySetting", "csharp");
+@@clientName(
+  LegacySettingsAPI.WorkspaceSetting,
+  "SecurityWorkspaceSetting",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadata,
+  "SecurityAssessmentMetadataGenerated",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadataResponse,
+  "SecurityAssessmentMetadata",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RuleResults,
+  "SqlVulnerabilityAssessmentBaselineRule",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanV2,
+  "SqlVulnerabilityAssessmentScan",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.Categories,
+  "SecurityAssessmentResourceCategory",
+  "csharp"
+);
+@@clientName(Common.Severity, "SecurityAssessmentSeverity", "csharp");
+@@clientName(
+  AssessmentAPI.UserImpact,
+  "SecurityAssessmentUserImpact",
+  "csharp"
+);
+@@clientName(AssessmentAPI.Threats, "SecurityThreat", "csharp");
+@@clientName(AssessmentAPI.AssessmentType, "SecurityAssessmentType", "csharp");
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadataPartnerData,
+  "SecurityAssessmentMetadataPartner",
+  "csharp"
+);
+@@clientName(IoTSecurityAPI.ValueType, "SecurityValueType", "csharp");
+@@clientName(IoTSecurityAPI.ValueType.IpCidr, "IPCidr", "csharp");
+@@clientName(
+  SecuritySolutionsAPI.Protocol,
+  "JitNetworkAccessPortProtocol",
+  "csharp"
+);
+@@clientName(SecuritySolutionsAPI.Protocol.TCP, "Tcp", "csharp");
+@@clientName(SecuritySolutionsAPI.Protocol.UDP, "Udp", "csharp");
+@@clientName(
+  SecuritySolutionsAPI.ExternalSecuritySolutionKind.AAD,
+  "Aad",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ExternalSecuritySolutionKind.ATA,
+  "Ata",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ExternalSecuritySolutionKind.CEF,
+  "Cef",
+  "csharp"
+);
+
+@@clientName(
+  SecuritySolutionsAPI.Status,
+  "JitNetworkAccessPortStatus",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.StatusReason,
+  "JitNetworkAccessPortStatusReason",
+  "csharp"
+);
+
+@@clientName(SubAssessmentsAPI.CVSS, "SecurityCvss", "csharp");
+@@clientName(SubAssessmentsAPI.CVE, "SecurityCve", "csharp");
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.Baseline,
+  "SqlVulnerabilityAssessmentBaseline",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RuleStatus,
+  "SqlVulnerabilityAssessmentScanResultRuleStatus",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanPropertiesV2,
+  "SqlVulnerabilityAssessmentScanProperties",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanResult,
+  "SqlVulnerabilityAssessmentScanResult",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanResultProperties,
+  "SqlVulnerabilityAssessmentScanResultProperties",
+  "csharp"
+);
+@@access(
+  SqlVulnerabilityAssessmentsAPI.SqlVulnerabilityAssessmentScanResults.get,
+  Access.internal,
+  "csharp"
+);
+@@access(
+  SqlVulnerabilityAssessmentsAPI.SqlVulnerabilityAssessmentScanResults.list,
+  Access.internal,
+  "csharp"
+);
+@@clientName(Common.State, "SecurityAlertNotificationByRoleState", "csharp");
+@@clientName(
+  AutomationsAPI.SecurityContactRole,
+  "SecurityAlertReceivingRole",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.DefenderForServersAwsOfferingVaAutoProvisioning,
+  "DefenderForServersAwsOfferingVulnerabilityAssessmentAutoProvisioning",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.DefenderForServersGcpOfferingDefenderForServers,
+  "GcpDefenderForServersInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.ScanningMode,
+  "DefenderForServersScanningMode",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.DefenderForDatabasesGcpOfferingDefenderForDatabasesArcAutoProvisioning,
+  "GcpDefenderForDatabasesArcAutoProvisioning",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType,
+  "IotSecurityRecommendationType",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_ACRAuthentication,
+  "IotAcrAuthentication",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_AgentSendsUnutilizedMessages,
+  "IotAgentSendsUnutilizedMessages",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_Baseline,
+  "IotBaseline",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_EdgeHubMemOptimize,
+  "IotEdgeHubMemOptimize",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_EdgeLoggingOptions,
+  "IotEdgeLoggingOptions",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_InconsistentModuleSettings,
+  "IotInconsistentModuleSettings",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_InstallAgent,
+  "IotInstallAgent",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_IPFilter_DenyAll,
+  "IotIPFilterDenyAll",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_IPFilter_PermissiveRule,
+  "IotIPFilterPermissiveRule",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_OpenPorts,
+  "IotOpenPorts",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_PermissiveFirewallPolicy,
+  "IotPermissiveFirewallPolicy",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_PermissiveInputFirewallRules,
+  "IotPermissiveInputFirewallRules",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_PermissiveOutputFirewallRules,
+  "IotPermissiveOutputFirewallRules",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_PrivilegedDockerOptions,
+  "IotPrivilegedDockerOptions",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_SharedCredentials,
+  "IotSharedCredentials",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.RecommendationType.IoT_VulnerableTLSCipherSuite,
+  "IotVulnerableTlsCipherSuite",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanTriggerType,
+  "SqlVulnerabilityAssessmentScanTriggerType",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.ScanState,
+  "SqlVulnerabilityAssessmentScanState",
+  "csharp"
+);
+@@clientName(
+  AlertsSuppressionRulesAPI.ScopeElement,
+  "SuppressionAlertsScopeElement",
+  "csharp"
+);
+
+@@clientName(
+  SecuritySolutionsAPI.DiscoveredSecuritySolutionsOperationGroup.list,
+  "GetDiscoveredSecuritySolutions",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ExternalSecuritySolutionsOperationGroup.list,
+  "GetExternalSecuritySolutions",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessPoliciesOperationGroup.list,
+  "GetJitNetworkAccessPolicies",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessPoliciesOperationGroup.listByResourceGroup,
+  "GetJitNetworkAccessPoliciesByResourceGroup",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.SecuritySolutionsOperationGroup.list,
+  "GetSecuritySolutions",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.SecuritySolutionsReferenceDataOperationGroup.list,
+  "GetAllSecuritySolutionsReferenceData",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.AllowedConnectionsOperationGroup.list,
+  "GetAllowedConnections",
+  "csharp"
+);
+@@clientName(
+  MdeOnboardingAPI.MdeOnboardings.list,
+  "GetMdeOnboardings",
+  "csharp"
+);
+@@clientName(
+  ApiCollectionsAPI.ApiCollections.listBySubscription,
+  "GetSecurityCenterApiCollections",
+  "csharp"
+);
+@@clientName(AlertsAPI.AlertsOperationGroup.list, "GetAlerts", "csharp");
+@@clientName(TasksAPI.TasksOperationGroup.list, "GetTasks", "csharp");
+@@clientName(
+  SecureScoreAPI.SecureScoreControlsOperationGroup.list,
+  "GetSecureScoreControls",
+  "csharp"
+);
+@@clientName(
+  SecureScoreAPI.SecureScoreControlDefinitionsOperationGroup.list,
+  "GetSecureScoreControlDefinitions",
+  "csharp"
+);
+@@clientName(
+  SecureScoreAPI.SecureScoreControlDefinitionsOperationGroup.listBySubscription,
+  "GetSecureScoreControlDefinitionsBySubscription",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.GetSensitivitySettingsResponse,
+  "SensitivitySetting",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.GetSensitivitySettingsResponseProperties,
+  "SensitivitySettingsProperties",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.GetSensitivitySettingsResponses.list,
+  "GetSensitivitySettings",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.GetSensitivitySettingsListResponse,
+  "SensitivitySettingsListResult",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.TopologyOperationGroup.list,
+  "GetTopologies",
+  "csharp"
+);
+@@clientName(
+  ApiCollectionsAPI.ApiCollectionsOperationGroup.listByResourceGroup,
+  "GetApiCollections",
+  "csharp"
+);
+@@clientName(
+  OperationsAPI.OperationResultsOperationGroup.get,
+  "GetOperationResult",
+  "csharp"
+);
+@@clientName(
+  OperationsAPI.OperationStatusesOperationGroup.get,
+  "GetOperationStatus",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.Alerts.updateSubscriptionLevelStateToActivate,
+  "Activate",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.AlertOperationGroup.updateResourceGroupLevelStateToActivate,
+  "Activate",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.Alerts.updateSubscriptionLevelStateToDismiss,
+  "Dismiss",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.AlertOperationGroup.updateResourceGroupLevelStateToDismiss,
+  "Dismiss",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.Alerts.updateSubscriptionLevelStateToResolve,
+  "Resolve",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.AlertOperationGroup.updateResourceGroupLevelStateToResolve,
+  "Resolve",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.Alerts.updateSubscriptionLevelStateToInProgress,
+  "UpdateSatateToInProgress",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Subscription and resource-group alert operations intentionally share the legacy C# action name."
+@@clientName(
+  AlertsAPI.AlertOperationGroup.updateResourceGroupLevelStateToInProgress,
+  "UpdateSatateToInProgress",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.DevOpsConfigurations.listAvailable,
+  "GetAvailableAzureDevOpsOrganizations",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.DevOpsConfigurations.gitHubOwnersListAvailable,
+  "GetAvailableGitHubOwners",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.DevOpsConfigurations.gitLabGroupsListAvailable,
+  "GetAvailableGitLabGroups",
+  "csharp"
+);
+@@clientName(
+  CSharpExternalSecuritySolutionReplacement,
+  "ExternalSecuritySolution",
+  "csharp"
+);
+@@clientName(
+  CSharpCefExternalSecuritySolutionReplacement,
+  "CefExternalSecuritySolution",
+  "csharp"
+);
+@@clientName(
+  CSharpAtaExternalSecuritySolutionReplacement,
+  "AtaExternalSecuritySolution",
+  "csharp"
+);
+@@clientName(
+  CSharpAadExternalSecuritySolutionReplacement,
+  "AadExternalSecuritySolution",
+  "csharp"
+);
+@@clientName(
+  CSharpSecurityAssessmentStatusResult,
+  "SecurityAssessmentStatusResult",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ConnectableResource,
+  "ConnectableResourceInfo",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ConnectedResource,
+  "ConnectedResourceInfo",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.AllowedConnectionsResource,
+  "SecurityCenterAllowedConnection",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.TopologyResource,
+  "SecurityTopology",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.ExternalSecuritySolutions.listByHomeRegion,
+  "GetExternalSecuritySolutionsByHomeRegion",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationValidationStatus,
+  "SecurityAutomationValidationStatus",
+  "csharp"
+);
+@@clientName(
+  AutomationsAPI.AutomationUpdateModel,
+  "SecurityAutomationPatch",
+  "csharp"
+);
+@@clientName(Common.Tags, "SecurityCenterPatchTags", "csharp");
+@@clientName(
+  AssessmentAPI.AssessmentStatus,
+  "SecurityAssessmentStatus",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.AssessmentStatusCode,
+  "SecurityAssessmentStatusCode",
+  "csharp"
+);
+@@clientName(
+  ComplianceResultsAPI.ResourceStatus,
+  "SecurityAssessmentResourceStatus",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.SeverityEnum,
+  "CustomRecommendationSeverity",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.SecurityIssue,
+  "CustomRecommendationSecurityIssue",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadataPropertiesResponse,
+  "SecurityAssessmentMetadataPropertiesResult",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadataPropertiesResponsePublishDates,
+  "SecurityAssessmentPublishDates",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentPartnerData,
+  "SecurityAssessmentPartner",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.AzureDevOpsOrgListResponse,
+  "AzureDevOpsOrgListResult",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitHubOwnerListResponse,
+  "GitHubOwnerListResult",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitLabGroupListResponse,
+  "GitLabGroupListResult",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.IssueCreationRequest,
+  "IssueCreationContent",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessPolicyInitiateRequest,
+  "JitNetworkAccessPolicyInitiateContent",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessRequest,
+  "JitNetworkAccessRequestInfo",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecuritySolutionProperties.unmaskedIpLoggingStatus,
+  "UnmaskedIPLoggingStatus",
+  "csharp"
+);
+@@clientName(
+  TasksAPI.SecurityTaskProperties,
+  "SecurityTaskPropertiesInfo",
+  "csharp"
+);
+@@clientName(
+  TasksAPI.SecurityTaskParameters,
+  "SecurityTaskProperties",
+  "csharp"
+);
+@@usage(TasksAPI.SecurityTask, Usage.input | Usage.output, "csharp");
+@@usage(TasksAPI.SecurityTaskProperties, Usage.input, "csharp");
+@@clientName(
+  SensitivitySettingsAPI.UpdateSensitivitySettingsRequest,
+  "SensitivitySettingCreateOrUpdateContent",
+  "csharp"
+);
+@@clientName(
+  SensitivitySettingsAPI.Label,
+  "InformationProtectionSensitivityLabel",
+  "csharp"
+);
+@@clientName(HealthReportsAPI.issue, "SecurityHealthIssue", "csharp");
+@@clientName(
+  SecurityConnectorsAPI.EnvironmentData,
+  "SecurityConnectorEnvironment",
+  "csharp"
+);
+@@clientName(SecurityConnectorsAPI.CloudName.AWS, "Aws", "csharp");
+@@clientName(SecurityConnectorsAPI.CloudName.GCP, "Gcp", "csharp");
+@@clientName(
+  SecurityConnectorsAPI.AwsEnvironmentData,
+  "AwsEnvironment",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GcpOrganizationalData,
+  "GcpOrganizationalInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GcpProjectEnvironmentData,
+  "GcpProjectEnvironment",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GithubScopeEnvironmentData,
+  "GithubScopeEnvironment",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.AzureDevOpsScopeEnvironmentData,
+  "AzureDevOpsScopeEnvironment",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.GitlabScopeEnvironmentData,
+  "GitlabScopeEnvironmentInfo",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.AadConnectivityState,
+  "AadConnectivityStateType",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.DockerHubEnvironmentData,
+  "DockerHubEnvironmentInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.JFrogEnvironmentData,
+  "JFrogEnvironmentInfo",
+  "csharp"
+);
+@@clientName(
+  GovernanceAPI.GovernanceAssignmentAdditionalData,
+  "GovernanceAssignmentAdditionalInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.StandardAssignmentPropertiesExemptionData,
+  "StandardAssignmentExemptionInfo",
+  "csharp"
+);
+@@clientName(
+  SecurityStandardsAPI.StandardAssignmentPropertiesAttestationData,
+  "StandardAssignmentAttestationInfo",
+  "csharp"
+);
+@@clientName(TasksAPI.SecurityTaskParameters.name, "TaskName", "csharp");
+@@clientName(
+  TasksAPI.SecurityTaskProperties.creationTimeUtc,
+  "CreatedOn",
+  "csharp"
+);
+@@clientName(
+  TasksAPI.SecurityTaskProperties.lastStateChangeTimeUtc,
+  "LastStateChangedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.cloudOffering,
+  "SecurityCenterCloudOffering",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.AwsOrganizationalData,
+  "AwsOrganizationalInfo",
+  "csharp"
+);
+@@clientName(
+  AlertsAPI.ResourceIdentifier,
+  "SecurityAlertResourceIdentifier",
+  "csharp"
+);
+@@clientName(AlertsAPI.AlertSeverity, "SecurityAlertSeverity", "csharp");
+@@clientName(AlertsAPI.Intent, "KillChainIntent", "csharp");
+@@clientName(AlertsAPI.AlertStatus, "SecurityAlertStatus", "csharp");
+@@clientName(AlertsAPI.AlertEntity, "SecurityAlertEntity", "csharp");
+@@clientName(
+  AlertsAPI.AlertPropertiesSupportingEvidence,
+  "SecurityAlertSupportingEvidence",
+  "csharp"
+);
+@@clientName(AlertsAPI.AlertEntity.type, "AlertEntityType", "csharp");
+@@clientName(
+  AlertsAPI.AlertPropertiesSupportingEvidence.type,
+  "SecurityAlertSupportingEvidenceType",
+  "csharp"
+);
+@@clientName(
+  AlertsAPI.AlertSimulatorRequestProperties,
+  "SecurityAlertSimulatorRequestProperties",
+  "csharp"
+);
+@@clientName(AlertsAPI.AlertProperties.startTimeUtc, "StartOn", "csharp");
+@@clientName(AlertsAPI.AlertProperties.endTimeUtc, "EndOn", "csharp");
+@@clientName(
+  AlertsAPI.AlertProperties.timeGeneratedUtc,
+  "GeneratedOn",
+  "csharp"
+);
+@@clientName(
+  AlertsAPI.AlertProperties.processingEndTimeUtc,
+  "ProcessingEndOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.AzureDevOpsOrgProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.AzureDevOpsProjectProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.AzureDevOpsRepositoryProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.DevOpsConfigurationProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitHubOwnerProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitHubRepositoryProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitLabGroupProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsDevOpsAPI.GitLabProjectProperties.provisioningStatusUpdateTimeUtc,
+  "ProvisioningStatusUpdatedOn",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessRequest.startTimeUtc,
+  "StartOn",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessRequestPort.endTimeUtc,
+  "EndOn",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessPolicyInitiatePort.endTimeUtc,
+  "EndOn",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.IoTSecurityAggregatedAlertProperties.aggregatedDateUtc,
+  "AggregatedOn",
+  "csharp"
+);
+@@clientName(
+  SubAssessmentsAPI.SecuritySubAssessmentProperties.timeGenerated,
+  "GeneratedOn",
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.SecurityAssessmentMetadataProperties.preview,
+  "IsPreview",
+  "csharp"
+);
+@@clientName(AssessmentAPI.Tactics, "SecurityAssessmentTactic", "csharp");
+@@clientName(AssessmentAPI.Techniques, "SecurityAssessmentTechnique", "csharp");
+@@clientName(
+  SubAssessmentsAPI.AdditionalData,
+  "SecuritySubAssessmentAdditionalInfo",
+  "csharp"
+);
+@@clientName(
+  IoTSecurityAPI.TagsResource,
+  "SecurityCenterTagsResourceInfo",
+  "csharp"
+);
+
+// C# resource metadata customizations.
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve the existing C# subscription-level alert resource name"
+@@clientOption(
+  AlertsAPI.Alerts.getSubscriptionLevel,
+  "resource-name",
+  "SubscriptionSecurityAlert",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve the existing C# resource-group-level alert resource name"
+@@clientOption(
+  AlertsAPI.AlertOperationGroup.getResourceGroupLevel,
+  "resource-name",
+  "ResourceGroupSecurityAlert",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve the existing C# subscription-level task resource name"
+@@clientOption(
+  TasksAPI.SecurityTasks.getSubscriptionLevelTask,
+  "resource-name",
+  "SubscriptionSecurityTask",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve the existing C# resource-group-level task resource name"
+@@clientOption(
+  TasksAPI.Tasks.getResourceGroupLevelTask,
+  "resource-name",
+  "ResourceGroupSecurityTask",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Place simulate on the security alert collection for backward compatibility"
+@@clientOption(
+  AlertsAPI.AlertsOperationGroup.simulate,
+  "resource-operation-kind",
+  "CollectionAction",
+  "csharp"
+);
+
+// Operation status was not exposed by the previous C# generator and is excluded for compatibility.
+@@scope(OperationsAPI.OperationStatusesOperationGroup.get, "!csharp");
+
+// C# compatibility replacement: the external security solution discriminator hierarchy
+// is a legacy model surface, not an ARM resource surface. Keep replacement models
+// until the generator can preserve that API shape with SDK custom base code.
+// C# compatibility replacement for the external security solution resource shape.
+#suppress "@azure-tools/typespec-azure-core/casing-style" "C# compatibility replacement type uses the CSharp prefix to avoid changing service model names."
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Replacement model for C# compatibility because the generated resource hierarchy is not API-compatible with the legacy model hierarchy."
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+model CSharpExternalSecuritySolutionReplacement
+  extends Azure.ResourceManager.Foundations.Resource {
+  /** The external security solution kind. */
+  kind?: SecuritySolutionsAPI.ExternalSecuritySolutionKind;
+
+  /** The resource location. */
+  @visibility(Lifecycle.Read)
+  location?: azureLocation;
+}
+
+// C# compatibility replacement for the CEF external security solution resource shape.
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Replacement model for C# compatibility because the generated resource hierarchy is not API-compatible with the legacy model hierarchy."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Matches the original legacy custom resource shape."
+#suppress "@azure-tools/typespec-azure-core/casing-style" "C# compatibility replacement type uses the CSharp prefix to avoid changing service model names."
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+model CSharpCefExternalSecuritySolutionReplacement
+  extends CSharpExternalSecuritySolutionReplacement {
+  /** The CEF solution properties. */
+  properties?: SecuritySolutionsAPI.CefSolutionProperties;
+
+  /** The external security solution kind. */
+  kind: "CEF";
+}
+
+// C# compatibility replacement for the ATA external security solution resource shape.
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Replacement model for C# compatibility because the generated resource hierarchy is not API-compatible with the legacy model hierarchy."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Matches the original legacy custom resource shape."
+#suppress "@azure-tools/typespec-azure-core/casing-style" "C# compatibility replacement type uses the CSharp prefix to avoid changing service model names."
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+model CSharpAtaExternalSecuritySolutionReplacement
+  extends CSharpExternalSecuritySolutionReplacement {
+  /** The ATA solution properties. */
+  properties?: SecuritySolutionsAPI.AtaSolutionProperties;
+
+  /** The external security solution kind. */
+  kind: "ATA";
+}
+
+// C# compatibility replacement for the AAD external security solution resource shape.
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Replacement model for C# compatibility because the generated resource hierarchy is not API-compatible with the legacy model hierarchy."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "Matches the original legacy custom resource shape."
+#suppress "@azure-tools/typespec-azure-core/casing-style" "C# compatibility replacement type uses the CSharp prefix to avoid changing service model names."
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+model CSharpAadExternalSecuritySolutionReplacement
+  extends CSharpExternalSecuritySolutionReplacement {
+  /** The AAD solution properties. */
+  properties?: SecuritySolutionsAPI.AadSolutionProperties;
+
+  /** The external security solution kind. */
+  kind: "AAD";
+}
+
+// C# compatibility replacement: keep the GA property name FirstEvaluatedOn while
+// preserving the service wire name firstEvaluationDate.
+// C# compatibility replacement for the security assessment status result shape.
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "Replacement model preserves the legacy .NET model hierarchy and property names."
+#suppress "@azure-tools/typespec-azure-core/casing-style" "C# compatibility replacement type uses the CSharp prefix to avoid changing service model names."
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+model CSharpSecurityAssessmentStatusResult
+  extends AssessmentAPI.AssessmentStatus {
+  /**
+   * The time that the assessment was created and first evaluated. Returned as UTC time in ISO 8601 format
+   */
+  @visibility(Lifecycle.Read)
+  @encodedName("application/json", "firstEvaluationDate")
+  firstEvaluatedOn?: utcDateTime;
+
+  /**
+   * The time that the status of the assessment last changed. Returned as UTC time in ISO 8601 format
+   */
+  @visibility(Lifecycle.Read)
+  @encodedName("application/json", "statusChangeDate")
+  statusChangeOn?: utcDateTime;
+}
+
+@@clientName(
+  SecuritySolutionsAPI.securitySolutionsReferenceData,
+  "SecuritySolutionsReferenceInfo",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.securitySolutionsReferenceDataList,
+  "SecuritySolutionsReferenceInfoList",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.securitySolutionsReferenceDataProperties,
+  "SecuritySolutionsReferenceInfoProperties",
+  "csharp"
+);
+
+@@alternateType(
+  SecuritySolutionsAPI.JitNetworkAccessPortRule.maxRequestAccessDuration,
+  duration,
+  "csharp"
+);
+@@usage(
+  CSharpSecurityAssessmentStatusResult,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  CSharpExternalSecuritySolutionReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  CSharpCefExternalSecuritySolutionReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  CSharpAtaExternalSecuritySolutionReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@usage(
+  CSharpAadExternalSecuritySolutionReplacement,
+  Usage.input | Usage.output,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.ConnectableResource.id,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.ConnectedResource.connectedResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.Location.location,
+  azureLocation,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.JitNetworkAccessPolicy.location,
+  Azure.Core.azureLocation | null,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.DiscoveredSecuritySolution.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.AllowedConnectionsResource.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.SecuritySolution.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.TopologyResource.location,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+@@alternateType(
+  IoTSecurityAPI.IoTSecuritySolutionModel.location,
+  Azure.Core.azureLocation | null,
+  "csharp"
+);
+@@alternateType(AutomationsAPI.Automation.etag, Azure.Core.eTag, "csharp");
+@@alternateType(
+  SecurityConnectorsAPI.SecurityConnector.etag,
+  Azure.Core.eTag,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.ConnectedWorkspace.id,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  LegacySettingsAPI.WorkspaceSettingProperties.workspaceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  StandardsAPI.Assignment.location,
+  Azure.Core.azureLocation | null,
+  "csharp"
+);
+@@alternateType(
+  StandardsAPI.Standard.location,
+  Azure.Core.azureLocation | null,
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.CloudName,
+  "SecurityCenterCloudName",
+  "csharp"
+);
+@@clientName(PricingsAPI.PricingTier, "SecurityCenterPricingTier", "csharp");
+@@clientName(SecureScoreAPI.ControlType, "SecurityControlType", "csharp");
+@@clientName(SensitivitySettingsAPI.BuiltInInfoType.type, "Dns", "csharp");
+@@clientName(AlertsAPI.BundleType.DNS, "Dns", "csharp");
+@@clientName(
+  GovernanceAPI.GovernanceRuleProperties.includeMemberScopes,
+  "IsIncludeMemberScopes",
+  "csharp"
+);
+@@clientName(
+  PricingsAPI.PricingProperties.deprecated,
+  "IsDeprecated",
+  "csharp"
+);
+@@clientName(
+  SubAssessmentsAPI.ContainerRegistryVulnerabilityProperties.patchable,
+  "IsPatchable",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.DefenderCspmJFrogOfferingMdcContainersImageAssessment.enabled,
+  "IsMdcContainersImageAssessmentEnabled",
+  "csharp"
+);
+@@clientName(
+  DefenderForStorageAPI.DefenderForStorageSettingProperties.overrideSubscriptionLevelSettings,
+  "IsOverrideSubscriptionLevelSettings",
+  "csharp"
+);
+@@clientName(
+  LegacySettingsAPI.InformationProtectionKeyword.custom,
+  "IsCustom",
+  "csharp"
+);
+@@clientName(
+  LegacySettingsAPI.InformationProtectionKeyword.excluded,
+  "IsExcluded",
+  "csharp"
+);
+@@clientName(
+  LegacySettingsAPI.InformationType,
+  "SecurityInformationTypeInfo",
+  "csharp"
+);
+@@clientName(LegacySettingsAPI.InformationType.enabled, "IsEnabled", "csharp");
+@@clientName(LegacySettingsAPI.InformationType.custom, "IsCustom", "csharp");
+@@alternateType(
+  LegacySettingsAPI.InformationType.recommendedLabelId,
+  uuid,
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.Remediation.automated,
+  "IsAutomated",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RuleResultsProperties.latestScan,
+  "IsLatestScan",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RuleResultsInput.latestScan,
+  "IsLatestScan",
+  "csharp"
+);
+@@clientName(
+  SqlVulnerabilityAssessmentsAPI.RulesResultsInput.latestScan,
+  "IsLatestScan",
+  "csharp"
+);
+@@clientName(
+  SubAssessmentsAPI.ServerVulnerabilityProperties.patchable,
+  "IsPatchable",
+  "csharp"
+);
+@@clientName(
+  SecurityConnectorsAPI.Authentication,
+  "SecurityConnectorAuthentication",
+  "csharp"
+);
+@@clientName(
+  PrivateLinksAPI.PublicNetworkAccess,
+  "SecurityCenterPublicNetworkAccess",
+  "csharp"
+);
+@@clientName(
+  GovernanceAPI.OperationResult,
+  "SecurityCenterOperationResult",
+  "csharp"
+);
+@@clientName(Common.OperationStatus, "SecurityCenterOperationStatus", "csharp");
+@@clientName(
+  Azure.ResourceManager.CommonTypes.Identity,
+  "SecurityConnectorIdentity",
+  "csharp"
+);
+@@clientName(Common.ResourceDetails, "SecurityCenterResourceDetails", "csharp");
+@@clientName(
+  HealthReportsAPI.resourceDetails,
+  "SecurityCloudResourceDetails",
+  "csharp"
+);
+@@clientName(Common.Source, "SecurityCenterResourceSource", "csharp");
+@@clientName(
+  Common.ProvisioningState,
+  "SecurityCenterProvisioningState",
+  "csharp"
+);
+@@clientName(
+  DefenderForStorageAPI.BlobScanResultsOptions,
+  "BlobScanResultsConfig",
+  "csharp"
+);
+@@alternateType(
+  StandardsAPI.Assignment.etag,
+  Azure.Core.EtagProperty.etag,
+  "csharp"
+);
+@@alternateType(
+  StandardsAPI.Standard.etag,
+  Azure.Core.EtagProperty.etag,
+  "csharp"
+);
+@@alternateType(
+  HealthReportsAPI.environmentDetails.nativeResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  SecurityConnectorsDevOpsAPI.IssueCreationRequest.securityAssessmentResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  SecureScoreAPI.SecureScoreControlDefinitionItemProperties.assessmentDefinitions,
+  Azure.ResourceManager.Models.SubResource[],
+  "csharp"
+);
+@@clientName(
+  GovernanceAPI.GovernanceRuleOwnerSource.type,
+  "SourceType",
+  "csharp"
+);
+@@alternateType(
+  AssessmentAPI.OnPremiseResourceDetailsProperties.vmuuid,
+  uuid,
+  "csharp"
+);
+@@clientName(
+  AssessmentAPI.OnPremiseResourceDetailsProperties.vmuuid,
+  "VmUuid",
+  "csharp"
+);
+@@clientName(
+  SecuritySolutionsAPI.JitNetworkAccessPolicyVirtualMachine.publicIpAddress,
+  "PublicIPAddress",
+  "csharp"
+);
+@@alternateType(
+  AssessmentAPI.AssessmentStatusResponse,
+  CSharpSecurityAssessmentStatusResult,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.ExternalSecuritySolution,
+  CSharpExternalSecuritySolutionReplacement,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.CefExternalSecuritySolution,
+  CSharpCefExternalSecuritySolutionReplacement,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.AtaExternalSecuritySolution,
+  CSharpAtaExternalSecuritySolutionReplacement,
+  "csharp"
+);
+@@alternateType(
+  SecuritySolutionsAPI.AadExternalSecuritySolution,
+  CSharpAadExternalSecuritySolutionReplacement,
+  "csharp"
+);
+@@usage(AlertsAPI.AlertPropertiesSupportingEvidence, Usage.input, "csharp");
+@@alternateType(AlertsAPI.AlertProperties.alertUri, url, "csharp");
+
+// C# pageable operation customizations.
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Required to preserve the legacy C# pageable operation shape."
+@@markAsPageable(PricingsAPI.Pricings.list, "csharp");
+
+// Other language customizations.
 @@clientName(
   Azure.ResourceManager.CommonTypes.PrivateEndpointConnection,
   "ArmPrivateEndpointConnection",
@@ -463,14 +2000,37 @@ op privateLinkResourcesGetCustomization(
 @@clientName(OperationResultStatus, "OperationResult", "python");
 @@clientName(OperationResult, "OperationResultAutoGenerated", "python");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "To mitigate breaking change for legacy Python SDK"
-@@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(
+@@clientDefaultValue(
   AdvancedThreatProtectionSettingNameAlias.settingName,
   "current",
   "python"
 );
-@@Azure.ClientGenerator.Core.alternateType(
+@@alternateType(
   AdvancedThreatProtectionSettingNameAlias.settingName,
   "current"
+);
+// The C# management generator recognizes these resources as singleton resources only
+// when the final name parameter is modeled as a closed literal union. Keep the
+// service TypeSpec enum unchanged for other languages and apply the fixed name
+// only to C# to preserve the singleton-shaped SDK API.
+// C# fixed name for the advanced threat protection singleton resource.
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The enum is made closed for .NET SDK in order to recognize the corresponding resource a singleton"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+@clientName("AdvancedThreatProtectionSettingName")
+union CSharpAdvancedThreatProtectionSettingName {
+  /** Current. */
+  Current: "current",
+}
+
+@@alternateType(
+  AdvancedThreatProtectionSettingName,
+  CSharpAdvancedThreatProtectionSettingName,
+  "csharp"
+);
+@@alternateType(
+  AdvancedThreatProtectionSettingNameAlias.settingName,
+  CSharpAdvancedThreatProtectionSettingName,
+  "csharp"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "To mitigate breaking change for legacy Python SDK"
 @@Azure.ClientGenerator.Core.Legacy.clientDefaultValue(
@@ -491,6 +2051,29 @@ op privateLinkResourcesGetCustomization(
 @@Azure.ClientGenerator.Core.alternateType(
   ServerVulnerabilityAssessmentNameAlias.serverVulnerabilityAssessment,
   "default"
+);
+// The C# management generator recognizes these resources as singleton resources only
+// when the final name parameter is modeled as a closed literal union. Keep the
+// service TypeSpec enum unchanged for other languages and apply the fixed name
+// only to C# to preserve the singleton-shaped SDK API.
+// C# fixed name for the server vulnerability assessment singleton resource.
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The enum is made closed for .NET SDK in order to recognize the corresponding resource a singleton"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "C# compatibility replacement helper should not generate public XML docs."
+@clientName("ServerVulnerabilityAssessmentName", "csharp")
+union CSharpServerVulnerabilityAssessmentName {
+  /** Default. */
+  Default: "default",
+}
+
+@@Azure.ClientGenerator.Core.alternateType(
+  ServerVulnerabilityAssessmentName,
+  CSharpServerVulnerabilityAssessmentName,
+  "csharp"
+);
+@@Azure.ClientGenerator.Core.alternateType(
+  ServerVulnerabilityAssessmentNameAlias.serverVulnerabilityAssessment,
+  CSharpServerVulnerabilityAssessmentName,
+  "csharp"
 );
 
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -584,14 +2167,14 @@ op sqlVulnerabilityAssessmentScanResultsGet(
 op alertsListResourceGroupLevelByRegionCustomized(
   ...ApiVersionParameter,
   ...SubscriptionIdParameter,
+  ...ResourceGroupParameter,
+  ...Azure.ResourceManager.Legacy.Provider,
 
   /** The location where ASC stores the data of the subscription. can be retrieved from Get locations */
   @path
   @segment("locations")
-  ascLocation: string,
-
-  ...ResourceGroupParameter,
-  ...Azure.ResourceManager.Legacy.Provider,
+  @key
+  ascLocation: Azure.Core.azureLocation,
 ): ArmResponse<AlertList> | ErrorResponse;
 
 @@override(

--- a/specification/security/resource-manager/Microsoft.Security/Security/csharp-arm-models.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/csharp-arm-models.tsp
@@ -1,0 +1,11 @@
+import "@azure-tools/typespec-azure-resource-manager";
+
+// This model is defined in the ARM Models namespace so C# maps it to
+// Azure.ResourceManager.Resources.Models.SubResource via @@alternateType.
+namespace Azure.ResourceManager.Models {
+  /** Represents a reference to an existing resource by its id. */
+  model SubResource {
+    /** The resource id. */
+    id?: Azure.Core.armResourceIdentifier;
+  }
+}

--- a/specification/security/resource-manager/Microsoft.Security/Security/tspconfig.yaml
+++ b/specification/security/resource-manager/Microsoft.Security/Security/tspconfig.yaml
@@ -2,6 +2,9 @@ parameters:
   "service-dir":
     default: "sdk/security"
 options:
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.SecurityCenter"
+    emitter-output-dir: "{output-dir}/sdk/securitycenter/{namespace}"
   "@azure-tools/typespec-python":
     service-dir: "sdk/security"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-security"
@@ -27,6 +30,7 @@ options:
       SecurityManagementClient: SecurityCenter
     flavor: "azure"
     compatibility-lro: true
+    generate-sample: false
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-security"


### PR DESCRIPTION
## Summary

Adds C# customizations for the `Azure.ResourceManager.SecurityCenter` TypeSpec migration.

## Changes

- Merged latest `main` and resolved the Security `client.tsp` conflict.
- Point C# generation to `sdk/securitycenter` and namespace `Azure.ResourceManager.SecurityCenter`.
- Preserve C# compatibility names and shapes for migrated SecurityCenter resources, models, and enums.
- Move SDK review naming fixes into C#-scoped TypeSpec decorators so the SDK no longer needs broad naming suppressions.
- Exclude Security operation-status route from C# generation with `@@scope(..., "!csharp")` because the SDK is not expected to expose `GetOperationStatus`.
- Set legacy-template `ResourceName` values for multi-path Alert/Task/AssessmentMetadata sources so generated C# resources are source-specific instead of relying on SDK suppressions.
- Reordered custom alert discriminator fields so generated constructors compile without SDK bridge constructors.
- Type JIT `maxRequestAccessDuration` as `duration` so generated C# serialization uses ISO 8601 duration formatting.
- Add replacement-model customizations for Security Solutions compatibility where `@@hierarchyBuilding` is not safe for these shapes.

## Validation

Generated and built the .NET SDK locally from this specs branch with:

```pwsh
pwsh eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1 -Services "Azure.ResourceManager.SecurityCenter" -LocalSpecRepoPath ../azure-rest-api-specs -SaveInputs
dotnet build sdk/securitycenter/Azure.ResourceManager.SecurityCenter/src/Azure.ResourceManager.SecurityCenter.csproj --no-restore /p:UseSharedCompilation=false /p:RunApiCompat=false /p:ValidateRunApiCompat=false -v:minimal
```

Resource hierarchy/ApiCompat parity still has known remaining blockers documented in the linked SDK PR.

## Related

- SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/59180
- Issue: https://github.com/Azure/azure-sdk-for-net/issues/58968
