### PR TITLE
feat(agents-session-files): add has_more, @list, and optional path to ListSessionFiles

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -43,4 +43,7 @@ model SessionDirectoryListResponse {
 
   @doc("The directory entries.")
   entries: SessionDirectoryEntry[];
+
+  @doc("A value indicating whether there are additional values available not captured in this list.")
+  has_more: boolean;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -79,9 +79,11 @@ interface AgentSessionFiles {
   /**
    * List files and directories at a given path in the session sandbox.
    * Returns only the immediate children of the specified directory (non-recursive).
+   * If path is not provided, lists the session home directory.
    */
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}/files")
+  @list
   @extension(
     "x-ms-foundry-meta",
     #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
@@ -95,8 +97,8 @@ interface AgentSessionFiles {
       /** The session ID. */
       @path session_id: string;
 
-      /** The directory path to list, relative to the session home directory. */
-      @query path: string;
+      /** The directory path to list, relative to the session home directory. Defaults to the home directory if not provided. */
+      @query path?: string;
     },
     SessionDirectoryListResponse
   >;


### PR DESCRIPTION
## ListSessionFiles: Add pagination signal and optional path

### Changes
1. **`has_more: boolean`** added to `SessionDirectoryListResponse` model — enables future pagination without breaking backward compatibility
2. **`@list` decorator** added to the `listSessionFiles` operation — follows Foundry SDK guidelines for list APIs
3. **`path` made optional** — when omitted, the server lists the home directory ($HOME)

### Context
- Companion AgentsV2 implementation PR: [vienna#2103392](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2103392)
- Follows [Foundry SDK paged result guidelines](https://github.com/coreai-microsoft/foundrysdk_specs/blob/main/guidelines/service-patterns.md#response-shape-agentspagedresultt)
- `has_more` will be hardcoded `false` until ADC supports pagination
- Original Files API spec: https://github.com/Azure/azure-rest-api-specs/pull/41586

### Files Changed
- `specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp` — added `has_more` property
- `specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp` — added `@list`, made `path` optional, updated docs