### PR TITLE
Use FoundryDataPlanePreviewOperation for EvaluationSuites operations

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4190,6 +4190,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },
@@ -4302,6 +4307,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -4132,72 +4132,6 @@
         }
       }
     },
-    "/evaluation_suites/{name}/run": {
-      "post": {
-        "operationId": "EvaluationSuites_run",
-        "description": "Run an evaluation using the suite's testing criteria and dataset.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the resource.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "The request has succeeded and a new resource has been created as a result.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EvaluationSuiteRunResponse"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EvaluationSuiteRunRequest"
-              }
-            }
-          }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "Evaluations=V1Preview"
-          ]
-        }
-      }
-    },
     "/evaluation_suites/{name}/versions": {
       "get": {
         "operationId": "EvaluationSuites_listVersions",
@@ -4253,18 +4187,6 @@
         "description": "Create a new EvaluationSuiteVersion with auto incremented version id",
         "parameters": [
           {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the resource.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "Foundry-Features",
             "in": "header",
             "required": false,
@@ -4275,6 +4197,25 @@
                 "Evaluations=V1Preview"
               ]
             }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the evaluation suite.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           }
         ],
         "responses": {
@@ -4290,23 +4231,25 @@
           },
           "default": {
             "description": "An unexpected error response.",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
             }
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSuiteVersionCreate"
+              }
+            }
+          },
+          "description": "The evaluation suite version to create."
         },
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -4502,6 +4445,83 @@
             }
           },
           "description": "The EvaluationSuiteVersion to create or update."
+        }
+      }
+    },
+    "/evaluation_suites/{name}:run": {
+      "post": {
+        "operationId": "EvaluationSuites_run",
+        "description": "Run an evaluation using the suite's testing criteria and dataset.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Evaluations=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the evaluation suite.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationSuiteRunResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSuiteRunRequest"
+              }
+            }
+          },
+          "description": "The run request parameters."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },
@@ -19299,6 +19319,100 @@
             "type": "string",
             "description": "The version of the resource.",
             "readOnly": true
+          }
+        },
+        "description": "An evaluation suite bundles testing criteria — an optional dataset, one or more\nevaluator configs with thresholds and init params — into a reusable, named artifact that\ncan gate agent changes across batch, scheduled, continuous, and CI/CD evals."
+      },
+      "EvaluationSuiteVersionCreate": {
+        "type": "object",
+        "required": [
+          "testing_criteria"
+        ],
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name.\nDoes not need to be unique. Shown in Foundry portal list views and eval reports."
+          },
+          "subtype": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationSuiteSubtype"
+              }
+            ],
+            "description": "Subtype of the evaluation suite."
+          },
+          "dataset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationDatasetReference"
+              }
+            ],
+            "description": "Dataset reference for evaluation.\nOptional — omit for evaluator-only suites where data comes from\nlive production traces or is provided at run time.\nThe referenced dataset must exist in the project's dataset registry."
+          },
+          "testing_criteria": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderLabelModel"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderStringCheck"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderTextSimilarity"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderPython"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderScoreModel"
+                },
+                {
+                  "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                }
+              ]
+            },
+            "minItems": 1,
+            "description": "Testing criteria — the evaluator configurations for this suite.\nSupports all grader types: azure_ai_evaluator, string_check, label_model,\nscore_model, text_similarity, python, etc.\nAt least one entry is required."
+          },
+          "target": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Target"
+              }
+            ],
+            "description": "Target for this evaluation suite. Uses the existing Target discriminated type\nfrom eval runs. Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.\nOptional — allows suites to exist without a target."
+          },
+          "input_messages": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference"
+              }
+            ],
+            "description": "How to send dataset rows to the target (agent or model).\nSupports template type (prompt with column placeholders) and\nitem_reference type (column containing pre-built messages)."
+          },
+          "evaluation_level": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationLevel"
+              }
+            ],
+            "description": "Default evaluation level for this suite. Can be overridden at run time."
+          },
+          "description": {
+            "type": "string",
+            "description": "The asset description text."
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Tag dictionary. Tags can be added, removed, and updated."
           }
         },
         "description": "An evaluation suite bundles testing criteria — an optional dataset, one or more\nevaluator configs with thresholds and init params — into a reusable, named artifact that\ncan gate agent changes across batch, scheduled, continuous, and CI/CD evals."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2808,6 +2808,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/EvaluationSuiteRunRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions:
     get:
       operationId: EvaluationSuites_listVersions
