### PR TITLE
containerservice: PreparedImageSpecification 2026-02-02-preview API updates

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_CreateOrUpdate.json
@@ -19,7 +19,8 @@
             "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
           }
         ],
-        "identityProfile": {}
+        "identityProfile": {},
+        "version": "1.0.0"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_Update.json
@@ -36,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+          "team": "blue"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -50,6 +50,11 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-08-02-preview/NodeCustomizations_Update.json
@@ -9,20 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {}
       }
     }
   },
@@ -50,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "team": "blue"
+          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -64,11 +50,6 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
-      }
-    },
-    "202": {
-      "headers": {
-        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_CreateOrUpdate.json
@@ -19,7 +19,8 @@
             "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
           }
         ],
-        "identityProfile": {}
+        "identityProfile": {},
+        "version": "1.0.0"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_Update.json
@@ -36,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+          "team": "blue"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -50,6 +50,11 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/examples/2025-09-02-preview/NodeCustomizations_Update.json
@@ -9,20 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {}
       }
     }
   },
@@ -50,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "team": "blue"
+          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -64,11 +50,6 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
-      }
-    },
-    "202": {
-      "headers": {
-        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
@@ -122,6 +122,11 @@ union ProvisioningState {
   Accepted: "Accepted",
 }
 
+@doc("Node customization patch resource")
+model NodeCustomizationPatch {
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+}
+
 @parentResource(NodeCustomization)
 @doc("A version of the Node Customization resource.")
 model NodeCustomizationVersion is ProxyResource<NodeCustomizationProperties> {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
@@ -129,9 +129,9 @@ model NodeCustomizationUpdate {
 @parentResource(NodeCustomization)
 @doc("A version of the Node Customization resource.")
 model NodeCustomizationVersion is ProxyResource<NodeCustomizationProperties> {
-  @pattern("^[\\w\\-\\.]+$")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,63}$")
   @minLength(1)
-  @maxLength(64)
+  @maxLength(63)
   @doc("The version of the Node Customization.")
   @key("version")
   @path

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/models.tsp
@@ -37,9 +37,8 @@ model NodeCustomizationProperties {
     """)
   identityProfile?: Foundations.UserAssignedIdentity;
 
-  @visibility(Lifecycle.Read)
-  @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
-  @pattern("^[\\w\\-\\.]+$")
+  @doc("The client-provided version of the node customization.")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,63}$")
   version?: string;
 
   @visibility(Lifecycle.Read)
@@ -122,8 +121,8 @@ union ProvisioningState {
   Accepted: "Accepted",
 }
 
-@doc("Node customization patch resource")
-model NodeCustomizationPatch {
+@doc("The type used for update operations of the NodeCustomization.")
+model NodeCustomizationUpdate {
   ...Azure.ResourceManager.Foundations.ArmTagsProperty;
 }
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
@@ -22,10 +22,10 @@ interface NodeCustomizations {
   >;
 
   #deprecated "Node Customization APIs are deprecated. Use Prepared Image Specification APIs instead."
-  @doc("Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.")
+  @doc("Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.")
   update is ArmCustomPatchSync<
     NodeCustomization,
-    PatchModel = NodeCustomizationPatch,
+    PatchModel = NodeCustomizationUpdate,
     Parameters = IfMatchParameters<NodeCustomization>
   >;
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
@@ -23,7 +23,7 @@ interface NodeCustomizations {
 
   #deprecated "Node Customization APIs are deprecated. Use Prepared Image Specification APIs instead."
   @doc("Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.")
-  update is ArmCustomPatchSync<
+  update is ArmCustomPatchAsync<
     NodeCustomization,
     PatchModel = NodeCustomizationUpdate,
     Parameters = IfMatchParameters<NodeCustomization>

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/operations.tsp
@@ -22,15 +22,11 @@ interface NodeCustomizations {
   >;
 
   #deprecated "Node Customization APIs are deprecated. Use Prepared Image Specification APIs instead."
-  @doc("Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.")
-  update is ArmCustomPatchAsync<
+  @doc("Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.")
+  update is ArmCustomPatchSync<
     NodeCustomization,
-    Azure.ResourceManager.Foundations.ResourceUpdateModel<
-      NodeCustomization,
-      NodeCustomizationProperties
-    >,
-    Azure.ResourceManager.Foundations.BaseParameters<NodeCustomization> &
-      IfMatchParameters<NodeCustomization>
+    PatchModel = NodeCustomizationPatch,
+    Parameters = IfMatchParameters<NodeCustomization>
   >;
 
   #deprecated "Node Customization APIs are deprecated. Use Prepared Image Specification APIs instead."

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_CreateOrUpdate.json
@@ -19,7 +19,8 @@
             "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
           }
         ],
-        "identityProfile": {}
+        "identityProfile": {},
+        "version": "1.0.0"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_Update.json
@@ -36,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+          "team": "blue"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -50,6 +50,11 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/examples/NodeCustomizations_Update.json
@@ -9,20 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {}
       }
     }
   },
@@ -50,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "team": "blue"
+          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -64,11 +50,6 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
-      }
-    },
-    "202": {
-      "headers": {
-        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
@@ -314,7 +314,7 @@
         "tags": [
           "NodeCustomizations"
         ],
-        "description": "Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.",
+        "description": "Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -349,7 +349,7 @@
             "description": "The resource properties to be updated.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/NodeCustomizationPatch"
+              "$ref": "#/definitions/NodeCustomizationUpdate"
             }
           }
         ],
@@ -707,19 +707,6 @@
         "value"
       ]
     },
-    "NodeCustomizationPatch": {
-      "type": "object",
-      "description": "Node customization patch resource",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "NodeCustomizationProperties": {
       "type": "object",
       "description": "The properties of the Node Customization resource.",
@@ -737,9 +724,8 @@
         },
         "version": {
           "type": "string",
-          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
-          "pattern": "^[\\w\\-\\.]+$",
-          "readOnly": true
+          "description": "The client-provided version of the node customization.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
         },
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -794,6 +780,19 @@
         "executionPoint",
         "scriptType"
       ]
+    },
+    "NodeCustomizationUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the NodeCustomization.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
     },
     "NodeCustomizationVersion": {
       "type": "object",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
@@ -314,7 +314,7 @@
         "tags": [
           "NodeCustomizations"
         ],
-        "description": "Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.",
+        "description": "Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -324,14 +324,6 @@
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
-            "required": false,
-            "type": "string",
-            "x-ms-client-name": "ifMatch"
           },
           {
             "name": "nodeCustomizationName",
@@ -344,12 +336,20 @@
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
             "name": "properties",
             "in": "body",
             "description": "The resource properties to be updated.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/NodeCustomizationUpdate"
+              "$ref": "#/definitions/NodeCustomizationPatch"
             }
           }
         ],
@@ -358,20 +358,6 @@
             "description": "Azure operation completed successfully.",
             "schema": {
               "$ref": "#/definitions/NodeCustomization"
-            }
-          },
-          "202": {
-            "description": "Resource update request accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
             }
           },
           "default": {
@@ -386,11 +372,7 @@
           "NodeCustomizations_Update": {
             "$ref": "./examples/NodeCustomizations_Update.json"
           }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
+        }
       },
       "delete": {
         "operationId": "NodeCustomizations_Delete",
@@ -725,6 +707,19 @@
         "value"
       ]
     },
+    "NodeCustomizationPatch": {
+      "type": "object",
+      "description": "Node customization patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "NodeCustomizationProperties": {
       "type": "object",
       "description": "The properties of the Node Customization resource.",
@@ -799,48 +794,6 @@
         "executionPoint",
         "scriptType"
       ]
-    },
-    "NodeCustomizationUpdate": {
-      "type": "object",
-      "description": "The type used for update operations of the NodeCustomization.",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "properties": {
-          "$ref": "#/definitions/NodeCustomizationUpdateProperties",
-          "description": "The resource-specific properties for this resource."
-        }
-      }
-    },
-    "NodeCustomizationUpdateProperties": {
-      "type": "object",
-      "description": "The updatable properties of the NodeCustomization.",
-      "properties": {
-        "containerImages": {
-          "type": "array",
-          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
-          "items": {
-            "type": "string"
-          }
-        },
-        "identityProfile": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
-          "description": "The identity used to execute node customization tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
-        },
-        "customizationScripts": {
-          "type": "array",
-          "description": "The scripts to customize the node before or after image capture.",
-          "items": {
-            "$ref": "#/definitions/NodeCustomizationScript"
-          },
-          "x-ms-identifiers": []
-        }
-      }
     },
     "NodeCustomizationVersion": {
       "type": "object",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
@@ -551,8 +551,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 64,
-            "pattern": "^[\\w\\-\\.]+$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {
@@ -617,8 +617,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 64,
-            "pattern": "^[\\w\\-\\.]+$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-08-02-preview/nodecustomization.json
@@ -360,6 +360,20 @@
               "$ref": "#/definitions/NodeCustomization"
             }
           },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
@@ -372,7 +386,11 @@
           "NodeCustomizations_Update": {
             "$ref": "./examples/NodeCustomizations_Update.json"
           }
-        }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       },
       "delete": {
         "operationId": "NodeCustomizations_Delete",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_CreateOrUpdate.json
@@ -19,7 +19,8 @@
             "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
           }
         ],
-        "identityProfile": {}
+        "identityProfile": {},
+        "version": "1.0.0"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_Update.json
@@ -36,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+          "team": "blue"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -50,6 +50,11 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/examples/NodeCustomizations_Update.json
@@ -9,20 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test node customization\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {}
       }
     }
   },
@@ -50,7 +36,7 @@
         },
         "eTag": "ETagValue",
         "tags": {
-          "team": "blue"
+          "key5558": "xufgvdnarflvwbcdkmhqhgbop"
         },
         "location": "westus2",
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/nodeCustomizations/my-node-customization",
@@ -64,11 +50,6 @@
           "lastModifiedByType": "User",
           "lastModifiedAt": "2025-05-02T04:08:43.702Z"
         }
-      }
-    },
-    "202": {
-      "headers": {
-        "location": "https://contoso.com/operationstatus"
       }
     }
   }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
@@ -314,7 +314,7 @@
         "tags": [
           "NodeCustomizations"
         ],
-        "description": "Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.",
+        "description": "Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -349,7 +349,7 @@
             "description": "The resource properties to be updated.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/NodeCustomizationPatch"
+              "$ref": "#/definitions/NodeCustomizationUpdate"
             }
           }
         ],
@@ -707,19 +707,6 @@
         "value"
       ]
     },
-    "NodeCustomizationPatch": {
-      "type": "object",
-      "description": "Node customization patch resource",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "NodeCustomizationProperties": {
       "type": "object",
       "description": "The properties of the Node Customization resource.",
@@ -737,9 +724,8 @@
         },
         "version": {
           "type": "string",
-          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
-          "pattern": "^[\\w\\-\\.]+$",
-          "readOnly": true
+          "description": "The client-provided version of the node customization.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
         },
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -794,6 +780,19 @@
         "executionPoint",
         "scriptType"
       ]
+    },
+    "NodeCustomizationUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the NodeCustomization.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
     },
     "NodeCustomizationVersion": {
       "type": "object",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
@@ -314,7 +314,7 @@
         "tags": [
           "NodeCustomizations"
         ],
-        "description": "Deprecated: Update a node customization. Use Prepared Image Specification APIs instead.",
+        "description": "Deprecated: Update the tags of a node customization. Use Prepared Image Specification APIs instead.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
@@ -324,14 +324,6 @@
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
-            "required": false,
-            "type": "string",
-            "x-ms-client-name": "ifMatch"
           },
           {
             "name": "nodeCustomizationName",
@@ -344,12 +336,20 @@
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
             "name": "properties",
             "in": "body",
             "description": "The resource properties to be updated.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/NodeCustomizationUpdate"
+              "$ref": "#/definitions/NodeCustomizationPatch"
             }
           }
         ],
@@ -358,20 +358,6 @@
             "description": "Azure operation completed successfully.",
             "schema": {
               "$ref": "#/definitions/NodeCustomization"
-            }
-          },
-          "202": {
-            "description": "Resource update request accepted.",
-            "headers": {
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
             }
           },
           "default": {
@@ -386,11 +372,7 @@
           "NodeCustomizations_Update": {
             "$ref": "./examples/NodeCustomizations_Update.json"
           }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
-        },
-        "x-ms-long-running-operation": true
+        }
       },
       "delete": {
         "operationId": "NodeCustomizations_Delete",
@@ -725,6 +707,19 @@
         "value"
       ]
     },
+    "NodeCustomizationPatch": {
+      "type": "object",
+      "description": "Node customization patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "NodeCustomizationProperties": {
       "type": "object",
       "description": "The properties of the Node Customization resource.",
@@ -799,48 +794,6 @@
         "executionPoint",
         "scriptType"
       ]
-    },
-    "NodeCustomizationUpdate": {
-      "type": "object",
-      "description": "The type used for update operations of the NodeCustomization.",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "properties": {
-          "$ref": "#/definitions/NodeCustomizationUpdateProperties",
-          "description": "The resource-specific properties for this resource."
-        }
-      }
-    },
-    "NodeCustomizationUpdateProperties": {
-      "type": "object",
-      "description": "The updatable properties of the NodeCustomization.",
-      "properties": {
-        "containerImages": {
-          "type": "array",
-          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
-          "items": {
-            "type": "string"
-          }
-        },
-        "identityProfile": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/UserAssignedIdentity",
-          "description": "The identity used to execute node customization tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
-        },
-        "customizationScripts": {
-          "type": "array",
-          "description": "The scripts to customize the node before or after image capture.",
-          "items": {
-            "$ref": "#/definitions/NodeCustomizationScript"
-          },
-          "x-ms-identifiers": []
-        }
-      }
     },
     "NodeCustomizationVersion": {
       "type": "object",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
@@ -551,8 +551,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 64,
-            "pattern": "^[\\w\\-\\.]+$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {
@@ -617,8 +617,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 64,
-            "pattern": "^[\\w\\-\\.]+$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/nodecustomization/preview/2025-09-02-preview/nodecustomization.json
@@ -360,6 +360,20 @@
               "$ref": "#/definitions/NodeCustomization"
             }
           },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
@@ -372,7 +386,11 @@
           "NodeCustomizations_Update": {
             "$ref": "./examples/NodeCustomizations_Update.json"
           }
-        }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       },
       "delete": {
         "operationId": "NodeCustomizations_Delete",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -8,6 +8,7 @@
     "preparedImageSpecificationName": "my-prepared-image-specification",
     "resource": {
       "properties": {
+        "version": "20250101-abcd1234",
         "containerImages": [
           "redis:8.0.0"
         ],
@@ -21,7 +22,8 @@
         ],
         "identityProfile": {
           "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        }
+        },
+        "version": "20250101-abcd1234"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -22,8 +22,7 @@
         ],
         "identityProfile": {
           "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        },
-        "version": "20250101-abcd1234"
+        }
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-02-02-preview/PreparedImageSpecifications_Update.json
@@ -9,22 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {
-          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        }
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -100,7 +100,6 @@ model PreparedImageSpecificationScript {
   postScriptAction?: PostScriptAction;
 }
 
-
 @doc("Prepared image specification patch resource")
 model PreparedImageSpecificationPatch {
   ...Azure.ResourceManager.Foundations.ArmTagsProperty;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -39,7 +39,7 @@ model PreparedImageSpecificationProperties {
   identityProfile?: PreparedImageSpecificationManagedIdentityProfile;
 
   @doc("The client-provided version of the prepared image specification.")
-  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,63}$")
   version?: string;
 
   @visibility(Lifecycle.Read)
@@ -161,9 +161,9 @@ union ProvisioningState {
 @doc("A version of the Prepared Image Specification resource.")
 model PreparedImageSpecificationVersion
   is ProxyResource<PreparedImageSpecificationProperties> {
-  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,63}$")
   @minLength(1)
-  @maxLength(128)
+  @maxLength(63)
   @doc("The version of the Prepared Image Specification.")
   @key("version")
   @path

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -38,7 +38,7 @@ model PreparedImageSpecificationProperties {
     """)
   identityProfile?: PreparedImageSpecificationManagedIdentityProfile;
 
-  @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
+  @doc("The client-provided version of the prepared image specification.")
   @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
   version?: string;
 
@@ -140,7 +140,7 @@ model PreparedImageSpecificationPatchProperties {
   @doc("The identity used to execute prepared image specification tasks during image build time and provisioning time.")
   identityProfile?: PreparedImageSpecificationManagedIdentityProfileUpdate;
 
-  @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
+  @doc("The client-provided version of the prepared image specification.")
   @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
   version?: string;
 

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -38,7 +38,6 @@ model PreparedImageSpecificationProperties {
     """)
   identityProfile?: PreparedImageSpecificationManagedIdentityProfile;
 
-  @visibility(Lifecycle.Read)
   @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
   @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
   version?: string;
@@ -140,6 +139,10 @@ model PreparedImageSpecificationPatchProperties {
 
   @doc("The identity used to execute prepared image specification tasks during image build time and provisioning time.")
   identityProfile?: PreparedImageSpecificationManagedIdentityProfileUpdate;
+
+  @doc("An auto-generated value that changes when the other fields of the image customization are changed.")
+  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
+  version?: string;
 
   @doc("The scripts to customize the node before or after image capture.")
   @identifiers(#[])

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/models.tsp
@@ -69,16 +69,6 @@ model PreparedImageSpecificationManagedIdentityProfile {
   clientId?: Azure.Core.uuid;
 }
 
-@doc("The managed identity profile used by the prepared image specification for update operations.")
-model PreparedImageSpecificationManagedIdentityProfileUpdate {
-  @doc("The resource ID of the user-assigned managed identity.")
-  resourceId?: Azure.Core.armResourceIdentifier<[
-    {
-      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
-    }
-  ]>;
-}
-
 @doc("Prepared image specification script")
 model PreparedImageSpecificationScript {
   @doc("""
@@ -110,51 +100,10 @@ model PreparedImageSpecificationScript {
   postScriptAction?: PostScriptAction;
 }
 
-@doc("Prepared image specification script for update operations")
-model PreparedImageSpecificationScriptUpdate {
-  @doc("The name for the customization script.")
-  @pattern("^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$")
-  @maxLength(263)
-  name?: string;
-
-  @doc("The stage at which the script is executed.")
-  executionPoint?: ExecutionPoint;
-
-  @doc("The runtime environment for the script (e.g. Bash).")
-  @example("Bash")
-  scriptType?: ScriptType;
-
-  @doc("The script content to be executed in plain text. Do not include secrets.")
-  @example("echo 'initializing node'")
-  script?: string;
-
-  @doc("The action to take after successful script execution.")
-  postScriptAction?: PostScriptAction;
-}
-
-@doc("The updatable properties of the Prepared Image Specification resource.")
-model PreparedImageSpecificationPatchProperties {
-  @doc("The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names")
-  containerImages?: string[];
-
-  @doc("The identity used to execute prepared image specification tasks during image build time and provisioning time.")
-  identityProfile?: PreparedImageSpecificationManagedIdentityProfileUpdate;
-
-  @doc("The client-provided version of the prepared image specification.")
-  @pattern("^(?![.-])[A-Za-z0-9_.-]{1,128}$")
-  version?: string;
-
-  @doc("The scripts to customize the node before or after image capture.")
-  @identifiers(#[])
-  customizationScripts?: PreparedImageSpecificationScriptUpdate[];
-}
 
 @doc("Prepared image specification patch resource")
 model PreparedImageSpecificationPatch {
   ...Azure.ResourceManager.Foundations.ArmTagsProperty;
-
-  @doc("Patchable prepared image specification properties.")
-  properties?: PreparedImageSpecificationPatchProperties;
 }
 
 @doc("The execution point for the script.")

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
@@ -11,7 +11,7 @@ namespace Microsoft.ContainerService;
 interface PreparedImageSpecifications {
   @doc("Get a prepared image specification at the latest version.")
   get is ArmResourceRead<PreparedImageSpecification>;
-  @doc("Create or update a prepared image specification resource. A new version is created only when the resource content changes.")
+  @doc("Create or update a prepared image specification resource with a client-provided version.")
   createOrUpdate is ArmResourceCreateOrUpdateAsync<
     PreparedImageSpecification,
     Azure.ResourceManager.Foundations.BaseParameters<PreparedImageSpecification> &
@@ -19,7 +19,7 @@ interface PreparedImageSpecifications {
       IfNoneMatchParameters<PreparedImageSpecification>
   >;
 
-  @doc("Update a prepared image specification. A new version is created only when the resource content changes.")
+  @doc("Update a prepared image specification with a client-provided version.")
   update is ArmCustomPatchSync<
     PreparedImageSpecification,
     PatchModel = PreparedImageSpecificationPatch,

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/operations.tsp
@@ -11,7 +11,7 @@ namespace Microsoft.ContainerService;
 interface PreparedImageSpecifications {
   @doc("Get a prepared image specification at the latest version.")
   get is ArmResourceRead<PreparedImageSpecification>;
-  @doc("Create or update a prepared image specification resource with a client-provided version.")
+  @doc("Create or update a prepared image specification resource with a client-provided version. Created versions are immutable; provide a different properties.version value to create a new version.")
   createOrUpdate is ArmResourceCreateOrUpdateAsync<
     PreparedImageSpecification,
     Azure.ResourceManager.Foundations.BaseParameters<PreparedImageSpecification> &
@@ -19,7 +19,7 @@ interface PreparedImageSpecifications {
       IfNoneMatchParameters<PreparedImageSpecification>
   >;
 
-  @doc("Update a prepared image specification with a client-provided version.")
+  @doc("Update the tags of a prepared image specification.")
   update is ArmCustomPatchSync<
     PreparedImageSpecification,
     PatchModel = PreparedImageSpecificationPatch,

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -8,6 +8,7 @@
     "preparedImageSpecificationName": "my-prepared-image-specification",
     "resource": {
       "properties": {
+        "version": "20250101-abcd1234",
         "containerImages": [
           "redis:8.0.0"
         ],
@@ -21,7 +22,8 @@
         ],
         "identityProfile": {
           "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        }
+        },
+        "version": "20250101-abcd1234"
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -22,8 +22,7 @@
         ],
         "identityProfile": {
           "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        },
-        "version": "20250101-abcd1234"
+        }
       },
       "tags": {
         "team": "blue"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/examples/PreparedImageSpecifications_Update.json
@@ -9,22 +9,6 @@
     "properties": {
       "tags": {
         "key5558": "xufgvdnarflvwbcdkmhqhgbop"
-      },
-      "properties": {
-        "containerImages": [
-          "qmetlvqgbvhjnncyraxlhs"
-        ],
-        "customizationScripts": [
-          {
-            "name": "initialize-node",
-            "executionPoint": "NodeImageBuildTime",
-            "scriptType": "Bash",
-            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
-          }
-        ],
-        "identityProfile": {
-          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
-        }
       }
     }
   },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -217,7 +217,7 @@
         "tags": [
           "PreparedImageSpecifications"
         ],
-        "description": "Create or update a prepared image specification resource. A new version is created only when the resource content changes.",
+        "description": "Create or update a prepared image specification resource with a client-provided version.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -310,7 +310,7 @@
         "tags": [
           "PreparedImageSpecifications"
         ],
-        "description": "Update a prepared image specification. A new version is created only when the resource content changes.",
+        "description": "Update a prepared image specification with a client-provided version.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -810,7 +810,7 @@
         },
         "version": {
           "type": "string",
-          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
+          "description": "The client-provided version of the prepared image specification.",
           "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
         },
         "customizationScripts": {
@@ -840,7 +840,7 @@
         },
         "version": {
           "type": "string",
-          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
+          "description": "The client-provided version of the prepared image specification.",
           "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
         },
         "provisioningState": {

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -217,7 +217,7 @@
         "tags": [
           "PreparedImageSpecifications"
         ],
-        "description": "Create or update a prepared image specification resource with a client-provided version.",
+        "description": "Create or update a prepared image specification resource with a client-provided version. Created versions are immutable; provide a different properties.version value to create a new version.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -310,7 +310,7 @@
         "tags": [
           "PreparedImageSpecifications"
         ],
-        "description": "Update a prepared image specification with a client-provided version.",
+        "description": "Update the tags of a prepared image specification.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -526,8 +526,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {
@@ -591,8 +591,8 @@
             "required": true,
             "type": "string",
             "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
           }
         ],
         "responses": {
@@ -789,7 +789,7 @@
         "version": {
           "type": "string",
           "description": "The client-provided version of the prepared image specification.",
-          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
         },
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -808,6 +808,11 @@
           "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfileUpdate",
           "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time."
         },
+        "version": {
+          "type": "string",
+          "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
+        },
         "customizationScripts": {
           "type": "array",
           "description": "The scripts to customize the node before or after image capture.",
@@ -836,8 +841,7 @@
         "version": {
           "type": "string",
           "description": "An auto-generated value that changes when the other fields of the image customization are changed.",
-          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$",
-          "readOnly": true
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
         },
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -874,13 +878,11 @@
         },
         "scriptType": {
           "$ref": "#/definitions/ScriptType",
-          "description": "The runtime environment for the script (e.g. Bash).",
-          "example": "Bash"
+          "description": "The runtime environment for the script (e.g. Bash)."
         },
         "script": {
           "type": "string",
-          "description": "The script content to be executed in plain text. Do not include secrets.",
-          "example": "echo 'initializing node'"
+          "description": "The script content to be executed in plain text. Do not include secrets."
         },
         "postScriptAction": {
           "$ref": "#/definitions/PostScriptAction",
@@ -909,13 +911,11 @@
         },
         "scriptType": {
           "$ref": "#/definitions/ScriptType",
-          "description": "The runtime environment for the script (e.g. Bash).",
-          "example": "Bash"
+          "description": "The runtime environment for the script (e.g. Bash)."
         },
         "script": {
           "type": "string",
-          "description": "The script content to be executed in plain text. Do not include secrets.",
-          "example": "echo 'initializing node'"
+          "description": "The script content to be executed in plain text. Do not include secrets."
         },
         "postScriptAction": {
           "$ref": "#/definitions/PostScriptAction",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-02-02-preview/preparedimagespecification.json
@@ -758,24 +758,6 @@
         "resourceId"
       ]
     },
-    "PreparedImageSpecificationManagedIdentityProfileUpdate": {
-      "type": "object",
-      "description": "The managed identity profile used by the prepared image specification for update operations.",
-      "properties": {
-        "resourceId": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "The resource ID of the user-assigned managed identity.",
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
-              }
-            ]
-          }
-        }
-      }
-    },
     "PreparedImageSpecificationPatch": {
       "type": "object",
       "description": "Prepared image specification patch resource",
@@ -786,40 +768,6 @@
           "additionalProperties": {
             "type": "string"
           }
-        },
-        "properties": {
-          "$ref": "#/definitions/PreparedImageSpecificationPatchProperties",
-          "description": "Patchable prepared image specification properties."
-        }
-      }
-    },
-    "PreparedImageSpecificationPatchProperties": {
-      "type": "object",
-      "description": "The updatable properties of the Prepared Image Specification resource.",
-      "properties": {
-        "containerImages": {
-          "type": "array",
-          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
-          "items": {
-            "type": "string"
-          }
-        },
-        "identityProfile": {
-          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfileUpdate",
-          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time."
-        },
-        "version": {
-          "type": "string",
-          "description": "The client-provided version of the prepared image specification.",
-          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,128}$"
-        },
-        "customizationScripts": {
-          "type": "array",
-          "description": "The scripts to customize the node before or after image capture.",
-          "items": {
-            "$ref": "#/definitions/PreparedImageSpecificationScriptUpdate"
-          },
-          "x-ms-identifiers": []
         }
       }
     },
