### PR TITLE
Renaming: `microsoft` to `Microsoft` - Microsoft.ApiManagement

### DIFF
--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/ApiManagementServiceResource.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/ApiManagementServiceResource.tsp
@@ -81,7 +81,7 @@ alias QuotaCounterKeyOps = Azure.ResourceManager.Legacy.RoutedOperations<
   QuotaCounterKeyParentParameters,
   QuotaCounterKeyParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/quotas/{quotaCounterKey}",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/quotas/{quotaCounterKey}",
   }
 >;
 
@@ -124,7 +124,7 @@ alias QuotaPeriodKeyOps = Azure.ResourceManager.Legacy.RoutedOperations<
   QuotaPeriodKeyParentParameters,
   QuotaPeriodKeyParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/quotas/{quotaCounterKey}/periods",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/quotas/{quotaCounterKey}/periods",
   }
 >;
 

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/GroupContract.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/GroupContract.tsp
@@ -93,7 +93,7 @@ alias GroupUserOps = Azure.ResourceManager.Legacy.RoutedOperations<
   GroupUserParentParameters,
   GroupUserParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/groups/{groupId}/users",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/groups/{groupId}/users",
   }
 >;
 
@@ -147,7 +147,7 @@ alias WorkspaceGroupUserOps = Azure.ResourceManager.Legacy.RoutedOperations<
   WorkspaceGroupUserParentParameters,
   WorkspaceGroupUserParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/groups/{groupId}/users",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/workspaces/{workspaceId}/groups/{groupId}/users",
   }
 >;
 

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/NotificationContract.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/NotificationContract.tsp
@@ -62,7 +62,7 @@ alias NotificationRecipientEmailOps = Azure.ResourceManager.Legacy.RoutedOperati
   NotificationRecipientEmailParentParameters,
   NotificationRecipientEmailParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/notifications/{notificationName}/recipientEmails/{email}",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/notifications/{notificationName}/recipientEmails/{email}",
   }
 >;
 
@@ -104,7 +104,7 @@ alias NotificationRecipientUserOps = Azure.ResourceManager.Legacy.RoutedOperatio
   NotificationRecipientUserParentParameters,
   NotificationRecipientUserParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/notifications/{notificationName}/recipientUsers",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/notifications/{notificationName}/recipientUsers",
   }
 >;
 

--- a/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/ProductContract.tsp
+++ b/specification/apimanagement/resource-manager/Microsoft.ApiManagement/ApiManagement/ProductContract.tsp
@@ -67,7 +67,7 @@ alias ProductApiOps = Azure.ResourceManager.Legacy.RoutedOperations<
   ProductApiParentParameters,
   ProductApiParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/products/{productId}/apis",
   }
 >;
 
@@ -112,7 +112,7 @@ alias ProductGroupOps = Azure.ResourceManager.Legacy.RoutedOperations<
   ProductGroupParentParameters,
   ProductGroupParameters,
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.ApiManagement/service/{serviceName}/products/{productId}/groups",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/products/{productId}/groups",
   }
 >;
 


### PR DESCRIPTION
Split from Azure/azure-rest-api-specs#43189.

This PR contains only Microsoft.ApiManagement changes.