### PR TITLE
Add versioned Skills API (mirroring Toolbox pattern)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/models.tsp
@@ -86,8 +86,120 @@ model SkillObject {
   @maxLength(1024)
   description?: string;
 
+  @doc("The version identifier that the skill currently points to. Defaults to the latest version. Can be changed via updateSkillDefaultVersion.")
+  default_version?: string;
+
   ...MetadataPropertyForRequest;
 }
+
+@doc("A specific version of a skill.")
+model SkillVersionObject {
+  ...MetadataPropertyForResponse;
+
+  @doc("The unique identifier of the skill version.")
+  id: string;
+
+  @doc("The name of the skill.")
+  @maxLength(63)
+  name: string;
+
+  @doc("The version identifier of the skill. Skill versions are immutable and every update creates a new version.")
+  version: string;
+
+  @doc("A human-readable description of the skill.")
+  @maxLength(1024)
+  description?: string;
+
+  @doc("Instructions that define the behavior of the skill.")
+  @maxLength(102400)
+  instructions?: string;
+
+  @doc("Whether the skill version was created from a zip blob package.")
+  has_blob: boolean;
+
+  @doc("The Unix timestamp (seconds) when the skill version was created.")
+  @encode("unixTimestamp", int32)
+  created_at: utcDateTime;
+}
+
+alias CreateSkillVersionRequest = {
+  @doc("The name of the skill. If the skill does not exist, it will be created.")
+  @path
+  @maxLength(63)
+  name: string;
+
+  @doc("A human-readable description of the skill.")
+  @maxLength(1024)
+  description?: string;
+
+  @doc("Instructions that define the behavior of the skill.")
+  @maxLength(102400)
+  instructions?: string;
+
+  ...MetadataPropertyForRequest;
+};
+
+alias CreateSkillVersionFromPackageRequest = {
+  @doc("The name of the skill. If the skill does not exist, it will be created.")
+  @path
+  @maxLength(63)
+  name: string;
+
+  @doc("The content type of the incoming skill package payload.")
+  @header("Content-Type")
+  content_type: "application/zip";
+
+  @doc("The zip package used to create the skill version.")
+  @body
+  content: bytes;
+};
+
+alias GetSkillVersionRequest = {
+  @doc("The name of the skill.")
+  @path
+  name: string;
+
+  @doc("The version identifier to retrieve.")
+  @path
+  version: string;
+};
+
+alias ListSkillVersionsRequest = {
+  @doc("The name of the skill to list versions for.")
+  @path
+  name: string;
+
+  ...CommonPageQueryParameters;
+};
+
+alias DownloadSkillVersionRequest = {
+  @doc("The name of the skill.")
+  @path
+  name: string;
+
+  @doc("The version identifier to download.")
+  @path
+  version: string;
+};
+
+model UpdateSkillDefaultVersionRequest {
+  @doc("The name of the skill to update.")
+  @path
+  name: string;
+
+  @doc("The version identifier that the skill should point to. When set, the skill's default version will resolve to this version instead of the latest.")
+  default_version: string;
+}
+
+alias DeleteSkillVersionRequest = {
+  @doc("The name of the skill.")
+  @path
+  name: string;
+
+  @doc("The version identifier to delete.")
+  @path
+  version: string;
+};
 
 @doc("A deleted skill Object")
 model DeleteSkillResponse {

--- a/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/skills/routes.tsp
@@ -4,8 +4,12 @@ import "./models.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using Azure.ClientGenerator.Core;
 
 namespace Azure.AI.Projects;
+
+@@usage(UpdateSkillDefaultVersionRequest, Usage.input);
+@@access(UpdateSkillDefaultVersionRequest, Access.public);
 
 alias SkillsPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.skills_v1_preview>;
 
@@ -88,5 +92,99 @@ interface Skills {
   deleteSkill is FoundryDataPlaneOperation<
     DeleteSkillRequest & SkillsPreviewHeader,
     DeleteSkillResponse
+  >;
+
+  // ── Versioned Skill Operations ────────────────────────
+
+  /**
+   * Creates a new version of a skill. If the skill does not exist, it will be created.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("createSkillVersion")
+  @post
+  @route("/skills/{name}/versions")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  createSkillVersion is FoundryDataPlaneOperation<
+    CreateSkillVersionRequest & SkillsPreviewHeader,
+    SkillVersionObject
+  >;
+
+  /**
+   * Creates a new version of a skill from a zip package. If the skill does not exist, it will be created.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("createSkillVersionFromPackage")
+  @post
+  @route("/skills/{name}/versions:import")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  createSkillVersionFromPackage is FoundryDataPlaneOperation<
+    CreateSkillVersionFromPackageRequest & SkillsPreviewHeader,
+    SkillVersionObject
+  >;
+
+  /**
+   * List all versions of a skill.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("listSkillVersions")
+  @get
+  @list
+  @route("/skills/{name}/versions")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  listSkillVersions is FoundryDataPlaneOperation<
+    ListSkillVersionsRequest & SkillsPreviewHeader,
+    AgentsPagedResult<SkillVersionObject>
+  >;
+
+  /**
+   * Retrieve a specific version of a skill.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("getSkillVersion")
+  @get
+  @route("/skills/{name}/versions/{version}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  getSkillVersion is FoundryDataPlaneOperation<
+    GetSkillVersionRequest & SkillsPreviewHeader,
+    SkillVersionObject
+  >;
+
+  /**
+   * Downloads the zip package for a specific version of a skill.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("downloadSkillVersion")
+  @get
+  @route("/skills/{name}/versions/{version}:download")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  downloadSkillVersion is FoundryDataPlaneOperation<
+    DownloadSkillVersionRequest & SkillsPreviewHeader,
+    DownloadSkillResponse
+  >;
+
+  /**
+   * Update a skill to point to a specific version.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("updateSkillDefaultVersion")
+  @patch
+  @route("/skills/{name}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  updateSkillDefaultVersion is FoundryDataPlaneOperation<
+    UpdateSkillDefaultVersionRequest & SkillsPreviewHeader,
+    SkillObject
+  >;
+
+  /**
+   * Delete a specific version of a skill.
+   */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
+  @operationId("deleteSkillVersion")
+  @delete
+  @route("/skills/{name}/versions/{version}")
+  @extension("x-ms-foundry-meta", SkillsRequiredPreviews)
+  deleteSkillVersion is FoundryDataPlaneOperation<
+    DeleteSkillVersionRequest & SkillsPreviewHeader,
+    void
   >;
 }


### PR DESCRIPTION
## Summary
Adds version support to the Skills API, mirroring the existing Toolbox versioning pattern. All existing flat routes are preserved.

### New models
- `SkillVersionObject` — immutable version snapshot with `id`, `name`, `version`, `description`, `instructions`, `has_blob`, `created_at`, `metadata`
- `default_version?` field added to `SkillObject`
- `UpdateSkillDefaultVersionRequest` — PATCH model for updating default version pointer

### New routes
| Method | Path | Operation |
|--------|------|-----------|
| POST | `/skills/{name}/versions` | `createSkillVersion` |
| POST | `/skills/{name}/versions:import` | `createSkillVersionFromPackage` |
| GET | `/skills/{name}/versions` | `listSkillVersions` |
| GET | `/skills/{name}/versions/{version}` | `getSkillVersion` |
| GET | `/skills/{name}/versions/{version}:download` | `downloadSkillVersion` |
| PATCH | `/skills/{name}` | `updateSkillDefaultVersion` |
| DELETE | `/skills/{name}/versions/{version}` | `deleteSkillVersion` |

### Validation
- TypeSpec compiles successfully (`tsp compile --no-emit`)