### PR TITLE
Add invocations_ws endpoint for hosted agent service

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/main.tsp
@@ -2,6 +2,7 @@ import "./src/agents/routes.tsp";
 import "./src/agents-containers/routes.tsp";
 import "./src/agents-session-files/routes.tsp";
 import "./src/agents-invocations/routes.tsp";
+import "./src/agents-invocations_ws/routes.tsp";
 import "./src/common/custom-types.tsp";
 import "./src/common/service.tsp";
 import "./src/connections/routes.tsp";

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -297,6 +297,126 @@
         ]
       }
     },
+    "/agents/endpoint/protocols/invocations_ws": {
+      "get": {
+        "operationId": "AgentWebsocket_connectEndpointWebsocket",
+        "description": "Establishes a WebSocket connection to a hosted agent. The target project and\nagent are passed as query parameters. The service resolves (or creates) a\nsession, resolves the agent version, then relays text and binary frames\nbidirectionally between the client and the agent (1 MB maximum frame size).\n\nThe client must send an HTTP GET with `Upgrade: websocket` headers.",
+        "parameters": [
+          {
+            "name": "project_name",
+            "in": "query",
+            "required": true,
+            "description": "The name of the project.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "agent_name",
+            "in": "query",
+            "required": true,
+            "description": "The name of the hosted agent.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "agent_session_id",
+            "in": "query",
+            "required": false,
+            "description": "Optional session/conversation ID. Pass the same value on a subsequent connection to reattach to an existing session. If not provided, the service auto-generates one.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "authorization",
+            "in": "query",
+            "required": false,
+            "description": "AAD bearer token for browser clients only. The W3C WebSocket API cannot set custom headers, so browser callers may pass the AAD token via this query parameter. Non-browser clients should use the `Authorization` header instead.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "foundry-features",
+            "in": "query",
+            "required": false,
+            "description": "Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HostedAgents=V1Preview"
+              ]
+            },
+            "explode": false
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HostedAgents=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "headers": {
+              "x-agent-session-id": {
+                "required": true,
+                "description": "Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Agent Invocations WebSocket"
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "HostedAgents=V1Preview"
+          ]
+        }
+      }
+    },
     "/agents/{agent_name}": {
       "get": {
         "operationId": "Agents_getAgent",
@@ -15492,7 +15612,8 @@
               "responses",
               "a2a",
               "mcp",
-              "invocations"
+              "invocations",
+              "invocations_ws"
             ]
           }
         ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -343,7 +343,7 @@
             "explode": false
           },
           {
-            "name": "foundry-features",
+            "name": "foundry_features",
             "in": "query",
             "required": false,
             "description": "Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -333,16 +333,6 @@
             "explode": false
           },
           {
-            "name": "authorization",
-            "in": "query",
-            "required": false,
-            "description": "AAD bearer token for browser clients only. The W3C WebSocket API cannot set custom headers, so browser callers may pass the AAD token via this query parameter. Non-browser clients should use the `Authorization` header instead.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
             "name": "foundry_features",
             "in": "query",
             "required": false,

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -1,0 +1,56 @@
+import "../common/models.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+namespace Azure.AI.Projects;
+
+alias AgentWebsocketPreviewHeader = WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
+
+const AgentWebsocketRequiredPreviews = #{
+  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
+};
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+@tag("Agent Invocations WebSocket")
+@removed(Versions.v1)
+interface AgentWebsocket {
+  /**
+   * Establishes a WebSocket connection to a hosted agent. The target project and
+   * agent are passed as query parameters. The service resolves (or creates) a
+   * session, resolves the agent version, then relays text and binary frames
+   * bidirectionally between the client and the agent (1 MB maximum frame size).
+   *
+   * The client must send an HTTP GET with `Upgrade: websocket` headers.
+   */
+  @get
+  @route("/agents/endpoint/protocols/invocations_ws")
+  @extension("x-ms-foundry-meta", AgentWebsocketRequiredPreviews)
+  connectEndpointWebsocket is FoundryDataPlaneOperation<
+    {
+      /** The name of the project. */
+      @query project_name: string;
+
+      /** The name of the hosted agent. */
+      @query agent_name: string;
+
+      /** Optional session/conversation ID. Pass the same value on a subsequent connection to reattach to an existing session. If not provided, the service auto-generates one. */
+      @query agent_session_id?: string;
+
+      /** AAD bearer token for browser clients only. The W3C WebSocket API cannot set custom headers, so browser callers may pass the AAD token via this query parameter. Non-browser clients should use the `Authorization` header instead. */
+      @query authorization?: string;
+
+      /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
+      @query("foundry-features")
+      foundryFeaturesQuery?: AgentDefinitionOptInKeys.hosted_agents_v1_preview;
+    } & AgentWebsocketPreviewHeader,
+    {
+      /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */
+      @header("x-agent-session-id") sessionId: string;
+
+      /** The response body (101 Switching Protocols). */
+      @body response: unknown;
+    }
+  >;
+}

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -42,7 +42,7 @@ interface AgentWebsocket {
       @query authorization?: string;
 
       /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
-      @query foundry_features?: AgentDefinitionOptInKeys.hosted_agents_v1_preview;
+      @query(#{ explode: false }) foundry_features?: AgentDefinitionOptInKeys[] = #[AgentDefinitionOptInKeys.hosted_agents_v1_preview];
     } & AgentWebsocketPreviewHeader,
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -38,9 +38,6 @@ interface AgentWebsocket {
       /** Optional session/conversation ID. Pass the same value on a subsequent connection to reattach to an existing session. If not provided, the service auto-generates one. */
       @query agent_session_id?: string;
 
-      /** AAD bearer token for browser clients only. The W3C WebSocket API cannot set custom headers, so browser callers may pass the AAD token via this query parameter. Non-browser clients should use the `Authorization` header instead. */
-      @query authorization?: string;
-
       /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
       @query(#{ explode: false }) foundry_features?: AgentDefinitionOptInKeys[] = #[AgentDefinitionOptInKeys.hosted_agents_v1_preview];
     } & AgentWebsocketPreviewHeader,

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -42,8 +42,7 @@ interface AgentWebsocket {
       @query authorization?: string;
 
       /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
-      @query("foundry-features")
-      foundryFeaturesQuery?: AgentDefinitionOptInKeys.hosted_agents_v1_preview;
+      @query foundry_features?: AgentDefinitionOptInKeys.hosted_agents_v1_preview;
     } & AgentWebsocketPreviewHeader,
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -295,6 +295,10 @@ union AgentEndpointProtocol {
   a2a: "a2a",
   mcp: "mcp",
   invocations: "invocations",
+
+  @doc("WebSocket-based protocol for hosted voice and real-time streaming agents.")
+  @removed(Versions.v1)
+  invocations_ws: "invocations_ws",
 }
 
 union AgentKind {

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-service-agents-contracts/main.tsp
@@ -1,6 +1,7 @@
 import "../servicepatterns.tsp";
 import "../agents/routes.tsp";
 import "../agents-containers/routes.tsp";
+import "../agents-invocations_ws/routes.tsp";
 import "../common/models.tsp";
 import "../common/service.tsp";
 import "../memory-stores/routes.tsp";


### PR DESCRIPTION
Adds the `invocations_ws` WebSocket endpoint for the hosted agent service.

Targets `feature/foundry-release` per @glecaros's review on #42712. Also addresses the snake_case naming feedback: query parameters are now `project_name` and `agent_name` (consistent with the rest of the agents surface).

Equivalent of #42712 retargeted to `feature/foundry-release`.