### PR TITLE
Renaming: `microsoft` to `Microsoft` - Microsoft.AlertsManagement

### DIFF
--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/preview/2025-07-01-preview/PreviewAlertRule.json
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/preview/2025-07-01-preview/PreviewAlertRule.json
@@ -40,7 +40,7 @@
   },
   "tags": [],
   "paths": {
-    "/{resourceId}/providers/microsoft.AlertsManagement/previewAlertRule": {
+    "/{resourceId}/providers/Microsoft.AlertsManagement/previewAlertRule": {
       "post": {
         "operationId": "PreviewAlertRule",
         "description": "Retrieves the results of a simulated historical execution of an alert rule",

--- a/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/routes.tsp
+++ b/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/PreviewAlertRule/routes.tsp
@@ -16,7 +16,7 @@ namespace Microsoft.AlertsManagement;
  */
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@route("/{resourceId}/providers/microsoft.AlertsManagement/previewAlertRule")
+@route("/{resourceId}/providers/Microsoft.AlertsManagement/previewAlertRule")
 @post
 op previewAlertRule(
   ...ApiVersionParameter,


### PR DESCRIPTION
Split from Azure/azure-rest-api-specs#43189.

This PR contains only Microsoft.AlertsManagement changes.