### PR TITLE
Revert External Agents commits from feature/foundry-release

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -13257,8 +13257,7 @@
           "mapping": {
             "hosted": "#/components/schemas/HostedAgentDefinition",
             "prompt": "#/components/schemas/PromptAgentDefinition",
-            "workflow": "#/components/schemas/WorkflowAgentDefinition",
-            "external": "#/components/schemas/ExternalAgentDefinition"
+            "workflow": "#/components/schemas/WorkflowAgentDefinition"
           }
         },
         "x-ms-foundry-meta": {
@@ -13266,8 +13265,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -13278,8 +13276,7 @@
           "WorkflowAgents=V1Preview",
           "ContainerAgents=V1Preview",
           "AgentEndpoints=V1Preview",
-          "CodeAgents=V1Preview",
-          "ExternalAgents=V1Preview"
+          "CodeAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
       },
@@ -13402,7 +13399,6 @@
               "activity",
               "responses",
               "a2a",
-              "mcp",
               "invocations"
             ]
           }
@@ -13553,8 +13549,7 @@
             "enum": [
               "prompt",
               "hosted",
-              "workflow",
-              "external"
+              "workflow"
             ]
           }
         ]
@@ -13675,7 +13670,6 @@
             "enum": [
               "activity_protocol",
               "responses",
-              "mcp",
               "invocations"
             ]
           }
@@ -16312,8 +16306,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },
@@ -16362,8 +16355,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -16512,8 +16504,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },
@@ -16536,8 +16527,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -20281,36 +20271,6 @@
           }
         },
         "description": "Evaluator Definition"
-      },
-      "ExternalAgentDefinition": {
-        "type": "object",
-        "required": [
-          "kind"
-        ],
-        "properties": {
-          "kind": {
-            "type": "string",
-            "enum": [
-              "external"
-            ]
-          },
-          "otel_agent_id": {
-            "type": "string",
-            "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",
-            "example": "gcp-travel-planner-agent"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AgentDefinition"
-          }
-        ],
-        "description": "The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).\nRegistration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)\nover customer-emitted OpenTelemetry data.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "ExternalAgents=V1Preview"
-          ]
-        }
       },
       "FabricDataAgentToolCall": {
         "type": "object",
@@ -45382,8 +45342,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15202,7 +15202,6 @@
             "hosted": "#/components/schemas/HostedAgentDefinition",
             "prompt": "#/components/schemas/PromptAgentDefinition",
             "workflow": "#/components/schemas/WorkflowAgentDefinition",
-            "external": "#/components/schemas/ExternalAgentDefinition",
             "container_app": "#/components/schemas/ContainerAppAgentDefinition"
           }
         },
@@ -15211,8 +15210,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -15223,8 +15221,7 @@
           "WorkflowAgents=V1Preview",
           "ContainerAgents=V1Preview",
           "AgentEndpoints=V1Preview",
-          "CodeAgents=V1Preview",
-          "ExternalAgents=V1Preview"
+          "CodeAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
       },
@@ -15347,7 +15344,6 @@
               "activity",
               "responses",
               "a2a",
-              "mcp",
               "invocations"
             ]
           }
@@ -15691,7 +15687,6 @@
               "prompt",
               "hosted",
               "workflow",
-              "external",
               "container_app"
             ]
           }
@@ -15813,7 +15808,6 @@
             "enum": [
               "activity_protocol",
               "responses",
-              "mcp",
               "invocations"
             ]
           }
@@ -18625,8 +18619,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },
@@ -18675,8 +18668,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -18825,8 +18817,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },
@@ -18849,8 +18840,7 @@
             "HostedAgents=V1Preview",
             "ContainerAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
-            "ExternalAgents=V1Preview"
+            "CodeAgents=V1Preview"
           ]
         }
       },
@@ -22804,36 +22794,6 @@
           }
         },
         "description": "Evaluator Definition"
-      },
-      "ExternalAgentDefinition": {
-        "type": "object",
-        "required": [
-          "kind"
-        ],
-        "properties": {
-          "kind": {
-            "type": "string",
-            "enum": [
-              "external"
-            ]
-          },
-          "otel_agent_id": {
-            "type": "string",
-            "description": "The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.\nSpans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.\nDefaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios\nwhere the running external agent already emits a stable id that differs from the Foundry agent name.\nThe resolved value is always echoed on read.",
-            "example": "gcp-travel-planner-agent"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/AgentDefinition"
-          }
-        ],
-        "description": "The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).\nRegistration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)\nover customer-emitted OpenTelemetry data.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "ExternalAgents=V1Preview"
-          ]
-        }
       },
       "FabricDataAgentToolCall": {
         "type": "object",
@@ -48171,8 +48131,7 @@
                 "HostedAgents=V1Preview",
                 "ContainerAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
-                "ExternalAgents=V1Preview"
+                "CodeAgents=V1Preview"
               ]
             }
           },

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -12,8 +12,7 @@ const AllConditionalAgentDefinitionPreviews = #{
     AgentDefinitionOptInKeys.hosted_agents_v1_preview,
     AgentDefinitionOptInKeys.container_agents_v1_preview,
     AgentDefinitionOptInKeys.workflow_agents_v1_preview,
-    AgentDefinitionOptInKeys.code_agents_v1_preview,
-    AgentDefinitionOptInKeys.external_agents_v1_preview
+    AgentDefinitionOptInKeys.code_agents_v1_preview
   ],
 };
 
@@ -303,7 +302,6 @@ union AgentKind {
   prompt: "prompt",
   hosted: "hosted",
   workflow: "workflow",
-  external: "external",
 
   @removed(Versions.v1)
   container_app: "container_app",
@@ -442,29 +440,6 @@ union CodeDependencyResolution {
 
   @doc("The service builds dependencies remotely from the manifest included in the uploaded zip.")
   remote_build: "remote_build",
-}
-
-@doc("""
-  The external agent definition. Represents a third-party agent hosted outside Foundry (for example, on GCP or AWS).
-  Registration is metadata-only: Foundry records the agent definition to light up observability experiences (traces, evaluations)
-  over customer-emitted OpenTelemetry data.
-  """)
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.external_agents_v1_preview] }
-)
-model ExternalAgentDefinition extends AgentDefinition {
-  kind: AgentKind.external;
-
-  @doc("""
-    The OpenTelemetry agent identifier used to attribute customer-emitted spans to this Foundry agent.
-    Spans must include the attribute `gen_ai.agent.id = <otel_agent_id>` to appear under this registration.
-    Defaults to the top-level agent name when omitted. Provide an explicit value only for migration scenarios
-    where the running external agent already emits a stable id that differs from the Foundry agent name.
-    The resolved value is always echoed on read.
-    """)
-  @example("gcp-travel-planner-agent")
-  otel_agent_id?: string;
 }
 
 @doc("The hosted agent definition.")

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -42,7 +42,6 @@ union AgentDefinitionOptInKeys {
   agent_endpoint_v1_preview: "AgentEndpoints=V1Preview",
 
   code_agents_v1_preview: "CodeAgents=V1Preview",
-  external_agents_v1_preview: "ExternalAgents=V1Preview",
 }
 
 union FoundryFeaturesOptInKeys {

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -40,6 +40,7 @@ union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   container_agents_v1_preview: "ContainerAgents=V1Preview",
   agent_endpoint_v1_preview: "AgentEndpoints=V1Preview",
+
   code_agents_v1_preview: "CodeAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
 }


### PR DESCRIPTION
Reverts the following commits that were pushed directly to feature/foundry-release:

- 0eafaebd60 update
- e05d359955 Add External Agents support to Foundry API specifications