### PR TITLE
Renaming: `microsoft` to `Microsoft` - Microsoft.Automation

### DIFF
--- a/specification/automation/Automation.Management/Runbook.tsp
+++ b/specification/automation/Automation.Management/Runbook.tsp
@@ -42,7 +42,7 @@ alias RunbookOps = Azure.ResourceManager.Legacy.RoutedOperations<
     ...KeysOf<Runbook>;
   },
   ResourceRoute = #{
-    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Automation/automationAccounts/{automationAccountName}/runbooks/{runbookName}",
+    route: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Automation/automationAccounts/{automationAccountName}/runbooks/{runbookName}",
   }
 >;
 


### PR DESCRIPTION
Split from Azure/azure-rest-api-specs#43189.

This PR contains only Microsoft.Automation changes.