### PR TITLE
Port EdgeMachines validate action to 2026-05-01-preview

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/EdgeMachine.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/EdgeMachine.tsp
@@ -59,6 +59,16 @@ interface EdgeMachines {
    * List all edge machines in a subscription.
    */
   listBySubscription is ArmListBySubscription<EdgeMachine>;
+
+  /**
+   * A long-running resource action to validate the edge machine.
+   */
+  @added(Versions.v2026_05_01_preview)
+  validate is ArmResourceActionAsync<
+    EdgeMachine,
+    EdgeMachineValidateRequest,
+    EdgeMachineValidateResponse
+  >;
 }
 
 @@doc(EdgeMachine.name, "Name of Device");

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_Validate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_Validate.json
@@ -1,0 +1,30 @@
+{
+  "title": "EdgeMachines_Validate",
+  "operationId": "EdgeMachines_Validate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "ArcInstance-rg",
+    "edgeMachineName": "machine-1",
+    "body": {
+      "edgeMachineIds": [
+        "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/edgeMachines/machine-2",
+        "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/edgeMachines/machine-3"
+      ],
+      "additionalInfo": "Validate before cluster creation"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-05-01-preview",
+        "Retry-After": "10"
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -6777,6 +6777,38 @@ model EdgeMachinePatch {
 }
 
 /**
+ * The validate request for Edge Machine.
+ */
+@added(Versions.v2026_05_01_preview)
+model EdgeMachineValidateRequest {
+  /**
+   * Machine Ids against which, current machine has to be validated.
+   */
+  edgeMachineIds: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.AzureStackHCI/edgeMachines";
+    }
+  ]>[];
+
+  /**
+   * Additional info required for validation.
+   */
+  additionalInfo?: string;
+}
+
+/**
+ * The validate response for Edge Machine.
+ */
+@added(Versions.v2026_05_01_preview)
+model EdgeMachineValidateResponse {
+  /**
+   * Edge machine validation status.
+   */
+  @visibility(Lifecycle.Read)
+  status?: string;
+}
+
+/**
  * Details for device provisioning.
  */
 @added(Versions.v2026_05_01_preview)

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_Validate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_Validate.json
@@ -1,0 +1,30 @@
+{
+  "title": "EdgeMachines_Validate",
+  "operationId": "EdgeMachines_Validate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "fd3c3665-1729-4b7b-9a38-238e83b0f98b",
+    "resourceGroupName": "ArcInstance-rg",
+    "edgeMachineName": "machine-1",
+    "body": {
+      "edgeMachineIds": [
+        "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/edgeMachines/machine-2",
+        "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/edgeMachines/machine-3"
+      ],
+      "additionalInfo": "Validate before cluster creation"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Succeeded"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/providers/Microsoft.AzureStackHCI/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-05-01-preview",
+        "Retry-After": "10"
+      }
+    }
+  }
+}

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
@@ -6295,6 +6295,80 @@
         "x-ms-long-running-operation": true
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/edgeMachines/{edgeMachineName}/validate": {
+      "post": {
+        "operationId": "EdgeMachines_Validate",
+        "tags": [
+          "EdgeMachines"
+        ],
+        "description": "A long-running resource action to validate the edge machine.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "edgeMachineName",
+            "in": "path",
+            "description": "Name of Device",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_]{3,63}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EdgeMachineValidateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EdgeMachineValidateResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "EdgeMachines_Validate": {
+            "$ref": "./examples/EdgeMachines_Validate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureStackHCI/locations/{location}/validateOwnershipVouchers": {
       "post": {
         "operationId": "OwnershipVouchers_Validate",
@@ -10045,6 +10119,46 @@
             "description": "Preparing EdgeMachine"
           }
         ]
+      }
+    },
+    "EdgeMachineValidateRequest": {
+      "type": "object",
+      "description": "The validate request for Edge Machine.",
+      "properties": {
+        "edgeMachineIds": {
+          "type": "array",
+          "description": "Machine Ids against which, current machine has to be validated.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.AzureStackHCI/edgeMachines"
+                }
+              ]
+            }
+          }
+        },
+        "additionalInfo": {
+          "type": "string",
+          "description": "Additional info required for validation."
+        }
+      },
+      "required": [
+        "edgeMachineIds"
+      ]
+    },
+    "EdgeMachineValidateResponse": {
+      "type": "object",
+      "description": "The validate response for Edge Machine.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Edge machine validation status.",
+          "readOnly": true
+        }
       }
     },
     "EdgeSolutionType": {


### PR DESCRIPTION
## Summary
Port the EdgeMachines validate long-running action from private preview (2026-03-15-preview) to public preview (2026-05-01-preview).

## Changes
- **EdgeMachine.tsp**: Added `validate` operation using `ArmResourceActionAsync`  
- **models.tsp**: Added `EdgeMachineValidateRequest` and `EdgeMachineValidateResponse` models
- **examples**: Added `EdgeMachines_Validate.json`
- All tagged with `@added(Versions.v2026_05_01_preview)`

## Validation
- [x] `tsp format` - formatted
- [x] `tsp compile .` - no warnings
- [x] `prettier` - examples formatted
- [x] `oav validate-example` - passes without errors