### PR TITLE
Foundry: rename Dimension.dimension_id -> id; drop category query param from evaluator_generation_jobs list

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6161,16 +6161,6 @@
             "explode": false
           },
           {
-            "name": "category",
-            "in": "query",
-            "required": false,
-            "description": "Filter evaluator generation jobs by category.",
-            "schema": {
-              "$ref": "#/components/schemas/EvaluatorCategory"
-            },
-            "explode": false
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -20646,12 +20636,12 @@
       "Dimension": {
         "type": "object",
         "required": [
-          "dimension_id",
+          "id",
           "description",
           "weight"
         ],
         "properties": {
-          "dimension_id": {
+          "id": {
             "type": "string",
             "description": "Stable identifier for this dimension (snake_case, e.g., `correct_resolution`). Required. Provided by the user when manually creating a rubric evaluator or during human-in-the-loop review of a generated set; the generation pipeline produces an initial value the user can edit. Editable when saving new versions."
           },
@@ -47909,7 +47899,7 @@
             "items": {
               "$ref": "#/components/schemas/Dimension"
             },
-            "description": "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with dimension_id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
+            "description": "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
           },
           "pass_threshold": {
             "type": "number",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4119,13 +4119,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: category
-          in: query
-          required: false
-          description: Filter evaluator generation jobs by category.
-          schema:
-            $ref: '#/components/schemas/EvaluatorCategory'
-          explode: false
         - name: api-version
           in: query
           required: true
@@ -13799,11 +13792,11 @@ components:
     Dimension:
       type: object
       required:
-        - dimension_id
+        - id
         - description
         - weight
       properties:
-        dimension_id:
+        id:
           type: string
           description: Stable identifier for this dimension (snake_case, e.g., `correct_resolution`). Required. Provided by the user when manually creating a rubric evaluator or during human-in-the-loop review of a generated set; the generation pipeline produces an initial value the user can edit. Editable when saving new versions.
         description:
@@ -33876,7 +33869,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Dimension'
-          description: "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with dimension_id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
+          description: "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
         pass_threshold:
           type: number
           format: float

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -7557,16 +7557,6 @@
             "explode": false
           },
           {
-            "name": "category",
-            "in": "query",
-            "required": false,
-            "description": "Filter evaluator generation jobs by category.",
-            "schema": {
-              "$ref": "#/components/schemas/EvaluatorCategory"
-            },
-            "explode": false
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -22970,12 +22960,12 @@
       "Dimension": {
         "type": "object",
         "required": [
-          "dimension_id",
+          "id",
           "description",
           "weight"
         ],
         "properties": {
-          "dimension_id": {
+          "id": {
             "type": "string",
             "description": "Stable identifier for this dimension (snake_case, e.g., `correct_resolution`). Required. Provided by the user when manually creating a rubric evaluator or during human-in-the-loop review of a generated set; the generation pipeline produces an initial value the user can edit. Editable when saving new versions."
           },
@@ -50610,7 +50600,7 @@
             "items": {
               "$ref": "#/components/schemas/Dimension"
             },
-            "description": "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with dimension_id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
+            "description": "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
           },
           "pass_threshold": {
             "type": "number",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -5073,13 +5073,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: category
-          in: query
-          required: false
-          description: Filter evaluator generation jobs by category.
-          schema:
-            $ref: '#/components/schemas/EvaluatorCategory'
-          explode: false
         - name: api-version
           in: query
           required: true
@@ -15398,11 +15391,11 @@ components:
     Dimension:
       type: object
       required:
-        - dimension_id
+        - id
         - description
         - weight
       properties:
-        dimension_id:
+        id:
           type: string
           description: Stable identifier for this dimension (snake_case, e.g., `correct_resolution`). Required. Provided by the user when manually creating a rubric evaluator or during human-in-the-loop review of a generated set; the generation pipeline produces an initial value the user can edit. Editable when saving new versions.
         description:
@@ -35735,7 +35728,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Dimension'
-          description: "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with dimension_id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
+          description: "The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure."
         pass_threshold:
           type: number
           format: float

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -119,7 +119,7 @@ model PromptBasedEvaluatorDefinition extends EvaluatorDefinition {
 @doc("A single dimension — one independent, measurable quality dimension within a rubric evaluator's scoring blueprint.")
 model Dimension {
   @doc("Stable identifier for this dimension (snake_case, e.g., `correct_resolution`). Required. Provided by the user when manually creating a rubric evaluator or during human-in-the-loop review of a generated set; the generation pipeline produces an initial value the user can edit. Editable when saving new versions.")
-  dimension_id: string;
+  id: string;
 
   @doc("What this dimension measures (e.g., 'Correctly identifies the user's reservation intent and pursues the appropriate workflow').")
   description: string;
@@ -137,7 +137,7 @@ model Dimension {
 model RubricBasedEvaluatorDefinition extends EvaluatorDefinition {
   type: EvaluatorDefinitionType.rubric;
 
-  @doc("The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with dimension_id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure.")
+  @doc("The set of dimensions — the scoring blueprint used by the LLM judge. Quality evaluators include a non-editable residual dimension with id 'general_quality' (always_applicable: true); safety evaluators include 'general_policy_compliance'. Both use the same Dimension structure.")
   dimensions: Dimension[];
 
   @doc("Pass/fail threshold for the aggregate rubric score, on the same normalized 0.0-1.0 scale as the emitted `score`. When the runtime weighted average meets or exceeds this value, the result is `pass`. Defaults to 0.5 (equivalent to a raw 1-5 weighted average of 3.0). The 'any dimension scored 1 → fail' rule still applies regardless of this threshold.")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
@@ -226,12 +226,7 @@ interface EvaluatorGenerationJobs {
   @extension("x-ms-foundry-meta", EvaluatorGenerationJobsRequiredPreviews)
   list is listJobsPreview<
     FoundryFeaturesOptInKeys.evaluations_v1_preview,
-    EvaluatorGenerationJob,
-    {
-      @doc("Filter evaluator generation jobs by category.")
-      @query
-      category?: EvaluatorCategory;
-    }
+    EvaluatorGenerationJob
   >;
 
   /**


### PR DESCRIPTION
## Summary

Two TypeSpec edits to the Foundry evaluators surface, per April Kwong's review:

1. **Rename `Dimension.dimension_id` → `Dimension.id`** to align with the server-side implementation (which uses the bare `id` field). Updates two `@doc` comments that previously referenced the field by its old name; the string values `general_quality` and `general_policy_compliance` are unchanged.

2. **Drop the `category` query parameter from the `evaluator_generation_jobs` list route.** The `category` field on `EvaluatorGenerationInputs` was dropped server-side in Vienna PR #2102363 (only the `quality` pipeline is implemented; `safety` is deferred), so the list filter parameter is no longer meaningful.

## Files

| File | Change |
|---|---|
| `specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp` | Rename `dimension_id` → `id`; two `@doc` text updates |
| `specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp` | Drop `category` query parameter (simplifies `list is listJobsPreview<...>`) |
| `specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.{json,yaml}` | Regenerated by `npx tsp compile .` |
| `specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}` | Regenerated by `npx tsp compile .` |

## Validation

- `npx tsp compile .` from the project root: ✅ 0 errors
- Net diff: `+15 / -54` lines (6 files)

## Scope notes

- **Out of scope**: the broader `@removed(Versions.v1)` decorator removals; those were already done in earlier commits on `feature/foundry-release` for the rubric / eval-gen models (no action needed here).
- The `category` *field* on `EvaluatorGenerationInputs` is intentionally **not** removed in this PR (only the list query parameter). If the field itself also needs to come out of the typespec contract, that's a follow-up.
