### PR TITLE
Update force param docs: clarify Hosted Agent applicability

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -164,7 +164,7 @@ interface Agents {
       /** The name of the agent to delete. */
       @path agent_name: string;
 
-      /** If true, force-deletes the agent even if its versions have active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
+      /** For Hosted Agents, if true, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. This value is not relevant for other Agent types. Defaults to false. */
       @query force?: boolean = false;
     },
     DeleteAgentResponse
@@ -260,7 +260,7 @@ interface Agents {
       /** The version of the agent to delete */
       @path agent_version: string;
 
-      /** If true, force-deletes the version even if it has active sessions (hosted agents), cascading deletion to all associated sessions. Defaults to false. */
+      /** For Hosted Agents, if true, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. This value is not relevant for other Agent types. Defaults to false. */
       @query force?: boolean = false;
     },
     DeleteAgentVersionResponse


### PR DESCRIPTION
Follow-up to #42970 — updates the `force` parameter description on DeleteAgent and DeleteAgentVersion to lead with "For Hosted Agents" and clarify irrelevance for other Agent types, per reviewer feedback from @dargilco.