### PR TITLE
Search 2026-05-01-preview: Remove WorkIQ KS

### DIFF
--- a/specification/search/data-plane/Search/CHANGELOG.md
+++ b/specification/search/data-plane/Search/CHANGELOG.md
@@ -51,7 +51,6 @@ It is maintained for internal engineering reference and API Stewardship Board re
 [NEW in this preview]
 
 - **`IndexedSql`**: `IndexedSqlKnowledgeSource`, `IndexedSqlKnowledgeSourceParameters` (connection string, query, column mappings), `ContentColumnMapping`, `EmbeddingColumnMapping`.
-- **`WorkIQ`**: `WorkIQKnowledgeSource`, `WorkIQKnowledgeSourceParams`.
 - **`File`**: `FileKnowledgeSource`, `FileKnowledgeSourceParameters`, `KnowledgeSourceFile`, `ListKnowledgeSourceFilesResult`.
 - **`McpServer`**: `McpServerKnowledgeSource`, `McpServerKnowledgeSourceParameters`; auth via `McpServerAuthentication` (Foundry/StoredHeaders variants); tools via `McpServerTool`; output via `McpServerOutputParsing` (`auto`, `json`, `split`, `none`).
 - **`FabricDataAgent`**: `FabricDataAgentKnowledgeSource`, `FabricDataAgentKnowledgeSourceParameters`; activity/reference types.
@@ -105,14 +104,13 @@ It is maintained for internal engineering reference and API Stewardship Board re
 
 [NEW in this preview]
 
-- **WorkIQ**: `KnowledgeBaseWorkIQActivityRecord`, `KnowledgeBaseWorkIQActivityArguments`, `KnowledgeBaseWorkIQReference` (`WorkIQAttribution[]`, `searchSensitivityLabelInfo`), `WorkIQAttribution` (`seeMoreWebUrl`).
 - **LLM web summarization**: `KnowledgeBaseModelWebSummarizationActivityRecord` (`inputTokens`, `outputTokens`, `modelName`).
-- **New enum values**: `modelWebSummarization`, `workIQ`, `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseActivityRecordType`; `workIQ`, `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseReferenceType`.
+- **New enum values**: `modelWebSummarization`, `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseActivityRecordType`; `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseReferenceType`.
 
 **Sensitivity label model**:
 
 [NEW in this preview]
-- `PurviewSensitivityLabelInfo` (replaces `SharePointSensitivityLabelInfo`): `displayName`, `sensitivityLabelId`, `toolTip`, `priority`, `color`, `isEncrypted`; added to `KnowledgeBaseSearchIndexReference`, `KnowledgeBaseAzureBlobReference`, `KnowledgeBaseIndexedOneLakeReference`, `KnowledgeBaseWorkIQReference`.
+- `PurviewSensitivityLabelInfo` (replaces `SharePointSensitivityLabelInfo`): `displayName`, `sensitivityLabelId`, `toolTip`, `priority`, `color`, `isEncrypted`; added to `KnowledgeBaseSearchIndexReference`, `KnowledgeBaseAzureBlobReference`, `KnowledgeBaseIndexedOneLakeReference`.
 
 ### Preview-to-Preview Changes (2025-11-01-preview → 2026-05-01-preview)
 