@@ -878,11 +826,13 @@
         },
         "scriptType": {
           "$ref": "#/definitions/ScriptType",
-          "description": "The runtime environment for the script (e.g. Bash)."
+          "description": "The runtime environment for the script (e.g. Bash).",
+          "example": "Bash"
         },
         "script": {
           "type": "string",
-          "description": "The script content to be executed in plain text. Do not include secrets."
+          "description": "The script content to be executed in plain text. Do not include secrets.",
+          "example": "echo 'initializing node'"
         },
         "postScriptAction": {
           "$ref": "#/definitions/PostScriptAction",
@@ -894,34 +844,6 @@
         "executionPoint",
         "scriptType"
       ]
-    },
-    "PreparedImageSpecificationScriptUpdate": {
-      "type": "object",
-      "description": "Prepared image specification script for update operations",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name for the customization script.",
-          "maxLength": 263,
-          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$"
-        },
-        "executionPoint": {
-          "$ref": "#/definitions/ExecutionPoint",
-          "description": "The stage at which the script is executed."
-        },
-        "scriptType": {
-          "$ref": "#/definitions/ScriptType",
-          "description": "The runtime environment for the script (e.g. Bash)."
-        },
-        "script": {
-          "type": "string",
-          "description": "The script content to be executed in plain text. Do not include secrets."
-        },
-        "postScriptAction": {
-          "$ref": "#/definitions/PostScriptAction",
-          "description": "The action to take after successful script execution."
-        }
-      }
     },
     "PreparedImageSpecificationVersion": {
       "type": "object",


### PR DESCRIPTION
## Changes in this PR

This PR corrects preview API specs for `Microsoft.ContainerService/preparedimagespecification` and the deprecated `Microsoft.ContainerService/nodecustomization` APIs. The public swagger currently documents fields and operations that **never functioned** in the service. This PR removes those non-functional elements so the spec matches the actual API contract.

The affected APIs are preview-only. The Prepared Image Specification feature is behind feature gating and is not broadly in use.

### 1. Correct PreparedImageSpecification PATCH to ARM tags only (spec correction)

Fixes ADO task [#38037921](https://msazure.visualstudio.com/CloudNativeCompute/_workitems/edit/38037921).

The `PreparedImageSpecification` PATCH operation was mistakenly documented as accepting mutable body properties (`containerImages`, `identityProfile`, `version`, `customizationScripts`). These fields **never functioned** on PATCH — the service only supports updating ARM `tags` via PATCH. This PR removes the incorrectly documented properties so the swagger matches the actual service contract.

- Removed `PreparedImageSpecificationPatchProperties` and related update-only models
- Changed `PreparedImageSpecificationPatch` to carry only ARM `tags`
- Updated PATCH examples to send only `tags`

### 2. Make PreparedImageSpecification `version` customer-provided on create

The service expects `version` to be supplied by the customer at create time (immutable afterwards). The swagger previously marked it as read-only, which incorrectly hid this required create-time input from clients.

- Removed `@visibility(Lifecycle.Read)` from `PreparedImageSpecificationProperties.version`
- Updated docs to clarify that `version` is client-provided and immutable after creation
- Limited the version format to 63 characters (matching Kubernetes label value length constraints)
- Added `version` to create/update examples

### 3. Align deprecated NodeCustomization PATCH body and version behavior

The deprecated `Microsoft.ContainerService/nodecustomization` preview APIs have the same body-shape and `version` issue — PATCH was documented with properties that never functioned, and `version` was incorrectly marked read-only. To minimize LRO-related changes in this PR, NodeCustomization PATCH remains documented as async; this PR only corrects the PATCH request body shape and `version` visibility/format.

- Changed NodeCustomization update model to tags-only (keeping original `NodeCustomizationUpdate` name to minimize diff)
- Kept NodeCustomization PATCH LRO shape unchanged as async to minimize behavior changes in this PR
- Made `version` customer-provided (same semantics as PIS)
- Updated examples for `2025-08-02-preview` and `2025-09-02-preview`

## Breaking change review context

- All changes affect **preview** API versions only.
- The Prepared Image Specification feature is behind feature gating and is not broadly in use.
- RP telemetry over 180 days shows 4 distinct subscriptions, 2 using PATCH (5 total PATCH calls, all HTTP 200). Request bodies are not logged, so field-level usage cannot be confirmed — but the fields never functioned regardless.
- Following `aka.ms/brch` for approval to correct the existing preview version.
- `PreparedImageSpecificationVersion` path-key tightening to `{1,63}` is intentional and in-scope for this same preview breaking-change approval context.

## Due diligence checklist

- [x] TypeSpec compiles cleanly
- [x] Generated swagger regenerated from TypeSpec
- [x] Examples updated to reflect actual API behavior

---

### ARM API Changes

<details>
<summary>Expand for ARM template, Bicep, Terraform, and Policy impact</summary>

These changes correct preview specs. The fields being removed from PATCH never functioned — no existing ARM templates, Bicep files, or Terraform configurations successfully use them today.

</details>
