### PR TITLE
ControlPlaneMetrics: graduate to 2026-04-01 stable

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -3773,7 +3773,7 @@ model ManagedClusterAzureMonitorProfileMetrics {
   /**
    * Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.
    */
-  @added(Versions.v2026_04_02_preview)
+  @added(Versions.v2026_04_01)
   controlPlane?: ManagedClusterAzureMonitorProfileMetricsControlPlane;
 }
 
@@ -3795,7 +3795,7 @@ model ManagedClusterAzureMonitorProfileKubeStateMetrics {
 /**
  * Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.
  */
-@added(Versions.v2026_04_02_preview)
+@added(Versions.v2026_04_01)
 model ManagedClusterAzureMonitorProfileMetricsControlPlane {
   /**
    * Whether to enable or disable collection of control plane metrics by the Azure Managed Prometheus addon. Defaults to disabled. See aka.ms/aks/controlplane-metrics for details.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
@@ -7080,11 +7080,25 @@
         "kubeStateMetrics": {
           "$ref": "#/definitions/ManagedClusterAzureMonitorProfileKubeStateMetrics",
           "description": "Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details."
+        },
+        "controlPlane": {
+          "$ref": "#/definitions/ManagedClusterAzureMonitorProfileMetricsControlPlane",
+          "description": "Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview."
         }
       },
       "required": [
         "enabled"
       ]
+    },
+    "ManagedClusterAzureMonitorProfileMetricsControlPlane": {
+      "type": "object",
+      "description": "Control plane metrics collection profile for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for an overview.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable or disable collection of control plane metrics by the Azure Managed Prometheus addon. Defaults to disabled. See aka.ms/aks/controlplane-metrics for details."
+        }
+      }
     },
     "ManagedClusterBootstrapProfile": {
       "type": "object",


### PR DESCRIPTION
Migrates PR #41280 (which added ManagedClusterAzureMonitorProfileMetricsControlPlane to 2026-02-02-preview) into the 2026-04 branch by lowering the @added version from v2026_04_02_preview to v2026_04_01, surfacing the field in the 2026-04-01 stable API for the upcoming GA of Managed Prometheus Control Plane Metrics.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
