### PR TITLE
Revert "Enforce @azure-typespec/http-client-csharp-mgmt emitter for management plane TypeSpec projects (#42159)"

### DIFF
--- a/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-tspconfig-validation.ts
@@ -777,41 +777,6 @@ export class TspConfigCsharpMgmtNamespaceSubRule extends TspconfigEmitterOptions
   }
 }
 
-// ----- CSharp mgmt emitter requirement rule -----
-const CSHARP_MGMT_EMITTER = "@azure-typespec/http-client-csharp-mgmt";
-const LEGACY_CSHARP_EMITTER = "@azure-tools/typespec-csharp";
-
-export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleBase {
-  constructor() {
-    super("emit", CSHARP_MGMT_EMITTER);
-  }
-
-  protected skip(_config: any, folder: string): SkipResult {
-    return skipForDataPlane(folder);
-  }
-
-  protected validate(config: any): RuleResult {
-    const emit: string[] | undefined = config?.emit;
-    const options: Record<string, any> | undefined = config?.options;
-
-    const hasLegacyEmitter =
-      emit?.includes(LEGACY_CSHARP_EMITTER) || options?.[LEGACY_CSHARP_EMITTER] !== undefined;
-
-    if (hasLegacyEmitter) {
-      return this.createFailedResult(
-        `Management plane TypeSpec projects must not use the legacy "${LEGACY_CSHARP_EMITTER}" emitter`,
-        `Please use "${CSHARP_MGMT_EMITTER}" instead of "${LEGACY_CSHARP_EMITTER}" in your tspconfig.yaml`,
-      );
-    }
-
-    return { success: true };
-  }
-
-  public getPathOfKeyToValidate(): string {
-    return `emit.${CSHARP_MGMT_EMITTER}`;
-  }
-}
-
 /**
  * Required rules: When a tspconfig.yaml exists, any applicable rule in the requiredRules array
  * that fails validation will cause the entire SdkTspConfigValidationRule to fail. For example,
@@ -820,7 +785,6 @@ export class TspConfigCsharpMgmtEmitterRequiredSubRule extends TspconfigSubRuleB
  */
 export const requiredRules = [
   new TspConfigCommonAzServiceDirMatchPatternSubRule(),
-  new TspConfigCsharpMgmtEmitterRequiredSubRule(),
   new TspConfigJavaAzEmitterOutputDirMatchPatternSubRule(),
   new TspConfigJavaMgmtEmitterOutputDirMatchPatternSubRule(),
   new TspConfigJavaMgmtNamespaceFormatSubRule(),

--- a/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-tspconfig-validation.test.ts
@@ -13,7 +13,6 @@ import {
   TspConfigCsharpDpEmitterOutputDirSubRule,
   TspConfigCsharpDpNamespaceSubRule,
   TspConfigCsharpMgmtEmitterOutputDirSubRule,
-  TspConfigCsharpMgmtEmitterRequiredSubRule,
   TspConfigCsharpMgmtNamespaceSubRule,
   TspConfigGoDpContainingModuleMatchPatternSubRule,
   TspConfigGoDpEmitterOutputDirMatchPatternSubRule,
@@ -613,94 +612,6 @@ const csharpMgmtEmitterOutputDirTestCases = createEmitterOptionTestCases(
   [new TspConfigCsharpMgmtEmitterOutputDirSubRule()],
 );
 
-// Test cases for CSharp mgmt emitter requirement rule
-const csharpMgmtEmitterRequiredTestCases: Case[] = [
-  {
-    description:
-      "Mgmt emitter required: pass when @azure-typespec/http-client-csharp-mgmt is in emit array",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-  - "@azure-typespec/http-client-csharp-mgmt"
-`,
-    success: true,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description:
-      "Mgmt emitter required: pass when @azure-typespec/http-client-csharp-mgmt is in options",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-options:
-  "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.Compute"
-`,
-    success: true,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description: "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in emit",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-  - "@azure-tools/typespec-csharp"
-`,
-    success: false,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description:
-      "Mgmt emitter required: fail when legacy @azure-tools/typespec-csharp is in options",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-options:
-  "@azure-tools/typespec-csharp":
-    namespace: "Azure.ResourceManager.Compute"
-`,
-    success: false,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description: "Mgmt emitter required: fail when both legacy and new emitters coexist",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-  - "@azure-tools/typespec-csharp"
-  - "@azure-typespec/http-client-csharp-mgmt"
-`,
-    success: false,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description: "Mgmt emitter required: pass when no .NET emitter is configured",
-    folder: managementTspconfigFolder,
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-`,
-    success: true,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-  {
-    description: "Mgmt emitter required: skip for data-plane folder",
-    folder: "contosowidgetmanager/Contoso.WidgetManager/",
-    tspconfigContent: `
-emit:
-  - "@azure-tools/typespec-autorest"
-  - "@azure-tools/typespec-csharp"
-`,
-    success: true,
-    subRules: [new TspConfigCsharpMgmtEmitterRequiredSubRule()],
-  },
-];
-
 // Test cases for emitter-output-dir with namespace variable resolution
 const emitterOutputDirWithNamespaceVariableTestCases: Case[] = [
   {
@@ -1012,8 +923,6 @@ describe("tspconfig", function () {
     ...pythonManagementGenerateTestTestCases,
     ...pythonManagementGenerateSampleTestCases,
     ...pythonDpEmitterOutputTestCases,
-    // csharp mgmt emitter requirement
-    ...csharpMgmtEmitterRequiredTestCases,
     // variable resolution in emitter-output-dir
     ...emitterOutputDirWithNamespaceVariableTestCases,
   ];


### PR DESCRIPTION
This reverts commit 00ef455313894705e1fb7286305b840baa1639e3 (#42159).

Reverted because not all specs in public/main and private/RPSaaSMaster are compliant with the rule, so this PR breaks check TSV-All in both branches.

You can re-merge the new rule, once all specs in main and RPSaaSMaster are updated.