--- a/specification/search/data-plane/Search/client.tsp
+++ b/specification/search/data-plane/Search/client.tsp
@@ -373,8 +373,6 @@ namespace KnowledgeBaseRetrievalClient {
 @@usage(WebKnowledgeSource, Usage.input);
 @@access(RemoteSharePointKnowledgeSource, Access.public);
 @@usage(RemoteSharePointKnowledgeSource, Usage.input);
-@@access(WorkIQKnowledgeSource, Access.public);
-@@usage(WorkIQKnowledgeSource, Usage.input);
 @@access(McpServerKnowledgeSource, Access.public);
 @@usage(McpServerKnowledgeSource, Usage.input);
 @@access(IndexedSqlKnowledgeSource, Access.public);
@@ -1987,15 +1985,6 @@ namespace KnowledgeBaseRetrievalClient {
 );
 @@clientNamespace(
   Search.EmbeddingColumnMapping,
-  "com.azure.search.documents.indexes",
-  "java"
-);
-@@clientNamespace(
-  Search.WorkIQKnowledgeSource,
-  "Azure.Search.Documents.Indexes"
-);
-@@clientNamespace(
-  Search.WorkIQKnowledgeSource,
   "com.azure.search.documents.indexes",
   "java"
 );
@@ -4895,51 +4884,6 @@ namespace KnowledgeBaseRetrievalClient {
 );
 @@clientNamespace(
   Search.PurviewSensitivityLabelInfo,
-  "com.azure.search.documents.knowledgebases",
-  "java"
-);
-@@clientNamespace(
-  Search.WorkIQKnowledgeSourceParams,
-  "Azure.Search.Documents.KnowledgeBases"
-);
-@@clientNamespace(
-  Search.WorkIQKnowledgeSourceParams,
-  "com.azure.search.documents.knowledgebases",
-  "java"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQActivityRecord,
-  "Azure.Search.Documents.KnowledgeBases"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQActivityRecord,
-  "com.azure.search.documents.knowledgebases",
-  "java"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQActivityArguments,
-  "Azure.Search.Documents.KnowledgeBases"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQActivityArguments,
-  "com.azure.search.documents.knowledgebases",
-  "java"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQReference,
-  "Azure.Search.Documents.KnowledgeBases"
-);
-@@clientNamespace(
-  Search.KnowledgeBaseWorkIQReference,
-  "com.azure.search.documents.knowledgebases",
-  "java"
-);
-@@clientNamespace(
-  Search.WorkIQAttribution,
-  "Azure.Search.Documents.KnowledgeBases"
-);
-@@clientNamespace(
-  Search.WorkIQAttribution,
   "com.azure.search.documents.knowledgebases",
   "java"
 );

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -241,14 +241,6 @@ model RemoteSharePointKnowledgeSourceParams extends KnowledgeSourceParams {
   filterExpressionAddOn?: string;
 }
 
-/** Specifies runtime parameters for a WorkIQ knowledge source */
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model WorkIQKnowledgeSourceParams extends KnowledgeSourceParams {
-  /** The discriminator value. */
-  kind: KnowledgeSourceKind.WorkIQ;
-}
-
 /** Specifies runtime parameters for a Fabric Data Agent knowledge source */
 @added(Versions.v2026_05_01_preview)
 model FabricDataAgentKnowledgeSourceParams extends KnowledgeSourceParams {
@@ -363,10 +355,6 @@ union KnowledgeBaseActivityRecordType {
   @added(Versions.v2026_05_01_preview)
   @removed(Versions.v2026_04_01)
   remoteSharePoint: "remoteSharePoint",
-
-  /** WorkIQ retrieval activity. */
-  @added(Versions.v2026_05_01_preview)
-  workIQ: "workIQ",
 
   /** Fabric Data Agent retrieval activity. */
   @added(Versions.v2026_05_01_preview)
@@ -576,29 +564,6 @@ model KnowledgeBaseRemoteSharePointActivityArguments {
   filterExpressionAddOn?: string;
 }
 
-/** Represents a WorkIQ retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model KnowledgeBaseWorkIQActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
-  /** The discriminator value. */
-  type: KnowledgeBaseActivityRecordType.workIQ;
-
-  /** The WorkIQ arguments for the retrieval activity. */
-  #suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-  workIQArguments?: KnowledgeBaseWorkIQActivityArguments;
-}
-
-/** Represents the arguments the WorkIQ retrieval activity was run with. */
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model KnowledgeBaseWorkIQActivityArguments {
-  /** The search string used to query the WorkIQ knowledge source. */
-  search?: string;
-}
-
 /** Represents a Fabric Data Agent retrieval activity record. */
 #suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
 #suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
@@ -738,10 +703,6 @@ union KnowledgeBaseReferenceType {
   @removed(Versions.v2026_04_01)
   remoteSharePoint: "remoteSharePoint",
 
-  /** Work IQ document reference. */
-  @added(Versions.v2026_05_01_preview)
-  workIQ: "workIQ",
-
   /** Fabric Data Agent document reference. */
   @added(Versions.v2026_05_01_preview)
   fabricDataAgent: "fabricDataAgent",
@@ -861,27 +822,6 @@ model KnowledgeBaseRemoteSharePointReference extends KnowledgeBaseReference {
   /** The sensitivity label information for the reference. */
   @added(Versions.v2026_05_01_preview)
   searchSensitivityLabelInfo?: PurviewSensitivityLabelInfo;
-}
-
-/** Represents a WorkIQ document reference. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model KnowledgeBaseWorkIQReference extends KnowledgeBaseReference {
-  /** The discriminator value. */
-  type: KnowledgeBaseReferenceType.workIQ;
-
-  /** The attributions for the reference. */
-  #suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-  attributions?: WorkIQAttribution[];
-}
-
-/** Attribution information for a WorkIQ reference. */
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model WorkIQAttribution {
-  /** The URL for the attribution. */
-  seeMoreWebUrl?: url;
 }
 
 /** Represents a Fabric Data Agent document reference. */

--- a/specification/search/data-plane/Search/models-service.tsp
+++ b/specification/search/data-plane/Search/models-service.tsp
@@ -4728,10 +4728,6 @@ union KnowledgeSourceKind {
   @removed(Versions.v2026_04_01)
   RemoteSharePoint: "remoteSharePoint",
 
-  /** A knowledge source that reads data from work IQ */
-  @added(Versions.v2026_05_01_preview)
-  WorkIQ: "workIQ",
-
   /** A knowledge source that supports direct file upload and indexing. */
   @added(Versions.v2026_05_01_preview)
   File: "file",
@@ -5062,13 +5058,6 @@ model RemoteSharePointKnowledgeSourceParameters {
 
   /** Container ID for SharePoint Embedded connection. When this is null, it will use SharePoint Online. */
   containerTypeId?: string;
-}
-
-/** Configuration for WorkIQ knowledge source. */
-#suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
-@added(Versions.v2026_05_01_preview)
-model WorkIQKnowledgeSource extends KnowledgeSource {
-  kind: KnowledgeSourceKind.WorkIQ;
 }
 
 /** Configuration for a knowledge source backed by an MCP (Model Context Protocol) server. */

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -10074,7 +10074,6 @@
         "indexedOneLake",
         "web",
         "remoteSharePoint",
-        "workIQ",
         "fabricDataAgent",
         "fabricOntology",
         "modelQueryPlanning",
@@ -10115,11 +10114,6 @@
             "name": "remoteSharePoint",
             "value": "remoteSharePoint",
             "description": "Remote SharePoint retrieval activity."
-          },
-          {
-            "name": "workIQ",
-            "value": "workIQ",
-            "description": "WorkIQ retrieval activity."
           },
           {
             "name": "fabricDataAgent",
@@ -10745,7 +10739,6 @@
         "indexedOneLake",
         "web",
         "remoteSharePoint",
-        "workIQ",
         "fabricDataAgent",
         "fabricOntology"
       ],
@@ -10782,11 +10775,6 @@
             "name": "remoteSharePoint",
             "value": "remoteSharePoint",
             "description": "Remote SharePoint document reference."
-          },
-          {
-            "name": "workIQ",
-            "value": "workIQ",
-            "description": "Work IQ document reference."
           },
           {
             "name": "fabricDataAgent",
@@ -11136,51 +11124,6 @@
         }
       ],
       "x-ms-discriminator-value": "web"
