### PR TITLE
Fix missing models of File KS and IndexedSql KS

### DIFF
--- a/specification/search/data-plane/Search/client.tsp
+++ b/specification/search/data-plane/Search/client.tsp
@@ -4907,6 +4907,24 @@ namespace KnowledgeBaseRetrievalClient {
   "java"
 );
 @@clientNamespace(
+  Search.FileKnowledgeSourceParams,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.FileKnowledgeSourceParams,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.IndexedSqlKnowledgeSourceParams,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.IndexedSqlKnowledgeSourceParams,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
   Search.KnowledgeBaseMcpServerActivityRecord,
   "Azure.Search.Documents.KnowledgeBases"
 );
@@ -4930,6 +4948,60 @@ namespace KnowledgeBaseRetrievalClient {
 );
 @@clientNamespace(
   Search.KnowledgeBaseMcpServerReference,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileActivityRecord,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileActivityRecord,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileActivityArguments,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileActivityArguments,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileReference,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseFileReference,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlActivityRecord,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlActivityRecord,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlActivityArguments,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlActivityArguments,
+  "com.azure.search.documents.knowledgebases",
+  "java"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlReference,
+  "Azure.Search.Documents.KnowledgeBases"
+);
+@@clientNamespace(
+  Search.KnowledgeBaseIndexedSqlReference,
   "com.azure.search.documents.knowledgebases",
   "java"
 );

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -270,6 +270,20 @@ model McpServerKnowledgeSourceParams extends KnowledgeSourceParams {
   kind: KnowledgeSourceKind.McpServer;
 }
 
+/** Specifies runtime parameters for a File knowledge source */
+@added(Versions.v2026_05_01_preview)
+model FileKnowledgeSourceParams extends KnowledgeSourceParams {
+  /** The discriminator value. */
+  kind: KnowledgeSourceKind.File;
+}
+
+/** Specifies runtime parameters for an indexed SQL knowledge source */
+@added(Versions.v2026_05_01_preview)
+model IndexedSqlKnowledgeSourceParams extends KnowledgeSourceParams {
+  /** The discriminator value. */
+  kind: KnowledgeSourceKind.IndexedSql;
+}
+
 /** An intended query to execute without model query planning. */
 @discriminator("type")
 model KnowledgeRetrievalIntent {
@@ -386,6 +400,14 @@ union KnowledgeBaseActivityRecordType {
   /** MCP server retrieval activity. */
   @added(Versions.v2026_05_01_preview)
   mcpServer: "mcpServer",
+
+  /** File retrieval activity. */
+  @added(Versions.v2026_05_01_preview)
+  file: "file",
+
+  /** Indexed SQL retrieval activity. */
+  @added(Versions.v2026_05_01_preview)
+  indexedSql: "indexedSql",
 
   /** LLM query planning activity. */
   @added(Versions.v2026_05_01_preview)
@@ -674,6 +696,46 @@ model KnowledgeBaseMcpServerActivityArguments {
   toolArguments?: Record<unknown>;
 }
 
+/** Represents a File retrieval activity record. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseFileActivityRecord
+  extends KnowledgeBaseRetrievalActivityRecord {
+  /** The discriminator value. */
+  type: KnowledgeBaseActivityRecordType.file;
+
+  /** The File arguments for the retrieval activity. */
+  fileArguments?: KnowledgeBaseFileActivityArguments;
+}
+
+/** Represents the arguments the File retrieval activity was run with. */
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseFileActivityArguments {
+  /** The search string used to query the File knowledge source. */
+  search?: string;
+}
+
+/** Represents an indexed SQL retrieval activity record. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseIndexedSqlActivityRecord
+  extends KnowledgeBaseRetrievalActivityRecord {
+  /** The discriminator value. */
+  type: KnowledgeBaseActivityRecordType.indexedSql;
+
+  /** The indexed SQL arguments for the retrieval activity. */
+  indexedSqlArguments?: KnowledgeBaseIndexedSqlActivityArguments;
+}
+
+/** Represents the arguments the indexed SQL retrieval activity was run with. */
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseIndexedSqlActivityArguments {
+  /** The search string used to query the indexed SQL knowledge source. */
+  search?: string;
+}
+
 /** Represents an LLM query planning activity record. */
 #suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
 @added(Versions.v2026_05_01_preview)
@@ -788,6 +850,14 @@ union KnowledgeBaseReferenceType {
   /** MCP server document reference. */
   @added(Versions.v2026_05_01_preview)
   mcpServer: "mcpServer",
+
+  /** File document reference. */
+  @added(Versions.v2026_05_01_preview)
+  file: "file",
+
+  /** Indexed SQL document reference. */
+  @added(Versions.v2026_05_01_preview)
+  indexedSql: "indexedSql",
 }
 
 /** Base type for references. */
