### PR TITLE
Pin Storage C# API version

### DIFF
--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -59,7 +59,7 @@ options:
     namespace: "Azure.ResourceManager.Storage"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-08-01"
+    api-version: "2025-06-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Pin the Storage C# management emitter API version back to 2025-06-01 so the .NET SDK refresh does not pick up the newer 2025-08-01 API version.