### PR TITLE
re-introduce isolation key header

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -52,6 +52,8 @@ interface AgentInvocations {
 
       /** The request body. */
       @body request: unknown;
+
+      ...UserIsolationKeyHeader;
     } & AgentInvocationPreviewHeader,
     {
       /** Unique identifier for this invocation. */
@@ -82,6 +84,8 @@ interface AgentInvocations {
 
       /** The unique identifier of the invocation. */
       @path invocation_id: string;
+
+      ...UserIsolationKeyHeader;
     } & AgentInvocationPreviewHeader,
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */
@@ -115,6 +119,8 @@ interface AgentInvocations {
 
       /** Optional request body. */
       @body request?: unknown;
+
+      ...UserIsolationKeyHeader;
     } & AgentInvocationPreviewHeader,
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -43,6 +43,8 @@ interface AgentWebsocket {
       foundry_features_query?: AgentDefinitionOptInKeys[] = #[
         AgentDefinitionOptInKeys.hosted_agents_v1_preview
       ];
+
+      ...UserIsolationKeyHeader;
     } & AgentWebsocketPreviewHeader,
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -47,6 +47,8 @@ interface AgentSessionFiles {
       @header("Content-Type") contentType: "application/octet-stream";
 
       @body content: bytes;
+
+      ...UserIsolationKeyHeader;
     },
     ResourceCreatedResponse<SessionFileWriteResponse>
   >;
@@ -71,6 +73,8 @@ interface AgentSessionFiles {
 
       /** The file path to download from the sandbox, relative to the session home directory. */
       @query path: string;
+
+      ...UserIsolationKeyHeader;
     },
     bytes
   >;
@@ -96,6 +100,8 @@ interface AgentSessionFiles {
 
       /** The directory path to list, relative to the session home directory. */
       @query path: string;
+
+      ...UserIsolationKeyHeader;
     },
     SessionDirectoryListResponse
   >;
@@ -124,6 +130,8 @@ interface AgentSessionFiles {
 
       /** Whether to recursively delete directory contents. Defaults to false. */
       @query recursive?: boolean = false;
+
+      ...UserIsolationKeyHeader;
     },
     void
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -27,6 +27,16 @@ alias AcceptJsonHeader = {
   @header accept: "application/json";
 };
 
+/**
+ * Optional request header carrying an opaque per-user isolation key forwarded to the agent
+ * endpoint. When present, the service scopes endpoint-scoped data access (responses,
+ * conversations, sessions) to the supplied user.
+ */
+alias UserIsolationKeyHeader = {
+  /** Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user. */
+  @header("x-ms-user-isolation-key") user_isolation_key?: string;
+};
+
 #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "OpenAI-based operations are not conventionally versioned"
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
 op OpenAIOperation<

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
@@ -18,7 +18,7 @@ interface Conversations {
   @post
   @operationId("createConversation")
   createConversation is OpenAIOperation<
-    OpenAI.CreateConversationBody,
+    OpenAI.CreateConversationBody & UserIsolationKeyHeader,
     OpenAI.ConversationResource
   >;
 
@@ -34,6 +34,7 @@ interface Conversations {
       @path conversation_id: string;
 
       ...OpenAI.UpdateConversationBody;
+      ...UserIsolationKeyHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -48,6 +49,8 @@ interface Conversations {
     {
       /** The id of the conversation to retrieve. */
       @path conversation_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -62,6 +65,8 @@ interface Conversations {
     {
       /** The id of the conversation to delete. */
       @path conversation_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     OpenAI.DeletedConversationResource
   >;
@@ -80,6 +85,7 @@ interface Conversations {
       ...CommonPageQueryParameters;
       ...AgentNameQueryParam;
       ...AgentIdQueryParam;
+      ...UserIsolationKeyHeader;
     },
     AgentsPagedResult<OpenAI.ConversationResource>
   >;
@@ -105,6 +111,8 @@ interface Conversations {
       #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
       @maxItems(20)
       items: OpenAI.Item[];
+
+      ...UserIsolationKeyHeader;
     },
     OpenAI.ConversationItemList
   >;
@@ -122,6 +130,8 @@ interface Conversations {
 
       /** The id of the conversation item to retrieve. */
       @path item_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     OpenAI.OutputItem
   >;
@@ -139,6 +149,8 @@ interface Conversations {
 
       /** The id of the conversation item to delete. */
       @path item_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -157,6 +169,7 @@ interface Conversations {
 
       ...CommonPageQueryParameters;
       ...ItemTypeQueryParameter;
+      ...UserIsolationKeyHeader;
     },
     AgentsPagedResult<OpenAI.OutputItem>
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-responses/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-responses/routes.tsp
@@ -24,7 +24,7 @@ interface Responses {
   @post
   @sharedRoute
   createResponse is OpenAIOperation<
-    OpenAI.CreateResponse,
+    OpenAI.CreateResponse & UserIsolationKeyHeader,
     AgentSessionIdResponseHeader & {
       @body body: OpenAI.Response;
     }
@@ -37,7 +37,7 @@ interface Responses {
   @post
   @sharedRoute
   createResponseStream is OpenAIOperation<
-    OpenAI.CreateResponse,
+    OpenAI.CreateResponse & UserIsolationKeyHeader,
     AgentSessionIdResponseHeader & SseResponseOf<OpenAI.CreateResponseStreamingResponse>
   >;
 
@@ -64,6 +64,8 @@ interface Responses {
 
       @query stream?: boolean = false;
       @query starting_after?: int32;
+
+      ...UserIsolationKeyHeader;
     },
     AgentSessionIdResponseHeader & {
       @body body: OpenAI.Response;
@@ -92,6 +94,8 @@ interface Responses {
 
       @header accept: "text/event-stream";
       @query starting_after?: int32;
+
+      ...UserIsolationKeyHeader;
     },
     AgentSessionIdResponseHeader & SseResponseOf<OpenAI.CreateResponseStreamingResponse>
   >;
@@ -110,6 +114,8 @@ interface Responses {
       @path
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     AgentSessionIdResponseHeader & {
       @body body: DeleteResponseResult;
@@ -130,6 +136,8 @@ interface Responses {
       @path
       @example("resp_677efb5139a88190b512bc3fef8e535d")
       response_id: string;
+
+      ...UserIsolationKeyHeader;
     },
     AgentSessionIdResponseHeader & {
       @body body: OpenAI.Response;
@@ -150,6 +158,7 @@ interface Responses {
       response_id: string;
 
       ...CommonPageQueryParameters;
+      ...UserIsolationKeyHeader;
     },
     AgentSessionIdResponseHeader & {
       @body body: AgentsPagedResult<OpenAI.ItemResource>;
@@ -168,6 +177,7 @@ interface Responses {
       ...AgentNameQueryParam;
       ...AgentIdQueryParam;
       ...ConversationIdQueryParam;
+      ...UserIsolationKeyHeader;
     },
     AgentsPagedResult<OpenAI.Response>
   >;


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Is this review for (select one):

- [ ] a private preview
- [ ] a public preview
- [x] GA release

### Change Scope
It was removed here with wrong header name: https://github.com/Azure/azure-rest-api-specs/pull/42825

now re-adding it with correct header name and in all of the places that the header is supported .
