### PR TITLE
Rename App Configuration deleted stores list method

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/client.tsp
@@ -140,6 +140,11 @@ using Azure.ClientGenerator.Core;
   "csharp"
 );
 @@clientName(
+  ConfigurationStoresOperationGroup.listDeleted,
+  "GetDeletedAppConfigurationStores",
+  "csharp"
+);
+@@clientName(
   OperationsOperationGroup.regionalCheckNameAvailability,
   "CheckAppConfigurationRegionalNameAvailability",
   "csharp"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
@@ -24,6 +24,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.AppConfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-06-01-preview"
     enable-wire-path-attribute: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-appconfiguration"


### PR DESCRIPTION
Updates the C# client name for the App Configuration deleted stores subscription list operation from \GetDeleted\ to \GetDeletedAppConfigurationStores\ so the generated .NET SDK surface is specific enough after resource detection changes.\n\nAlso pins C# management SDK generation to API version \2025-06-01-preview\ to avoid pulling unrelated latest API-version changes into the SDK mitigation.\n\nValidation: \
px tsp compile . --warn-as-error=false --pretty=false\ from \specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration\.