@@ -2877,6 +2880,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions/{version}:
     get:
       operationId: EvaluationSuites_getVersion

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2771,46 +2771,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-  /evaluation_suites/{name}/run:
-    post:
-      operationId: EvaluationSuites_run
-      description: Run an evaluation using the suite's testing criteria and dataset.
-      parameters:
-        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
-        - name: name
-          in: path
-          required: true
-          description: The name of the resource.
-          schema:
-            type: string
-      responses:
-        '201':
-          description: The request has succeeded and a new resource has been created as a result.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluationSuiteRunResponse'
-        default:
-          description: An unexpected error response.
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EvaluationSuiteRunRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions:
     get:
       operationId: EvaluationSuites_listVersions
@@ -2846,13 +2806,6 @@ paths:
       operationId: EvaluationSuites_createEvaluationSuiteVersion
       description: Create a new EvaluationSuiteVersion with auto incremented version id
       parameters:
-        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
-        - name: name
-          in: path
-          required: true
-          description: The name of the resource.
-          schema:
-            type: string
         - name: Foundry-Features
           in: header
           required: false
@@ -2861,6 +2814,19 @@ paths:
             type: string
             enum:
               - Evaluations=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the evaluation suite.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
       responses:
         '201':
           description: The request has succeeded and a new resource has been created as a result.
@@ -2870,16 +2836,17 @@ paths:
                 $ref: '#/components/schemas/EvaluationSuiteVersion'
         default:
           description: An unexpected error response.
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+                $ref: '#/components/schemas/ApiErrorResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluationSuiteVersionCreate'
+        description: The evaluation suite version to create.
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
@@ -3001,6 +2968,55 @@ paths:
             schema:
               $ref: '#/components/schemas/EvaluationSuiteVersionUpdate'
         description: The EvaluationSuiteVersion to create or update.
+  /evaluation_suites/{name}:run:
+    post:
+      operationId: EvaluationSuites_run
+      description: Run an evaluation using the suite's testing criteria and dataset.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Evaluations=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the evaluation suite.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationSuiteRunResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluationSuiteRunRequest'
+        description: The run request parameters.
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluationrules:
     get:
       operationId: EvaluationRules_list
@@ -13103,6 +13119,75 @@ components:
           type: string
           description: The version of the resource.
           readOnly: true
+      description: |-
+        An evaluation suite bundles testing criteria — an optional dataset, one or more
+        evaluator configs with thresholds and init params — into a reusable, named artifact that
+        can gate agent changes across batch, scheduled, continuous, and CI/CD evals.
+    EvaluationSuiteVersionCreate:
+      type: object
+      required:
+        - testing_criteria
+      properties:
+        display_name:
+          type: string
+          description: |-
+            Human-readable display name.
+            Does not need to be unique. Shown in Foundry portal list views and eval reports.
+        subtype:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationSuiteSubtype'
+          description: Subtype of the evaluation suite.
+        dataset:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationDatasetReference'
+          description: |-
+            Dataset reference for evaluation.
+            Optional — omit for evaluator-only suites where data comes from
+            live production traces or is provided at run time.
+            The referenced dataset must exist in the project's dataset registry.
+        testing_criteria:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.EvalGraderLabelModel'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderStringCheck'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderTextSimilarity'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
+              - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+          minItems: 1
+          description: |-
+            Testing criteria — the evaluator configurations for this suite.
+            Supports all grader types: azure_ai_evaluator, string_check, label_model,
+            score_model, text_similarity, python, etc.
+            At least one entry is required.
+        target:
+          allOf:
+            - $ref: '#/components/schemas/Target'
+          description: |-
+            Target for this evaluation suite. Uses the existing Target discriminated type
+            from eval runs. Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
+            Optional — allows suites to exist without a target.
+        input_messages:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate'
+            - $ref: '#/components/schemas/OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference'
+          description: |-
+            How to send dataset rows to the target (agent or model).
+            Supports template type (prompt with column placeholders) and
+            item_reference type (column containing pre-built messages).
+        evaluation_level:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationLevel'
+          description: Default evaluation level for this suite. Can be overridden at run time.
+        description:
+          type: string
+          description: The asset description text.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Tag dictionary. Tags can be added, removed, and updated.
       description: |-
         An evaluation suite bundles testing criteria — an optional dataset, one or more
         evaluator configs with thresholds and init params — into a reusable, named artifact that

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5070,72 +5070,6 @@
         }
       }
     },
