### PR TITLE
Fix TypeSpec validation by applying formatter output

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/Commit.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/Commit.tsp
@@ -151,6 +151,7 @@ interface Commits {
 
 @@doc(Commit.name, "The name of the commit.");
 @@doc(Commit.properties, "The Commit properties");
-@@doc(Commits.createOrUpdate::parameters.resource,
+@@doc(
+  Commits.createOrUpdate::parameters.resource,
   "Parameters supplied to specify which commit to create"
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/ConnectionPolicy.tsp
@@ -79,12 +79,15 @@ interface ConnectionPolicies {
   >;
 }
 
-@@doc(ConnectionPolicy.name,
+@@doc(
+  ConnectionPolicy.name,
   "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource."
 );
-@@doc(ConnectionPolicy.properties,
+@@doc(
+  ConnectionPolicy.properties,
   "Properties of the ConnectionPolicy resource."
 );
-@@doc(ConnectionPolicies.createOrUpdate::parameters.resource,
+@@doc(
+  ConnectionPolicies.createOrUpdate::parameters.resource,
   "Parameters supplied to create or update a ConnectionPolicy."
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
@@ -144,15 +144,19 @@ interface Subgroups {
 
 @@doc(InterconnectGroup.name, "The name of the interconnect group.");
 @@doc(InterconnectGroup.properties, "Properties of the interconnect group.");
-@@doc(InterconnectGroups.createOrUpdate::parameters.resource,
+@@doc(
+  InterconnectGroups.createOrUpdate::parameters.resource,
   "Parameters supplied to the create or update interconnect group operation."
 );
-@@doc(InterconnectGroups.updateTags::parameters.properties,
+@@doc(
+  InterconnectGroups.updateTags::parameters.properties,
   "Parameters supplied to update interconnect group tags."
 );
-@@clientName(InterconnectGroups.createOrUpdate::parameters.resource,
+@@clientName(
+  InterconnectGroups.createOrUpdate::parameters.resource,
   "parameters"
 );
-@@clientName(InterconnectGroups.updateTags::parameters.properties,
+@@clientName(
+  InterconnectGroups.updateTags::parameters.properties,
   "parameters"
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/back-compatible.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/back-compatible.tsp
@@ -2092,6 +2092,7 @@ using TypeSpec.Versioning;
 
 @@added(DdosSettings.ddosCustomPolicy, Microsoft.Network.Versions.v2025_07_01);
 
-@@added(DdosCustomPolicyPropertiesFormat.publicIPAddresses,
+@@added(
+  DdosCustomPolicyPropertiesFormat.publicIPAddresses,
   Microsoft.Network.Versions.v2025_07_01
 );

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -77,7 +77,8 @@ namespace CombineClient;
 @@clientName(Microsoft.Network.QosIpRange.startIP, "startIp", "java");
 @@clientName(Microsoft.Network.QosIpRange.endIP, "endIp", "java");
 // Mitigate ProvisioningState split: create unified union with all values
-@@clientName(Common.ProvisioningState,
+@@clientName(
+  Common.ProvisioningState,
   "CommonProvisioningState",
   "java,javascript"
 );


### PR DESCRIPTION
Changes are for fixing TypeSpec Validation Formatting Errors for Network API