### PR TITLE
Add target and input_messages to evaluation suite generation inputs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -279,6 +279,7 @@ model EvaluationSuiteGenerationJobInputs {
   @doc("""
     Data generation options. Controls how the evaluation dataset is generated.
     If omitted, defaults are used (simple_qna, 100 max_samples).
+    For conversation level, dataset generation is skipped — user provides their own dataset.
     """)
   data_generation_options?: EvaluationSuiteDataGenerationOptions;
 
@@ -286,16 +287,26 @@ model EvaluationSuiteGenerationJobInputs {
     Target for the generated suite. Stored on the suite so it can be run
     immediately after generation completes.
     Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
+    Required for turn-level evaluation. Optional for conversation-level.
     """)
   target?: Target;
 
   @doc("""
     How to send dataset rows to the target.
-    If omitted and target is provided, defaults to a template using {{item.query}}.
+    If omitted and target is provided, defaults to a template using item.query.
+    Not applicable for conversation-level evaluation.
     """)
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Supporting both input message types"
   input_messages?: OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate
     | OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference;
+
+  @doc("""
+    Evaluation level for the generated suite.
+    Default: turn (single-turn evaluation).
+    Use conversation for multi-turn evaluation — dataset generation is skipped
+    and the user provides their own multi-turn dataset.
+    """)
+  evaluation_level?: EvaluationLevel;
 }
 
 @doc("Options for dataset generation within an evaluation suite generation job.")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -281,6 +281,21 @@ model EvaluationSuiteGenerationJobInputs {
     If omitted, defaults are used (simple_qna, 100 max_samples).
     """)
   data_generation_options?: EvaluationSuiteDataGenerationOptions;
+
+  @doc("""
+    Target for the generated suite. Stored on the suite so it can be run
+    immediately after generation completes.
+    Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
+    """)
+  target?: Target;
+
+  @doc("""
+    How to send dataset rows to the target.
+    If omitted and target is provided, defaults to a template using {{item.query}}.
+    """)
+  #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Supporting both input message types"
+  input_messages?: OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate
+    | OpenAI.CreateEvalCompletionsRunDataSourceInputMessagesItemReference;
 }
 
 @doc("Options for dataset generation within an evaluation suite generation job.")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -286,14 +286,12 @@ model EvaluationSuiteGenerationJobInputs {
     Target for the generated suite. Stored on the suite so it can be run
     immediately after generation completes.
     Supports azure_ai_agent, azure_ai_model, azure_ai_assistant.
-    Required for turn-level evaluation. Optional for conversation-level.
     """)
   target?: Target;
 
   @doc("""
     How to send dataset rows to the target.
     If omitted and target is provided, defaults to a template using item.query.
-    Not applicable for conversation-level evaluation.
     """)
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Supporting both input message types"
   input_messages?: OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/models.tsp
@@ -279,7 +279,6 @@ model EvaluationSuiteGenerationJobInputs {
   @doc("""
     Data generation options. Controls how the evaluation dataset is generated.
     If omitted, defaults are used (simple_qna, 100 max_samples).
-    For conversation level, dataset generation is skipped — user provides their own dataset.
     """)
   data_generation_options?: EvaluationSuiteDataGenerationOptions;
 
@@ -303,8 +302,7 @@ model EvaluationSuiteGenerationJobInputs {
   @doc("""
     Evaluation level for the generated suite.
     Default: turn (single-turn evaluation).
-    Use conversation for multi-turn evaluation — dataset generation is skipped
-    and the user provides their own multi-turn dataset.
+    Use conversation for multi-turn evaluation.
     """)
   evaluation_level?: EvaluationLevel;
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-suites/routes.tsp
@@ -25,6 +25,7 @@ const EvaluationSuitesRequiredPreviews = #{
   ],
 };
 
+@removed(Versions.v1)
 interface EvaluationSuites
   extends VersionedOperations<
       EvaluationSuiteVersion,
@@ -88,6 +89,7 @@ const EvaluationSuiteGenerationJobsRequiredPreviews = #{
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "OpenAI-based operations are definitionally non-standard"
 #suppress "@azure-tools/typespec-azure-core/long-running-polling-operation-required" "LRO polling is handled by the client via Operation-Location"
 @tag("EvaluationSuiteGenerationJobs")
+@removed(Versions.v1)
 interface EvaluationSuiteGenerationJobs {
   @summary("Creates an evaluation suite generation job.")
   @route("evaluation_suite_generation_jobs")


### PR DESCRIPTION
- Added optional target field to EvaluationSuiteGenerationJobInputs
- Added optional input_messages field (template or item_reference)
- Target is stored on the generated suite so it can be run immediately
- input_messages defaults to template with {{item.query}} if omitted

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
