### PR TITLE
Fix format of newly added code

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/DataCollectionRuleConfigurationMetadata/main.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/DataCollectionRuleConfigurationMetadata/main.tsp
@@ -52,5 +52,7 @@ interface DataCollectionRuleConfigurationMetadata {
     /** Request body containing filter options and stream metadata flag. */
     @body
     body?: DataCollectionRuleConfigurationMetadataRequest,
-  ): ArmResponse<DataCollectionRuleConfigurationMetadataResponse> | ErrorResponse;
+  ):
+    | ArmResponse<DataCollectionRuleConfigurationMetadataResponse>
+    | ErrorResponse;
 }

--- a/specification/security/resource-manager/Microsoft.Security/Security/ServerVulnerabilityAssessmentsSettings/ServerVulnerabilityAssessmentsSetting.tsp
+++ b/specification/security/resource-manager/Microsoft.Security/Security/ServerVulnerabilityAssessmentsSettings/ServerVulnerabilityAssessmentsSetting.tsp
@@ -30,7 +30,8 @@ model ServerVulnerabilityAssessmentsSetting
   >;
 }
 
-@@doc(ServerVulnerabilityAssessmentsSetting.kind,
+@@doc(
+  ServerVulnerabilityAssessmentsSetting.kind,
   "The kind of the server vulnerability assessments setting."
 );
 @@pattern(ServerVulnerabilityAssessmentsSetting.kind, "");


### PR DESCRIPTION
Format prs that didn't reformat since tsp upgrade