### PR TITLE
Adjust C# API version overrides for Storage, CDN, and Azure Stack HCI

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
@@ -34,6 +34,7 @@ options:
     namespace: "Azure.ResourceManager.Hci"
     emitter-output-dir: "{output-dir}/sdk/azurestackhci/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2026-04-01-preview"
   "@azure-tools/typespec-ts":
     service-dir: "sdk/azurestackhci"
     package-dir: "arm-azurestackhci"

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
@@ -52,6 +52,7 @@ options:
     package-name: "Azure.ResourceManager.Cdn"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2025-09-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -59,7 +59,6 @@ options:
     namespace: "Azure.ResourceManager.Storage"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-06-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Remove the explicit Storage C# emitter api-version override and pin CDN/Azure Stack HCI C# generation to the API versions currently used by the .NET SDK refresh.