### PR TITLE
Fix missing models of MCP Server KS

### DIFF
--- a/specification/search/data-plane/Search/CHANGELOG.md
+++ b/specification/search/data-plane/Search/CHANGELOG.md
@@ -53,7 +53,7 @@ It is maintained for internal engineering reference and API Stewardship Board re
 - **`IndexedSql`**: `IndexedSqlKnowledgeSource`, `IndexedSqlKnowledgeSourceParameters` (connection string, query, column mappings), `ContentColumnMapping`, `EmbeddingColumnMapping`.
 - **`WorkIQ`**: `WorkIQKnowledgeSource`, `WorkIQKnowledgeSourceParams`.
 - **`File`**: `FileKnowledgeSource`, `FileKnowledgeSourceParameters`, `KnowledgeSourceFile`, `ListKnowledgeSourceFilesResult`.
-- **`McpServer`**: `McpServerKnowledgeSource`, `McpServerKnowledgeSourceParameters`; auth via `McpServerAuthentication` (Foundry/StoredHeaders variants); tools via `McpServerTool`; output via `McpServerOutputParsing` (`auto`, `json`, `split`, `none`).
+- **`McpServer`**: `McpServerKnowledgeSource`, `McpServerKnowledgeSourceParameters`, `McpServerKnowledgeSourceParams`; auth via `McpServerAuthentication` (Foundry/StoredHeaders variants); tools via `McpServerTool`; output via `McpServerOutputParsing` (`auto`, `json`, `split`, `none`).
 - **`FabricDataAgent`**: `FabricDataAgentKnowledgeSource`, `FabricDataAgentKnowledgeSourceParameters`; activity/reference types.
 - **`FabricOntology`**: `FabricOntologyKnowledgeSource`, `FabricOntologyKnowledgeSourceParameters`; activity/reference types.
 
@@ -106,8 +106,9 @@ It is maintained for internal engineering reference and API Stewardship Board re
 [NEW in this preview]
 
 - **WorkIQ**: `KnowledgeBaseWorkIQActivityRecord`, `KnowledgeBaseWorkIQActivityArguments`, `KnowledgeBaseWorkIQReference` (`WorkIQAttribution[]`, `searchSensitivityLabelInfo`), `WorkIQAttribution` (`seeMoreWebUrl`).
+- **MCP Server**: `KnowledgeBaseMcpServerActivityRecord`, `KnowledgeBaseMcpServerActivityArguments` (`toolName`, `toolArguments`), `KnowledgeBaseMcpServerReference` (`toolName`, `title`).
 - **LLM web summarization**: `KnowledgeBaseModelWebSummarizationActivityRecord` (`inputTokens`, `outputTokens`, `modelName`).
-- **New enum values**: `modelWebSummarization`, `workIQ`, `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseActivityRecordType`; `workIQ`, `fabricDataAgent`, `fabricOntology` → `KnowledgeBaseReferenceType`.
+- **New enum values**: `modelWebSummarization`, `workIQ`, `fabricDataAgent`, `fabricOntology`, `mcpServer` → `KnowledgeBaseActivityRecordType`; `workIQ`, `fabricDataAgent`, `fabricOntology`, `mcpServer` → `KnowledgeBaseReferenceType`.
 
 **Sensitivity label model**:
 

--- a/specification/search/data-plane/Search/client.tsp
+++ b/specification/search/data-plane/Search/client.tsp
@@ -4898,6 +4898,42 @@ namespace KnowledgeBaseRetrievalClient {
   "java"
 );
 @@clientNamespace(
+  Search.McpServerKnowledgeSourceParams,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.McpServerKnowledgeSourceParams,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerActivityRecord,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerActivityRecord,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerActivityArguments,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerActivityArguments,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerReference,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseMcpServerReference,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
   Search.PurviewSensitivityLabelInfo,
   "Azure.Search.Documents.KnowledgeBases"
 );

