### PR TITLE
Add AddServer and RepairServer ClusterJob types for 2026-05-01-preview

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_CreateOrUpdate_AddServer.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_CreateOrUpdate_AddServer.json
@@ -1,0 +1,185 @@
+{
+  "title": "ClusterJobs_CreateOrUpdate_AddServerJob",
+  "operationId": "ClusterJobs_CreateOrUpdate",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "addserver",
+    "api-version": "2026-05-01-preview",
+    "resource": {
+      "properties": {
+        "jobType": "AddServer",
+        "deploymentMode": "Deploy",
+        "addServerJobServerDetails": [
+          {
+            "serverName": "Node-2",
+            "hostIpv4Address": "192.168.10.10",
+            "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+          }
+        ],
+        "secrets": [
+          {
+            "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "LocalAdminCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+          },
+          {
+            "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "AzureStackLCMUserCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/fakeid?api-version=2026-05-01-preview"
+      },
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "provisioningState": "Accepted",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_CreateOrUpdate_RepairServer.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_CreateOrUpdate_RepairServer.json
@@ -1,0 +1,182 @@
+{
+  "title": "ClusterJobs_CreateOrUpdate_RepairServerJob",
+  "operationId": "ClusterJobs_CreateOrUpdate",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "repairserver",
+    "api-version": "2026-05-01-preview",
+    "resource": {
+      "properties": {
+        "jobType": "RepairServer",
+        "deploymentMode": "Deploy",
+        "repairServerJobServerDetails": [
+          {
+            "serverName": "Node-2",
+            "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+          }
+        ],
+        "secrets": [
+          {
+            "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "LocalAdminCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+          },
+          {
+            "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "AzureStackLCMUserCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/fakeid?api-version=2026-05-01-preview"
+      },
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "provisioningState": "Accepted",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_Get_AddServerJob.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_Get_AddServerJob.json
@@ -1,0 +1,117 @@
+{
+  "title": "ClusterJobs_Get_AddServerJob",
+  "operationId": "ClusterJobs_Get",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "addserver",
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_Get_RepairServerJob.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/ClusterJobs_Get_RepairServerJob.json
@@ -1,0 +1,116 @@
+{
+  "title": "ClusterJobs_Get_RepairServerJob",
+  "operationId": "ClusterJobs_Get",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "repairserver",
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -16,6 +16,12 @@ namespace Microsoft.AzureStackHCI;
 union HciJobType {
   string,
 
+  /** Job to add a server to the cluster. */
+  AddServer: "AddServer",
+
+  /** Job to repair a server in the cluster. */
+  RepairServer: "RepairServer",
+
   /**
    * Job to CVM  intent for the cluster.
    */
@@ -6435,6 +6441,79 @@ model HciConfigureCvmJobProperties extends ClusterJobProperties {
    * Defines the customer's intent for updating confidential VM properties
    */
   confidentialVmIntent: ConfidentialVmIntent;
+}
+
+////////////////////////////////////////////////////////////////
+////////////////////// Add Server Job Models ///////////////////
+////////////////////////////////////////////////////////////////
+
+/** Details of servers to be added to the cluster. */
+@added(Versions.v2026_05_01_preview)
+model AddServerJobServerDetails {
+  /** Name of server to be added to cluster. */
+  serverName: string;
+
+  /** Ip address of server to be added to cluster. */
+  hostIpv4Address: string;
+
+  /** Local availability zone name of server to be added to rack aware cluster. */
+  localAvailabilityZoneName?: string;
+
+  /** Azure resource id of machine part of cluster for which job will be triggered. */
+  serverResourceId: Azure.Core.armResourceIdentifier;
+}
+
+/** Properties for adding a server in the cluster. */
+@added(Versions.v2026_05_01_preview)
+model HciAddServerJobProperties extends ClusterJobProperties {
+  /** ClusterJob Type to support polymorphic resource. */
+  jobType: HciJobType.AddServer;
+
+  /** Details of servers to be added to the cluster. */
+  @Azure.ResourceManager.identifiers(#[])
+  addServerJobServerDetails: AddServerJobServerDetails[];
+
+  /** List of protected parameters to pass to trigger the job for the cluster. */
+  @Azure.ResourceManager.identifiers(#["secretName"])
+  secrets?: EceDeploymentSecrets[];
+
+  /** Use a cloud witness if you have internet access and if you use an Azure Storage account to provide a vote on cluster quorum. A cloud witness uses Azure Blob Storage to read or write a blob file and then uses it to arbitrate in split-brain resolution. Only allowed values are 'Cloud', 'FileShare'. */
+  witnessType?: string;
+
+  /** Specify the fileshare path for the local witness for your Azure Stack HCI cluster. */
+  witnessPath?: string;
+
+  /** Specify the Azure Storage account name for cloud witness for your Azure Stack HCI cluster. */
+  cloudAccountName?: string;
+}
+
+////////////////////////////////////////////////////////////////
+////////////////////// Repair Server Job Models ////////////////
+////////////////////////////////////////////////////////////////
+
+/** Details of servers to be repaired in the cluster. */
+@added(Versions.v2026_05_01_preview)
+model RepairServerJobServerDetails {
+  /** Name of server to be repaired in cluster. */
+  serverName: string;
+
+  /** Azure resource id of Arc machine part of cluster for which job will be triggered. */
+  serverResourceId: Azure.Core.armResourceIdentifier;
+}
+
+/** Properties for repairing a server in the cluster. */
+@added(Versions.v2026_05_01_preview)
+model HciRepairServerJobProperties extends ClusterJobProperties {
+  /** ClusterJob Type to support polymorphic resource. */
+  jobType: HciJobType.RepairServer;
+
+  /** Details of servers to be repaired in the cluster. */
+  @Azure.ResourceManager.identifiers(#[])
+  repairServerJobServerDetails: RepairServerJobServerDetails[];
+
+  /** List of protected parameters to pass to trigger job for cluster. */
+  @Azure.ResourceManager.identifiers(#["secretName"])
+  secrets?: EceDeploymentSecrets[];
 }
 
 ////////////////////////////////////////////////////////////////

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_CreateOrUpdate_AddServer.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_CreateOrUpdate_AddServer.json
@@ -1,0 +1,185 @@
+{
+  "title": "ClusterJobs_CreateOrUpdate_AddServerJob",
+  "operationId": "ClusterJobs_CreateOrUpdate",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "addserver",
+    "api-version": "2026-05-01-preview",
+    "resource": {
+      "properties": {
+        "jobType": "AddServer",
+        "deploymentMode": "Deploy",
+        "addServerJobServerDetails": [
+          {
+            "serverName": "Node-2",
+            "hostIpv4Address": "192.168.10.10",
+            "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+          }
+        ],
+        "secrets": [
+          {
+            "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "LocalAdminCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+          },
+          {
+            "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "AzureStackLCMUserCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/fakeid?api-version=2026-05-01-preview"
+      },
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "provisioningState": "Accepted",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_CreateOrUpdate_RepairServer.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_CreateOrUpdate_RepairServer.json
@@ -1,0 +1,182 @@
+{
+  "title": "ClusterJobs_CreateOrUpdate_RepairServerJob",
+  "operationId": "ClusterJobs_CreateOrUpdate",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "repairserver",
+    "api-version": "2026-05-01-preview",
+    "resource": {
+      "properties": {
+        "jobType": "RepairServer",
+        "deploymentMode": "Deploy",
+        "repairServerJobServerDetails": [
+          {
+            "serverName": "Node-2",
+            "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+          }
+        ],
+        "secrets": [
+          {
+            "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "LocalAdminCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+          },
+          {
+            "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+            "eceSecretName": "AzureStackLCMUserCredential",
+            "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/fakeid?api-version=2026-05-01-preview"
+      },
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "provisioningState": "Accepted",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_Get_AddServerJob.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_Get_AddServerJob.json
@@ -1,0 +1,117 @@
+{
+  "title": "ClusterJobs_Get_AddServerJob",
+  "operationId": "ClusterJobs_Get",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "addserver",
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/addserver",
+        "name": "addserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "AddServer",
+          "deploymentMode": "Deploy",
+          "addServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "hostIpv4Address": "192.168.10.10",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Add Server Deployment",
+                  "description": "Add Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_Get_RepairServerJob.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/ClusterJobs_Get_RepairServerJob.json
@@ -1,0 +1,116 @@
+{
+  "title": "ClusterJobs_Get_RepairServerJob",
+  "operationId": "ClusterJobs_Get",
+  "parameters": {
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "test-rg",
+    "clusterName": "myCluster",
+    "jobsName": "repairserver",
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/clusters/myCluster/jobs/repairserver",
+        "name": "repairserver",
+        "type": "Microsoft.AzureStackHCI/clusters/jobs",
+        "systemData": {
+          "createdBy": "user@microsoft.com",
+          "createdByType": "User",
+          "createdAt": "2024-01-29T10:43:27.9471574Z",
+          "lastModifiedBy": "user@microsoft.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-01-29T10:43:27.9471574Z"
+        },
+        "properties": {
+          "jobType": "RepairServer",
+          "deploymentMode": "Deploy",
+          "repairServerJobServerDetails": [
+            {
+              "serverName": "Node-2",
+              "serverResourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.HybridCompute/machines/Node-2"
+            }
+          ],
+          "secrets": [
+            {
+              "secretName": "cluster1-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "LocalAdminCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-LocalAdminCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4b"
+            },
+            {
+              "secretName": "cluster2-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63",
+              "eceSecretName": "AzureStackLCMUserCredential",
+              "secretLocation": "https://sclusterkvnirhci35.vault.azure.net/secrets/cluster-34232342-AzureStackLCMUserCredential-f5bcc1d9-23af-4ae9-aca1-041d0f593a63/9276354aabfc492fa9b2cdbefb54ae4c"
+            }
+          ],
+          "reportedProperties": {
+            "validationStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            },
+            "deploymentStatus": {
+              "status": "Error",
+              "steps": [
+                {
+                  "fullStepIndex": "0",
+                  "name": "Repair Server Deployment",
+                  "description": "Repair Server.",
+                  "startTimeUtc": "2023-06-09T00:08:19",
+                  "endTimeUtc": "2023-06-09T04:01:47",
+                  "status": "Error",
+                  "exception": [
+                    "exception1",
+                    "exception2"
+                  ],
+                  "steps": [
+                    {
+                      "fullStepIndex": "0.1",
+                      "name": "Before Cloud Deployment",
+                      "description": "Before Cloud Deployment",
+                      "startTimeUtc": "2023-06-09T00:08:23",
+                      "endTimeUtc": "2023-06-09T01:10:10",
+                      "exception": [
+                        "exception1",
+                        "exception2"
+                      ],
+                      "steps": []
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "status": "NotSpecified"
+        }
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
@@ -3231,8 +3231,14 @@
           }
         },
         "x-ms-examples": {
+          "ClusterJobs_Get_AddServerJob": {
+            "$ref": "./examples/ClusterJobs_Get_AddServerJob.json"
+          },
           "ClusterJobs_Get_ConfigureSdnIntegrationJob": {
             "$ref": "./examples/ClusterJobs_Get_ConfigureSdnIntegrationJob.json"
+          },
+          "ClusterJobs_Get_RepairServerJob": {
+            "$ref": "./examples/ClusterJobs_Get_RepairServerJob.json"
           }
         }
       },
@@ -3309,11 +3315,17 @@
           }
         },
         "x-ms-examples": {
+          "ClusterJobs_CreateOrUpdate_AddServerJob": {
+            "$ref": "./examples/ClusterJobs_CreateOrUpdate_AddServer.json"
+          },
           "ClusterJobs_CreateOrUpdate_ConfigureCVMJob": {
             "$ref": "./examples/ClusterJobs_CreateOrUpdate_ConfigureCVM.json"
           },
           "ClusterJobs_CreateOrUpdate_ConfigureSdnIntegration_Enable": {
             "$ref": "./examples/ClusterJobs_CreateOrUpdate_ConfigureSdnIntegration_Enable.json"
+          },
+          "ClusterJobs_CreateOrUpdate_RepairServerJob": {
+            "$ref": "./examples/ClusterJobs_CreateOrUpdate_RepairServer.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -6356,6 +6368,34 @@
           }
         ]
       }
+    },
+    "AddServerJobServerDetails": {
+      "type": "object",
+      "description": "Details of servers to be added to the cluster.",
+      "properties": {
+        "serverName": {
+          "type": "string",
+          "description": "Name of server to be added to cluster."
+        },
+        "hostIpv4Address": {
+          "type": "string",
+          "description": "Ip address of server to be added to cluster."
+        },
+        "localAvailabilityZoneName": {
+          "type": "string",
+          "description": "Local availability zone name of server to be added to rack aware cluster."
+        },
+        "serverResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource id of machine part of cluster for which job will be triggered."
+        }
+      },
+      "required": [
+        "serverName",
+        "hostIpv4Address",
+        "serverResourceId"
+      ]
     },
     "ArcConnectivityProperties": {
       "type": "object",
@@ -10483,6 +10523,51 @@
         }
       }
     },
+    "HciAddServerJobProperties": {
+      "type": "object",
+      "description": "Properties for adding a server in the cluster.",
+      "properties": {
+        "addServerJobServerDetails": {
+          "type": "array",
+          "description": "Details of servers to be added to the cluster.",
+          "items": {
+            "$ref": "#/definitions/AddServerJobServerDetails"
+          },
+          "x-ms-identifiers": []
+        },
+        "secrets": {
+          "type": "array",
+          "description": "List of protected parameters to pass to trigger the job for the cluster.",
+          "items": {
+            "$ref": "#/definitions/EceDeploymentSecrets"
+          },
+          "x-ms-identifiers": [
+            "secretName"
+          ]
+        },
+        "witnessType": {
+          "type": "string",
+          "description": "Use a cloud witness if you have internet access and if you use an Azure Storage account to provide a vote on cluster quorum. A cloud witness uses Azure Blob Storage to read or write a blob file and then uses it to arbitrate in split-brain resolution. Only allowed values are 'Cloud', 'FileShare'."
+        },
+        "witnessPath": {
+          "type": "string",
+          "description": "Specify the fileshare path for the local witness for your Azure Stack HCI cluster."
+        },
+        "cloudAccountName": {
+          "type": "string",
+          "description": "Specify the Azure Storage account name for cloud witness for your Azure Stack HCI cluster."
+        }
+      },
+      "required": [
+        "addServerJobServerDetails"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClusterJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AddServer"
+    },
     "HciCollectLogJobProperties": {
       "type": "object",
       "description": "Represents the properties of an HCI Collect Log job.",
@@ -10969,6 +11054,8 @@
       "type": "string",
       "description": "ClusterJob Type supported.",
       "enum": [
+        "AddServer",
+        "RepairServer",
         "ConfigureCVM",
         "ConfigureSdnIntegration"
       ],
@@ -10976,6 +11063,16 @@
         "name": "HciJobType",
         "modelAsString": true,
         "values": [
+          {
+            "name": "AddServer",
+            "value": "AddServer",
+            "description": "Job to add a server to the cluster."
+          },
+          {
+            "name": "RepairServer",
+            "value": "RepairServer",
+            "description": "Job to repair a server in the cluster."
+          },
           {
             "name": "ConfigureCVM",
             "value": "ConfigureCVM",
@@ -11187,6 +11284,39 @@
         }
       ],
       "x-ms-discriminator-value": "RemoteSupport"
+    },
+    "HciRepairServerJobProperties": {
+      "type": "object",
+      "description": "Properties for repairing a server in the cluster.",
+      "properties": {
+        "repairServerJobServerDetails": {
+          "type": "array",
+          "description": "Details of servers to be repaired in the cluster.",
+          "items": {
+            "$ref": "#/definitions/RepairServerJobServerDetails"
+          },
+          "x-ms-identifiers": []
+        },
+        "secrets": {
+          "type": "array",
+          "description": "List of protected parameters to pass to trigger job for cluster.",
+          "items": {
+            "$ref": "#/definitions/EceDeploymentSecrets"
+          },
+          "x-ms-identifiers": [
+            "secretName"
+          ]
+        }
+      },
+      "required": [
+        "repairServerJobServerDetails"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClusterJobProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "RepairServer"
     },
     "HciReportedProperties": {
       "type": "object",
@@ -14072,6 +14202,25 @@
           }
         ]
       }
+    },
+    "RepairServerJobServerDetails": {
+      "type": "object",
+      "description": "Details of servers to be repaired in the cluster.",
+      "properties": {
+        "serverName": {
+          "type": "string",
+          "description": "Name of server to be repaired in cluster."
+        },
+        "serverResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource id of Arc machine part of cluster for which job will be triggered."
+        }
+      },
+      "required": [
+        "serverName",
+        "serverResourceId"
+      ]
     },
     "ReportedProperties": {
       "type": "object",


### PR DESCRIPTION
## Summary
Port AddServer and RepairServer ClusterJob features from private preview to public preview (2026-05-01-preview).

## Changes
- **models.tsp**: Added `AddServer` and `RepairServer` members to `HciJobType` union
- **models.tsp**: Added `AddServerJobServerDetails`, `HciAddServerJobProperties`, `RepairServerJobServerDetails`, `HciRepairServerJobProperties` models
- **examples**: Added 4 example files (CreateOrUpdate + Get for each job type)
- All tagged with `@added(Versions.v2026_05_01_preview)`

## Validation
- [x] `tsp format` - formatted
- [x] `tsp compile .` - no warnings
- [x] `prettier` - examples formatted
- [x] `oav validate-example` - passes without errors