### PR TITLE
Tsv all concurency and better logging

### DIFF
--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -53,8 +53,8 @@ jobs:
         # the GitHub Jobs UI.
         ref: ${{ fromJSON(github.event_name == 'schedule' && '["default", "next"]' || '["default"]') }}
         os: [ubuntu, windows]
-        # shards must start at 0 and increment by 1
-        shard: [0, 1, 2]
+        # shards are 1-based
+        shard: [1, 2, 3]
         # total-shards must be an accurate count of the number of shards
         total-shards: [3]
 
@@ -74,15 +74,4 @@ jobs:
         uses: ./.github/actions/setup-node-install-deps
 
       - name: Validate All Specs
-        run: |
-          # Keep processing when errors are written. Nonzero exit will mark the 
-          # step as failed. 
-          $ErrorActionPreference = 'Continue'
-
-          ./eng/scripts/TypeSpec-Validation.ps1 `
-            -Shard ${{ matrix.shard }} `
-            -TotalShards ${{ matrix.total-shards }} `
-            -CheckAll `
-            -GitClean `
-            -Verbose
-        shell: pwsh
+        run: npx tsv --all --shard=${{ matrix.shard }}/${{ matrix.total-shards }} --git-clean specification

--- a/.github/workflows/typespec-validation-all.yaml
+++ b/.github/workflows/typespec-validation-all.yaml
@@ -74,4 +74,4 @@ jobs:
         uses: ./.github/actions/setup-node-install-deps
 
       - name: Validate All Specs
-        run: npx tsv --all --shard=${{ matrix.shard }}/${{ matrix.total-shards }} --git-clean specification
+        run: npx tsv --all --shard=${{ matrix.shard }}/${{ matrix.total-shards }} specification

--- a/eng/tools/typespec-validation/src/concurrency.ts
+++ b/eng/tools/typespec-validation/src/concurrency.ts
@@ -1,0 +1,51 @@
+/** Run tasks with limited concurrency */
+export async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  processor: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const toRun = [...items];
+  const results: R[] = [];
+  let completed = 0;
+  let running = 0;
+
+  return new Promise((resolve, reject) => {
+    function runNext() {
+      if (toRun.length === 0 || running >= concurrency) {
+        return;
+      }
+
+      const item = toRun.shift();
+      if (!item) {
+        return;
+      }
+
+      running++;
+      processor(item)
+        .then((result) => {
+          results.push(result);
+          completed++;
+          running--;
+
+          if (completed === items.length) {
+            resolve(results);
+            return;
+          }
+
+          runNext();
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }
+
+    // Start initial batch of tasks up to concurrency limit
+    for (let i = 0; i < Math.min(concurrency, toRun.length); i++) {
+      runNext();
+    }
+  });
+}

--- a/eng/tools/typespec-validation/src/concurrency.ts
+++ b/eng/tools/typespec-validation/src/concurrency.ts
@@ -39,6 +39,7 @@ export async function runWithConcurrency<T, R>(
           runNext();
         })
         .catch((error) => {
+          // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
           reject(error);
         });
     }

--- a/eng/tools/typespec-validation/src/index.ts
+++ b/eng/tools/typespec-validation/src/index.ts
@@ -1,7 +1,6 @@
 import { stat } from "node:fs/promises";
 import { ParseArgsConfig, parseArgs } from "node:util";
 import { Suppression } from "suppressions";
-import { runAll, type ShardConfig } from "./run-all.js";
 import { CompileRule } from "./rules/compile.js";
 import { EmitAutorestRule } from "./rules/emit-autorest.js";
 import { FlavorAzureRule } from "./rules/flavor-azure.js";
@@ -10,6 +9,7 @@ import { FormatRule } from "./rules/format.js";
 import { LinterRulesetRule } from "./rules/linter-ruleset.js";
 import { NpmPrefixRule } from "./rules/npm-prefix.js";
 import { SdkTspConfigValidationRule } from "./rules/sdk-tspconfig-validation.js";
+import { runAll, type ShardConfig } from "./run-all.js";
 import { fileExists, getSuppressions, normalizePath } from "./utils.js";
 
 // Context argument may add new properties or override checkingAllSpecs
@@ -33,20 +33,18 @@ export async function main() {
     shard: {
       type: "string",
     },
-    "git-clean": {
-      type: "boolean",
-      default: false,
-    },
   };
   const parsedArgs = parseArgs({ args, options, allowPositionals: true } as ParseArgsConfig);
 
   if (parsedArgs.values.all) {
     context = { ...context, checkingAllSpecs: true };
     const specDir = parsedArgs.positionals[0] ?? "specification";
-    const shard = parsedArgs.values.shard !== undefined ? parseShard(parsedArgs.values.shard as string) : undefined;
+    const shard =
+      parsedArgs.values.shard !== undefined
+        ? parseShard(parsedArgs.values.shard as string)
+        : undefined;
     await runAll(specDir, {
       shard,
-      gitClean: Boolean(parsedArgs.values["git-clean"]),
     });
     return;
   }

--- a/eng/tools/typespec-validation/src/index.ts
+++ b/eng/tools/typespec-validation/src/index.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
 import { ParseArgsConfig, parseArgs } from "node:util";
 import { Suppression } from "suppressions";
+import { runAll, type ShardConfig } from "./run-all.js";
 import { CompileRule } from "./rules/compile.js";
 import { EmitAutorestRule } from "./rules/emit-autorest.js";
 import { FlavorAzureRule } from "./rules/flavor-azure.js";
@@ -25,8 +26,31 @@ export async function main() {
       type: "string",
       short: "c",
     },
+    all: {
+      type: "boolean",
+      default: false,
+    },
+    shard: {
+      type: "string",
+    },
+    "git-clean": {
+      type: "boolean",
+      default: false,
+    },
   };
   const parsedArgs = parseArgs({ args, options, allowPositionals: true } as ParseArgsConfig);
+
+  if (parsedArgs.values.all) {
+    context = { ...context, checkingAllSpecs: true };
+    const specDir = parsedArgs.positionals[0] ?? "specification";
+    const shard = parsedArgs.values.shard !== undefined ? parseShard(parsedArgs.values.shard as string) : undefined;
+    await runAll(specDir, {
+      shard,
+      gitClean: Boolean(parsedArgs.values["git-clean"]),
+    });
+    return;
+  }
+
   const folder = parsedArgs.positionals[0];
 
   if (parsedArgs.positionals[1]) {
@@ -86,4 +110,20 @@ export async function main() {
   if (!success) {
     process.exitCode = 1;
   }
+}
+
+/** Parse `--shard=<index>/<count>` (1-based, like Jest/Vitest/Playwright) */
+function parseShard(value: string): ShardConfig {
+  const match = value.match(/^(\d+)\/(\d+)$/);
+  if (!match) {
+    console.error(`Invalid --shard format: "${value}". Expected <index>/<count> (e.g. 1/3)`);
+    process.exit(1);
+  }
+  const index = Number(match[1]);
+  const count = Number(match[2]);
+  if (index < 1 || index > count) {
+    console.error(`Invalid --shard: index ${index} must be between 1 and ${count}`);
+    process.exit(1);
+  }
+  return { index, count };
 }

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -165,7 +165,7 @@ async function validateProject(folder: string): Promise<ProjectResult> {
       return {
         name,
         status: "fail",
-        output: output + `\nRule ${rule.name} threw: ${error}`,
+        output: output + `\nRule ${rule.name} threw: ${String(error)}`,
       };
     }
 

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -124,7 +124,7 @@ async function validateProject(folder: string): Promise<ProjectResult> {
   try {
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
-      ["--no-warnings", resolve(import.meta.dirname, "../cmd/tsv.js"), folder, context],
+      ["--no-warnings", resolve(import.meta.dirname, "../../cmd/tsv.js"), folder, context],
       { maxBuffer: 64 * 1024 * 1024 },
     );
     const output = (stdout + stderr).trim();

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -49,7 +49,8 @@ export async function runAll(specDir: string, options: RunAllOptions = {}): Prom
     projectDirs.map((dir) => pc.bold(relative(absoluteSpecDir, dir))).join("\n"),
   );
 
-  const concurrency = options.gitClean ? 1 : CONCURRENCY;
+  const concurrency = CONCURRENCY;
+  console.log(`Running with concurrency: ${pc.yellow(String(concurrency))}`);
 
   const results = await runWithConcurrency(projectDirs, concurrency, async (projectDir) => {
     const result = await validateProject(projectDir);
@@ -57,9 +58,12 @@ export async function runAll(specDir: string, options: RunAllOptions = {}): Prom
     runner.reportTaskWithDetails(result.status, name, result.output);
 
     if (options.gitClean) {
+      // Scope git clean to the top-level spec folder (e.g. specification/<service>/)
+      // so parallel projects don't interfere with each other
+      const topSpecFolder = projectDir.replace(/(^.*specification\/[^/]*)(.*)/, "$1");
       const git = simpleGit();
-      await git.checkout(["--", "."]);
-      await git.clean("f", ["-d"]);
+      await git.checkout(["--", topSpecFolder]);
+      await git.clean("f", ["-d", topSpecFolder]);
     }
 
     return { ...result, name };

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -11,7 +11,8 @@ import { normalizePath } from "./utils.js";
 
 const execFileAsync = promisify(execFile);
 
-const CONCURRENCY = cpus().length;
+// Double cpu as there should be a lot of IO wait
+const CONCURRENCY = cpus().length * 2;
 
 export interface ShardConfig {
   /** 1-based shard index */

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -1,0 +1,208 @@
+import { cpus } from "os";
+import { dirname, relative, resolve } from "path";
+import { globby } from "globby";
+import pc from "picocolors";
+import { simpleGit } from "simple-git";
+import { getSuppressions as getSuppressionsRaw, Suppression } from "suppressions";
+import { runWithConcurrency } from "./concurrency.js";
+import { RuleResult } from "./rule-result.js";
+import { Rule } from "./rule.js";
+import { CompileRule } from "./rules/compile.js";
+import { EmitAutorestRule } from "./rules/emit-autorest.js";
+import { FlavorAzureRule } from "./rules/flavor-azure.js";
+import { FolderStructureRule } from "./rules/folder-structure.js";
+import { FormatRule } from "./rules/format.js";
+import { LinterRulesetRule } from "./rules/linter-ruleset.js";
+import { NpmPrefixRule } from "./rules/npm-prefix.js";
+import { SdkTspConfigValidationRule } from "./rules/sdk-tspconfig-validation.js";
+import { TaskRunner } from "./runner.js";
+import { getSuppressions, normalizePath } from "./utils.js";
+
+const CONCURRENCY = cpus().length;
+
+export interface ShardConfig {
+  /** 1-based shard index */
+  index: number;
+  /** Total number of shards */
+  count: number;
+}
+
+export interface RunAllOptions {
+  shard?: ShardConfig;
+  gitClean?: boolean;
+}
+
+export async function runAll(specDir: string, options: RunAllOptions = {}): Promise<void> {
+  const runner = new TaskRunner();
+  const absoluteSpecDir = normalizePath(specDir);
+  let projectDirs = await findTspProjects(absoluteSpecDir);
+
+  if (projectDirs.length === 0) {
+    console.log("No TypeSpec projects found");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.shard) {
+    projectDirs = shardArray(projectDirs, options.shard.index, options.shard.count);
+    console.log(
+      `Shard ${pc.yellow(String(options.shard.index))}/${pc.yellow(String(options.shard.count))}: ${pc.yellow(String(projectDirs.length))} projects`,
+    );
+  }
+
+  runner.group(
+    `Found ${pc.yellow(String(projectDirs.length))} TypeSpec projects`,
+    projectDirs.map((dir) => pc.bold(relative(absoluteSpecDir, dir))).join("\n"),
+  );
+
+  const concurrency = options.gitClean ? 1 : CONCURRENCY;
+
+  const results = await runWithConcurrency(projectDirs, concurrency, async (projectDir) => {
+    const result = await validateProject(projectDir);
+    const name = relative(absoluteSpecDir, projectDir);
+    runner.reportTaskWithDetails(result.status, name, result.output);
+
+    if (options.gitClean) {
+      const git = simpleGit();
+      await git.checkout(["--", "."]);
+      await git.clean("f", ["-d"]);
+    }
+
+    return { ...result, name };
+  });
+
+  // Summary
+  let successCount = 0;
+  let failureCount = 0;
+  let skippedCount = 0;
+  const failedProjects: string[] = [];
+
+  for (const result of results) {
+    switch (result.status) {
+      case "pass":
+        successCount++;
+        break;
+      case "fail":
+        failureCount++;
+        failedProjects.push(result.name);
+        break;
+      case "skip":
+        skippedCount++;
+        break;
+    }
+  }
+
+  console.log(`\n=== Summary ===`);
+  const passed = pc.bold(pc.green(`${successCount} passed`));
+  const failed = failureCount > 0 ? pc.bold(pc.red(`${failureCount} failed`)) : undefined;
+  const skipped = skippedCount > 0 ? pc.bold(pc.gray(`${skippedCount} skipped`)) : undefined;
+  console.log(
+    [passed, failed, skipped].filter(Boolean).join(pc.gray(" | ")),
+    pc.gray(`(${projectDirs.length})`),
+  );
+
+  if (failureCount > 0) {
+    console.log("\nFailed folders:");
+    failedProjects.forEach((x) => console.log(`  - ${x}`));
+    process.exitCode = 1;
+  }
+}
+
+interface ProjectResult {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  output: string;
+}
+
+async function validateProject(folder: string): Promise<ProjectResult> {
+  const name = folder;
+
+  // Check TypeSpecValidationAll suppression (used to skip specs in the "all" run)
+  const allSuppressions: Suppression[] = await getSuppressionsRaw(
+    "TypeSpecValidationAll",
+    folder,
+    { checkingAllSpecs: true },
+  );
+  const allToolSuppressions = allSuppressions.filter(
+    (s) => !s.rules?.length && !s.subRules?.length,
+  );
+  if (allToolSuppressions.length > 0) {
+    return {
+      name,
+      status: "skip",
+      output: `Suppressed (TypeSpecValidationAll): ${allToolSuppressions[0].reason}`,
+    };
+  }
+
+  // Check TypeSpecValidation suppression
+  const suppressions: Suppression[] = await getSuppressions(folder);
+  const toolSuppressions = suppressions.filter((s) => !s.rules?.length && !s.subRules?.length);
+  if (toolSuppressions.length > 0) {
+    return {
+      name,
+      status: "skip",
+      output: `Suppressed: ${toolSuppressions[0].reason}`,
+    };
+  }
+
+  const rules: Rule[] = [
+    new FolderStructureRule(),
+    new NpmPrefixRule(),
+    new EmitAutorestRule(),
+    new FlavorAzureRule(),
+    new LinterRulesetRule(),
+    new CompileRule(),
+    new FormatRule(),
+    new SdkTspConfigValidationRule(),
+  ];
+
+  let output = "";
+  for (const rule of rules) {
+    let result: RuleResult;
+    try {
+      result = await rule.execute(folder);
+    } catch (error) {
+      return {
+        name,
+        status: "fail",
+        output: output + `\nRule ${rule.name} threw: ${error}`,
+      };
+    }
+
+    if (result.stdOutput) output += result.stdOutput + "\n";
+
+    if (!result.success) {
+      if (result.errorOutput) output += result.errorOutput + "\n";
+      return { name, status: "fail", output: output + `Rule ${rule.name} failed` };
+    }
+  }
+
+  return { name, status: "pass", output };
+}
+
+async function findTspProjects(specDir: string): Promise<string[]> {
+  const files = await globby("**/tspconfig.yaml", {
+    cwd: specDir,
+    ignore: ["**/node_modules/**"],
+  });
+  const result = files.map((file) => dirname(resolve(specDir, file)));
+  result.sort();
+  return result;
+}
+
+/** Shard an array using 1-based index (like Jest/Vitest/Playwright) */
+function shardArray<T>(array: T[], index: number, count: number): T[] {
+  if (count < 2) {
+    return array;
+  }
+  if (index < 1 || index > count) {
+    throw new Error(`Shard index (${index}) must be between 1 and ${count}`);
+  }
+  if (count > array.length) {
+    throw new Error("Cannot shard array into more pieces than there are elements");
+  }
+  const shardSize = Math.ceil(array.length / count);
+  const start = (index - 1) * shardSize;
+  const end = Math.min(start + shardSize, array.length);
+  return array.slice(start, end);
+}

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -1,11 +1,10 @@
 import { execFile } from "child_process";
+import { globby } from "globby";
 import { cpus } from "os";
 import { dirname, relative, resolve } from "path";
-import { promisify } from "util";
-import { globby } from "globby";
 import pc from "picocolors";
-import { simpleGit } from "simple-git";
 import { getSuppressions as getSuppressionsRaw, Suppression } from "suppressions";
+import { promisify } from "util";
 import { runWithConcurrency } from "./concurrency.js";
 import { TaskRunner } from "./runner.js";
 import { normalizePath } from "./utils.js";
@@ -23,7 +22,6 @@ export interface ShardConfig {
 
 export interface RunAllOptions {
   shard?: ShardConfig;
-  gitClean?: boolean;
 }
 
 export async function runAll(specDir: string, options: RunAllOptions = {}): Promise<void> {
@@ -56,15 +54,6 @@ export async function runAll(specDir: string, options: RunAllOptions = {}): Prom
     const result = await validateProject(projectDir);
     const name = relative(absoluteSpecDir, projectDir);
     runner.reportTaskWithDetails(result.status, name, result.output);
-
-    if (options.gitClean) {
-      // Scope git clean to the top-level spec folder (e.g. specification/<service>/)
-      // so parallel projects don't interfere with each other
-      const topSpecFolder = projectDir.replace(/(^.*specification\/[^/]*)(.*)/, "$1");
-      const git = simpleGit();
-      await git.checkout(["--", topSpecFolder]);
-      await git.clean("f", ["-d", topSpecFolder]);
-    }
 
     return { ...result, name };
   });
@@ -116,11 +105,9 @@ async function validateProject(folder: string): Promise<ProjectResult> {
   const name = folder;
 
   // Check TypeSpecValidationAll suppression (used to skip specs in the "all" run)
-  const allSuppressions: Suppression[] = await getSuppressionsRaw(
-    "TypeSpecValidationAll",
-    folder,
-    { checkingAllSpecs: true },
-  );
+  const allSuppressions: Suppression[] = await getSuppressionsRaw("TypeSpecValidationAll", folder, {
+    checkingAllSpecs: true,
+  });
   const allToolSuppressions = allSuppressions.filter(
     (s) => !s.rules?.length && !s.subRules?.length,
   );
@@ -137,12 +124,7 @@ async function validateProject(folder: string): Promise<ProjectResult> {
   try {
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
-      [
-        "--no-warnings",
-        resolve(import.meta.dirname, "../cmd/tsv.js"),
-        folder,
-        context,
-      ],
+      ["--no-warnings", resolve(import.meta.dirname, "../cmd/tsv.js"), folder, context],
       { maxBuffer: 64 * 1024 * 1024 },
     );
     const output = (stdout + stderr).trim();

--- a/eng/tools/typespec-validation/src/run-all.ts
+++ b/eng/tools/typespec-validation/src/run-all.ts
@@ -1,22 +1,16 @@
+import { execFile } from "child_process";
 import { cpus } from "os";
 import { dirname, relative, resolve } from "path";
+import { promisify } from "util";
 import { globby } from "globby";
 import pc from "picocolors";
 import { simpleGit } from "simple-git";
 import { getSuppressions as getSuppressionsRaw, Suppression } from "suppressions";
 import { runWithConcurrency } from "./concurrency.js";
-import { RuleResult } from "./rule-result.js";
-import { Rule } from "./rule.js";
-import { CompileRule } from "./rules/compile.js";
-import { EmitAutorestRule } from "./rules/emit-autorest.js";
-import { FlavorAzureRule } from "./rules/flavor-azure.js";
-import { FolderStructureRule } from "./rules/folder-structure.js";
-import { FormatRule } from "./rules/format.js";
-import { LinterRulesetRule } from "./rules/linter-ruleset.js";
-import { NpmPrefixRule } from "./rules/npm-prefix.js";
-import { SdkTspConfigValidationRule } from "./rules/sdk-tspconfig-validation.js";
 import { TaskRunner } from "./runner.js";
-import { getSuppressions, normalizePath } from "./utils.js";
+import { normalizePath } from "./utils.js";
+
+const execFileAsync = promisify(execFile);
 
 const CONCURRENCY = cpus().length;
 
@@ -134,50 +128,26 @@ async function validateProject(folder: string): Promise<ProjectResult> {
     };
   }
 
-  // Check TypeSpecValidation suppression
-  const suppressions: Suppression[] = await getSuppressions(folder);
-  const toolSuppressions = suppressions.filter((s) => !s.rules?.length && !s.subRules?.length);
-  if (toolSuppressions.length > 0) {
-    return {
-      name,
-      status: "skip",
-      output: `Suppressed: ${toolSuppressions[0].reason}`,
-    };
+  // Run tsv as a child process to fully isolate stdout/stderr per project
+  const context = JSON.stringify({ checkingAllSpecs: true });
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [
+        "--no-warnings",
+        resolve(import.meta.dirname, "../cmd/tsv.js"),
+        folder,
+        context,
+      ],
+      { maxBuffer: 64 * 1024 * 1024 },
+    );
+    const output = (stdout + stderr).trim();
+    return { name, status: "pass", output };
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string; code?: number };
+    const output = ((execError.stdout ?? "") + (execError.stderr ?? "")).trim();
+    return { name, status: "fail", output };
   }
-
-  const rules: Rule[] = [
-    new FolderStructureRule(),
-    new NpmPrefixRule(),
-    new EmitAutorestRule(),
-    new FlavorAzureRule(),
-    new LinterRulesetRule(),
-    new CompileRule(),
-    new FormatRule(),
-    new SdkTspConfigValidationRule(),
-  ];
-
-  let output = "";
-  for (const rule of rules) {
-    let result: RuleResult;
-    try {
-      result = await rule.execute(folder);
-    } catch (error) {
-      return {
-        name,
-        status: "fail",
-        output: output + `\nRule ${rule.name} threw: ${String(error)}`,
-      };
-    }
-
-    if (result.stdOutput) output += result.stdOutput + "\n";
-
-    if (!result.success) {
-      if (result.errorOutput) output += result.errorOutput + "\n";
-      return { name, status: "fail", output: output + `Rule ${rule.name} failed` };
-    }
-  }
-
-  return { name, status: "pass", output };
 }
 
 async function findTspProjects(specDir: string): Promise<string[]> {

--- a/eng/tools/typespec-validation/src/runner.ts
+++ b/eng/tools/typespec-validation/src/runner.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import pc from "picocolors";
 
 export class TaskRunner {

--- a/eng/tools/typespec-validation/src/runner.ts
+++ b/eng/tools/typespec-validation/src/runner.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+import pc from "picocolors";
+
+export class TaskRunner {
+  #verbose: boolean;
+
+  constructor(options: { verbose?: boolean } = {}) {
+    this.#verbose = options.verbose === undefined ? Boolean(process.env.CI) : options.verbose;
+  }
+
+  reportTaskWithDetails(status: "pass" | "fail" | "skip", name: string, details: string) {
+    const statusStr =
+      status === "pass" ? pc.green("pass") : status === "fail" ? pc.red("fail") : pc.gray("skip");
+    const message = `${statusStr} ${name}`;
+    if (this.#verbose || status === "fail") {
+      this.group(message, details);
+    } else {
+      console.log(message);
+    }
+  }
+
+  group(name: string, content: string) {
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::group::${name}`);
+      console.log(content);
+      console.log("::endgroup::");
+    } else {
+      console.group(name);
+      console.log(content);
+      console.groupEnd();
+    }
+  }
+}


### PR DESCRIPTION
1. Add `--all` to tsv. `npx tsv --all` instead of separate pwsh script
1. Run in concurrency
2. Show the status of each project on the group
<img width="666" height="425" alt="image" src="https://github.com/user-attachments/assets/6bdc44f9-1246-44a5-b3f7-49bce027e2c4" />
<img width="794" height="315" alt="image" src="https://github.com/user-attachments/assets/80fd3297-4d54-4cab-99a5-3f013f8d8551" />