-    },
-    "KnowledgeBaseWorkIQActivityArguments": {
-      "type": "object",
-      "description": "Represents the arguments the WorkIQ retrieval activity was run with.",
-      "properties": {
-        "search": {
-          "type": "string",
-          "description": "The search string used to query the WorkIQ knowledge source."
-        }
-      }
-    },
-    "KnowledgeBaseWorkIQActivityRecord": {
-      "type": "object",
-      "description": "Represents a WorkIQ retrieval activity record.",
-      "properties": {
-        "workIQArguments": {
-          "$ref": "#/definitions/KnowledgeBaseWorkIQActivityArguments",
-          "description": "The WorkIQ arguments for the retrieval activity."
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
-        }
-      ],
-      "x-ms-discriminator-value": "workIQ"
-    },
-    "KnowledgeBaseWorkIQReference": {
-      "type": "object",
-      "description": "Represents a WorkIQ document reference.",
-      "properties": {
-        "attributions": {
-          "type": "array",
-          "description": "The attributions for the reference.",
-          "items": {
-            "$ref": "#/definitions/WorkIQAttribution"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeBaseReference"
-        }
-      ],
-      "x-ms-discriminator-value": "workIQ"
     },
     "KnowledgeRetrievalIntent": {
       "type": "object",
@@ -11568,7 +11511,6 @@
         "indexedSql",
         "web",
         "remoteSharePoint",
-        "workIQ",
         "file",
         "mcpServer",
         "fabricDataAgent",
@@ -11612,11 +11554,6 @@
             "name": "RemoteSharePoint",
             "value": "remoteSharePoint",
             "description": "A knowledge source that reads data from remote SharePoint."
-          },
-          {
-            "name": "WorkIQ",
-            "value": "workIQ",
-            "description": "A knowledge source that reads data from work IQ"
           },
           {
             "name": "File",
@@ -22717,37 +22654,6 @@
         }
       ],
       "x-ms-discriminator-value": "#Microsoft.Azure.Search.WordDelimiterTokenFilter"