--- a/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceCreateKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceCreateKnowledgeSourceMcpServer.json
@@ -1,0 +1,90 @@
+{
+  "operationId": "KnowledgeSources_Create",
+  "title": "SearchServiceCreateKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
+    "knowledgeSource": {
+      "mcpServerParameters": {
+        "serverURL": "https://mcp.contoso.com/sse",
+        "authentication": {
+          "foundryConnectionParameters": {
+            "connectionId": "conn-123"
+          },
+          "kind": "foundryConnection"
+        },
+        "tools": [
+          {
+            "name": "search-code",
+            "outputParsing": {
+              "jsonParameters": {
+                "documentsPath": "$.documents[*]",
+                "includeContext": true
+              },
+              "kind": "json"
+            },
+            "inclusionMode": "reranked",
+            "maxOutputTokens": 4096
+          }
+        ]
+      },
+      "name": "ks-preview-test",
+      "description": "Description of the MCP server knowledge source.",
+      "kind": "mcpServer",
+      "@odata.etag": "0x1234568AE7E58A1",
+      "encryptionKey": {
+        "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+        "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+        "keyVaultUri": "https://myKeyVault.vault.azure.net",
+        "accessCredentials": {
+          "applicationId": "00000000-0000-0000-0000-000000000000",
+          "applicationSecret": "<applicationSecret>"
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json
@@ -1,0 +1,135 @@
+{
+  "operationId": "KnowledgeSources_CreateOrUpdate",
+  "title": "SearchServiceCreateOrUpdateKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "sourceName": "ks-preview-test",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
+    "If-Match": null,
+    "If-None-Match": null,
+    "Prefer": "return=representation",
+    "knowledgeSource": {
+      "mcpServerParameters": {
+        "serverURL": "https://mcp.contoso.com/sse",
+        "authentication": {
+          "foundryConnectionParameters": {
+            "connectionId": "conn-123"
+          },
+          "kind": "foundryConnection"
+        },
+        "tools": [
+          {
+            "name": "search-code",
+            "outputParsing": {
+              "jsonParameters": {
+                "documentsPath": "$.documents[*]",
+                "includeContext": true
+              },
+              "kind": "json"
+            },
+            "inclusionMode": "reranked",
+            "maxOutputTokens": 4096
+          }
+        ]
+      },
+      "name": "ks-preview-test",
+      "description": "Description of the MCP server knowledge source.",
+      "kind": "mcpServer",
+      "@odata.etag": "0x1234568AE7E58A1",
+      "encryptionKey": {
+        "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+        "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+        "keyVaultUri": "https://myKeyVault.vault.azure.net",
+        "accessCredentials": {
+          "applicationId": "00000000-0000-0000-0000-000000000000",
+          "applicationSecret": "<applicationSecret>"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceGetKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceGetKnowledgeSourceMcpServer.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "KnowledgeSources_Get",
+  "title": "SearchServiceGetKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "sourceName": "ks-preview-test",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceListKnowledgeSourcesMcpServer.json
+++ b/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceListKnowledgeSourcesMcpServer.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "KnowledgeSources_List",
+  "title": "SearchServiceListKnowledgeSourcesMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "@odata.etag": "0x1234568AE7E58A1",
+            "name": "ks-preview-test",
+            "kind": "mcpServer",
+            "description": "Description of the MCP server knowledge source.",
+            "encryptionKey": {
+              "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+              "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+              "keyVaultUri": "https://myKeyVault.vault.azure.net",
+              "isServiceLevelKey": false,
+              "accessCredentials": {
+                "applicationId": "00000000-0000-0000-0000-000000000000",
+                "applicationSecret": "<applicationSecret>"
+              }
+            },
+            "mcpServerParameters": {
+              "serverURL": "https://mcp.contoso.com/sse",
+              "authentication": {
+                "kind": "foundryConnection",
+                "foundryConnectionParameters": {
+                  "connectionId": "conn-123"
+                }
+              },
+              "tools": [
+                {
+                  "name": "search-code",
+                  "inclusionMode": "reranked",
+                  "maxOutputTokens": 4096,
+                  "outputParsing": {
+                    "kind": "json",
+                    "jsonParameters": {
+                      "documentsPath": "$.documents[*]",
+                      "includeContext": true
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -263,6 +263,13 @@ model FabricOntologyKnowledgeSourceParams extends KnowledgeSourceParams {
   kind: KnowledgeSourceKind.FabricOntology;
 }
 
+/** Specifies runtime parameters for an MCP server knowledge source */
+@added(Versions.v2026_05_01_preview)
+model McpServerKnowledgeSourceParams extends KnowledgeSourceParams {
+  /** The discriminator value. */
+  kind: KnowledgeSourceKind.McpServer;
+}
+
 /** An intended query to execute without model query planning. */
 @discriminator("type")
 model KnowledgeRetrievalIntent {
@@ -375,6 +382,10 @@ union KnowledgeBaseActivityRecordType {
   /** Fabric Ontology retrieval activity. */
   @added(Versions.v2026_05_01_preview)
   fabricOntology: "fabricOntology",
+
+  /** MCP server retrieval activity. */
+  @added(Versions.v2026_05_01_preview)
+  mcpServer: "mcpServer",
 
   /** LLM query planning activity. */
   @added(Versions.v2026_05_01_preview)
@@ -639,6 +650,30 @@ model KnowledgeBaseFabricOntologyActivityArguments {
   search?: string;
 }
 
+/** Represents an MCP server retrieval activity record. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseMcpServerActivityRecord
+  extends KnowledgeBaseRetrievalActivityRecord {
+  /** The discriminator value. */
+  type: KnowledgeBaseActivityRecordType.mcpServer;
+
+  /** The MCP server arguments for the retrieval activity. */
+  mcpServerArguments?: KnowledgeBaseMcpServerActivityArguments;
+}
+
+/** Represents the arguments the MCP server retrieval activity was run with. */
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseMcpServerActivityArguments {
+  /** The name of the MCP server tool used for the retrieval activity. */
+  toolName?: string;
+
+  /** The arguments passed to the MCP server tool. */
+  #suppress "@azure-tools/typespec-azure-core/bad-record-type" "Allows arbitrary JSON via additionalProperties: true."
+  toolArguments?: Record<unknown>;
+}
+
 /** Represents an LLM query planning activity record. */
 #suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
 @added(Versions.v2026_05_01_preview)
@@ -749,6 +784,10 @@ union KnowledgeBaseReferenceType {
   /** Fabric Ontology document reference. */
   @added(Versions.v2026_05_01_preview)
   fabricOntology: "fabricOntology",
+
+  /** MCP server document reference. */
+  @added(Versions.v2026_05_01_preview)
+  mcpServer: "mcpServer",
 }
 
 /** Base type for references. */
@@ -910,6 +949,20 @@ model KnowledgeBaseFabricOntologyReference extends KnowledgeBaseReference {
 
   /** The ontology ID within the workspace. */
   ontologyId?: string;
+}
+
+/** Represents an MCP server document reference. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseMcpServerReference extends KnowledgeBaseReference {
+  /** The discriminator value. */
+  type: KnowledgeBaseReferenceType.mcpServer;
+
+  /** The name of the MCP server tool that produced the reference. */
+  toolName?: string;
+
+  /** The title of the MCP server tool result. */
+  title?: string;
 }
 
 /** Information about the sensitivity label applied to a SharePoint document. */

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceCreateKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceCreateKnowledgeSourceMcpServer.json
@@ -1,0 +1,90 @@
+{
+  "operationId": "KnowledgeSources_Create",
+  "title": "SearchServiceCreateKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
+    "knowledgeSource": {
+      "mcpServerParameters": {
+        "serverURL": "https://mcp.contoso.com/sse",
+        "authentication": {
+          "foundryConnectionParameters": {
+            "connectionId": "conn-123"
+          },
+          "kind": "foundryConnection"
+        },
+        "tools": [
+          {
+            "name": "search-code",
+            "outputParsing": {
+              "jsonParameters": {
+                "documentsPath": "$.documents[*]",
+                "includeContext": true
+              },
+              "kind": "json"
+            },
+            "inclusionMode": "reranked",
+            "maxOutputTokens": 4096
+          }
+        ]
+      },
+      "name": "ks-preview-test",
+      "description": "Description of the MCP server knowledge source.",
+      "kind": "mcpServer",
+      "@odata.etag": "0x1234568AE7E58A1",
+      "encryptionKey": {
+        "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+        "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+        "keyVaultUri": "https://myKeyVault.vault.azure.net",
+        "accessCredentials": {
+          "applicationId": "00000000-0000-0000-0000-000000000000",
+          "applicationSecret": "<applicationSecret>"
+        }
+      }
+    }
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json
@@ -1,0 +1,135 @@
+{
+  "operationId": "KnowledgeSources_CreateOrUpdate",
+  "title": "SearchServiceCreateOrUpdateKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "sourceName": "ks-preview-test",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
+    "If-Match": null,
+    "If-None-Match": null,
+    "Prefer": "return=representation",
+    "knowledgeSource": {
+      "mcpServerParameters": {
+        "serverURL": "https://mcp.contoso.com/sse",
+        "authentication": {
+          "foundryConnectionParameters": {
+            "connectionId": "conn-123"
+          },
+          "kind": "foundryConnection"
+        },
+        "tools": [
+          {
+            "name": "search-code",
+            "outputParsing": {
+              "jsonParameters": {
+                "documentsPath": "$.documents[*]",
+                "includeContext": true
+              },
+              "kind": "json"
+            },
+            "inclusionMode": "reranked",
+            "maxOutputTokens": 4096
+          }
+        ]
+      },
+      "name": "ks-preview-test",
+      "description": "Description of the MCP server knowledge source.",
+      "kind": "mcpServer",
+      "@odata.etag": "0x1234568AE7E58A1",
+      "encryptionKey": {
+        "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+        "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+        "keyVaultUri": "https://myKeyVault.vault.azure.net",
+        "accessCredentials": {
+          "applicationId": "00000000-0000-0000-0000-000000000000",
+          "applicationSecret": "<applicationSecret>"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceGetKnowledgeSourceMcpServer.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceGetKnowledgeSourceMcpServer.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "KnowledgeSources_Get",
+  "title": "SearchServiceGetKnowledgeSourceMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "sourceName": "ks-preview-test",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "@odata.etag": "0x1234568AE7E58A1",
+        "name": "ks-preview-test",
+        "kind": "mcpServer",
+        "description": "Description of the MCP server knowledge source.",
+        "encryptionKey": {
+          "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+          "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+          "keyVaultUri": "https://myKeyVault.vault.azure.net",
+          "isServiceLevelKey": false,
+          "accessCredentials": {
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "applicationSecret": "<applicationSecret>"
+          }
+        },
+        "mcpServerParameters": {
+          "serverURL": "https://mcp.contoso.com/sse",
+          "authentication": {
+            "kind": "foundryConnection",
+            "foundryConnectionParameters": {
+              "connectionId": "conn-123"
+            }
+          },
+          "tools": [
+            {
+              "name": "search-code",
+              "inclusionMode": "reranked",
+              "maxOutputTokens": 4096,
+              "outputParsing": {
+                "kind": "json",
+                "jsonParameters": {
+                  "documentsPath": "$.documents[*]",
+                  "includeContext": true
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceListKnowledgeSourcesMcpServer.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceListKnowledgeSourcesMcpServer.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "KnowledgeSources_List",
+  "title": "SearchServiceListKnowledgeSourcesMcpServer",
+  "parameters": {
+    "endpoint": "https://previewexampleservice.search.windows.net",
+    "api-version": "2026-05-01-preview",
+    "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "@odata.etag": "0x1234568AE7E58A1",
+            "name": "ks-preview-test",
+            "kind": "mcpServer",
+            "description": "Description of the MCP server knowledge source.",
+            "encryptionKey": {
+              "keyVaultKeyName": "myUserManagedEncryptionKey-createdinAzureKeyVault",
+              "keyVaultKeyVersion": "myKeyVersion-32charAlphaNumericString",
+              "keyVaultUri": "https://myKeyVault.vault.azure.net",
+              "isServiceLevelKey": false,
+              "accessCredentials": {
+                "applicationId": "00000000-0000-0000-0000-000000000000",
+                "applicationSecret": "<applicationSecret>"
+              }
+            },
+            "mcpServerParameters": {
+              "serverURL": "https://mcp.contoso.com/sse",
+              "authentication": {
+                "kind": "foundryConnection",
+                "foundryConnectionParameters": {
+                  "connectionId": "conn-123"
+                }
+              },
+              "tools": [
+                {
+                  "name": "search-code",
+                  "inclusionMode": "reranked",
+                  "maxOutputTokens": 4096,
+                  "outputParsing": {
+                    "kind": "json",
+                    "jsonParameters": {
+                      "documentsPath": "$.documents[*]",
+                      "includeContext": true
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -3248,6 +3248,9 @@
           "SearchServiceListKnowledgeSourcesIndexedSharePoint": {
             "$ref": "./examples/SearchServiceListKnowledgeSourcesIndexedSharePoint.json"
           },
+          "SearchServiceListKnowledgeSourcesMcpServer": {
+            "$ref": "./examples/SearchServiceListKnowledgeSourcesMcpServer.json"
+          },
           "SearchServiceListKnowledgeSourcesWeb": {
             "$ref": "./examples/SearchServiceListKnowledgeSourcesWeb.json"
           }
@@ -3316,6 +3319,9 @@
           },
           "SearchServiceCreateKnowledgeSourceIndexedSharePoint": {
             "$ref": "./examples/SearchServiceCreateKnowledgeSourceIndexedSharePoint.json"
+          },
+          "SearchServiceCreateKnowledgeSourceMcpServer": {
+            "$ref": "./examples/SearchServiceCreateKnowledgeSourceMcpServer.json"
           },
           "SearchServiceCreateKnowledgeSourceWeb": {
             "$ref": "./examples/SearchServiceCreateKnowledgeSourceWeb.json"
@@ -3389,6 +3395,9 @@
           },
           "SearchServiceGetKnowledgeSourceIndexedSharePoint": {
             "$ref": "./examples/SearchServiceGetKnowledgeSourceIndexedSharePoint.json"
+          },
+          "SearchServiceGetKnowledgeSourceMcpServer": {
+            "$ref": "./examples/SearchServiceGetKnowledgeSourceMcpServer.json"
           },
           "SearchServiceGetKnowledgeSourceWeb": {
             "$ref": "./examples/SearchServiceGetKnowledgeSourceWeb.json"
@@ -3502,6 +3511,9 @@
           },
           "SearchServiceCreateOrUpdateKnowledgeSourceIndexedSharePoint": {
             "$ref": "./examples/SearchServiceCreateOrUpdateKnowledgeSourceIndexedSharePoint.json"
+          },
+          "SearchServiceCreateOrUpdateKnowledgeSourceMcpServer": {
+            "$ref": "./examples/SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json"
           },
           "SearchServiceCreateOrUpdateKnowledgeSourceWeb": {
             "$ref": "./examples/SearchServiceCreateOrUpdateKnowledgeSourceWeb.json"
@@ -10077,6 +10089,7 @@
         "workIQ",
         "fabricDataAgent",
         "fabricOntology",
+        "mcpServer",
         "modelQueryPlanning",
         "modelAnswerSynthesis",
         "modelWebSummarization",
@@ -10130,6 +10143,11 @@
             "name": "fabricOntology",
             "value": "fabricOntology",
             "description": "Fabric Ontology retrieval activity."
+          },
+          {
+            "name": "mcpServer",
+            "value": "mcpServer",
+            "description": "MCP server retrieval activity."
           },
           {
             "name": "modelQueryPlanning",
@@ -10494,6 +10512,57 @@
       ],
       "x-ms-discriminator-value": "indexedSharePoint"
     },
+    "KnowledgeBaseMcpServerActivityArguments": {
+      "type": "object",
+      "description": "Represents the arguments the MCP server retrieval activity was run with.",
+      "properties": {
+        "toolName": {
+          "type": "string",
+          "description": "The name of the MCP server tool used for the retrieval activity."
+        },
+        "toolArguments": {
+          "type": "object",
+          "description": "The arguments passed to the MCP server tool.",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "KnowledgeBaseMcpServerActivityRecord": {
+      "type": "object",
+      "description": "Represents an MCP server retrieval activity record.",
+      "properties": {
+        "mcpServerArguments": {
+          "$ref": "#/definitions/KnowledgeBaseMcpServerActivityArguments",
+          "description": "The MCP server arguments for the retrieval activity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+        }
+      ],
+      "x-ms-discriminator-value": "mcpServer"
+    },
+    "KnowledgeBaseMcpServerReference": {
+      "type": "object",
+      "description": "Represents an MCP server document reference.",
+      "properties": {
+        "toolName": {
+          "type": "string",
+          "description": "The name of the MCP server tool that produced the reference."
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of the MCP server tool result."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseReference"
+        }
+      ],
+      "x-ms-discriminator-value": "mcpServer"
+    },
     "KnowledgeBaseMessage": {
       "type": "object",
       "description": "The natural language message style object.",
@@ -10747,7 +10816,8 @@
         "remoteSharePoint",
         "workIQ",
         "fabricDataAgent",
-        "fabricOntology"
+        "fabricOntology",
+        "mcpServer"
       ],
       "x-ms-enum": {
         "name": "KnowledgeBaseReferenceType",
@@ -10797,6 +10867,11 @@
             "name": "fabricOntology",
             "value": "fabricOntology",
             "description": "Fabric Ontology document reference."
+          },
+          {
+            "name": "mcpServer",
+            "value": "mcpServer",
+            "description": "MCP server document reference."
           }
         ]
       }
@@ -13249,6 +13324,16 @@
         "serverURL",
         "tools"
       ]
+    },
+    "McpServerKnowledgeSourceParams": {
+      "type": "object",
+      "description": "Specifies runtime parameters for an MCP server knowledge source",
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeSourceParams"
+        }
+      ],
+      "x-ms-discriminator-value": "mcpServer"
     },
     "McpServerNoneOutputParsing": {
       "type": "object",


### PR DESCRIPTION
This pull request adds comprehensive support for the new "MCP Server" knowledge source type to the Azure Search data-plane API (2026-05-01-preview). It introduces new models, enum values, and example API requests/responses for creating, updating, retrieving, and listing MCP Server knowledge sources, as well as tracking their usage in activity and reference records. The changes ensure that MCP Server is treated as a first-class knowledge source alongside existing types.

**Key changes:**

**1. Model and Enum Additions for MCP Server Support**
- Added the `McpServerKnowledgeSourceParams` model to represent runtime parameters for MCP Server knowledge sources.
- Introduced `KnowledgeBaseMcpServerActivityRecord` and `KnowledgeBaseMcpServerActivityArguments` models to represent retrieval activities and their arguments for MCP Server.
- Added `KnowledgeBaseMcpServerReference` model for representing MCP Server document references.
- Extended the `KnowledgeBaseActivityRecordType` and `KnowledgeBaseReferenceType` enums to include the new `mcpServer` value. [[1]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259R386-R389) [[2]](diffhunk://#diff-b096e838006db2e576ece1cf37df796689e515f8606cf058f8e0317612752259R787-R790)

**2. API Example Coverage for MCP Server**
- Added example JSON files for creating, updating, retrieving, and listing MCP Server knowledge sources (`SearchServiceCreateKnowledgeSourceMcpServer.json`, `SearchServiceCreateOrUpdateKnowledgeSourceMcpServer.json`, `SearchServiceGetKnowledgeSourceMcpServer.json`, `SearchServiceListKnowledgeSourcesMcpServer.json`). [[1]](diffhunk://#diff-59fcf4420d4389f4396573fc2010869bcf5c85a951fb201f3adbf93f1c95f3cfR1-R90) [[2]](diffhunk://#diff-7697957e51c2335ea9e9e75d986a323f88bc8c1cb1364809b89746b82ee49d95R1-R135) [[3]](diffhunk://#diff-490bed1d75cc66c90a2f40e8914e1ce65fd0292d4b688843fe30b2331b52c7d0R1-R53) [[4]](diffhunk://#diff-bb2def0141dc596385842ee5852d2c56a0f5203ccbadc56151ec5f2a35dc5bd8R1-R56)

**3. Changelog and Documentation Updates**
- Updated the changelog to document the addition of MCP Server models, parameters, and enum values, and to clarify the new API capabilities. [[1]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dL56-R56) [[2]](diffhunk://#diff-334add3e16ca58d036c9ab7a7f10176b0447e2c8f4f1f9a68af0076a74e0662dR109-R111)

These changes collectively enable full lifecycle management and tracking of MCP Server-based knowledge sources within the Azure Search knowledge base API.