### PR TITLE
Revert tspconfig api-version changes from PR 43257

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
@@ -24,7 +24,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.AppConfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2025-06-01-preview"
     enable-wire-path-attribute: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-appconfiguration"

--- a/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
+++ b/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
@@ -15,7 +15,6 @@ options:
     namespace: "Azure.ResourceManager.CognitiveServices"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: 2026-01-15-preview
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-cognitiveservices"
     namespace: "azure.mgmt.cognitiveservices"

--- a/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
@@ -14,7 +14,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.Resources.Policy"
-    api-version: "2025-12-01-preview"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-resource-policy"
     namespace: "azure.mgmt.resource.policy"

--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -60,7 +60,7 @@ options:
     namespace: "Azure.ResourceManager.Storage"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: "2025-08-01"
+    api-version: 2025-08-01
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -60,7 +60,7 @@ options:
     namespace: "Azure.ResourceManager.Storage"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: 2025-06-01
+    api-version: "2025-08-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Reverts the C# emitter api-version changes introduced by #43257 in the following tspconfig.yaml files:

- specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
- specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
- specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
- specification/storage/Storage.Management/tspconfig.yaml

The first three added api-version entries are removed, and Storage.Management is restored to api-version "2025-08-01".