### PR TITLE
Add MaintenanceWindow peer resource to 2026-04-02-preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
@@ -88,7 +88,6 @@ interface MaintenanceWindows {
  * Properties of a maintenance window.
  * For more information, see https://aka.ms/aks/maintenance-windows.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "AKS uses custom provisioning states beyond standard ARM states. Using string type for forward compatibility."
 @added(Versions.v2026_04_02_preview)
 model MaintenanceWindowResourceProperties {
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
@@ -43,9 +43,7 @@ model MaintenanceWindowResource
 
 @@maxLength(MaintenanceWindowResource.name, 63);
 @@minLength(MaintenanceWindowResource.name, 1);
-@@doc(MaintenanceWindowResource.name,
-  "The name of the maintenance window."
-);
+@@doc(MaintenanceWindowResource.name, "The name of the maintenance window.");
 @@doc(MaintenanceWindowResource.properties,
   "Properties of a maintenance window."
 );

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
@@ -1,0 +1,149 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./MaintenanceConfiguration.tsp"; // reuse Schedule, DateSpan, WeekDay, Type
+
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+
+namespace Microsoft.ContainerService;
+
+// =============================================================================
+// MaintenanceWindow peer resource and operations
+//
+// MaintenanceWindow is a resource-group-scoped peer of managedClusters
+// (sibling to Snapshot / ManagedClusterSnapshot in this same project). It is
+// modeled with the TypeSpec identifier `MaintenanceWindowResource` because
+// `MaintenanceWindow` is already taken by the existing inline maintenance
+// window schedule model used on `maintenanceConfigurations.properties.maintenanceWindow`
+// (see MaintenanceConfiguration.tsp). The ARM resource type remains
+// `Microsoft.ContainerService/maintenanceWindows` via the `SegmentName` below,
+// so this naming is internal to the TypeSpec / generated SDK only.
+// =============================================================================
+
+/**
+ * A maintenance window is a resource-group-scoped resource that defines a reusable
+ * maintenance schedule which can be linked to maintenance configurations on one
+ * or more managed clusters.
+ * For more information, see https://aka.ms/aks/maintenance-windows.
+ */
+@added(Versions.v2026_04_02_preview)
+model MaintenanceWindowResource
+  is Azure.ResourceManager.TrackedResource<MaintenanceWindowResourceProperties> {
+  ...ResourceNameParameter<
+    Resource = MaintenanceWindowResource,
+    KeyName = "maintenanceWindowName",
+    SegmentName = "maintenanceWindows",
+    NamePattern = "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+  >;
+}
+
+@@maxLength(MaintenanceWindowResource.name, 63);
+@@minLength(MaintenanceWindowResource.name, 1);
+@@doc(MaintenanceWindowResource.name,
+  "The name of the maintenance window."
+);
+@@doc(MaintenanceWindowResource.properties,
+  "Properties of a maintenance window."
+);
+@@doc(MaintenanceWindows.createOrUpdate::parameters.resource,
+  "The maintenance window to create or update."
+);
+
+@armResourceOperations
+@added(Versions.v2026_04_02_preview)
+interface MaintenanceWindows {
+  /**
+   * Gets the specified maintenance window.
+   */
+  get is ArmResourceRead<MaintenanceWindowResource>;
+
+  /**
+   * Creates or updates a maintenance window.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<MaintenanceWindowResource>;
+
+  /**
+   * Deletes a maintenance window.
+   */
+  delete is ArmResourceDeleteWithoutOkAsync<MaintenanceWindowResource>;
+
+  /**
+   * Lists maintenance windows in the specified resource group.
+   */
+  list is ArmResourceListByParent<MaintenanceWindowResource>;
+
+  /**
+   * Lists maintenance windows in the specified subscription.
+   */
+  listBySubscription is ArmListBySubscription<MaintenanceWindowResource>;
+}
+
+// =============================================================================
+// MaintenanceWindow models
+// =============================================================================
+
+/**
+ * Properties of a maintenance window.
+ * For more information, see https://aka.ms/aks/maintenance-windows.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "AKS uses custom provisioning states beyond standard ARM states. Using string type for forward compatibility."
+@added(Versions.v2026_04_02_preview)
+model MaintenanceWindowResourceProperties {
+  /**
+   * The provisioning state of the maintenance window.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: Azure.ResourceManager.ResourceProvisioningState;
+
+  /**
+   * Recurrence schedule for the maintenance window. One and only one of the schedule
+   * types should be specified: 'daily', 'weekly', 'absoluteMonthly', or 'relativeMonthly'.
+   */
+  schedule: Schedule;
+
+  /**
+   * The date the maintenance window activates. If the current date is before this
+   * date, the maintenance window is inactive and will not be used. If not specified,
+   * the maintenance window will be active right away.
+   */
+  startDate?: plainDate;
+
+  /**
+   * The start time of the maintenance window. Accepted values are from '00:00' to
+   * '23:59'. 'utcOffset' applies to this field. For example: '02:00' with
+   * 'utcOffset: +02:00' means UTC time '00:00'.
+   */
+  @pattern("^([01]\\d|2[0-3]):[0-5]\\d$")
+  startTime: string;
+
+  /**
+   * Length of the maintenance window in hours.
+   */
+  @minValue(4)
+  @maxValue(24)
+  durationHours: int32 = 4;
+
+  /**
+   * The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00'
+   * for PST. If not specified, the default is '+00:00'.
+   * Note: this is a static offset and does not adjust for Daylight Saving Time.
+   * Customers in DST-observing regions should pick the offset that matches their
+   * preferred wall-clock time year-round; the maintenance window will shift by one
+   * hour relative to local time when DST starts or ends.
+   */
+  @pattern("^(-|\\+)[0-9]{2}:[0-9]{2}$")
+  utcOffset?: string;
+
+  /**
+   * Date ranges during which maintenance is not allowed. 'utcOffset' applies to
+   * these dates. For example, with 'utcOffset: +02:00' and a date span of
+   * '2026-12-23' to '2027-01-03', maintenance will be blocked from
+   * '2026-12-22 22:00' to '2027-01-03 22:00' in UTC time.
+   */
+  @identifiers(#[])
+  notAllowedDates?: DateSpan[];
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsCreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsCreateOrUpdate.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "production"
+      },
+      "properties": {
+        "schedule": {
+          "weekly": {
+            "intervalWeeks": 1,
+            "dayOfWeek": "Saturday"
+          }
+        },
+        "startDate": "2026-04-05",
+        "startTime": "02:00",
+        "durationHours": 8,
+        "utcOffset": "-07:00",
+        "notAllowedDates": [
+          {
+            "start": "2026-12-23",
+            "end": "2027-01-03"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-04-02-preview"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Creating",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_CreateOrUpdate",
+  "title": "Create/Update Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsDelete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-04-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "MaintenanceWindows_Delete",
+  "title": "Delete Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsGet.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_Get",
+  "title": "Get Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsList.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+            "name": "production-weekends",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "eastus",
+            "tags": {
+              "environment": "production"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "weekly": {
+                  "intervalWeeks": 1,
+                  "dayOfWeek": "Saturday"
+                }
+              },
+              "startDate": "2026-04-05",
+              "startTime": "02:00",
+              "durationHours": 8,
+              "utcOffset": "-07:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-01T10:00:00Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-01T10:00:00Z"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/dev-nightly",
+            "name": "dev-nightly",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "westus2",
+            "tags": {
+              "environment": "development"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "daily": {
+                  "intervalDays": 1
+                }
+              },
+              "startTime": "22:00",
+              "durationHours": 6,
+              "utcOffset": "+00:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-02T14:30:00Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-02T14:30:00Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_List",
+  "title": "List Maintenance Windows by Resource Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-04-02-preview/MaintenanceWindowsListBySubscription.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+            "name": "production-weekends",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "eastus",
+            "tags": {
+              "environment": "production"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "weekly": {
+                  "intervalWeeks": 1,
+                  "dayOfWeek": "Saturday"
+                }
+              },
+              "startDate": "2026-04-05",
+              "startTime": "02:00",
+              "durationHours": 8,
+              "utcOffset": "-07:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-01T10:00:00Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-01T10:00:00Z"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/dev-nightly",
+            "name": "dev-nightly",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "westus2",
+            "tags": {
+              "environment": "development"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "daily": {
+                  "intervalDays": 1
+                }
+              },
+              "startTime": "22:00",
+              "durationHours": 6,
+              "utcOffset": "+00:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-02T14:30:00Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-02T14:30:00Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_ListBySubscription",
+  "title": "List Maintenance Windows by Subscription"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
@@ -21,6 +21,7 @@ import "./SafeguardsAvailableVersion.tsp";
 import "./MeshRevisionProfile.tsp";
 import "./MeshUpgradeProfile.tsp";
 import "./MaintenanceConfiguration.tsp";
+import "./MaintenanceWindow.tsp";
 import "./ManagedNamespace.tsp";
 import "./AgentPool.tsp";
 import "./AgentPoolUpgradeProfile.tsp";

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsCreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsCreateOrUpdate.json
@@ -1,0 +1,115 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resource": {
+      "location": "eastus",
+      "tags": {
+        "environment": "production"
+      },
+      "properties": {
+        "schedule": {
+          "weekly": {
+            "intervalWeeks": 1,
+            "dayOfWeek": "Saturday"
+          }
+        },
+        "startDate": "2026-04-05",
+        "startTime": "02:00",
+        "durationHours": 8,
+        "utcOffset": "-07:00",
+        "notAllowedDates": [
+          {
+            "start": "2026-12-23",
+            "end": "2027-01-03"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-04-02-preview"
+      },
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Creating",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_CreateOrUpdate",
+  "title": "Create/Update Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsDelete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsDelete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ContainerService/locations/eastus/operations/00000000-0000-0000-0000-000000000000?api-version=2026-04-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "MaintenanceWindows_Delete",
+  "title": "Delete Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsGet.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsGet.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "maintenanceWindowName": "production-weekends",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+        "name": "production-weekends",
+        "type": "Microsoft.ContainerService/maintenanceWindows",
+        "location": "eastus",
+        "tags": {
+          "environment": "production"
+        },
+        "properties": {
+          "provisioningState": "Succeeded",
+          "schedule": {
+            "weekly": {
+              "intervalWeeks": 1,
+              "dayOfWeek": "Saturday"
+            }
+          },
+          "startDate": "2026-04-05",
+          "startTime": "02:00",
+          "durationHours": 8,
+          "utcOffset": "-07:00",
+          "notAllowedDates": [
+            {
+              "start": "2026-12-23",
+              "end": "2027-01-03"
+            }
+          ]
+        },
+        "systemData": {
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-04-01T10:00:00Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-04-01T10:00:00Z"
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_Get",
+  "title": "Get Maintenance Window"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsList.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsList.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "resourceGroupName": "rg-maintenance",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+            "name": "production-weekends",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "eastus",
+            "tags": {
+              "environment": "production"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "weekly": {
+                  "intervalWeeks": 1,
+                  "dayOfWeek": "Saturday"
+                }
+              },
+              "startDate": "2026-04-05",
+              "startTime": "02:00",
+              "durationHours": 8,
+              "utcOffset": "-07:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-01T10:00:00Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-01T10:00:00Z"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/dev-nightly",
+            "name": "dev-nightly",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "westus2",
+            "tags": {
+              "environment": "development"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "daily": {
+                  "intervalDays": 1
+                }
+              },
+              "startTime": "22:00",
+              "durationHours": 6,
+              "utcOffset": "+00:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-02T14:30:00Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-02T14:30:00Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_List",
+  "title": "List Maintenance Windows by Resource Group"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/examples/MaintenanceWindowsListBySubscription.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/production-weekends",
+            "name": "production-weekends",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "eastus",
+            "tags": {
+              "environment": "production"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "weekly": {
+                  "intervalWeeks": 1,
+                  "dayOfWeek": "Saturday"
+                }
+              },
+              "startDate": "2026-04-05",
+              "startTime": "02:00",
+              "durationHours": 8,
+              "utcOffset": "-07:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-01T10:00:00Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-01T10:00:00Z"
+            }
+          },
+          {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-maintenance/providers/Microsoft.ContainerService/maintenanceWindows/dev-nightly",
+            "name": "dev-nightly",
+            "type": "Microsoft.ContainerService/maintenanceWindows",
+            "location": "westus2",
+            "tags": {
+              "environment": "development"
+            },
+            "properties": {
+              "provisioningState": "Succeeded",
+              "schedule": {
+                "daily": {
+                  "intervalDays": 1
+                }
+              },
+              "startTime": "22:00",
+              "durationHours": 6,
+              "utcOffset": "+00:00",
+              "notAllowedDates": []
+            },
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-04-02T14:30:00Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-04-02T14:30:00Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceWindows_ListBySubscription",
+  "title": "List Maintenance Windows by Subscription"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
@@ -61,6 +61,9 @@
       "name": "MaintenanceConfigurations"
     },
     {
+      "name": "MaintenanceWindows"
+    },
+    {
       "name": "ManagedNamespaces"
     },
     {
@@ -583,6 +586,45 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/maintenanceWindows": {
+      "get": {
+        "operationId": "MaintenanceWindows_ListBySubscription",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Lists maintenance windows in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Maintenance Windows by Subscription": {
+            "$ref": "./examples/MaintenanceWindowsListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
     "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/managedClusters": {
       "get": {
         "operationId": "ManagedClusters_List",
@@ -698,6 +740,237 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/maintenanceWindows": {
+      "get": {
+        "operationId": "MaintenanceWindows_List",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Lists maintenance windows in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Maintenance Windows by Resource Group": {
+            "$ref": "./examples/MaintenanceWindowsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/maintenanceWindows/{maintenanceWindowName}": {
+      "get": {
+        "operationId": "MaintenanceWindows_Get",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Gets the specified maintenance window.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "maintenanceWindowName",
+            "in": "path",
+            "description": "The name of the maintenance window.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Maintenance Window": {
+            "$ref": "./examples/MaintenanceWindowsGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "MaintenanceWindows_CreateOrUpdate",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Creates or updates a maintenance window.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "maintenanceWindowName",
+            "in": "path",
+            "description": "The name of the maintenance window.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The maintenance window to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MaintenanceWindowResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'MaintenanceWindowResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResource"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/Update Maintenance Window": {
+            "$ref": "./examples/MaintenanceWindowsCreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/MaintenanceWindowResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "MaintenanceWindows_Delete",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Deletes a maintenance window.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "maintenanceWindowName",
+            "in": "path",
+            "description": "The name of the maintenance window.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Maintenance Window": {
+            "$ref": "./examples/MaintenanceWindowsDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters": {
@@ -7215,6 +7488,37 @@
         }
       }
     },
+    "Azure.ResourceManager.ResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of a resource type.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
     "AzureKeyVaultKms": {
       "type": "object",
       "description": "Azure Key Vault key management service settings for the security profile.",
@@ -10134,6 +10438,93 @@
         "schedule",
         "durationHours",
         "startTime"
+      ]
+    },
+    "MaintenanceWindowResource": {
+      "type": "object",
+      "description": "A maintenance window is a resource-group-scoped resource that defines a reusable\nmaintenance schedule which can be linked to maintenance configurations on one\nor more managed clusters.\nFor more information, see https://aka.ms/aks/maintenance-windows.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MaintenanceWindowResourceProperties",
+          "description": "Properties of a maintenance window."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "MaintenanceWindowResourceListResult": {
+      "type": "object",
+      "description": "The response of a MaintenanceWindowResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MaintenanceWindowResource items on this page",
+          "items": {
+            "$ref": "#/definitions/MaintenanceWindowResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MaintenanceWindowResourceProperties": {
+      "type": "object",
+      "description": "Properties of a maintenance window.\nFor more information, see https://aka.ms/aks/maintenance-windows.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the maintenance window.",
+          "readOnly": true
+        },
+        "schedule": {
+          "$ref": "#/definitions/Schedule",
+          "description": "Recurrence schedule for the maintenance window. One and only one of the schedule\ntypes should be specified: 'daily', 'weekly', 'absoluteMonthly', or 'relativeMonthly'."
+        },
+        "startDate": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the maintenance window activates. If the current date is before this\ndate, the maintenance window is inactive and will not be used. If not specified,\nthe maintenance window will be active right away."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "The start time of the maintenance window. Accepted values are from '00:00' to\n'23:59'. 'utcOffset' applies to this field. For example: '02:00' with\n'utcOffset: +02:00' means UTC time '00:00'.",
+          "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$"
+        },
+        "durationHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length of the maintenance window in hours.",
+          "default": 4,
+          "minimum": 4,
+          "maximum": 24
+        },
+        "utcOffset": {
+          "type": "string",
+          "description": "The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00'\nfor PST. If not specified, the default is '+00:00'.\nNote: this is a static offset and does not adjust for Daylight Saving Time.\nCustomers in DST-observing regions should pick the offset that matches their\npreferred wall-clock time year-round; the maintenance window will shift by one\nhour relative to local time when DST starts or ends.",
+          "pattern": "^(-|\\+)[0-9]{2}:[0-9]{2}$"
+        },
+        "notAllowedDates": {
+          "type": "array",
+          "description": "Date ranges during which maintenance is not allowed. 'utcOffset' applies to\nthese dates. For example, with 'utcOffset: +02:00' and a date span of\n'2026-12-23' to '2027-01-03', maintenance will be blocked from\n'2026-12-22 22:00' to '2027-01-03 22:00' in UTC time.",
+          "items": {
+            "$ref": "#/definitions/DateSpan"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "schedule",
+        "startTime",
+        "durationHours"
       ]
     },
     "ManagedCluster": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -1482,6 +1482,10 @@ directive:
   - suppress: TrackedResourcePatchOperation
     from: containerService.json
     reason: ACS service is deprecated so a PATCH endpoint won't be implemented
+  - suppress: TrackedResourcePatchOperation
+    from: managedClusters.json
+    where: $.definitions.MaintenanceWindowResource
+    reason: Maintenance windows do not expose a separate PATCH operation; tags are updated via the createOrUpdate PUT operation.
   - suppress: DefinitionsPropertiesNamesCamelCase
     from: managedClusters.json
     where: $.definitions.ManagedClusterSecurityProfile.properties.customCATrustCertificates      


### PR DESCRIPTION
Introduces Microsoft.ContainerService/maintenanceWindows as a new resource-group-scoped tracked resource at API version 2026-04-02-preview. A maintenance window defines a reusable maintenance schedule which will later be linkable to maintenance configurations on managed clusters.

Structure follows the established sibling-project convention: a self-contained spec project under specification/containerservice/resource-manager/Microsoft.ContainerService/maintenancewindows/ that emits its own maintenancewindows.json swagger and ships as an independent SDK package.

Operations:
- Get
- CreateOrUpdate (async LRO; completes synchronously today)
- Delete (async LRO; completes synchronously today)
- List by resource group
- List by subscription

Schedule/DateSpan/WeekDay/Type and the DailySchedule/WeeklySchedule/ AbsoluteMonthlySchedule/RelativeMonthlySchedule variants are duplicated into schedule.tsp because each sibling spec project under Microsoft.ContainerService is compiled and emitted as an independent autorest output file.

Approved Design proposal:
https://github.com/azure-management-and-platforms/aks-handbook/pull/97

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