@@ -963,6 +1033,31 @@ model KnowledgeBaseMcpServerReference extends KnowledgeBaseReference {
 
   /** The title of the MCP server tool result. */
   title?: string;
+}
+
+/** Represents a File document reference. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseFileReference extends KnowledgeBaseReference {
+  /** The discriminator value. */
+  type: KnowledgeBaseReferenceType.file;
+
+  /** The unique identifier of the file. */
+  fileId?: string;
+
+  /** The name of the file. */
+  fileName?: string;
+}
+
+/** Represents an indexed SQL document reference. */
+#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
+@added(Versions.v2026_05_01_preview)
+model KnowledgeBaseIndexedSqlReference extends KnowledgeBaseReference {
+  /** The discriminator value. */
+  type: KnowledgeBaseReferenceType.indexedSql;
+
+  /** The document key for the reference. */
+  docKey?: string;
 }
 
 /** Information about the sensitivity label applied to a SharePoint document. */

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -712,7 +712,7 @@ model KnowledgeBaseFileActivityRecord
 /** Represents the arguments the File retrieval activity was run with. */
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseFileActivityArguments {
-  /** The search string used to query the File knowledge source. */
+  /** The search string used to query file contents. */
   search?: string;
 }
 
@@ -732,7 +732,7 @@ model KnowledgeBaseIndexedSqlActivityRecord
 /** Represents the arguments the indexed SQL retrieval activity was run with. */
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseIndexedSqlActivityArguments {
-  /** The search string used to query the indexed SQL knowledge source. */
+  /** The search string used to query indexed SQL contents. */
   search?: string;
 }
 
@@ -1035,29 +1035,26 @@ model KnowledgeBaseMcpServerReference extends KnowledgeBaseReference {
   title?: string;
 }
 
-/** Represents a File document reference. */
+/** Represents a file document reference. */
 #suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseFileReference extends KnowledgeBaseReference {
   /** The discriminator value. */
   type: KnowledgeBaseReferenceType.file;
 
-  /** The unique identifier of the file. */
-  fileId?: string;
-
-  /** The name of the file. */
-  fileName?: string;
+  /** The document name for the reference. */
+  docName?: string;
 }
 
-/** Represents an indexed SQL document reference. */
+/** Represents an Azure SQL document reference. */
 #suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseIndexedSqlReference extends KnowledgeBaseReference {
   /** The discriminator value. */
   type: KnowledgeBaseReferenceType.indexedSql;
 
-  /** The document key for the reference. */
-  docKey?: string;
+  /** The document URL for the reference. */
+  docUrl?: string;
 }
 
 /** Information about the sensitivity label applied to a SharePoint document. */

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -8027,6 +8027,16 @@
         }
       }
     },
+    "FileKnowledgeSourceParams": {
+      "type": "object",
+      "description": "Specifies runtime parameters for a File knowledge source",
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeSourceParams"
+        }
+      ],
+      "x-ms-discriminator-value": "file"
+    },
     "FreshnessPolicy": {
       "type": "object",
       "description": "Configuration for freshness-aware retrieval. When set, newer documents receive a ranking boost during retrieval.",
@@ -8966,6 +8976,16 @@
         "connectionString",
         "tableOrView"
       ]
+    },
+    "IndexedSqlKnowledgeSourceParams": {
+      "type": "object",
+      "description": "Specifies runtime parameters for an indexed SQL knowledge source",
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeSourceParams"
+        }
+      ],
+      "x-ms-discriminator-value": "indexedSql"
     },
     "IndexerCurrentState": {
       "type": "object",
@@ -10090,6 +10110,8 @@
         "fabricDataAgent",
         "fabricOntology",
         "mcpServer",
+        "file",
+        "indexedSql",
         "modelQueryPlanning",
         "modelAnswerSynthesis",
         "modelWebSummarization",
@@ -10148,6 +10170,16 @@
             "name": "mcpServer",
             "value": "mcpServer",
             "description": "MCP server retrieval activity."
+          },
+          {
+            "name": "file",
+            "value": "file",
+            "description": "File retrieval activity."
+          },
+          {
+            "name": "indexedSql",
+            "value": "indexedSql",
+            "description": "Indexed SQL retrieval activity."
           },
           {
             "name": "modelQueryPlanning",
@@ -10406,6 +10438,52 @@
       ],
       "x-ms-discriminator-value": "fabricOntology"
     },
+    "KnowledgeBaseFileActivityArguments": {
+      "type": "object",
+      "description": "Represents the arguments the File retrieval activity was run with.",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "The search string used to query the File knowledge source."
+        }
+      }
+    },
+    "KnowledgeBaseFileActivityRecord": {
+      "type": "object",
+      "description": "Represents a File retrieval activity record.",
+      "properties": {
+        "fileArguments": {
+          "$ref": "#/definitions/KnowledgeBaseFileActivityArguments",
+          "description": "The File arguments for the retrieval activity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+        }
+      ],
+      "x-ms-discriminator-value": "file"
+    },
+    "KnowledgeBaseFileReference": {
+      "type": "object",
+      "description": "Represents a File document reference.",
+      "properties": {
+        "fileId": {
+          "type": "string",
+          "description": "The unique identifier of the file."
+        },
+        "fileName": {
+          "type": "string",
+          "description": "The name of the file."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseReference"
+        }
+      ],
+      "x-ms-discriminator-value": "file"
+    },
     "KnowledgeBaseImageContent": {
       "type": "object",
       "description": "Image content.",
@@ -10511,6 +10589,48 @@
         }
       ],
       "x-ms-discriminator-value": "indexedSharePoint"