-    },
-    "WorkIQAttribution": {
-      "type": "object",
-      "description": "Attribution information for a WorkIQ reference.",
-      "properties": {
-        "seeMoreWebUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "The URL for the attribution."
-        }
-      }
-    },
-    "WorkIQKnowledgeSource": {
-      "type": "object",
-      "description": "Configuration for WorkIQ knowledge source.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeSource"
-        }
-      ],
-      "x-ms-discriminator-value": "workIQ"
-    },
-    "WorkIQKnowledgeSourceParams": {
-      "type": "object",
-      "description": "Specifies runtime parameters for a WorkIQ knowledge source",
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeSourceParams"
-        }
-      ],
-      "x-ms-discriminator-value": "workIQ"
     }
   },
   "parameters": {


### PR DESCRIPTION
This pull request removes all references to the WorkIQ knowledge source and its related types, parameters, and activity/record definitions from the Search data-plane API. The changes affect both the TypeSpec models and the generated OpenAPI/JSON files, as well as client configuration and documentation. The intent is to fully deprecate and eliminate WorkIQ support from the 2026-05-01-preview API.

Key removals and deprecations:

**WorkIQ knowledge source and parameters:**
* Removed the `WorkIQKnowledgeSource` and `WorkIQKnowledgeSourceParams` models, as well as their registration in the `KnowledgeSourceKind` union and all related configuration and documentation. [[1]](diffhunk://#diff-58cdb5fd8251bdcbeceeefde8de0f31c4473427b115ea1d7bb94116f1fdbcf06L4731-L4734) [[2]](diffhunk://#diff-58cdb5fd8251bdcbeceeefde8de0f31c4473427b115ea1d7bb94116f1fdbcf06L5067-L5073) [[3]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL11616-L11620) [[4]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL11571) [[5]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL22720-L22750) [[6]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dL54) [[7]](diffhunk://#diff-95273a458bc74275788f8b860fe1cf144a5f1b4e3415fc4c0035c9ac88291f5cL376-L377) [[8]](diffhunk://#diff-95273a458bc74275788f8b860fe1cf144a5f1b4e3415fc4c0035c9ac88291f5cL1993-L2001) [[9]](diffhunk://#diff-95273a458bc74275788f8b860fe1cf144a5f1b4e3415fc4c0035c9ac88291f5cL4901-L4945)

**WorkIQ activity and reference types:**
* Removed all WorkIQ-related activity record, arguments, and reference models (`KnowledgeBaseWorkIQActivityRecord`, `KnowledgeBaseWorkIQActivityArguments`, `KnowledgeBaseWorkIQReference`, `WorkIQAttribution`) and their usage in unions, enums, and OpenAPI definitions. [[1]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L244-L251) [[2]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L367-L370) [[3]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L579-L601) [[4]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L741-L744) [[5]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L866-L886) [[6]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL10119-L10123) [[7]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL11140-L11184) [[8]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL22720-L22750) [[9]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dL108-R113)

**Enum and discriminator value cleanup:**
* Removed `workIQ` values from all relevant enums and discriminator lists in both TypeSpec and OpenAPI/JSON files, including `KnowledgeBaseActivityRecordType` and `KnowledgeBaseReferenceType`. [[1]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L367-L370) [[2]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259L741-L744) [[3]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL10077) [[4]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL10748) [[5]](diffhunk://#diff-5eac3421daec8b098f50b088f92b9a8b1aab76da6830b3fd66256d5d146a689cL10786-L10790)

**Changelog and documentation updates:**
* Updated the changelog and preview notes to remove references to WorkIQ types, parameters, and enum values. [[1]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dL54) [[2]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dL108-R113)

These changes ensure that the WorkIQ knowledge source and all its related features are fully removed from the API surface.