-    "/evaluation_suites/{name}/run": {
-      "post": {
-        "operationId": "EvaluationSuites_run",
-        "description": "Run an evaluation using the suite's testing criteria and dataset.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the resource.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "The request has succeeded and a new resource has been created as a result.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EvaluationSuiteRunResponse"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/EvaluationSuiteRunRequest"
-              }
-            }
-          }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "Evaluations=V1Preview"
-          ]
-        }
-      }
-    },
     "/evaluation_suites/{name}/versions": {
       "get": {
         "operationId": "EvaluationSuites_listVersions",
@@ -5191,18 +5125,6 @@
         "description": "Create a new EvaluationSuiteVersion with auto incremented version id",
         "parameters": [
           {
-            "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          },
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the resource.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "Foundry-Features",
             "in": "header",
             "required": false,
@@ -5213,6 +5135,25 @@
                 "Evaluations=V1Preview"
               ]
             }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the evaluation suite.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           }
         ],
         "responses": {
@@ -5228,23 +5169,25 @@
           },
           "default": {
             "description": "An unexpected error response.",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
             }
           }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSuiteVersionCreate"
+              }
+            }
+          },
+          "description": "The evaluation suite version to create."
         },
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -5440,6 +5383,83 @@
             }
           },
           "description": "The EvaluationSuiteVersion to create or update."
+        }
+      }
+    },
+    "/evaluation_suites/{name}:run": {
+      "post": {
+        "operationId": "EvaluationSuites_run",
+        "description": "Run an evaluation using the suite's testing criteria and dataset.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Evaluations=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the evaluation suite.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationSuiteRunResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationSuiteRunRequest"
+              }
+            }
+          },
+          "description": "The run request parameters."
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },
@@ -21741,6 +21761,100 @@
             "type": "string",
             "description": "The version of the resource.",
             "readOnly": true
+          }
+        },
+        "description": "An evaluation suite bundles testing criteria — an optional dataset, one or more\nevaluator configs with thresholds and init params — into a reusable, named artifact that\ncan gate agent changes across batch, scheduled, continuous, and CI/CD evals."
+      },
+      "EvaluationSuiteVersionCreate": {
+        "type": "object",
+        "required": [
+          "testing_criteria"
+        ],
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name.\nDoes not need to be unique. Shown in Foundry portal list views and eval reports."
+          },
+          "subtype": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationSuiteSubtype"
+              }
+            ],
+            "description": "Subtype of the evaluation suite."
+          },
+          "dataset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationDatasetReference"
+              }
+            ],
+            "description": "Dataset reference for evaluation.\nOptional — omit for evaluator-only suites where data comes from\nlive production traces or is provided at run time.\nThe referenced dataset must exist in the project's dataset registry."
+          },
+          "testing_criteria": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderLabelModel"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderStringCheck"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderTextSimilarity"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderPython"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.EvalGraderScoreModel"
+                },
+                {
+                  "$ref": "#/components/schemas/TestingCriterionAzureAIEvaluator"
+                }
+              ]
+            },
+            "minItems": 1,
+            "description": "Testing criteria — the evaluator configurations for this suite.\nSupports all grader types: azure_ai_evaluator, string_check, label_model,\nscore_model, text_similarity, python, etc.\nAt least one entry is required."
+          },
+          "target": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Target"
+              }
+            ],
+            "description": "Target for this evaluation suite. Uses the existing Target discriminated type\nfrom eval runs. Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.\nOptional — allows suites to exist without a target."
+          },
+          "input_messages": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference"
+              }
+            ],
+            "description": "How to send dataset rows to the target (agent or model).\nSupports template type (prompt with column placeholders) and\nitem_reference type (column containing pre-built messages)."
+          },
+          "evaluation_level": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationLevel"
+              }
+            ],
+            "description": "Default evaluation level for this suite. Can be overridden at run time."
+          },
+          "description": {
+            "type": "string",
+            "description": "The asset description text."
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Tag dictionary. Tags can be added, removed, and updated."
           }
         },
         "description": "An evaluation suite bundles testing criteria — an optional dataset, one or more\nevaluator configs with thresholds and init params — into a reusable, named artifact that\ncan gate agent changes across batch, scheduled, continuous, and CI/CD evals."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -5128,6 +5128,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },
@@ -5240,6 +5245,11 @@
               }
             }
           }
+        },
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "Evaluations=V1Preview"
+          ]
         }
       }
     },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3473,6 +3473,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/EvaluationSuiteRunRequest'
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions:
     get:
       operationId: EvaluationSuites_listVersions
@@ -3542,6 +3545,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions/{version}:
     get:
       operationId: EvaluationSuites_getVersion

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3436,46 +3436,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-  /evaluation_suites/{name}/run:
-    post:
-      operationId: EvaluationSuites_run
-      description: Run an evaluation using the suite's testing criteria and dataset.
-      parameters:
-        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
-        - name: name
-          in: path
-          required: true
-          description: The name of the resource.
-          schema:
-            type: string
-      responses:
-        '201':
-          description: The request has succeeded and a new resource has been created as a result.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EvaluationSuiteRunResponse'
-        default:
-          description: An unexpected error response.
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EvaluationSuiteRunRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - Evaluations=V1Preview
   /evaluation_suites/{name}/versions:
     get:
       operationId: EvaluationSuites_listVersions
@@ -3511,13 +3471,6 @@ paths:
       operationId: EvaluationSuites_createEvaluationSuiteVersion
       description: Create a new EvaluationSuiteVersion with auto incremented version id
       parameters:
-        - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
-        - name: name
-          in: path
-          required: true
-          description: The name of the resource.
-          schema:
-            type: string
         - name: Foundry-Features
           in: header
           required: false
@@ -3526,6 +3479,19 @@ paths:
             type: string
             enum:
               - Evaluations=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the evaluation suite.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
       responses:
         '201':
           description: The request has succeeded and a new resource has been created as a result.
@@ -3535,16 +3501,17 @@ paths:
                 $ref: '#/components/schemas/EvaluationSuiteVersion'
         default:
           description: An unexpected error response.
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
+                $ref: '#/components/schemas/ApiErrorResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluationSuiteVersionCreate'
+        description: The evaluation suite version to create.
       x-ms-foundry-meta:
         required_previews:
           - Evaluations=V1Preview
@@ -3666,6 +3633,55 @@ paths:
             schema:
               $ref: '#/components/schemas/EvaluationSuiteVersionUpdate'
         description: The EvaluationSuiteVersion to create or update.
+  /evaluation_suites/{name}:run:
+    post:
+      operationId: EvaluationSuites_run
+      description: Run an evaluation using the suite's testing criteria and dataset.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - Evaluations=V1Preview
+        - name: name
+          in: path
+          required: true
+          description: The name of the evaluation suite.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluationSuiteRunResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluationSuiteRunRequest'
+        description: The run request parameters.
+      x-ms-foundry-meta:
+        required_previews:
+          - Evaluations=V1Preview
   /evaluationrules:
     get:
       operationId: EvaluationRules_list
@@ -14772,6 +14788,75 @@ components:
           type: string
           description: The version of the resource.
           readOnly: true
