### PR TITLE
Remove HCI and CDN C# API version overrides

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
@@ -34,7 +34,6 @@ options:
     namespace: "Azure.ResourceManager.Hci"
     emitter-output-dir: "{output-dir}/sdk/azurestackhci/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2026-04-01-preview"
   "@azure-tools/typespec-ts":
     service-dir: "sdk/azurestackhci"
     package-dir: "arm-azurestackhci"

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
@@ -52,7 +52,6 @@ options:
     package-name: "Azure.ResourceManager.Cdn"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-09-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Remove the explicit C# emitter api-version overrides from Azure Stack HCI and CDN tspconfig.yaml files.