### PR TITLE
Update release plan info to inlcude information about new release plan dashboard in auto generated SDK pull request

### DIFF
--- a/eng/scripts/Get-ReleasePlan-Info.ps1
+++ b/eng/scripts/Get-ReleasePlan-Info.ps1
@@ -16,18 +16,35 @@ Set-StrictMode -Version 3
 
 . $PSScriptRoot/../common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
 
+$releasePlanInfoUnavailableMessage = "Release plan information is not available. Create a release plan and link SDK pull request to the release plan. Refer aka.ms/azsdk/releaseplan-dashboard for more info."
+$releasePlanInfo = $releasePlanInfoUnavailableMessage
+
+if (($null -eq $ReleasePlanWorkItemId) -or ([string]::IsNullOrWhiteSpace("$ReleasePlanWorkItemId")) -or ($ReleasePlanWorkItemId -eq 0))
+{
+    Write-Host "Release plan information is not available for work item ID: $ReleasePlanWorkItemId"
+    Write-Output $releasePlanInfo
+    return
+}
+
 
 Write-Host "Getting release plan info for work item ID: $ReleasePlanWorkItemId"
 $releasePlan = Get-ReleasePlan-Link $ReleasePlanWorkItemId
-$releasePlanInfo = ""
 if ($null -eq $releasePlan)
 {
     Write-Host "Failed to retrieve the Release Plan work item or the release plan work item is not present with Id [$ReleasePlanWorkItemId]."
 }
 else
 {
-    $releasePlanLink = $releasePlan["Custom.ReleasePlanLink"]
-    $submittedBy = $releasePlan["Custom.ReleasePlanSubmittedby"]
-    $releasePlanInfo = "**Release plan link:** [$releasePlanLink]($releasePlanLink) **Submitted by**: $submittedBy"
+    $releasePlanId = $releasePlan["Custom.ReleasePlanID"]
+    if ([string]::IsNullOrWhiteSpace("$releasePlanId") -or ($releasePlanId -eq 0))
+    {
+        Write-Host "Release plan ID is empty or 0 for work item ID: $ReleasePlanWorkItemId"
+    }
+    else
+    {
+        $releasePlanLink = "https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=" + $releasePlanId
+        $submittedBy = $releasePlan["Custom.ReleasePlanSubmittedby"]
+        $releasePlanInfo = "**Release plan link:** [$releasePlanLink]($releasePlanLink) **Submitted by**: $submittedBy"
+    }
 }
 Write-Output $releasePlanInfo

--- a/eng/scripts/Get-ReleasePlan-Info.ps1
+++ b/eng/scripts/Get-ReleasePlan-Info.ps1
@@ -19,7 +19,7 @@ Set-StrictMode -Version 3
 $releasePlanInfoUnavailableMessage = "Release plan information is not available. Create a release plan and link SDK pull request to the release plan. Refer aka.ms/azsdk/releaseplan-dashboard for more info."
 $releasePlanInfo = $releasePlanInfoUnavailableMessage
 
-if (($null -eq $ReleasePlanWorkItemId) -or ([string]::IsNullOrWhiteSpace("$ReleasePlanWorkItemId")) -or ($ReleasePlanWorkItemId -eq 0))
+if (([string]::IsNullOrWhiteSpace("$ReleasePlanWorkItemId")) -or ($ReleasePlanWorkItemId -eq 0))
 {
     Write-Host "Release plan information is not available for work item ID: $ReleasePlanWorkItemId"
     Write-Output $releasePlanInfo


### PR DESCRIPTION
SDK generation pipeline will include links to release plan on new dashboard app instead of showing old release planner app with this change,
