### PR TITLE
advisor: keep Go SDK root client and Duration enum names

### DIFF
--- a/specification/advisor/resource-manager/Microsoft.Advisor/Advisor/client.tsp
+++ b/specification/advisor/resource-manager/Microsoft.Advisor/Advisor/client.tsp
@@ -4,6 +4,20 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 using Microsoft.Advisor;
 
+// Preserve the pre-TypeSpec Go SDK names for `Duration` enum members
+// (`DurationSeven`/`DurationFourteen`/...) instead of the `Duration7`/`Duration14`/...
+// that the Go emitter would otherwise produce from the numeric variant names.
+@@clientName(Microsoft.Advisor.Duration.`7`, "Seven", "go");
+@@clientName(Microsoft.Advisor.Duration.`14`, "Fourteen", "go");
+@@clientName(Microsoft.Advisor.Duration.`21`, "TwentyOne", "go");
+@@clientName(Microsoft.Advisor.Duration.`30`, "Thirty", "go");
+@@clientName(Microsoft.Advisor.Duration.`60`, "Sixty", "go");
+@@clientName(Microsoft.Advisor.Duration.`90`, "Ninety", "go");
+
+// Preserve the pre-TypeSpec Go SDK root client name (`ManagementClient`) instead
+// of the default `Client` derived from the `Microsoft.Advisor` namespace.
+@@clientName(Microsoft.Advisor, "ManagementClient", "go");
+
 @@clientName(
   ResourceRecommendationBases.patch::parameters.properties,
   "trackedProperties"


### PR DESCRIPTION
Adds Go-only TypeSpec customizations for **advisor** to preserve the pre-TypeSpec Go SDK shape:

- Rename root client (`Microsoft.Advisor` namespace) from the default `Client` back to `ManagementClient` (so `ClientFactory.NewManagementClient()` / `NewManagementClient(...)` are restored).
- Rename `Duration` union variants `7`/`14`/`21`/`30`/`60`/`90` to `Seven`/`Fourteen`/`TwentyOne`/`Thirty`/`Sixty`/`Ninety` so the Go emitter produces `DurationSeven`/`DurationFourteen`/... instead of `Duration7`/`Duration14`/...

All decorators are scoped to the `go` emitter only; other language SDKs are unaffected.

Related: Go SDK refresh PR Azure/azure-sdk-for-go#26331.