+      description: |-
+        An evaluation suite bundles testing criteria — an optional dataset, one or more
+        evaluator configs with thresholds and init params — into a reusable, named artifact that
+        can gate agent changes across batch, scheduled, continuous, and CI/CD evals.
+    EvaluationSuiteVersionCreate:
+      type: object
+      required:
+        - testing_criteria
+      properties:
+        display_name:
+          type: string
+          description: |-
+            Human-readable display name.
+            Does not need to be unique. Shown in Foundry portal list views and eval reports.
+        subtype:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationSuiteSubtype'
+          description: Subtype of the evaluation suite.
+        dataset:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationDatasetReference'
+          description: |-
+            Dataset reference for evaluation.
+            Optional — omit for evaluator-only suites where data comes from
+            live production traces or is provided at run time.
+            The referenced dataset must exist in the project's dataset registry.
+        testing_criteria:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.EvalGraderLabelModel'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderStringCheck'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderTextSimilarity'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderPython'
+              - $ref: '#/components/schemas/OpenAI.EvalGraderScoreModel'
+              - $ref: '#/components/schemas/TestingCriterionAzureAIEvaluator'
+          minItems: 1
+          description: |-
+            Testing criteria — the evaluator configurations for this suite.
+            Supports all grader types: azure_ai_evaluator, string_check, label_model,
+            score_model, text_similarity, python, etc.
+            At least one entry is required.
+        target:
+          allOf:
+            - $ref: '#/components/schemas/Target'
+          description: |-
+            Target for this evaluation suite. Uses the existing Target discriminated type
+            from eval runs. Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
+            Optional — allows suites to exist without a target.
+        input_messages:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate'
+            - $ref: '#/components/schemas/OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference'
+          description: |-
+            How to send dataset rows to the target (agent or model).
+            Supports template type (prompt with column placeholders) and
+            item_reference type (column containing pre-built messages).
+        evaluation_level:
+          allOf:
+            - $ref: '#/components/schemas/EvaluationLevel'
+          description: Default evaluation level for this suite. Can be overridden at run time.
+        description:
+          type: string
+          description: The asset description text.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: Tag dictionary. Tags can be added, removed, and updated.
       description: |-
         An evaluation suite bundles testing criteria — an optional dataset, one or more
         evaluator configs with thresholds and init params — into a reusable, named artifact that

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
@@ -37,27 +37,41 @@ interface EvaluationSuites
   // POST /evaluation_suites/{name}/versions
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
   @doc("Create a new {name} with auto incremented version id", EvaluationSuiteVersion)
-  @Rest.segment("versions")
   @post
+  @route("/evaluation_suites/{name}/versions")
   @extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)
-  createEvaluationSuiteVersion is Azure.Core.Foundations.ResourceOperation<
-    EvaluationSuiteVersion,
+  createEvaluationSuiteVersion is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
     {
-      ...WithConditionalFoundryPreviewHeader<FoundryFeaturesOptInKeys.evaluations_v1_preview>;
+      @doc("The name of the evaluation suite.")
+      @path
+      name: string;
+
+      @doc("The evaluation suite version to create.")
+      @bodyRoot
+      evaluationSuiteVersion: EvaluationSuiteVersion;
     },
-    Azure.Core.Foundations.ResourceCreatedResponse<EvaluationSuiteVersion>
+    Response<201> & EvaluationSuiteVersion
   >;
 
   // POST /evaluation_suites/{name}:run
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations"
   @doc("Run an evaluation using the suite's testing criteria and dataset.")
-  @action("run")
   @post
+  @route("/evaluation_suites/{name}:run")
   @extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)
-  run is Azure.Core.Foundations.ResourceOperation<
-    EvaluationSuiteVersion,
-    EvaluationSuiteRunRequest,
-    Azure.Core.Foundations.ResourceCreatedResponse<EvaluationSuiteRunResponse>
+  run is FoundryDataPlanePreviewOperation<
+    FoundryFeaturesOptInKeys.evaluations_v1_preview,
+    {
+      @doc("The name of the evaluation suite.")
+      @path
+      name: string;
+
+      @doc("The run request parameters.")
+      @body
+      body: EvaluationSuiteRunRequest;
+    },
+    Response<201> & EvaluationSuiteRunResponse
   >;
 }
 


### PR DESCRIPTION
Updates the `EvaluationSuites` interface to:

1. **Stop extending `VersionedOperations`** — the generic template doesn't support preview headers or `x-ms-foundry-meta` extensions
2. **Expand each CRUD operation inline** (following the `Evaluators` interface pattern) with the conditional preview header (`Foundry-Features`) spread into each operation's params
3. **Use `FoundryDataPlanePreviewOperation`** for the custom operations (`createEvaluationSuiteVersion` and `run`) with explicit routes
4. **Add `@extension("x-ms-foundry-meta", EvaluationSuitesRequiredPreviews)`** with `required_previews` to all newly added operations

The `EvaluationSuiteGenerationJobs` interface already uses preview job templates correctly and is unchanged.

Follows the same pattern established by the `Evaluators` interface in `src/evaluators/routes.tsp`.

Targets PR #42424 branch (`vebudumu/eval-suite-foundry-release`).