+    },
+    "KnowledgeBaseIndexedSqlActivityArguments": {
+      "type": "object",
+      "description": "Represents the arguments the indexed SQL retrieval activity was run with.",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "The search string used to query the indexed SQL knowledge source."
+        }
+      }
+    },
+    "KnowledgeBaseIndexedSqlActivityRecord": {
+      "type": "object",
+      "description": "Represents an indexed SQL retrieval activity record.",
+      "properties": {
+        "indexedSqlArguments": {
+          "$ref": "#/definitions/KnowledgeBaseIndexedSqlActivityArguments",
+          "description": "The indexed SQL arguments for the retrieval activity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+        }
+      ],
+      "x-ms-discriminator-value": "indexedSql"
+    },
+    "KnowledgeBaseIndexedSqlReference": {
+      "type": "object",
+      "description": "Represents an indexed SQL document reference.",
+      "properties": {
+        "docKey": {
+          "type": "string",
+          "description": "The document key for the reference."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KnowledgeBaseReference"
+        }
+      ],
+      "x-ms-discriminator-value": "indexedSql"
     },
     "KnowledgeBaseMcpServerActivityArguments": {
       "type": "object",
@@ -10817,7 +10937,9 @@
         "workIQ",
         "fabricDataAgent",
         "fabricOntology",
-        "mcpServer"
+        "mcpServer",
+        "file",
+        "indexedSql"
       ],
       "x-ms-enum": {
         "name": "KnowledgeBaseReferenceType",
@@ -10872,6 +10994,16 @@
             "name": "mcpServer",
             "value": "mcpServer",
             "description": "MCP server document reference."
+          },
+          {
+            "name": "file",
+            "value": "file",
+            "description": "File document reference."
+          },
+          {
+            "name": "indexedSql",
+            "value": "indexedSql",
+            "description": "Indexed SQL document reference."
           }
         ]
       }

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -10444,7 +10444,7 @@
       "properties": {
         "search": {
           "type": "string",
-          "description": "The search string used to query the File knowledge source."
+          "description": "The search string used to query file contents."
         }
       }
     },
@@ -10466,15 +10466,11 @@
     },
     "KnowledgeBaseFileReference": {
       "type": "object",
-      "description": "Represents a File document reference.",
+      "description": "Represents a file document reference.",
       "properties": {
-        "fileId": {
+        "docName": {
           "type": "string",
-          "description": "The unique identifier of the file."
-        },
-        "fileName": {
-          "type": "string",
-          "description": "The name of the file."
+          "description": "The document name for the reference."
         }
       },
       "allOf": [
@@ -10596,7 +10592,7 @@
       "properties": {
         "search": {
           "type": "string",
-          "description": "The search string used to query the indexed SQL knowledge source."
+          "description": "The search string used to query indexed SQL contents."
         }
       }
     },
@@ -10618,11 +10614,11 @@
     },
     "KnowledgeBaseIndexedSqlReference": {
       "type": "object",
-      "description": "Represents an indexed SQL document reference.",
+      "description": "Represents an Azure SQL document reference.",
       "properties": {
-        "docKey": {
+        "docUrl": {
           "type": "string",
-          "description": "The document key for the reference."
+          "description": "The document URL for the reference."
         }
       },
       "allOf": [


### PR DESCRIPTION
models-knowledgebase.tsp:

- Added file and indexedSql enum values to KnowledgeBaseActivityRecordType and KnowledgeBaseReferenceType
- Added FileKnowledgeSourceParams and IndexedSqlKnowledgeSourceParams (after McpServerKnowledgeSourceParams)
- Added KnowledgeBaseFileActivityRecord + **KnowledgeBaseFileActivityArguments**
- Added KnowledgeBaseIndexedSqlActivityRecord + **KnowledgeBaseIndexedSqlActivityArguments**
- Added **KnowledgeBaseFileReference**
- Added **KnowledgeBaseIndexedSqlReference**

client.tsp: 

- Added @@clientNamespace blocks (.NET + Java, KnowledgeBases namespace) for all 6 new models: FileKnowledgeSourceParams, IndexedSqlKnowledgeSourceParams, KnowledgeBaseFileActivityRecord, KnowledgeBaseFileActivityArguments, KnowledgeBaseFileReference, KnowledgeBaseIndexedSqlActivityRecord, KnowledgeBaseIndexedSqlActivityArguments, KnowledgeBaseIndexedSqlReference
