### PR TITLE
[RecoveryServicesBackup] Add multi-VDI policy support (stable 2026-06-01)

### DIFF
--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupFeature_Validate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupFeature_Validate.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "featureType": "AzureVMResourceBackup",
+      "vmSize": "Basic_A0",
+      "vmSku": "Premium"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "supportStatus": "DefaultOFF"
+      }
+    }
+  },
+  "operationId": "FeatureSupport_Validate",
+  "title": "Check Azure Vm Backup Feature Support"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupPolicies_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupPolicies_List.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultPolicy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 30,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2017-12-05T19:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2017-12-05T19:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            }
+          },
+          {
+            "name": "testPolicy1",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2018-01-24T02:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupProtectableItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupProtectableItems_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectableItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "friendlyName": "iaasvm-1",
+              "protectableItemType": "Microsoft.ClassicCompute/virtualMachines",
+              "protectionState": "NotProtected",
+              "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "workloadType": "VM"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectableItems_List",
+  "title": "List protectable items with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupProtectedItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/BackupProtectedItems_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM' and itemType eq 'VM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "containerName": "iaasvmcontainer;iaasvm-rg;iaasvm-1",
+              "friendlyName": "iaasvm-1",
+              "healthStatus": "Passed",
+              "lastBackupStatus": "Completed",
+              "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+              "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+              "policyId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+              "policyType": "V2",
+              "protectedItemDataId": "636482643132986882",
+              "protectedItemType": "Microsoft.ClassicCompute/virtualMachines",
+              "protectionState": "Protected",
+              "protectionStatus": "Healthy",
+              "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "workloadType": "VM"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectedItems_List",
+  "title": "List protected items with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ClassicCompute_ProtectedItem_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ClassicCompute_ProtectedItem_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainer;iaasvm-rg;iaasvm-1",
+          "friendlyName": "iaasvm-1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "policyType": "V1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.ClassicCompute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+          "workloadType": "VM"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItems_Get",
+  "title": "Get Protected Classic Virtual Machine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Compute_ProtectedItem_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Compute_ProtectedItem_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+          "friendlyName": "iaasvm-1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "policyType": "V2",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.Compute/virtualMachines/iaasvm-1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.Compute/virtualMachines/iaasvm-1",
+          "workloadType": "VM"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItems_Get",
+  "title": "Get Protected Virtual Machine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ConfigureProtection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ConfigureProtection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "policyId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+        "protectedItemType": "Microsoft.Compute/virtualMachines",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectedItems_CreateOrUpdate",
+  "title": "Enable Protection on Azure IaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/GetBackupStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/GetBackupStatus.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Compute/VirtualMachines/testVm",
+      "resourceType": "VM"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "containerName": "iaasvmcontainer;iaasvmcontainerv2;testRg;testVm",
+        "errorCode": "Success",
+        "errorMessage": "ErrorMessage",
+        "fabricName": "Azure",
+        "policyName": "myPolicy",
+        "protectedItemName": "vm;iaasvmcontainerv2;testRg;testVm",
+        "protectionStatus": "Protected",
+        "vaultId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/Vaults/testVault"
+      }
+    }
+  },
+  "operationId": "BackupStatus_Get",
+  "title": "Get Azure Virtual Machine Backup Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectedItemOperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectedItemOperationResults.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectedItemOperationResults_Get",
+  "title": "Get Operation Results of Protected Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectedItemOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectedItemOperationStatus.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "2017-10-29T06:04:18.207325Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "jobId": "00000000-0000-0000-0000-000000000000",
+          "objectType": "OperationStatusJobExtendedInfo"
+        },
+        "startTime": "2017-10-29T06:04:18.207325Z",
+        "status": "Succeeded"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItemOperationStatuses_Get",
+  "title": "Get Operation Status of Protected Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionIntent_CreateOrUpdate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionIntent_CreateOrUpdate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+    "parameters": {
+      "properties": {
+        "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+        "protectionIntentItemType": "AzureResourceItem",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chamsrgtest/providers/Microsoft.Compute/virtualMachines/chamscandel"
+      }
+    },
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+        "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+          "protectionIntentItemType": "AzureResourceItem",
+          "protectionState": "Protected"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_CreateOrUpdate",
+  "title": "Create or Update Azure Vm Protection Intent"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionIntent_Validate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionIntent_Validate.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "properties": "",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/arunaupgrade/providers/Microsoft.Compute/VirtualMachines/upgrade1",
+      "resourceType": "VM",
+      "vaultId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/Vaults/myVault"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "containerName": "iaasvmcontainer;iaasvmcontainerv2;arunaupgrade;upgrade1",
+        "errorCode": "VirtualMachineAlreadyProtected",
+        "errorMessage": "Virtual machine with same name and same resource group is already protected. Please select `Disable' choice above for backup and go to backup item corresponding to this VM in the vault",
+        "protectedItemName": "vm;iaasvmcontainerv2;arunaupgrade;upgrade1",
+        "recommendation": "Please do not enable protection again.",
+        "status": "Failed"
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_Validate",
+  "title": "Validate Enable Protection on Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Complex.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Complex.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 2,
+              "durationType": "Months"
+            },
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Wednesday",
+                "Thursday"
+              ],
+              "weeksOfTheMonth": [
+                "First",
+                "Third"
+              ]
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Monday",
+              "Wednesday",
+              "Thursday"
+            ],
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "February",
+              "November"
+            ],
+            "retentionDuration": {
+              "count": 4,
+              "durationType": "Years"
+            },
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Monday",
+                "Thursday"
+              ],
+              "weeksOfTheMonth": [
+                "Fourth"
+              ]
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunDays": [
+            "Monday",
+            "Wednesday",
+            "Thursday"
+          ],
+          "scheduleRunFrequency": "Weekly",
+          "scheduleRunTimes": [
+            "2018-01-24T10:00:00Z"
+          ]
+        },
+        "timeZone": "Pacific Standard Time"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 2,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Wednesday",
+                  "Thursday"
+                ],
+                "weeksOfTheMonth": [
+                  "First",
+                  "Third"
+                ]
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Monday",
+                "Wednesday",
+                "Thursday"
+              ],
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "February",
+                "November"
+              ],
+              "retentionDuration": {
+                "count": 4,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Monday",
+                  "Thursday"
+                ],
+                "weeksOfTheMonth": [
+                  "Fourth"
+                ]
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunDays": [
+              "Monday",
+              "Wednesday",
+              "Thursday"
+            ],
+            "scheduleRunFrequency": "Weekly",
+            "scheduleRunTimes": [
+              "2018-01-24T10:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Full Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Simple.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Simple.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2018-01-24T02:00:00Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy"
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2018-01-24T02:00:00Z"
+          ]
+        },
+        "timeZone": "Pacific Standard Time"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Simple Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionPolicies_Delete",
+  "title": "Delete Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicies_Get.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_Get",
+  "title": "Get Azure IaasVm Protection Policy Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicyOperationResults_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicyOperationResults_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 1,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicyOperationResults_Get",
+  "title": "Get Protection Policy Operation Results"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicyOperationStatuses_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ProtectionPolicyOperationStatuses_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "GetProtectionPolicyOperationStatus",
+        "endTime": "2018-01-24T12:57:32.1142968Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "failedJobsError": {},
+          "jobIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "objectType": "OperationStatusJobsExtendedInfo"
+        },
+        "startTime": "2018-01-24T12:57:32.1142968Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "ProtectionPolicyOperationStatuses_Get",
+  "title": "Get Protection Policy Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Provision_Ilr.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Provision_Ilr.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "initiatorName": "Hello World",
+        "objectType": "IaasVMILRRegistrationRequest",
+        "recoveryPointId": "38823086363464",
+        "renewExistingRegistration": true,
+        "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pysdktestrg/providers/Microsoft.Compute/virtualMachines/pysdktestv2vm1"
+      }
+    },
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "recoveryPointId": "1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ItemLevelRecoveryConnections_Provision",
+  "title": "Provision Instant Item Level Recovery for Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPointsRecommendedForMove_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPointsRecommendedForMove_List.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "parameters": {
+      "excludedRPList": [
+        "348916168024334",
+        "348916168024335"
+      ],
+      "objectType": "ListRecoveryPointsRecommendedForMoveRequest"
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "22244821112382",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/22244821112382",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2017-12-21T22:48:25.4353958Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1"
+            }
+          },
+          {
+            "name": "24977149827250",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/24977149827250",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "ArchivedRP",
+                  "extendedInfo": {
+                    "RehydratedRPExpiryTime": "2020-12-21T22:48:25.4353958Z"
+                  },
+                  "status": "Rehydrated"
+                }
+              ],
+              "recoveryPointTime": "2017-12-20T22:49:44.3317945Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1",
+              "zones": [
+                "1"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RecoveryPointsRecommendedForMove_List",
+  "title": "Get Protected Azure Vm Recovery Points Recommended for Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPoints_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPoints_Get.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "recoveryPointId": "26083826328862",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "26083826328862",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/26083826328862",
+        "properties": {
+          "isInstantIlrSessionActive": false,
+          "isManagedVirtualMachine": true,
+          "isPrivateAccessEnabledOnAnyDisk": true,
+          "isSourceVMEncrypted": false,
+          "objectType": "IaasVMRecoveryPoint",
+          "originalStorageAccountOption": false,
+          "recoveryPointAdditionalInfo": "",
+          "recoveryPointMoveReadinessInfo": {
+            "ArchivedRP": {
+              "isReadyForMove": true
+            }
+          },
+          "recoveryPointTierDetails": [
+            {
+              "type": "HardenedRP",
+              "status": "Valid"
+            }
+          ],
+          "recoveryPointTime": "2017-11-22T22:32:46.6088472Z",
+          "recoveryPointType": "CrashConsistent",
+          "sourceVMStorageType": "NormalStorage",
+          "virtualMachineSize": "Standard_D1",
+          "zones": [
+            "1"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "RecoveryPoints_Get",
+  "title": "Get Azure Vm Recovery Point Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPoints_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/RecoveryPoints_List.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "22244821112382",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/22244821112382",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "Archive": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2017-12-21T22:48:25.4353958Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1"
+            }
+          },
+          {
+            "name": "24977149827250",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/24977149827250",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isPrivateAccessEnabledOnAnyDisk": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "additionalInfo": "Recovery point cannot be moved to archive tier since it has already been moved.",
+                  "isReadyForMove": false
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "ArchivedRP",
+                  "extendedInfo": {
+                    "RehydratedRPExpiryTime": "2020-12-21T22:48:25.4353958Z"
+                  },
+                  "status": "Rehydrated"
+                }
+              ],
+              "recoveryPointTime": "2017-12-20T22:49:44.3317945Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1",
+              "zones": [
+                "1"
+              ]
+            }
+          },
+          {
+            "name": "70477518625276",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/FijiValidation-asr-microsoftrrdclab3-408/providers/Microsoft.RecoveryServices/vaults/testVault408/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;fijivalidation-asr-microsoftrrdclab3-408;vm408/protectedItems/VM;iaasvmcontainerv2;fijivalidation-asr-microsoftrrdclab3-408;vm408/recoveryPoints/70477518625276",
+            "properties": {
+              "extendedLocation": {
+                "name": "microsoftrrdclab3",
+                "type": "EdgeZone"
+              },
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isPrivateAccessEnabledOnAnyDisk": false,
+              "isSourceVMEncrypted": true,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "osType": "Windows",
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "additionalInfo": "We're still determining if this Recovery Point can be moved.. Please check again after some time.",
+                  "isReadyForMove": false
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Valid"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2023-09-22T20:02:00.1225746Z",
+              "recoveryPointType": "CrashConsistent",
+              "securityType": "None",
+              "sourceVMStorageType": "PremiumVMOnPartialPremiumStorage",
+              "virtualMachineSize": "Standard_D2s_v3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RecoveryPoints_List",
+  "title": "Get Protected Azure Vm Recovery Points"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Revoke_Ilr.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/Revoke_Ilr.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "recoveryPointId": "1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ItemLevelRecoveryConnections_Revoke",
+  "title": "Revoke Instant Item Level Recovery for Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/StopProtection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/StopProtection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "protectedItemType": "Microsoft.Compute/virtualMachines",
+        "protectionState": "ProtectionStopped",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "ProtectionStopped",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectedItems_CreateOrUpdate",
+  "title": "Stop Protection with retain data on Azure IaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": true
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": true
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreRequest with identityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreWithRehydrationRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreWithRehydrationRequest.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "objectType": "IaasVMRestoreWithRehydrationRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryPointRehydrationInfo": {
+          "rehydrationPriority": "High",
+          "rehydrationRetentionDuration": "P7D"
+        },
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreWithRehydrationRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ResourceGuardEnabled.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_ResourceGuardEnabled.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "resourceGuardOperationRequests": [
+          "/subscriptions/063bf7bc-e4dc-4cde-8840-8416fbd7921e/resourcegroups/ankurRG1/providers/Microsoft.DataProtection/resourceGuards/RG341/triggerRestoreRequests/default"
+        ],
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore with Resource Guard Enabled"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount",
+        "targetDiskNetworkAccessSettings": {
+          "targetDiskAccessId": "/subscriptions/e7a191f5-713c-4bdb-b5e4-cf3dd90230ef/resourceGroups/arpja/providers/Microsoft.Compute/diskAccesses/arpja-diskaccess-ccy",
+          "targetDiskNetworkAccessOption": "EnablePrivateAccessForAllDisks"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreRequest with IdentityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreWithRehydrationRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreWithRehydrationRequest.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "objectType": "IaasVMRestoreWithRehydrationRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryPointRehydrationInfo": {
+          "rehydrationPriority": "Standard",
+          "rehydrationRetentionDuration": "P7D"
+        },
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreWithRehydrationRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerValidateOperation_RestoreDisk.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/TriggerValidateOperation_RestoreDisk.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupValidateOperationsStatuses/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupValidateOperationResults/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Retry-After": 10
+      }
+    }
+  },
+  "operationId": "ValidateOperation_Trigger",
+  "title": "Trigger Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/IaaS_v2_daily.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/IaaS_v2_daily.json
@@ -1,0 +1,193 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "instantRpRetentionRangeInDays": 30,
+        "policyType": "V2",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 180,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "dailySchedule": {
+            "scheduleRunTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "schedulePolicyType": "SimpleSchedulePolicyV2",
+          "scheduleRunFrequency": "Daily"
+        },
+        "snapshotConsistencyType": "OnlyCrashConsistent",
+        "timeZone": "India Standard Time"
+      }
+    },
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 180,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "dailySchedule": {
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Daily"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "India Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operations/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Enhanced Azure Vm Protection Policy with daily backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/IaaS_v2_hourly.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/IaaS_v2_hourly.json
@@ -1,0 +1,193 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "instantRpRetentionRangeInDays": 30,
+        "policyType": "V2",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 180,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "hourlySchedule": {
+            "interval": 4,
+            "scheduleWindowDuration": 16,
+            "scheduleWindowStartTime": "2021-12-17T08:00:00Z"
+          },
+          "schedulePolicyType": "SimpleSchedulePolicyV2",
+          "scheduleRunFrequency": "Hourly"
+        },
+        "snapshotConsistencyType": "OnlyCrashConsistent",
+        "timeZone": "India Standard Time"
+      }
+    },
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 180,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "hourlySchedule": {
+              "interval": 4,
+              "scheduleWindowDuration": 16,
+              "scheduleWindowStartTime": "2021-12-17T08:00:00Z"
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Hourly"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "India Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operations/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Enhanced Azure Vm Protection Policy with Hourly backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/v2-Get-Policy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/v2-Get-Policy.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "dailySchedule": {
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Daily"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_Get",
+  "title": "Get Azure IaasVm Enhanced Protection Policy Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/v2-List-Policies.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/V2Policy/v2-List-Policies.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultPolicy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 30,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2017-12-05T19:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2017-12-05T19:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            }
+          },
+          {
+            "name": "testPolicy1",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2018-01-24T02:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          },
+          {
+            "name": "v2-daily-policy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-policy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "dailySchedule": {
+                  "scheduleRunTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "schedulePolicyType": "SimpleSchedulePolicyV2",
+                "scheduleRunFrequency": "Daily"
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureIaasVm with both V1 and V2 policies"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperationResults.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupValidateOperationsStatuses/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupValidateOperationResults/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Retry-After": 10
+      }
+    }
+  },
+  "operationId": "ValidateOperationResults_Get",
+  "title": "Get Operation Results of Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperationStatus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "2017-10-29T06:04:18.207325Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "objectType": "OperationStatusValidateOperationExtendedInfo",
+          "validateOperationResponse": {
+            "validationResults": [
+              {
+                "code": "UserErrorCoreCountSubscriptionQuotaReached",
+                "message": "Core Count subscription quota has been reached.",
+                "recommendations": [
+                  "Contact Azure support to increase the limits."
+                ]
+              }
+            ]
+          }
+        },
+        "startTime": "2017-10-29T06:04:18.207325Z",
+        "status": "Succeeded"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ValidateOperationStatuses_Get",
+  "title": "Get Operation Status of Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperation_RestoreDisk.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperation_RestoreDisk.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operation_Validate",
+  "title": "Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperation_RestoreDisk_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureIaasVm/ValidateOperation_RestoreDisk_IdentityBasedRestoreDetails.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityBasedRestoreDetails": {
+            "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operation_Validate",
+  "title": "Validate Operation with identityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectableContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectableContainers_List.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureStorage' and workloadType eq 'AzureFileShare'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;storage;test-rg;testst",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectableContainers/StorageContainer;storage;test-rg;teststorage",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/teststorage",
+              "friendlyName": "teststorage",
+              "healthStatus": "Healthy",
+              "protectableContainerType": "StorageContainer"
+            }
+          },
+          {
+            "name": "StorageContainer;ClassicStorage;test-rg;teststorage",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectableContainers/StorageContainer;ClassicStorage;test-rg;teststorage",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ClassicStorage/storageAccounts/teststorage",
+              "friendlyName": "teststorage",
+              "healthStatus": "Healthy",
+              "protectableContainerType": "StorageContainer"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProtectableContainers_List",
+  "title": "List protectable items with backupManagementType filter as AzureStorage"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Inquire.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Inquire.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "storagecontainer;Storage;test-rg;teststorage",
+    "fabricName": "Azure",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Inquire",
+  "title": "Inquire Azure Storage Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Inquire_Result.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Inquire_Result.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;testRG;testSQL",
+    "fabricName": "Azure",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VMAppContainer;Compute;testRG;testSQL",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "containerType": "VMAppContainer",
+          "extendedInfo": {
+            "hostServerName": "testsql",
+            "inquiryInfo": {
+              "errorDetail": {
+                "code": "Success",
+                "message": "Not Available",
+                "recommendations": [
+                  "Not Available"
+                ]
+              },
+              "inquiryDetails": [
+                {
+                  "type": "sql",
+                  "inquiryValidation": {
+                    "errorDetail": {
+                      "code": "Success",
+                      "message": "Not Available",
+                      "recommendations": [
+                        "Not Available"
+                      ]
+                    },
+                    "status": "Success"
+                  },
+                  "itemCount": 14
+                }
+              ],
+              "status": "Success"
+            },
+            "nodesList": []
+          },
+          "friendlyName": "testSQL",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.Compute/virtualMachines/testSQL",
+          "workloadType": null
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainerOperationResults_Get",
+  "title": "Get Azure Storage Protection Container Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;Storage;testrg;suchandrtestsa125",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+            "id": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourcegroups/testrg/providers/microsoft.recoveryservices/vaults/suchandr-test-vault-wcus/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;testrg;suchandrtestsa125",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerType": "StorageContainer",
+              "friendlyName": "suchandrtestsa125",
+              "healthStatus": "Healthy",
+              "protectedItemCount": 2,
+              "registrationStatus": "Registered",
+              "sourceResourceId": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/suchandrtestsa125"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectionContainers_List",
+  "title": "List Backup Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Register.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionContainers_Register.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "acquireStorageAccountLock": "Acquire",
+        "backupManagementType": "AzureStorage",
+        "containerType": "StorageContainer",
+        "friendlyName": "swaggertestsa",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/SwaggerTestRg/providers/Microsoft.Storage/storageAccounts/swaggertestsa"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+        "properties": {
+          "acquireStorageAccountLock": "Acquire",
+          "backupManagementType": "AzureStorage",
+          "containerType": "StorageContainer",
+          "friendlyName": "swaggertestsa",
+          "healthStatus": "Healthy",
+          "protectedItemCount": 0,
+          "registrationStatus": "Registered",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/SwaggerTestRg/providers/Microsoft.Storage/storageAccounts/swaggertestsa"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2019-05-13-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Register",
+  "title": "RegisterAzure Storage ProtectionContainers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Daily.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Daily.json
@@ -1,0 +1,182 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2021-09-29T08:00:00.000Z"
+          ]
+        },
+        "timeZone": "UTC",
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "dailyPolicy2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dailyPolicy2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 5,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2021-09-29T08:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "UTC"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Daily Azure Storage Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hardened.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hardened.json
@@ -1,0 +1,189 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2023-07-18T09:30:00.000Z"
+          ]
+        },
+        "timeZone": "UTC",
+        "vaultRetentionPolicy": {
+          "snapshotRetentionInDays": 5,
+          "vaultRetention": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 30,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            }
+          }
+        },
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "newPolicyV2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "newPolicyV2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2023-07-18T09:30:00.000Z"
+            ]
+          },
+          "timeZone": "UTC",
+          "vaultRetentionPolicy": {
+            "snapshotRetentionInDays": 5,
+            "vaultRetention": {
+              "dailySchedule": {
+                "retentionDuration": {
+                  "count": 30,
+                  "durationType": "Days"
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "monthlySchedule": {
+                "retentionDuration": {
+                  "count": 60,
+                  "durationType": "Months"
+                },
+                "retentionScheduleDaily": null,
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "First"
+                  ]
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "retentionPolicyType": "LongTermRetentionPolicy",
+              "weeklySchedule": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "retentionDuration": {
+                  "count": 12,
+                  "durationType": "Weeks"
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "yearlySchedule": {
+                "monthsOfYear": [
+                  "January"
+                ],
+                "retentionDuration": {
+                  "count": 10,
+                  "durationType": "Years"
+                },
+                "retentionScheduleDaily": null,
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "First"
+                  ]
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Azure Storage Vault Standard Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hourly.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hourly.json
@@ -1,0 +1,178 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Days"
+            },
+            "retentionTimes": null
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": null
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": null
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": null
+          }
+        },
+        "schedulePolicy": {
+          "hourlySchedule": {
+            "interval": 4,
+            "scheduleWindowDuration": 12,
+            "scheduleWindowStartTime": "2021-09-29T08:00:00.000Z"
+          },
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Hourly"
+        },
+        "timeZone": "UTC",
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "newPolicy2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "newPolicy2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 5,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "hourlySchedule": {
+              "interval": 4,
+              "scheduleWindowDuration": 12,
+              "scheduleWindowStartTime": "2021-09-29T08:00:00Z"
+            },
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Hourly",
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "UTC"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Hourly Azure Storage Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/SoftDeletedContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureStorage/SoftDeletedContainers_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;Storage;testrg;suchandrtestsa125",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+            "id": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourcegroups/testrg/providers/microsoft.recoveryservices/vaults/suchandr-test-vault-wcus/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;testrg;suchandrtestsa125",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerType": "StorageContainer",
+              "friendlyName": "suchandrtestsa125",
+              "healthStatus": "Healthy",
+              "protectedItemCount": 2,
+              "registrationStatus": "SoftDeleted",
+              "sourceResourceId": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/suchandrtestsa125"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DeletedProtectionContainers_List",
+  "title": "List Backup Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupPolicies_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupPolicies_List.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "HourlyLogBackup",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/HourlyLogBackup",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "protectedItemsCount": 0,
+              "settings": {
+                "issqlcompression": false,
+                "timeZone": "UTC"
+              },
+              "subProtectionPolicy": [
+                {
+                  "policyType": "Full",
+                  "retentionPolicy": {
+                    "dailySchedule": {
+                      "retentionDuration": {
+                        "count": 30,
+                        "durationType": "Days"
+                      },
+                      "retentionTimes": [
+                        "2017-12-05T19:00:00Z"
+                      ]
+                    },
+                    "retentionPolicyType": "LongTermRetentionPolicy"
+                  },
+                  "schedulePolicy": {
+                    "schedulePolicyType": "SimpleSchedulePolicy",
+                    "scheduleRunFrequency": "Daily",
+                    "scheduleRunTimes": [
+                      "2017-12-05T19:00:00Z"
+                    ],
+                    "scheduleWeeklyFrequency": 0
+                  }
+                },
+                {
+                  "policyType": "Log",
+                  "retentionPolicy": {
+                    "retentionDuration": {
+                      "count": 30,
+                      "durationType": "Days"
+                    },
+                    "retentionPolicyType": "SimpleRetentionPolicy"
+                  },
+                  "schedulePolicy": {
+                    "scheduleFrequencyInMins": 60,
+                    "schedulePolicyType": "LogSchedulePolicy"
+                  }
+                }
+              ],
+              "workLoadType": "SQLDataBase"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureWorkload"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_Delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "249D9B07-D2EF-4202-AA64-65F35418564E",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "ProtectionIntent_Delete",
+  "title": "Delete Protection intent from item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "249D9B07-D2EF-4202-AA64-65F35418564E",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "249D9B07-D2EF-4202-AA64-65F35418564E",
+        "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/249D9B07-D2EF-4202-AA64-65F35418564E",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "itemId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupProtectionContainer/VMAppContainer;Compute;testVmName/backupProtectableItems/SQLInstance;MSSQLSERVER",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+          "protectionIntentItemType": "AzureWorkloadContainerAutoProtectionIntent"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_Get",
+  "title": "Get ProtectionIntent for an item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupProtectionIntent_List.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "249D9B07-D2EF-4202-AA64-65F35418564E",
+            "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/249D9B07-D2EF-4202-AA64-65F35418564E",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "itemId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupProtectionContainer/VMAppContainer;Compute;testVmName/backupProtectableItems/SQLInstance;MSSQLSERVER",
+              "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+              "protectionIntentItemType": "AzureWorkloadContainerAutoProtectionIntent"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectionIntent_List",
+  "title": "List protection intent with backupManagementType filter"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupWorkloadItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/BackupWorkloadItems_List.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;bvtdtestag;sqlserver-1",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "suchandr-seacan-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "SQLInstance;MSSQLSERVER",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/items",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/testRg/providers/Microsoft.RecoveryServices/vaults/suchandr-seacan-rsv/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;bvtdtestag;sqlserver-1/protectableItems/SQLInstance;MSSQLSERVER",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "dataDirectoryPaths": [
+                {
+                  "type": "Data",
+                  "path": "F:\\DATA\\"
+                },
+                {
+                  "type": "Log",
+                  "path": "F:\\LOG\\"
+                }
+              ],
+              "friendlyName": "MSSQLSERVER",
+              "isAutoProtectable": true,
+              "parentName": "MSSQLSERVER",
+              "protectionState": "NotProtected",
+              "serverName": "sqlserver-1.contoso.com",
+              "subWorkloadItemCount": 3,
+              "subinquireditemcount": 0,
+              "workloadItemType": "SQLInstance",
+              "workloadType": "SQL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupWorkloadItems_List",
+  "title": "List Workload Items in Container"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionContainers_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionContainers_Get.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;testRG;testSQL",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VMAppContainer;Compute;testRG;testSQL",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "containerType": "VMAppContainer",
+          "extendedInfo": {
+            "hostServerName": "testsql",
+            "inquiryInfo": {
+              "errorDetail": {
+                "code": "Success",
+                "message": "Not Available",
+                "recommendations": [
+                  "Not Available"
+                ]
+              },
+              "inquiryDetails": [
+                {
+                  "type": "sql",
+                  "inquiryValidation": {
+                    "errorDetail": {
+                      "code": "Success",
+                      "message": "Not Available",
+                      "recommendations": [
+                        "Not Available"
+                      ]
+                    },
+                    "status": "Success"
+                  },
+                  "itemCount": 14
+                }
+              ],
+              "status": "Success"
+            },
+            "nodesList": []
+          },
+          "friendlyName": "testSQL",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.Compute/virtualMachines/testSQL",
+          "workloadType": null
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Get",
+  "title": "Get Protection Container Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionContainers_Unregister.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionContainers_Unregister.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "storagecontainer;Storage;test-rg;teststorage",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainers_Unregister",
+  "title": "Unregister Protection Container"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionPolicies_CreateOrUpdate_Complex.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionPolicies_CreateOrUpdate_Complex.json
@@ -1,0 +1,262 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureWorkload",
+        "settings": {
+          "issqlcompression": false,
+          "timeZone": "Pacific Standard Time"
+        },
+        "subProtectionPolicy": [
+          {
+            "policyType": "Full",
+            "retentionPolicy": {
+              "monthlySchedule": {
+                "retentionDuration": {
+                  "count": 1,
+                  "durationType": "Months"
+                },
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "Second"
+                  ]
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              },
+              "retentionPolicyType": "LongTermRetentionPolicy",
+              "weeklySchedule": {
+                "daysOfTheWeek": [
+                  "Sunday",
+                  "Tuesday"
+                ],
+                "retentionDuration": {
+                  "count": 2,
+                  "durationType": "Weeks"
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              },
+              "yearlySchedule": {
+                "monthsOfYear": [
+                  "January",
+                  "June",
+                  "December"
+                ],
+                "retentionDuration": {
+                  "count": 1,
+                  "durationType": "Years"
+                },
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "Last"
+                  ]
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              }
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Sunday",
+                "Tuesday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Differential",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 8,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Friday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Log",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "scheduleFrequencyInMins": 60,
+              "schedulePolicyType": "LogSchedulePolicy"
+            }
+          }
+        ],
+        "workLoadType": "SQLDataBase"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "protectedItemsCount": 0,
+          "settings": {
+            "issqlcompression": false,
+            "timeZone": "Pacific Standard Time"
+          },
+          "subProtectionPolicy": [
+            {
+              "policyType": "Full",
+              "retentionPolicy": {
+                "monthlySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Months"
+                  },
+                  "retentionScheduleFormatType": "Weekly",
+                  "retentionScheduleWeekly": {
+                    "daysOfTheWeek": [
+                      "Sunday"
+                    ],
+                    "weeksOfTheMonth": [
+                      "Second"
+                    ]
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy",
+                "weeklySchedule": {
+                  "daysOfTheWeek": [
+                    "Sunday",
+                    "Tuesday"
+                  ],
+                  "retentionDuration": {
+                    "count": 2,
+                    "durationType": "Weeks"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "yearlySchedule": {
+                  "monthsOfYear": [
+                    "January",
+                    "June",
+                    "December"
+                  ],
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Years"
+                  },
+                  "retentionScheduleFormatType": "Weekly",
+                  "retentionScheduleWeekly": {
+                    "daysOfTheWeek": [
+                      "Sunday"
+                    ],
+                    "weeksOfTheMonth": [
+                      "Last"
+                    ]
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                }
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Sunday",
+                  "Tuesday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2018-01-24T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Differential",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 8,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Friday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2018-01-24T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Log",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 7,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "scheduleFrequencyInMins": 60,
+                "schedulePolicyType": "LogSchedulePolicy"
+              }
+            }
+          ],
+          "workLoadType": "SQLDataBase"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Full Azure Workload Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureWorkload",
+        "settings": {
+          "issqlcompression": false,
+          "isCompression": true,
+          "timeZone": "Pacific Standard Time",
+          "vdiSettings": {
+            "isMultiVdiSupportEnabled": true,
+            "noOfVdiStreams": 8
+          }
+        },
+        "subProtectionPolicy": [
+          {
+            "policyType": "Full",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 30,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Sunday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2026-06-01T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Log",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "scheduleFrequencyInMins": 60,
+              "schedulePolicyType": "LogSchedulePolicy"
+            }
+          }
+        ],
+        "workLoadType": "SQLDataBase"
+      }
+    },
+    "policyName": "sqlMultiVdiPolicy",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sqlMultiVdiPolicy",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "protectedItemsCount": 0,
+          "settings": {
+            "issqlcompression": false,
+            "isCompression": true,
+            "timeZone": "Pacific Standard Time",
+            "vdiSettings": {
+              "isMultiVdiSupportEnabled": true,
+              "noOfVdiStreams": 8
+            }
+          },
+          "subProtectionPolicy": [
+            {
+              "policyType": "Full",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 30,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Sunday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2026-06-01T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Log",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 7,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "scheduleFrequencyInMins": 60,
+                "schedulePolicyType": "LogSchedulePolicy"
+              }
+            }
+          ],
+          "workLoadType": "SQLDataBase"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update SQL Azure Workload Protection Policy with multi-VDI streaming enabled"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/BackupDataMoveOperationStatus_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/BackupDataMoveOperationStatus_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "GetOperationStatus",
+  "title": "Get OperationStatus"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/PrepareDataMoveOperationResult_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/PrepareDataMoveOperationResult_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "PrepareDataMoveResponse"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/operationResult/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSPrepareDataMoveOperationResult_Get",
+  "title": "Get operation result for PrepareDataMove"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/PrepareDataMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/PrepareDataMove_Post.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "dataMoveLevel": "Vault",
+      "targetRegion": "USGov Virginia",
+      "targetResourceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/targetRG/providers/Microsoft.RecoveryServices/vaults/target-rsv"
+    },
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/backupDataMove/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/prepareDataMove/operationResult/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSPrepareDataMove",
+  "title": "Prepare Data Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/TriggerDataMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupDataMove/TriggerDataMove_Post.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "correlationId": "MTg2OTcyMzM4NzYyMjc1NDY3Nzs1YmUzYmVmNi04YjJiLTRhOTItOTllYi01NTM0MDllYjk2NjE=",
+      "dataMoveLevel": "Vault",
+      "sourceRegion": "USGov Iowa",
+      "sourceResourceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv"
+    },
+    "resourceGroupName": "targetRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "target-rsv"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/backupDataMove/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSTriggerDataMove",
+  "title": "Trigger Data Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupResourceEncryptionConfig_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupResourceEncryptionConfig_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "rishgrp",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rishTestVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "backupResourceEncryptionConfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupEncryptionConfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rishgrp/providers/Microsoft.RecoveryServicesBVTD2/vaults/rishTestVault/backupEncryptionConfigs/backupResourceEncryptionConfig",
+        "properties": {
+          "encryptionAtRestType": "CustomerManaged",
+          "infrastructureEncryptionState": "Disabled",
+          "keyUri": "https://gktestkv1.vault.azure.net/keys/Test1/ed2e8cdc7f86477ebf0c6462b504a9ed",
+          "lastUpdateStatus": "Succeeded",
+          "subscriptionId": "1a2311d9-66f5-47d3-a9fb-7a37da63934b",
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentity": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceEncryptionConfigs_Get",
+  "title": "Get Vault Encryption Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupResourceEncryptionConfig_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/BackupResourceEncryptionConfig_Put.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "encryptionAtRestType": "CustomerManaged",
+        "infrastructureEncryptionState": "true",
+        "keyUri": "https://gktestkv1.vault.azure.net/keys/Test1/ed2e8cdc7f86477ebf0c6462b504a9ed",
+        "subscriptionId": "1a2311d9-66f5-47d3-a9fb-7a37da63934b"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "BackupResourceEncryptionConfigs_Update",
+  "title": "Update Vault Encryption Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupProtectedItem_UsageSummary_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupProtectedItem_UsageSummary_Get.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "$filter": "type eq 'BackupProtectedItemCountSummary'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Azure Virtual Machine",
+              "value": "AzureIaasVM"
+            },
+            "currentValue": 7,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Agent",
+              "value": "MAB"
+            },
+            "currentValue": 3,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Server",
+              "value": "AzureBackupServer"
+            },
+            "currentValue": 1,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Storage (Azure Files)",
+              "value": "AzureStorage"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "SQL in Azure VM",
+              "value": "AzureWorkload"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupUsageSummaries_List",
+  "title": "Get Protected Items Usages Summary"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupProtectionContainers_UsageSummary_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupProtectionContainers_UsageSummary_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "$filter": "type eq 'BackupProtectionContainerCountSummary'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Azure Backup Server",
+              "value": "AzureBackupServer"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Agent",
+              "value": "MAB"
+            },
+            "currentValue": 3,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "SQL in Azure VM",
+              "value": "AzureWorkload"
+            },
+            "currentValue": 1,
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupUsageSummaries_List",
+  "title": "Get Protected Containers Usages Summary"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Get",
+  "title": "Get Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Patch.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Patch.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "enhancedSecurityState": "Enabled"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Update",
+  "title": "Update Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupResourceVaultConfigs_Put.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "enhancedSecurityState": "Enabled",
+        "softDeleteFeatureState": "Enabled"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled",
+          "softDeleteFeatureState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Put",
+  "title": "Update Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupSecurityPin_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupSecurityPin_Get.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiryTimeInUtcTicks": 636495150137443100,
+        "securityPIN": "200432",
+        "token": "200432"
+      }
+    }
+  },
+  "operationId": "SecurityPINs_Get",
+  "title": "Get Vault Security Pin"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultstorageconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupstorageconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupstorageconfig/vaultstorageconfig",
+        "properties": {
+          "storageModelType": "GeoRedundant",
+          "storageType": "GeoRedundant",
+          "storageTypeState": "Locked"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Get",
+  "title": "Get Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Patch.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Patch.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "storageType": "LocallyRedundant",
+        "storageTypeState": "Unlocked"
+      }
+    },
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Patch",
+  "title": "Update Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/BackupStorageConfig_Put.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "storageType": "LocallyRedundant",
+        "storageTypeState": "Unlocked"
+      }
+    },
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultstorageconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupstorageconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupstorageconfig/vaultstorageconfig",
+        "properties": {
+          "storageModelType": "LocallyRedundant",
+          "storageType": "LocallyRedundant",
+          "storageTypeState": "Unlocked"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Update",
+  "title": "Update Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/CancelJobOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/CancelJobOperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "JobOperationResults_Get",
+  "title": "Cancel Job Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ExportJobsOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ExportJobsOperationResult.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "headers": {},
+        "operation": {
+          "blobSasKey": "?sv=2014-02-14&sr=b&sig=<sas_signature>&st=2017-11-29T07%3A53%3A34Z&se=2017-11-29T08%3A03%3A34Z&sp=r",
+          "blobUrl": "https://azureblob.blob.core.windows.net/reportcontainer/exportjobsreportc00000000-0000-0000-0000-000000000000",
+          "objectType": "ExportJobsOperationResultInfo"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "body": {
+        "headers": {
+          "Location": [
+            "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01"
+          ],
+          "Retry-After": [
+            "60"
+          ]
+        },
+        "operation": {
+          "objectType": "ExportJobsOperationResultInfo"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ExportJobsOperationResults_Get",
+  "title": "Export Jobs Operation Results"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/GetJobDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/GetJobDetails.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "activityId": "00000000-0000-0000-0000-000000000000",
+          "backupManagementType": "AzureIaasVM",
+          "duration": "PT9.8782791S",
+          "entityFriendlyName": "testvm",
+          "extendedInfo": {
+            "propertyBag": {
+              "VM Name": "testvm"
+            },
+            "tasksList": [
+              {
+                "duration": "PT0S",
+                "status": "InProgress",
+                "taskId": "Take Snapshot"
+              },
+              {
+                "duration": "PT0S",
+                "status": "NotStarted",
+                "taskId": "Transfer data to vault"
+              }
+            ]
+          },
+          "jobType": "AzureIaaSVMJob",
+          "operation": "Backup",
+          "startTime": "2017-08-03T05:31:07.014604Z",
+          "status": "InProgress",
+          "virtualMachineVersion": "Compute"
+        }
+      }
+    }
+  },
+  "operationId": "JobDetails_Get",
+  "title": "Get Job Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobs.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobs.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          },
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT31.3066291S",
+              "endTime": "2017-08-03T05:31:03.7553376Z",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "ConfigureBackup",
+              "startTime": "2017-08-03T05:30:32.4487085Z",
+              "status": "Completed",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List All Jobs"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobsWithAllSupportedFilters.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobsWithAllSupportedFilters.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "$filter": "startTime eq '2016-01-01 00:00:00 AM' and endTime eq '2017-11-29 00:00:00 AM' and operation eq 'Backup' and backupManagementType eq 'AzureIaasVM' and status eq 'InProgress'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List Jobs With Filters"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobsWithStartTimeAndEndTimeFilters.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ListJobsWithStartTimeAndEndTimeFilters.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "$filter": "startTime eq '2016-01-01 00:00:00 AM' and endTime eq '2017-11-29 00:00:00 AM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs?api-version=2017-07-01&%24filter=startTime+eq+%272016-01-01+00%3a00%3a00+AM%27+and+endTime+eq+%272017-11-29+00%3a00%3a00+AM%27&%24skiptoken=%3c%3fxml+version%3d%221.0%22+encoding%3d%22utf-16%22%3f%3e%0d%0a%3cContinuationToken%3e%0d%0a++%3cContinuationToken%3e%0d%0a++++%3cVersion%3e2.0%3c%2fVersion%3e%0d%0a++++%3cType%3eTable%3c%2fType%3e%0d%0a++++%3cNextPartitionKey%3e1!28!NzI5MTk0OTM1MDkwNjEwODQzMA--%3c%2fNextPartitionKey%3e%0d%0a++++%3cNextRowKey%3e1!108!am9ic3N0YXJ0dGltZWluZGV4XzBfMjUxODkxNDYzNTI2NjE5Nzg5OF8wXzYwOWZkM2JmLTU4MzctNDFkYi1iMjExLTY1MzliNDNlZjM1OA--%3c%2fNextRowKey%3e%0d%0a++++%3cTargetLocation%3ePrimary%3c%2fTargetLocation%3e%0d%0a++%3c%2fContinuationToken%3e%0d%0a%3c%2fContinuationToken%3e",
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          },
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT31.3066291S",
+              "endTime": "2017-08-03T05:31:03.7553376Z",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "ConfigureBackup",
+              "startTime": "2017-08-03T05:30:32.4487085Z",
+              "status": "Completed",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List Jobs With Time Filter"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperations/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectedItems_Delete",
+  "title": "Delete Protection from Azure Virtual Machine"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete_OperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete_OperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperations/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BackupOperationResults_Get",
+  "title": "Get Result for Protected Item Delete Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete_OperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/ProtectedItem_Delete_OperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "0001-01-01T00:00:00.00000Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "startTime": "2017-08-03T06:52:53.886027Z",
+        "status": "InProgress"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupOperationStatuses_Get",
+  "title": "Get Protected Item Delete Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/RefreshContainers.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/RefreshContainers.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Refresh",
+  "title": "Trigger Azure Vm Discovery"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/RefreshContainers_OperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/RefreshContainers_OperationResults.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainerRefreshOperationResults_Get",
+  "title": "Azure Vm Discovery Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerBackup_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerBackup_Post.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testrg;v1win2012r",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "objectType": "IaasVMBackupRequest"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testrg;v1win2012r",
+    "resourceGroupName": "linuxRsVaultRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "linuxRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/linuxRsVaultRG/providers/Microsoft.RecoveryServices/vaults/linuxRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;testrg;v1win2012r/protectedItems/VM;iaasvmcontainer;testrg;v1win2012r/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/linuxRsVaultRG/providers/Microsoft.RecoveryServices/vaults/linuxRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;testrg;v1win2012r/protectedItems/VM;iaasvmcontainer;testrg;v1win2012r/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Backups_Trigger",
+  "title": "Trigger Backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerCancelJob.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerCancelJob.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "JobCancellations_Trigger",
+  "title": "Cancel Job"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerExportJobs.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Common/TriggerExportJobs.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Jobs_Export",
+  "title": "Export Jobs"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Dpm/BackupEngines_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Dpm/BackupEngines_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "backupEngineName": "testServer",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testServer",
+        "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer",
+        "properties": {
+          "azureBackupAgentVersion": "2.0.9532.0",
+          "backupEngineState": "Active",
+          "backupEngineType": "DpmBackupEngine",
+          "dpmVersion": "5.1.348.0",
+          "extendedInfo": {
+            "availableDiskSpace": 50,
+            "diskCount": 5,
+            "protectedItemsCount": 35,
+            "protectedServersCount": 21,
+            "usedDiskSpace": 20
+          },
+          "friendlyName": "testServer",
+          "isAzureBackupAgentUpgradeAvailable": false,
+          "isDpmUpgradeAvailable": false,
+          "registrationStatus": "Registered"
+        }
+      }
+    }
+  },
+  "operationId": "BackupEngines_Get",
+  "title": "Get Dpm/AzureBackupServer/Lajolla Backup Engine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Dpm/BackupEngines_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/Dpm/BackupEngines_List.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testServer1",
+            "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer1",
+            "properties": {
+              "azureBackupAgentVersion": "2.0.9532.0",
+              "backupEngineState": "Active",
+              "backupEngineType": "DpmBackupEngine",
+              "dpmVersion": "5.1.348.0",
+              "extendedInfo": {
+                "availableDiskSpace": 50,
+                "diskCount": 5,
+                "protectedItemsCount": 35,
+                "protectedServersCount": 21,
+                "usedDiskSpace": 20
+              },
+              "friendlyName": "testServer1",
+              "isAzureBackupAgentUpgradeAvailable": false,
+              "isDpmUpgradeAvailable": false,
+              "registrationStatus": "Registered"
+            }
+          },
+          {
+            "name": "testServer5",
+            "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer5",
+            "properties": {
+              "azureBackupAgentVersion": "2.0.9530.0",
+              "backupEngineState": "Active",
+              "backupEngineType": "DpmBackupEngine",
+              "dpmVersion": "5.1.348.0",
+              "extendedInfo": {
+                "availableDiskSpace": 50,
+                "diskCount": 5,
+                "protectedItemsCount": 35,
+                "protectedServersCount": 21,
+                "usedDiskSpace": 20
+              },
+              "friendlyName": "testServer5",
+              "isAzureBackupAgentUpgradeAvailable": false,
+              "isDpmUpgradeAvailable": false,
+              "registrationStatus": "Registered"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupEngines_List",
+  "title": "List Dpm/AzureBackupServer/Lajolla Backup Engines"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ListOperations.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ListOperations.json
@@ -1,0 +1,465 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "microsoft.recoveryservices/vaults/usages/read",
+            "display": {
+              "description": "Returns usage details for a Recovery Services Vault.",
+              "operation": "Recovery Services Vault usage details.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Usage"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupUsageSummaries/read",
+            "display": {
+              "description": "Returns summaries for Protected Items and Protected Servers for a Recovery Services .",
+              "operation": "Recovery Services Protected Items and Protected Servers usage summaries details.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Usages Summaries"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/storageConfig/read",
+            "display": {
+              "description": "Returns Storage Configuration for Recovery Services Vault.",
+              "operation": "Get Resource Storage Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Storage Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/storageConfig/write",
+            "display": {
+              "description": "Updates Storage Configuration for Recovery Services Vault.",
+              "operation": "Write Resource Storage Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Storage Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupconfig/vaultconfig/read",
+            "display": {
+              "description": "Returns Configuration for Recovery Services Vault.",
+              "operation": "Get Resource Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupconfig/vaultconfig/write",
+            "display": {
+              "description": "Updates Configuration for Recovery Services Vault.",
+              "operation": "Update Resource Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/tokenInfo/read",
+            "display": {
+              "description": "Returns token information for Recovery Services Vault.",
+              "operation": "Get Vault Token Info",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Token Info"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupSecurityPIN/read",
+            "display": {
+              "description": "Returns Security PIN Information for Recovery Services Vault.",
+              "operation": "Get Security PIN Info",
+              "provider": "microsoft.recoveryservices",
+              "resource": "SecurityPINInfo"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupManagementMetaData/read",
+            "display": {
+              "description": "Returns Backup Management Metadata for Recovery Services Vault.",
+              "operation": "Get Backup Management Metadata",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Management Metadata"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupOperationResults/read",
+            "display": {
+              "description": "Returns Backup Operation Result for Recovery Services Vault.",
+              "operation": "Get Backup Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupOperations/read",
+            "display": {
+              "description": "Returns Backup Operation Status for Recovery Services Vault.",
+              "operation": "Get Backup Operation Status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/read",
+            "display": {
+              "description": "Returns all Job Objects",
+              "operation": "Get Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/cancel/action",
+            "display": {
+              "description": "Cancel the Job",
+              "operation": "Cancel Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobsExport/action",
+            "display": {
+              "description": "Export Jobs",
+              "operation": "Export Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Export Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/operationResults/read",
+            "display": {
+              "description": "Returns the Result of Job Operation.",
+              "operation": "Get Job Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobsExport/operationResults/read",
+            "display": {
+              "description": "Returns the Result of Export Job Operation.",
+              "operation": "Get Export Job Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Export Backup Jobs Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read",
+            "display": {
+              "description": "Get Recovery Points for Protected Items.",
+              "operation": "Get Recovery Points",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action",
+            "display": {
+              "description": "Restore Recovery Points for Protected Items.",
+              "operation": "Restore Recovery Points",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/provisionInstantItemRecovery/action",
+            "display": {
+              "description": "Provision Instant Item Recovery for Protected Item",
+              "operation": "Provision Instant Item Recovery for Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/revokeInstantItemRecovery/action",
+            "display": {
+              "description": "Revoke Instant Item Recovery for Protected Item",
+              "operation": "Revoke Instant Item Recovery for Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/read",
+            "display": {
+              "description": "Returns all Protection Policies",
+              "operation": "Get Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/write",
+            "display": {
+              "description": "Creates Protection Policy",
+              "operation": "Create Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/delete",
+            "display": {
+              "description": "Delete a Protection Policy",
+              "operation": "Delete Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/operationResults/read",
+            "display": {
+              "description": "Get Results of Policy Operation.",
+              "operation": "Get Policy Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policy Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/operationsStatus/read",
+            "display": {
+              "description": "Get Status of Policy Operation.",
+              "operation": "Get Policy Operation Status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policy Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/read",
+            "display": {
+              "description": "Returns object details of the Protected Item",
+              "operation": "Get Protected Item Details",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectedItems/read",
+            "display": {
+              "description": "Returns the list of all Protected Items.",
+              "operation": "Get All Protected Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/write",
+            "display": {
+              "description": "Create a backup Protected Item",
+              "operation": "Create Backup Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/delete",
+            "display": {
+              "description": "Deletes Protected Item",
+              "operation": "Delete Protected Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read",
+            "display": {
+              "description": "Gets Result of Operation Performed on Protected Items.",
+              "operation": "Get Protected Items Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Item Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read",
+            "display": {
+              "description": "Returns the status of Operation performed on Protected Items.",
+              "operation": "Get Protected Items operation status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Item Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/backup/action",
+            "display": {
+              "description": "Performs Backup for Protected Item.",
+              "operation": "Backup Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectableItems/read",
+            "display": {
+              "description": "Returns list of all Protectable Items.",
+              "operation": "Get Protectable Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Protectable Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/refreshContainers/read",
+            "display": {
+              "description": "Refreshes the container list",
+              "operation": "Refresh container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Refresh Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/operationResults/read",
+            "display": {
+              "description": "Returns status of the operation",
+              "operation": "Get Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Refresh Containers Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectionContainers/read",
+            "display": {
+              "description": "Returns all containers belonging to the subscription",
+              "operation": "Get Containers In Subscription",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Protection Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/read",
+            "display": {
+              "description": "Returns all registered containers",
+              "operation": "Get Registered Container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/operationResults/read",
+            "display": {
+              "description": "Gets result of Operation performed on Protection Container.",
+              "operation": "Get Container Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupEngines",
+            "display": {
+              "description": "Returns all the backup management servers registered with vault.",
+              "operation": "List of backup management servers.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Engines"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupStatus",
+            "display": {
+              "description": "Check Backup Status for Recovery Services Vaults",
+              "operation": "Check Backup Status for Vault",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPreValidateProtection",
+            "display": {
+              "description": "",
+              "operation": "Pre Validate Enable Protection",
+              "provider": "microsoft.recoveryservices",
+              "resource": "PreValidate Protection"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupValidateFeatures",
+            "display": {
+              "description": "Validate Features",
+              "operation": "Validate Features",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Validate Features"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/backupProtectionIntent/write",
+            "display": {
+              "description": "Create a backup Protection Intent",
+              "operation": "Create backup Protection Intent",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Intent"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/{fabricName}/protectionContainers/{containerName}/items/read",
+            "display": {
+              "description": "Get all items in a container",
+              "operation": "Get all items in a container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Workload Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/inquire/action",
+            "display": {
+              "description": "Get all items in a container",
+              "operation": "Get all items in a container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers Inquire"
+            },
+            "origin": "user"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "ListOperations"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/DeletePrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/DeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/6c48fa17-39c7-45f1-90ac-47a587128ace/resourceGroups/backupadminrg/providers/Microsoft.RecoveryServices/Vaults/demo-pevault-2/privateEndpointConnections/autoapprovalpeecy4.3679789459502941542.backup.5ede856d-d9f0-461e-a15b-370c84525817/operationsStatus/2908a25d-8036-48d2-bdcc-fdce26b9771f?api-versi",
+        "Retry-After": "60"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnection_Delete",
+  "title": "Delete PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/GetPrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/GetPrivateEndpointConnection.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Pending"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnection_Get",
+  "title": "Get PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/GetPrivateEndpointConnectionOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/GetPrivateEndpointConnectionOperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "PrivateEndpoint_GetOperationStatus",
+  "title": "Get OperationStatus"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/PutPrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/PrivateEndpointConnection/PutPrivateEndpointConnection.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "groupIds": [
+          "AzureBackup_secondary"
+        ],
+        "privateEndpoint": {
+          "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "Approved by johndoe@company.com",
+          "status": "Approved"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Pending"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/6c48fa17-39c7-45f1-90ac-47a587128ace/resourceGroups/backupadminrg/providers/Microsoft.RecoveryServices/Vaults/demo-pevault-2/privateEndpointConnections/autoapprovalpeecy4.3679789459502941542.backup.5ede856d-d9f0-461e-a15b-370c84525817/operationsStatus/2908a25d-8036-48d2-bdcc-fdce26b9771f?api-versi",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnection_Put",
+  "title": "Update PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ResourceGuardProxy_Delete",
+  "title": "Delete ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "swaggerExample",
+        "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+        "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "properties": {
+          "description": "Please take JIT access before performing any of the critical operation",
+          "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+          "resourceGuardOperationDetails": [
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/resourceguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+        }
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_Get",
+  "title": "Get ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "swaggerExample",
+            "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+            "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+            "properties": {
+              "description": "Please take JIT access before performing any of the critical operation",
+              "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+              "resourceGuardOperationDetails": [
+                {
+                  "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+                  "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+                },
+                {
+                  "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+                  "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+                }
+              ],
+              "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxies_Get",
+  "title": "Get VaultGuardProxies"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+      }
+    },
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "swaggerExample",
+        "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+        "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "properties": {
+          "description": "Please take JIT access before performing any of the critical operation",
+          "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+          "resourceGuardOperationDetails": [
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+        }
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_Put",
+  "title": "Create ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "resourceGuardOperationRequests": [
+        "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteProtectedItemRequests/default"
+      ],
+      "resourceToBeDeleted": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/gaallarg/providers/Microsoft.RecoveryServices/vaults/MercuryCrrVault/backupFabrics/Azure/protectionContainers/VMAppContainer;compute;crrtestrg;crrtestvm/protectedItems/SQLDataBase;mssqlserver;testdb"
+    },
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "unlockDeleteExpiryTime": "2021-02-11T13:12:27.7870742Z"
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_UnlockDelete",
+  "title": "UnlockDelete ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForPolicy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForPolicy.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "objectType": "FetchTieringCostSavingsInfoForPolicyRequest",
+      "policyName": "monthly",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForProtectedItem.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForProtectedItem.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "objectType": "FetchTieringCostSavingsInfoForProtectedItemRequest",
+      "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for protected item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForRehydrate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForRehydrate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "objectType": "FetchTieringCostInfoForRehydrationRequest",
+      "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "recoveryPointId": "1222343434",
+      "rehydrationPriority": "High",
+      "sourceTierType": "ArchivedRP",
+      "targetTierType": "HardenedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostRehydrationInfo",
+        "rehydrationSizeInBytes": 1204000,
+        "retailRehydrationCostPerGBPerMonth": 0.02
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the rehydration cost for recovery point"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForVault.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/FetchTieringCostForVault.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "objectType": "FetchTieringCostSavingsInfoForVaultRequest",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for vault"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/GetTieringCostOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/GetTieringCostOperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    }
+  },
+  "operationId": "GetTieringCostOperationResult_Get",
+  "title": "Fetch Tiering Cost Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/GetTieringCostOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TieringCost/GetTieringCostOperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "TieringCostOperationStatus_Get",
+  "title": "Fetch Tiering Cost Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TriggerRecoveryPointMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/examples/2026-06-01/TriggerRecoveryPointMove_Post.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "objectType": "MoveRPAcrossTiersRequest",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2026-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "MoveRecoveryPoint",
+  "title": "Trigger RP Move Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/main.tsp
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/main.tsp
@@ -68,6 +68,11 @@ enum Versions {
    * The 2026-02-01 API version.
    */
   v2026_02_01: "2026-02-01",
+
+  /**
+   * The 2026-06-01 API version.
+   */
+  v2026_06_01: "2026-06-01",
 }
 
 interface Operations

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/models.tsp
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/models.tsp
@@ -1,5 +1,6 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 
@@ -3632,6 +3633,30 @@ model Settings {
    * will be deprecated once clients upgrade to consider this flag.
    */
   isCompression?: boolean;
+
+  /**
+   * VDI (Virtual Device Interface) settings used while taking backups. Currently applicable to SQL workload only.
+   */
+  @added(Versions.v2026_06_01)
+  vdiSettings?: VdiSettings;
+}
+
+/**
+ * VDI settings used while taking backups. Controls multi-stream VDI behavior for SQL workloads.
+ */
+@added(Versions.v2026_06_01)
+model VdiSettings {
+  /**
+   * Flag to indicate whether multi-stream VDI backup is enabled for the workload.
+   */
+  isMultiVdiSupportEnabled?: boolean;
+
+  /**
+   * Number of VDI streams to use when multi-VDI is enabled. Allowed range is 1 to 32.
+   */
+  @minValue(1)
+  @maxValue(32)
+  noOfVdiStreams?: int32;
 }
 
 /**

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/readme.md
@@ -28,7 +28,7 @@ These are the global settings for the RecoveryServicesBackup API.
 title: Recovery Services Backup Client
 description: Open API 2.0 Specs for Azure RecoveryServices Backup service
 openapi-type: arm
-tag: package-2026-02-01
+tag: package-2026-06-01
 csharp-sdks-folder: ./Generated/CSharp
 python-sdks-folder: ./Generated/Python
 go-sdk-folder: ./Generated/Golang
@@ -41,7 +41,7 @@ tag: package-passivestamp-2023-01-15
 ```
 
 ```yaml $(package-activestamp)
-tag: package-2026-02-01
+tag: package-2026-06-01
 ```
 
 ### Validations
@@ -53,6 +53,15 @@ azure-validator: true
 model-validator: true
 semantic-validator: true
 message-format: json
+```
+
+### Tag: package-2026-06-01
+
+These settings apply only when `--tag=package-2026-06-01` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-06-01'
+input-file:
+  - stable/2026-06-01/bms.json
 ```
 
 ### Tag: package-2026-02-01

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/bms.json
@@ -229,6 +229,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "ListOperations": {
+            "$ref": "./examples/ListOperations.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -279,6 +284,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Validate Enable Protection on Azure Vm": {
+            "$ref": "./examples/AzureIaasVm/ProtectionIntent_Validate.json"
+          }
         }
       }
     },
@@ -327,6 +337,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Azure Virtual Machine Backup Status": {
+            "$ref": "./examples/AzureIaasVm/GetBackupStatus.json"
+          }
         }
       }
     },
@@ -374,6 +389,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Check Azure Vm Backup Feature Support": {
+            "$ref": "./examples/AzureIaasVm/BackupFeature_Validate.json"
           }
         }
       }
@@ -424,6 +444,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List Backup Protection Containers": {
+            "$ref": "./examples/AzureStorage/SoftDeletedContainers_List.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -466,6 +491,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Vault Encryption Configuration": {
+            "$ref": "./examples/BackupResourceEncryptionConfig_Get.json"
           }
         }
       },
@@ -511,6 +541,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Update Vault Encryption Configuration": {
+            "$ref": "./examples/BackupResourceEncryptionConfig_Put.json"
           }
         }
       }
@@ -566,6 +601,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Dpm/AzureBackupServer/Lajolla Backup Engines": {
+            "$ref": "./examples/Dpm/BackupEngines_List.json"
           }
         },
         "x-ms-pageable": {
@@ -632,6 +672,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Dpm/AzureBackupServer/Lajolla Backup Engine Details": {
+            "$ref": "./examples/Dpm/BackupEngines_Get.json"
+          }
         }
       }
     },
@@ -686,6 +731,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get ProtectionIntent for an item": {
+            "$ref": "./examples/AzureWorkload/BackupProtectionIntent_Get.json"
           }
         }
       },
@@ -749,6 +799,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Create or Update Azure Vm Protection Intent": {
+            "$ref": "./examples/AzureIaasVm/ProtectionIntent_CreateOrUpdate.json"
+          }
         }
       },
       "delete": {
@@ -798,6 +853,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Protection intent from item": {
+            "$ref": "./examples/AzureWorkload/BackupProtectionIntent_Delete.json"
           }
         }
       }
@@ -854,6 +914,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Azure Vm Discovery Operation Result": {
+            "$ref": "./examples/Common/RefreshContainers_OperationResults.json"
+          }
         }
       }
     },
@@ -907,6 +972,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List protectable items with backupManagementType filter as AzureStorage": {
+            "$ref": "./examples/AzureStorage/ProtectableContainers_List.json"
           }
         },
         "x-ms-pageable": {
@@ -965,6 +1035,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Protection Container Details": {
+            "$ref": "./examples/AzureWorkload/ProtectionContainers_Get.json"
           }
         }
       },
@@ -1043,6 +1118,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "RegisterAzure Storage ProtectionContainers": {
+            "$ref": "./examples/AzureStorage/ProtectionContainers_Register.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ProtectionContainerResource"
@@ -1103,6 +1183,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Unregister Protection Container": {
+            "$ref": "./examples/AzureWorkload/ProtectionContainers_Unregister.json"
+          }
         }
       }
     },
@@ -1161,6 +1246,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Inquire Azure Storage Protection Containers": {
+            "$ref": "./examples/AzureStorage/ProtectionContainers_Inquire.json"
           }
         }
       }
@@ -1230,6 +1320,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Workload Items in Container": {
+            "$ref": "./examples/AzureWorkload/BackupWorkloadItems_List.json"
           }
         },
         "x-ms-pageable": {
@@ -1302,6 +1397,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Azure Storage Protection Container Operation Result": {
+            "$ref": "./examples/AzureStorage/ProtectionContainers_Inquire_Result.json"
+          }
         }
       }
     },
@@ -1370,6 +1470,14 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Protected Classic Virtual Machine Details": {
+            "$ref": "./examples/AzureIaasVm/ClassicCompute_ProtectedItem_Get.json"
+          },
+          "Get Protected Virtual Machine Details": {
+            "$ref": "./examples/AzureIaasVm/Compute_ProtectedItem_Get.json"
           }
         }
       },
@@ -1461,6 +1569,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Enable Protection on Azure IaasVm": {
+            "$ref": "./examples/AzureIaasVm/ConfigureProtection.json"
+          },
+          "Stop Protection with retain data on Azure IaasVm": {
+            "$ref": "./examples/AzureIaasVm/StopProtection.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/ProtectedItemResource"
@@ -1527,6 +1643,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Protection from Azure Virtual Machine": {
+            "$ref": "./examples/Common/ProtectedItem_Delete.json"
           }
         }
       }
@@ -1595,6 +1716,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger Backup": {
+            "$ref": "./examples/Common/TriggerBackup_Post.json"
           }
         }
       }
@@ -1671,6 +1797,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Operation Results of Protected Vm": {
+            "$ref": "./examples/AzureIaasVm/ProtectedItemOperationResults.json"
+          }
         }
       }
     },
@@ -1740,6 +1871,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Operation Status of Protected Vm": {
+            "$ref": "./examples/AzureIaasVm/ProtectedItemOperationStatus.json"
+          }
         }
       }
     },
@@ -1808,6 +1944,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Protected Azure Vm Recovery Points": {
+            "$ref": "./examples/AzureIaasVm/RecoveryPoints_List.json"
           }
         },
         "x-ms-pageable": {
@@ -1880,6 +2021,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure Vm Recovery Point Details": {
+            "$ref": "./examples/AzureIaasVm/RecoveryPoints_Get.json"
           }
         }
       }
@@ -1968,6 +2114,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Trigger RP Move Operation": {
+            "$ref": "./examples/TriggerRecoveryPointMove_Post.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2045,6 +2196,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Provision Instant Item Level Recovery for Azure Vm": {
+            "$ref": "./examples/AzureIaasVm/Provision_Ilr.json"
           }
         }
       }
@@ -2139,6 +2295,29 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Restore Disks with IaasVMRestoreRequest": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest.json"
+          },
+          "Restore Disks with IaasVMRestoreRequest with IdentityBasedRestoreDetails": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json"
+          },
+          "Restore Disks with IaasVMRestoreWithRehydrationRequest": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreWithRehydrationRequest.json"
+          },
+          "Restore to New Azure IaasVm with IaasVMRestoreRequest": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest.json"
+          },
+          "Restore to New Azure IaasVm with IaasVMRestoreRequest with identityBasedRestoreDetails": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json"
+          },
+          "Restore to New Azure IaasVm with IaasVMRestoreWithRehydrationRequest": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreWithRehydrationRequest.json"
+          },
+          "Restore with Resource Guard Enabled": {
+            "$ref": "./examples/AzureIaasVm/TriggerRestore_ResourceGuardEnabled.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -2207,6 +2386,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Revoke Instant Item Level Recovery for Azure Vm": {
+            "$ref": "./examples/AzureIaasVm/Revoke_Ilr.json"
           }
         }
       }
@@ -2280,6 +2464,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Protected Azure Vm Recovery Points Recommended for Move": {
+            "$ref": "./examples/AzureIaasVm/RecoveryPointsRecommendedForMove_List.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -2333,6 +2522,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger Azure Vm Discovery": {
+            "$ref": "./examples/Common/RefreshContainers.json"
           }
         }
       }
@@ -2390,6 +2584,17 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List All Jobs": {
+            "$ref": "./examples/Common/ListJobs.json"
+          },
+          "List Jobs With Filters": {
+            "$ref": "./examples/Common/ListJobsWithAllSupportedFilters.json"
+          },
+          "List Jobs With Time Filter": {
+            "$ref": "./examples/Common/ListJobsWithStartTimeAndEndTimeFilters.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -2440,6 +2645,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Job Details": {
+            "$ref": "./examples/Common/GetJobDetails.json"
+          }
         }
       }
     },
@@ -2484,6 +2694,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Cancel Job": {
+            "$ref": "./examples/Common/TriggerCancelJob.json"
           }
         }
       }
@@ -2543,6 +2758,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Cancel Job Operation Result": {
+            "$ref": "./examples/Common/CancelJobOperationResult.json"
+          }
         }
       }
     },
@@ -2597,6 +2817,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Export Jobs Operation Results": {
+            "$ref": "./examples/Common/ExportJobsOperationResult.json"
+          }
         }
       }
     },
@@ -2641,6 +2866,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Export Jobs": {
+            "$ref": "./examples/Common/TriggerExportJobs.json"
           }
         }
       }
@@ -2693,6 +2923,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Result for Protected Item Delete Operation": {
+            "$ref": "./examples/Common/ProtectedItem_Delete_OperationResult.json"
+          }
         }
       }
     },
@@ -2741,6 +2976,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Protected Item Delete Operation Status": {
+            "$ref": "./examples/Common/ProtectedItem_Delete_OperationStatus.json"
+          }
         }
       }
     },
@@ -2788,6 +3028,17 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List protection policies with backupManagementType filter as AzureIaasVm": {
+            "$ref": "./examples/AzureIaasVm/BackupPolicies_List.json"
+          },
+          "List protection policies with backupManagementType filter as AzureIaasVm with both V1 and V2 policies": {
+            "$ref": "./examples/AzureIaasVm/V2Policy/v2-List-Policies.json"
+          },
+          "List protection policies with backupManagementType filter as AzureWorkload": {
+            "$ref": "./examples/AzureWorkload/BackupPolicies_List.json"
           }
         },
         "x-ms-pageable": {
@@ -2839,6 +3090,14 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Azure IaasVm Enhanced Protection Policy Details": {
+            "$ref": "./examples/AzureIaasVm/V2Policy/v2-Get-Policy.json"
+          },
+          "Get Azure IaasVm Protection Policy Details": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicies_Get.json"
           }
         }
       },
@@ -2904,6 +3163,35 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Create or Update Azure Storage Vault Standard Protection Policy": {
+            "$ref": "./examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hardened.json"
+          },
+          "Create or Update Daily Azure Storage Protection Policy": {
+            "$ref": "./examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Daily.json"
+          },
+          "Create or Update Enhanced Azure Vm Protection Policy with Hourly backup": {
+            "$ref": "./examples/AzureIaasVm/V2Policy/IaaS_v2_hourly.json"
+          },
+          "Create or Update Enhanced Azure Vm Protection Policy with daily backup": {
+            "$ref": "./examples/AzureIaasVm/V2Policy/IaaS_v2_daily.json"
+          },
+          "Create or Update Full Azure Vm Protection Policy": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Complex.json"
+          },
+          "Create or Update Full Azure Workload Protection Policy": {
+            "$ref": "./examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_Complex.json"
+          },
+          "Create or Update Hourly Azure Storage Protection Policy": {
+            "$ref": "./examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hourly.json"
+          },
+          "Create or Update SQL Azure Workload Protection Policy with multi-VDI streaming enabled": {
+            "$ref": "./examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json"
+          },
+          "Create or Update Simple Azure Vm Protection Policy": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Simple.json"
+          }
         }
       },
       "delete": {
@@ -2965,6 +3253,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete Azure Vm Protection Policy": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicies_Delete.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -3023,6 +3316,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Protection Policy Operation Results": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicyOperationResults_Get.json"
+          }
         }
       }
     },
@@ -3078,6 +3376,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Protection Policy Operation Status": {
+            "$ref": "./examples/AzureIaasVm/ProtectionPolicyOperationStatuses_Get.json"
+          }
         }
       }
     },
@@ -3132,6 +3435,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List protectable items with backupManagementType filter as AzureIaasVm": {
+            "$ref": "./examples/AzureIaasVm/BackupProtectableItems_List.json"
           }
         },
         "x-ms-pageable": {
@@ -3192,6 +3500,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List protected items with backupManagementType filter as AzureIaasVm": {
+            "$ref": "./examples/AzureIaasVm/BackupProtectedItems_List.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3241,6 +3554,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "List Backup Protection Containers": {
+            "$ref": "./examples/AzureStorage/ProtectionContainers_List.json"
           }
         },
         "x-ms-pageable": {
@@ -3301,6 +3619,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "List protection intent with backupManagementType filter": {
+            "$ref": "./examples/AzureWorkload/BackupProtectionIntent_List.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3343,6 +3666,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get VaultGuardProxies": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json"
           }
         },
         "x-ms-pageable": {
@@ -3394,6 +3722,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json"
           }
         }
       },
@@ -3450,6 +3783,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Create ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json"
+          }
         }
       },
       "delete": {
@@ -3495,6 +3833,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Delete ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json"
           }
         }
       }
@@ -3553,6 +3896,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "UnlockDelete ResourceGuardProxy": {
+            "$ref": "./examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json"
+          }
         }
       }
     },
@@ -3608,6 +3956,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Vault Security Pin": {
+            "$ref": "./examples/Common/BackupSecurityPin_Get.json"
           }
         }
       }
@@ -3677,6 +4030,20 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get the rehydration cost for recovery point": {
+            "$ref": "./examples/TieringCost/FetchTieringCostForRehydrate.json"
+          },
+          "Get the tiering savings cost info for policy": {
+            "$ref": "./examples/TieringCost/FetchTieringCostForPolicy.json"
+          },
+          "Get the tiering savings cost info for protected item": {
+            "$ref": "./examples/TieringCost/FetchTieringCostForProtectedItem.json"
+          },
+          "Get the tiering savings cost info for vault": {
+            "$ref": "./examples/TieringCost/FetchTieringCostForVault.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/TieringCostInfo"
@@ -3731,6 +4098,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Fetch Tiering Cost Operation Result": {
+            "$ref": "./examples/TieringCost/GetTieringCostOperationResult.json"
+          }
         }
       }
     },
@@ -3780,6 +4152,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Fetch Tiering Cost Operation Status": {
+            "$ref": "./examples/TieringCost/GetTieringCostOperationStatus.json"
           }
         }
       }
@@ -3838,6 +4215,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger Validate Operation": {
+            "$ref": "./examples/AzureIaasVm/TriggerValidateOperation_RestoreDisk.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -3899,6 +4281,14 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Get Protected Containers Usages Summary": {
+            "$ref": "./examples/Common/BackupProtectionContainers_UsageSummary_Get.json"
+          },
+          "Get Protected Items Usages Summary": {
+            "$ref": "./examples/Common/BackupProtectedItem_UsageSummary_Get.json"
+          }
+        },
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
@@ -3951,6 +4341,14 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Validate Operation": {
+            "$ref": "./examples/AzureIaasVm/ValidateOperation_RestoreDisk.json"
+          },
+          "Validate Operation with identityBasedRestoreDetails": {
+            "$ref": "./examples/AzureIaasVm/ValidateOperation_RestoreDisk_IdentityBasedRestoreDetails.json"
+          }
         }
       }
     },
@@ -4002,6 +4400,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Operation Results of Validate Operation": {
+            "$ref": "./examples/AzureIaasVm/ValidateOperationResults.json"
+          }
         }
       }
     },
@@ -4050,6 +4453,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get Operation Status of Validate Operation": {
+            "$ref": "./examples/AzureIaasVm/ValidateOperationStatus.json"
+          }
         }
       }
     },
@@ -4090,6 +4498,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Vault Security Config": {
+            "$ref": "./examples/Common/BackupResourceVaultConfigs_Get.json"
           }
         }
       },
@@ -4145,6 +4558,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Update Vault Security Config": {
+            "$ref": "./examples/Common/BackupResourceVaultConfigs_Put.json"
+          }
         }
       },
       "patch": {
@@ -4199,6 +4617,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Update Vault Security Config": {
+            "$ref": "./examples/Common/BackupResourceVaultConfigs_Patch.json"
+          }
         }
       }
     },
@@ -4239,6 +4662,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get Vault Storage Configuration": {
+            "$ref": "./examples/Common/BackupStorageConfig_Get.json"
           }
         }
       },
@@ -4288,6 +4716,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Update Vault Storage Configuration": {
+            "$ref": "./examples/Common/BackupStorageConfig_Put.json"
+          }
         }
       },
       "patch": {
@@ -4332,6 +4765,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Update Vault Storage Configuration": {
+            "$ref": "./examples/Common/BackupStorageConfig_Patch.json"
           }
         }
       }
@@ -4384,6 +4822,11 @@
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
           }
+        },
+        "x-ms-examples": {
+          "Get operation result for PrepareDataMove": {
+            "$ref": "./examples/BackupDataMove/PrepareDataMoveOperationResult_Get.json"
+          }
         }
       }
     },
@@ -4431,6 +4874,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get OperationStatus": {
+            "$ref": "./examples/BackupDataMove/BackupDataMoveOperationStatus_Get.json"
           }
         }
       }
@@ -4492,6 +4940,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Prepare Data Move": {
+            "$ref": "./examples/BackupDataMove/PrepareDataMove_Post.json"
           }
         },
         "x-ms-long-running-operation-options": {
@@ -4559,6 +5012,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Trigger Data Move": {
+            "$ref": "./examples/BackupDataMove/TriggerDataMove_Post.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -4609,6 +5067,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get PrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/GetPrivateEndpointConnection.json"
           }
         }
       },
@@ -4683,6 +5146,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Update PrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/PutPrivateEndpointConnection.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location",
           "final-state-schema": "#/definitions/PrivateEndpointConnectionResource"
@@ -4748,6 +5216,11 @@
             }
           }
         },
+        "x-ms-examples": {
+          "Delete PrivateEndpointConnection": {
+            "$ref": "./examples/PrivateEndpointConnection/DeletePrivateEndpointConnection.json"
+          }
+        },
         "x-ms-long-running-operation-options": {
           "final-state-via": "location"
         },
@@ -4805,6 +5278,11 @@
             "schema": {
               "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
             }
+          }
+        },
+        "x-ms-examples": {
+          "Get OperationStatus": {
+            "$ref": "./examples/PrivateEndpointConnection/GetPrivateEndpointConnectionOperationStatus.json"
           }
         }
       }

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/bms.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/bms.json
@@ -1,0 +1,14785 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Recovery Services Backup Client",
+    "version": "2026-06-01",
+    "description": "Open API 2.0 Specs for Azure RecoveryServices Backup service",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "BackupResourceStorageConfigsNonCRR"
+    },
+    {
+      "name": "BMSPrepareDataMoveOperationResult"
+    },
+    {
+      "name": "BackupResourceConfigOperationStatuses"
+    },
+    {
+      "name": "ProtectionIntentResources"
+    },
+    {
+      "name": "BackupResourceVaultConfigs"
+    },
+    {
+      "name": "BackupResourceEncryptionConfigs"
+    },
+    {
+      "name": "PrivateEndpointConnectionResources"
+    },
+    {
+      "name": "PrivateEndpointOperationStatuses"
+    },
+    {
+      "name": "ProtectedItems"
+    },
+    {
+      "name": "Backups"
+    },
+    {
+      "name": "RecoveryPointsRecommendedForMove"
+    },
+    {
+      "name": "ProtectedItemOperationStatuses"
+    },
+    {
+      "name": "ProtectedItemOperationResults"
+    },
+    {
+      "name": "ProtectionContainers"
+    },
+    {
+      "name": "BackupWorkloadItems"
+    },
+    {
+      "name": "ProtectionContainerOperationResults"
+    },
+    {
+      "name": "RecoveryPoints"
+    },
+    {
+      "name": "Restores"
+    },
+    {
+      "name": "ItemLevelRecoveryConnections"
+    },
+    {
+      "name": "ProtectionPolicies"
+    },
+    {
+      "name": "BackupPolicies"
+    },
+    {
+      "name": "ProtectionPolicyOperationResults"
+    },
+    {
+      "name": "ProtectionPolicyOperationStatuses"
+    },
+    {
+      "name": "JobDetails"
+    },
+    {
+      "name": "BackupJobs"
+    },
+    {
+      "name": "JobCancellations"
+    },
+    {
+      "name": "JobOperationResults"
+    },
+    {
+      "name": "ExportJobsOperationResults"
+    },
+    {
+      "name": "BackupEngines"
+    },
+    {
+      "name": "ResourceGuardProxy"
+    },
+    {
+      "name": "ResourceGuardProxies"
+    },
+    {
+      "name": "ProtectionIntent"
+    },
+    {
+      "name": "BackupStatus"
+    },
+    {
+      "name": "FeatureSupport"
+    },
+    {
+      "name": "BackupProtectionIntent"
+    },
+    {
+      "name": "BackupUsageSummaries"
+    },
+    {
+      "name": "Jobs"
+    },
+    {
+      "name": "BackupProtectedItems"
+    },
+    {
+      "name": "Operation"
+    },
+    {
+      "name": "ValidateOperation"
+    },
+    {
+      "name": "ValidateOperationResults"
+    },
+    {
+      "name": "ValidateOperationStatuses"
+    },
+    {
+      "name": "ProtectionContainerRefreshOperationResults"
+    },
+    {
+      "name": "ProtectableContainers"
+    },
+    {
+      "name": "BackupOperationResults"
+    },
+    {
+      "name": "BackupOperationStatuses"
+    },
+    {
+      "name": "BackupProtectableItems"
+    },
+    {
+      "name": "BackupProtectionContainers"
+    },
+    {
+      "name": "SoftDeletedContainers"
+    },
+    {
+      "name": "SecurityPINs"
+    },
+    {
+      "name": "FetchTieringCost"
+    },
+    {
+      "name": "GetTieringCostOperationResult"
+    },
+    {
+      "name": "TieringCostOperationStatus"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.RecoveryServices/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ClientDiscoveryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.RecoveryServices/locations/{azureRegion}/backupPreValidateProtection": {
+      "post": {
+        "operationId": "ProtectionIntent_Validate",
+        "tags": [
+          "ProtectionIntent"
+        ],
+        "summary": "It will validate followings\n1. Vault capacity\n2. VM is already protected\n3. Any VM related configuration passed in properties.",
+        "description": "It will validate followings\n1. Vault capacity\n2. VM is already protected\n3. Any VM related configuration passed in properties.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "azureRegion",
+            "in": "path",
+            "description": "Azure region to hit Api",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Enable backup validation request on Virtual Machine",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreValidateEnableBackupRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreValidateEnableBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.RecoveryServices/locations/{azureRegion}/backupStatus": {
+      "post": {
+        "operationId": "BackupStatus_Get",
+        "tags": [
+          "BackupStatus"
+        ],
+        "summary": "Get the container backup status",
+        "description": "Get the container backup status",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "azureRegion",
+            "in": "path",
+            "description": "Azure region to hit Api",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Container Backup Status Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupStatusRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.RecoveryServices/locations/{azureRegion}/backupValidateFeatures": {
+      "post": {
+        "operationId": "FeatureSupport_Validate",
+        "tags": [
+          "FeatureSupport"
+        ],
+        "summary": "It will validate if given feature with resource properties is supported in service",
+        "description": "It will validate if given feature with resource properties is supported in service",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "azureRegion",
+            "in": "path",
+            "description": "Azure region to hit Api",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Feature support request object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FeatureSupportRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureVMResourceFeatureSupportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupDeletedProtectionContainers": {
+      "get": {
+        "operationId": "DeletedProtectionContainers_List",
+        "tags": [
+          "SoftDeletedContainers"
+        ],
+        "description": "Lists the soft deleted containers registered to Recovery Services Vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupEncryptionConfigs/backupResourceEncryptionConfig": {
+      "get": {
+        "operationId": "BackupResourceEncryptionConfigs_Get",
+        "tags": [
+          "BackupResourceEncryptionConfigs"
+        ],
+        "description": "Fetches Vault Encryption config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceEncryptionConfigExtendedResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "BackupResourceEncryptionConfigs_Update",
+        "tags": [
+          "BackupResourceEncryptionConfigs"
+        ],
+        "description": "Updates Vault encryption config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vault encryption input config request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupResourceEncryptionConfigResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupEngines": {
+      "get": {
+        "operationId": "BackupEngines_List",
+        "tags": [
+          "BackupEngines"
+        ],
+        "description": "Backup management servers registered to Recovery Services Vault. Returns a pageable list of servers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupEngineBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupEngines/{backupEngineName}": {
+      "get": {
+        "operationId": "BackupEngines_Get",
+        "tags": [
+          "BackupEngines"
+        ],
+        "description": "Returns backup management server registered to Recovery Services Vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "backupEngineName",
+            "in": "path",
+            "description": "Name of the backup management server.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupEngineBaseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/backupProtectionIntent/{intentObjectName}": {
+      "get": {
+        "operationId": "ProtectionIntent_Get",
+        "tags": [
+          "ProtectionIntentResources"
+        ],
+        "description": "Provides the details of the protection intent up item. This is an asynchronous operation. To know the status of the operation,\ncall the GetItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "intentObjectName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionIntentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProtectionIntent_CreateOrUpdate",
+        "tags": [
+          "ProtectionIntentResources"
+        ],
+        "description": "Create Intent for Enabling backup of an item. This is a synchronous operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "intentObjectName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource backed up item",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProtectionIntentResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProtectionIntentResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProtectionIntentResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ProtectionIntent_Delete",
+        "tags": [
+          "ProtectionIntentResources"
+        ],
+        "description": "Used to remove intent from an item",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "intentObjectName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/operationResults/{operationId}": {
+      "get": {
+        "operationId": "ProtectionContainerRefreshOperationResults_Get",
+        "tags": [
+          "ProtectionContainerRefreshOperationResults"
+        ],
+        "description": "Provides the result of the refresh operation triggered by the BeginRefresh operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "Fabric name associated with the container.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "Operation ID associated with the operation whose result needs to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted."
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectableContainers": {
+      "get": {
+        "operationId": "ProtectableContainers_List",
+        "tags": [
+          "ProtectableContainers"
+        ],
+        "description": "Lists the containers that can be registered to Recovery Services Vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectableContainerResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}": {
+      "get": {
+        "operationId": "ProtectionContainers_Get",
+        "tags": [
+          "ProtectionContainers"
+        ],
+        "description": "Gets details of the specific container registered to your Recovery Services Vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProtectionContainers_Register",
+        "tags": [
+          "ProtectionContainers"
+        ],
+        "description": "Registers the container with Recovery Services vault.\nThis is an asynchronous operation. To track the operation status, use location header to call get latest status of\nthe operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProtectionContainerResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ProtectionContainerResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ProtectionContainers_Unregister",
+        "tags": [
+          "ProtectionContainers"
+        ],
+        "description": "Unregisters the given container from your Recovery Services Vault. This is an asynchronous operation. To determine\nwhether the backend service has finished processing the request, call Get Container Operation Result API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/inquire": {
+      "post": {
+        "operationId": "ProtectionContainers_Inquire",
+        "tags": [
+          "ProtectionContainers"
+        ],
+        "description": "This is an async operation and the results should be tracked using location header or Azure-async-url.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/items": {
+      "get": {
+        "operationId": "BackupWorkloadItems_List",
+        "tags": [
+          "BackupWorkloadItems"
+        ],
+        "description": "Provides a pageable list of workload item of a specific container according to the query filter and the pagination\nparameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadItemResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/operationResults/{operationId}": {
+      "get": {
+        "operationId": "ProtectionContainerOperationResults_Get",
+        "tags": [
+          "ProtectionContainerOperationResults"
+        ],
+        "description": "Fetches the result of any operation on the container.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "backupFabrics",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the ProtectionContainerResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the ProtectionContainerResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResource"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}": {
+      "get": {
+        "operationId": "ProtectedItems_Get",
+        "tags": [
+          "ProtectedItems"
+        ],
+        "description": "Provides the details of the backed up item. This is an asynchronous operation. To know the status of the operation,\ncall the GetItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectedItemResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProtectedItems_CreateOrUpdate",
+        "tags": [
+          "ProtectedItems"
+        ],
+        "description": "Enables backup of an item or to modifies the backup policy information of an already backed up item. This is an\nasynchronous operation. To know the status of the operation, call the GetItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource backed up item",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProtectedItemResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProtectedItemResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProtectedItemResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ProtectedItemResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ProtectedItems_Delete",
+        "tags": [
+          "ProtectedItems"
+        ],
+        "description": "Used to disable backup of an item within a container. This is an asynchronous operation. To know the status of the\nrequest, call the GetItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/backup": {
+      "post": {
+        "operationId": "Backups_Trigger",
+        "tags": [
+          "Backups"
+        ],
+        "description": "Triggers backup for specified backed up item. This is an asynchronous operation. To know the status of the\noperation, call GetProtectedItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource backup request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupRequestResource"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/operationResults/{operationId}": {
+      "get": {
+        "operationId": "ProtectedItemOperationResults_Get",
+        "tags": [
+          "ProtectedItemOperationResults"
+        ],
+        "description": "Fetches the result of any operation on the backup item.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "backupFabrics",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the ProtectionContainerResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "The name of the ProtectedItemResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the ProtectedItemResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectedItemResource"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/operationsStatus/{operationId}": {
+      "get": {
+        "operationId": "ProtectedItemOperationStatuses_Get",
+        "tags": [
+          "ProtectedItemOperationStatuses"
+        ],
+        "description": "Fetches the status of an operation such as triggering a backup, restore. The status can be in progress, completed\nor failed. You can refer to the OperationStatus enum for all the possible states of the operation. Some operations\ncreate jobs. This method returns the list of jobs associated with the operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "backupFabrics",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "The name of the ProtectionContainerResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "The name of the ProtectedItemResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the ProtectedItemResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints": {
+      "get": {
+        "operationId": "RecoveryPoints_List",
+        "tags": [
+          "RecoveryPoints"
+        ],
+        "description": "Lists the backup copies for the backed up item.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RecoveryPointResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}": {
+      "get": {
+        "operationId": "RecoveryPoints_Get",
+        "tags": [
+          "RecoveryPoints"
+        ],
+        "description": "Provides the information of the backed up data identified using RecoveryPointID. This is an asynchronous operation.\nTo know the status of the operation, call the GetProtectedItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "description": "RecoveryPointID represents the backed up data to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RecoveryPointResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/move": {
+      "post": {
+        "operationId": "MoveRecoveryPoint",
+        "tags": [
+          "RecoveryPoints"
+        ],
+        "description": "Move recovery point from one datastore to another store.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "description": "RecoveryPointID represents the backed up data to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Move Resource Across Tiers Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MoveRPAcrossTiersRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/provisionInstantItemRecovery": {
+      "post": {
+        "operationId": "ItemLevelRecoveryConnections_Provision",
+        "tags": [
+          "ItemLevelRecoveryConnections"
+        ],
+        "description": "Provisions a script which invokes an iSCSI connection to the backup data. Executing this script opens a file\nexplorer displaying all the recoverable files and folders. This is an asynchronous operation. To know the status of\nprovisioning, call GetProtectedItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "description": "RecoveryPointID represents the backed up data to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource ILR request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ILRRequestResource"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/restore": {
+      "post": {
+        "operationId": "Restores_Trigger",
+        "tags": [
+          "Restores"
+        ],
+        "description": "Restores the specified backed up data. This is an asynchronous operation. To know the status of this API call, use\nGetProtectedItemOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "description": "RecoveryPointID represents the backed up data to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource restore request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RestoreRequestResource"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPoints/{recoveryPointId}/revokeInstantItemRecovery": {
+      "post": {
+        "operationId": "ItemLevelRecoveryConnections_Revoke",
+        "tags": [
+          "ItemLevelRecoveryConnections"
+        ],
+        "description": "Revokes an iSCSI connection which can be used to download a script. Executing this script opens a file explorer\ndisplaying all recoverable files and folders. This is an asynchronous operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "recoveryPointId",
+            "in": "path",
+            "description": "RecoveryPointID represents the backed up data to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/protectionContainers/{containerName}/protectedItems/{protectedItemName}/recoveryPointsRecommendedForMove": {
+      "post": {
+        "operationId": "RecoveryPointsRecommendedForMove_List",
+        "tags": [
+          "RecoveryPointsRecommendedForMove"
+        ],
+        "description": "Lists the recovery points recommended for move to another tier",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "The name of the BackupFabricResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerName",
+            "in": "path",
+            "description": "Name of the container whose details need to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "protectedItemName",
+            "in": "path",
+            "description": "Backed up item name whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "List Recovery points Recommended for Move Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ListRecoveryPointsRecommendedForMoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RecoveryPointResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupFabrics/{fabricName}/refreshContainers": {
+      "post": {
+        "operationId": "ProtectionContainers_Refresh",
+        "tags": [
+          "ProtectionContainers"
+        ],
+        "description": "Discovers all the containers in the subscription that can be backed up to Recovery Services Vault. This is an\nasynchronous operation. To know the status of the operation, call GetRefreshOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fabricName",
+            "in": "path",
+            "description": "Fabric name associated the container.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobs": {
+      "get": {
+        "operationId": "BackupJobs_List",
+        "tags": [
+          "BackupJobs"
+        ],
+        "description": "Provides a pageable list of jobs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobs/{jobName}": {
+      "get": {
+        "operationId": "JobDetails_Get",
+        "tags": [
+          "JobDetails"
+        ],
+        "description": "Gets extended information associated with the job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the job whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobs/{jobName}/cancel": {
+      "post": {
+        "operationId": "JobCancellations_Trigger",
+        "tags": [
+          "JobCancellations"
+        ],
+        "description": "Cancels a job. This is an asynchronous operation. To know the status of the cancellation, call\nGetCancelOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the job whose details are to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobs/{jobName}/operationResults/{operationId}": {
+      "get": {
+        "operationId": "JobOperationResults_Get",
+        "tags": [
+          "JobOperationResults"
+        ],
+        "description": "Fetches the result of any operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "The name of the JobResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the JobResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobs/operationResults/{operationId}": {
+      "get": {
+        "operationId": "ExportJobsOperationResults_Get",
+        "tags": [
+          "ExportJobsOperationResults"
+        ],
+        "description": "Gets the operation result of operation triggered by Export Jobs API. If the operation is successful, then it also\ncontains URL of a Blob and a SAS key to access the same. The blob contains exported jobs in JSON serialized format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the JobResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationResultInfoBaseResource"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/OperationResultInfoBaseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupJobsExport": {
+      "post": {
+        "operationId": "Jobs_Export",
+        "tags": [
+          "Jobs"
+        ],
+        "description": "Triggers export of jobs specified by filters and returns an OperationID to track.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupOperationResults/{operationId}": {
+      "get": {
+        "operationId": "BackupOperationResults_Get",
+        "tags": [
+          "BackupOperationResults"
+        ],
+        "description": "Provides the status of the delete operations such as deleting backed up item. Once the operation has started, the\nstatus code in the response would be Accepted. It will continue to be in this state till it reaches completion. On\nsuccessful completion, the status code will be OK. This method expects OperationID as an argument. OperationID is\npart of the Location header of the operation response.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "OperationID which represents the operation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted."
+          },
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupOperations/{operationId}": {
+      "get": {
+        "operationId": "BackupOperationStatuses_Get",
+        "tags": [
+          "BackupOperationStatuses"
+        ],
+        "description": "Fetches the status of an operation such as triggering a backup, restore. The status can be in progress, completed\nor failed. You can refer to the OperationStatus enum for all the possible states of an operation. Some operations\ncreate jobs. This method returns the list of jobs when the operation is complete.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "OperationID which represents the operation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupPolicies": {
+      "get": {
+        "operationId": "BackupPolicies_List",
+        "tags": [
+          "BackupPolicies"
+        ],
+        "description": "Lists of backup policies associated with Recovery Services Vault. API provides pagination parameters to fetch\nscoped results.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionPolicyResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupPolicies/{policyName}": {
+      "get": {
+        "operationId": "ProtectionPolicies_Get",
+        "tags": [
+          "ProtectionPolicies"
+        ],
+        "description": "Provides the details of the backup policies associated to Recovery Services Vault. This is an asynchronous\noperation. Status of the operation can be fetched using GetPolicyOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Backup policy information to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionPolicyResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProtectionPolicies_CreateOrUpdate",
+        "tags": [
+          "ProtectionPolicies"
+        ],
+        "description": "Creates or modifies a backup policy. This is an asynchronous operation. Status of the operation can be fetched\nusing GetPolicyOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Backup policy information to be fetched.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource backup policy",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProtectionPolicyResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ProtectionPolicyResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ProtectionPolicyResource"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ProtectionPolicies_Delete",
+        "tags": [
+          "ProtectionPolicies"
+        ],
+        "description": "Deletes specified backup policy from your Recovery Services Vault. This is an asynchronous operation. Status of the\noperation can be fetched using GetProtectionPolicyOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "Backup policy information to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupPolicies/{policyName}/operationResults/{operationId}": {
+      "get": {
+        "operationId": "ProtectionPolicyOperationResults_Get",
+        "tags": [
+          "ProtectionPolicyOperationResults"
+        ],
+        "description": "Provides the result of an operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "The name of the ProtectionPolicyResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the ProtectionPolicyResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionPolicyResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupPolicies/{policyName}/operations/{operationId}": {
+      "get": {
+        "operationId": "ProtectionPolicyOperationStatuses_Get",
+        "tags": [
+          "ProtectionPolicyOperationStatuses"
+        ],
+        "description": "Provides the status of the asynchronous operations like backup, restore. The status can be in progress, completed\nor failed. You can refer to the Operation Status enum for all the possible states of an operation. Some operations\ncreate jobs. This method returns the list of jobs associated with operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "The name of the ProtectionPolicyResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the ProtectionPolicyResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupProtectableItems": {
+      "get": {
+        "operationId": "BackupProtectableItems_List",
+        "tags": [
+          "BackupProtectableItems"
+        ],
+        "description": "Provides a pageable list of protectable objects within your subscription according to the query filter and the\npagination parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkloadProtectableItemResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupProtectedItems": {
+      "get": {
+        "operationId": "BackupProtectedItems_List",
+        "tags": [
+          "BackupProtectedItems"
+        ],
+        "description": "Provides a pageable list of all items that are backed up within a vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectedItemResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupProtectionContainers": {
+      "get": {
+        "operationId": "BackupProtectionContainers_List",
+        "tags": [
+          "BackupProtectionContainers"
+        ],
+        "description": "Lists the containers registered to Recovery Services Vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionContainerResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupProtectionIntents": {
+      "get": {
+        "operationId": "BackupProtectionIntent_List",
+        "tags": [
+          "BackupProtectionIntent"
+        ],
+        "description": "Provides a pageable list of all intents that are present within a vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProtectionIntentResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupResourceGuardProxies": {
+      "get": {
+        "operationId": "ResourceGuardProxies_Get",
+        "tags": [
+          "ResourceGuardProxies"
+        ],
+        "description": "List the ResourceGuardProxies under vault",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResourceList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupResourceGuardProxies/{resourceGuardProxyName}": {
+      "get": {
+        "operationId": "ResourceGuardProxy_Get",
+        "tags": [
+          "ResourceGuardProxy"
+        ],
+        "description": "Returns ResourceGuardProxy under vault and with the name referenced in request",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ResourceGuardProxy_Put",
+        "tags": [
+          "ResourceGuardProxy"
+        ],
+        "description": "Add or Update ResourceGuardProxy under vault\nSecures vault critical operations",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ResourceGuardProxyBaseResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ResourceGuardProxy_Delete",
+        "tags": [
+          "ResourceGuardProxy"
+        ],
+        "description": "Delete ResourceGuardProxy under vault",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupResourceGuardProxies/{resourceGuardProxyName}/unlockDelete": {
+      "post": {
+        "operationId": "ResourceGuardProxy_UnlockDelete",
+        "tags": [
+          "ResourceGuardProxy"
+        ],
+        "description": "Secures delete ResourceGuardProxy operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGuardProxyName",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UnlockDeleteRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UnlockDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupSecurityPIN": {
+      "post": {
+        "operationId": "SecurityPINs_Get",
+        "tags": [
+          "SecurityPINs"
+        ],
+        "description": "Get the security PIN.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "security pin request",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/SecurityPinBase"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TokenInformation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTieringCost/default/fetchTieringCost": {
+      "post": {
+        "operationId": "FetchTieringCost_Post",
+        "tags": [
+          "FetchTieringCost"
+        ],
+        "description": "Provides the details of the tiering related sizes and cost.\nStatus of the operation can be fetched using GetTieringCostOperationStatus API and result using GetTieringCostOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 50,
+            "pattern": "^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Fetch Tiering Cost Request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FetchTieringCostInfoRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TieringCostInfo"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TieringCostInfo"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTieringCost/default/operationResults/{operationId}": {
+      "get": {
+        "operationId": "GetTieringCostOperationResult_Get",
+        "tags": [
+          "GetTieringCostOperationResult"
+        ],
+        "description": "Gets the result of async operation for tiering cost",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 50,
+            "pattern": "^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TieringCostInfo"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTieringCost/default/operationsStatus/{operationId}": {
+      "get": {
+        "operationId": "TieringCostOperationStatus_Get",
+        "tags": [
+          "TieringCostOperationStatus"
+        ],
+        "description": "Gets the status of async operations of tiering cost",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 50,
+            "pattern": "^[A-Za-z][-A-Za-z0-9]*[A-Za-z0-9]$"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupTriggerValidateOperation": {
+      "post": {
+        "operationId": "ValidateOperation_Trigger",
+        "tags": [
+          "ValidateOperation"
+        ],
+        "description": "Validate operation for specified backed up item in the form of an asynchronous operation. Returns tracking headers which can be tracked using GetValidateOperationResult API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource validate operation request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateOperationRequestResource"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupUsageSummaries": {
+      "get": {
+        "operationId": "BackupUsageSummaries_List",
+        "tags": [
+          "BackupUsageSummaries"
+        ],
+        "description": "Fetches the backup management usage summaries of the vault.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "OData filter options.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "skipToken Filter.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupManagementUsageList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupValidateOperation": {
+      "post": {
+        "operationId": "Operation_Validate",
+        "tags": [
+          "Operation"
+        ],
+        "description": "Validate operation for specified backed up item. This is a synchronous operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource validate operation request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateOperationRequestResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ValidateOperationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupValidateOperationResults/{operationId}": {
+      "get": {
+        "operationId": "ValidateOperationResults_Get",
+        "tags": [
+          "ValidateOperationResults"
+        ],
+        "description": "Fetches the result of a triggered validate operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "OperationID which represents the operation whose result needs to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ValidateOperationsResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupValidateOperationsStatuses/{operationId}": {
+      "get": {
+        "operationId": "ValidateOperationStatuses_Get",
+        "tags": [
+          "ValidateOperationStatuses"
+        ],
+        "description": "Fetches the status of a triggered validate operation. The status can be in progress, completed\nor failed. You can refer to the OperationStatus enum for all the possible states of the operation.\nIf operation has completed, this method returns the list of errors obtained while validating the operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the recovery services vault.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "OperationID represents the operation whose status needs to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupconfig/vaultconfig": {
+      "get": {
+        "operationId": "BackupResourceVaultConfigs_Get",
+        "tags": [
+          "BackupResourceVaultConfigs"
+        ],
+        "description": "Fetches resource vault config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceVaultConfigResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "BackupResourceVaultConfigs_Put",
+        "tags": [
+          "BackupResourceVaultConfigs"
+        ],
+        "description": "Updates vault security config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource config request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupResourceVaultConfigResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BackupResourceVaultConfigResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceVaultConfigResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "BackupResourceVaultConfigs_Update",
+        "tags": [
+          "BackupResourceVaultConfigs"
+        ],
+        "description": "Updates vault security config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-authorization-auxiliary",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "resource config request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupResourceVaultConfigResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceVaultConfigResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig": {
+      "get": {
+        "operationId": "BackupResourceStorageConfigsNonCRR_Get",
+        "tags": [
+          "BackupResourceStorageConfigsNonCRR"
+        ],
+        "description": "Fetches resource storage config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceConfigResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "BackupResourceStorageConfigsNonCRR_Update",
+        "tags": [
+          "BackupResourceStorageConfigsNonCRR"
+        ],
+        "description": "Updates vault storage model type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vault storage config request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupResourceConfigResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BackupResourceConfigResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BackupResourceConfigResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "BackupResourceStorageConfigsNonCRR_Patch",
+        "tags": [
+          "BackupResourceStorageConfigsNonCRR"
+        ],
+        "description": "Updates vault storage model type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vault storage config request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackupResourceConfigResource"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/operationResults/{operationId}": {
+      "get": {
+        "operationId": "BMSPrepareDataMoveOperationResult_Get",
+        "tags": [
+          "BMSPrepareDataMoveOperationResult"
+        ],
+        "description": "Fetches operation status for data move operation on vault",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the BackupResourceConfigResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VaultStorageConfigOperationResultResponse"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/operationStatus/{operationId}": {
+      "get": {
+        "operationId": "GetOperationStatus",
+        "tags": [
+          "BackupResourceConfigOperationStatuses"
+        ],
+        "description": "Fetches Operation Result for Prepare Data Move",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the BackupResourceConfigResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/prepareDataMove": {
+      "post": {
+        "operationId": "BMSPrepareDataMove",
+        "tags": [
+          "BackupResourceStorageConfigsNonCRR"
+        ],
+        "description": "Prepares source vault for Data Move operation",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Prepare data move request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrepareDataMoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/backupstorageconfig/vaultstorageconfig/triggerDataMove": {
+      "post": {
+        "operationId": "BMSTriggerDataMove",
+        "tags": [
+          "BackupResourceStorageConfigsNonCRR"
+        ],
+        "description": "Triggers Data Move Operation on target vault",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Trigger data move request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TriggerDataMoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnection_Get",
+        "tags": [
+          "PrivateEndpointConnectionResources"
+        ],
+        "description": "Get Private Endpoint Connection. This call is made by Backup Admin.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnection_Put",
+        "tags": [
+          "PrivateEndpointConnectionResources"
+        ],
+        "description": "Approve or Reject Private Endpoint requests. This call is made by Backup Admin.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Request body for operation",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnectionResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnectionResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionResource"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateEndpointConnectionResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnection_Delete",
+        "tags": [
+          "PrivateEndpointConnectionResources"
+        ],
+        "description": "Delete Private Endpoint requests. This call is made by Backup Admin.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "The name of the VaultResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.RecoveryServices/vaults/{vaultName}/privateEndpointConnections/{privateEndpointConnectionName}/operationsStatus/{operationId}": {
+      "get": {
+        "operationId": "PrivateEndpoint_GetOperationStatus",
+        "tags": [
+          "PrivateEndpointOperationStatuses"
+        ],
+        "description": "Gets the operation status for a private endpoint connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vaultName",
+            "in": "path",
+            "description": "vaults",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the PrivateEndpointConnectionResource",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The name of the PrivateEndpointConnectionResource",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationStatus"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AcquireStorageAccountLock": {
+      "type": "string",
+      "description": "Whether storage account lock is to be acquired for this container or not.",
+      "enum": [
+        "Acquire",
+        "NotAcquire"
+      ],
+      "x-ms-enum": {
+        "name": "AcquireStorageAccountLock",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Acquire",
+            "value": "Acquire"
+          },
+          {
+            "name": "NotAcquire",
+            "value": "NotAcquire"
+          }
+        ]
+      }
+    },
+    "Azure.Core.azureLocation": {
+      "type": "string",
+      "description": "Represents an Azure geography region where supported resource providers live."
+    },
+    "AzureBackupGoalFeatureSupportRequest": {
+      "type": "object",
+      "description": "Azure backup goal feature specific request.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FeatureSupportRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureBackupGoals"
+    },
+    "AzureBackupServerContainer": {
+      "type": "object",
+      "description": "AzureBackupServer (DPMVenus) workload-specific protection container.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DpmContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureBackupServerContainer"
+    },
+    "AzureBackupServerEngine": {
+      "type": "object",
+      "description": "Backup engine type when Azure Backup Server is used to manage the backups.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupEngineBase"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureBackupServerEngine"
+    },
+    "AzureFileShareBackupRequest": {
+      "type": "object",
+      "description": "AzureFileShare workload-specific backup request.",
+      "properties": {
+        "recoveryPointExpiryTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Backup copy will expire after the time specified (UTC)."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShareBackupRequest"
+    },
+    "AzureFileShareProtectableItem": {
+      "type": "object",
+      "description": "Protectable item for Azure Fileshare workloads.",
+      "properties": {
+        "parentContainerFabricId": {
+          "type": "string",
+          "description": "Full Fabric ID of container to which this protectable item belongs. For example, ARM ID."
+        },
+        "parentContainerFriendlyName": {
+          "type": "string",
+          "description": "Friendly name of container to which this protectable item belongs."
+        },
+        "azureFileShareType": {
+          "$ref": "#/definitions/AzureFileShareType",
+          "description": "File Share type XSync or XSMB."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/WorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShare"
+    },
+    "AzureFileShareProtectionPolicy": {
+      "type": "object",
+      "description": "AzureStorage backup policy.",
+      "properties": {
+        "workLoadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Type of workload for the backup management"
+        },
+        "schedulePolicy": {
+          "$ref": "#/definitions/SchedulePolicy",
+          "description": "Backup schedule specified as part of backup policy."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Retention policy with the details on backup copy retention ranges."
+        },
+        "vaultRetentionPolicy": {
+          "$ref": "#/definitions/VaultRetentionPolicy",
+          "description": "Retention policy with the details on hardened backup copy retention ranges."
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "TimeZone optional input as string. For example: TimeZone = \"Pacific Standard Time\"."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureStorage"
+    },
+    "AzureFileShareProvisionILRRequest": {
+      "type": "object",
+      "description": "Update snapshot Uri with the correct friendly Name of the source Azure file share.",
+      "properties": {
+        "recoveryPointId": {
+          "type": "string",
+          "description": "Recovery point ID."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "Source Storage account ARM Id"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ILRRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShareProvisionILRRequest"
+    },
+    "AzureFileShareRecoveryPoint": {
+      "type": "object",
+      "description": "Azure File Share workload specific backup copy.",
+      "properties": {
+        "recoveryPointType": {
+          "type": "string",
+          "description": "Type of the backup copy. Specifies whether it is a crash consistent backup or app consistent."
+        },
+        "recoveryPointTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which this backup copy was created."
+        },
+        "fileShareSnapshotUri": {
+          "type": "string",
+          "description": "Contains Url to the snapshot of fileshare, if applicable"
+        },
+        "recoveryPointSizeInGB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Contains recovery point size"
+        },
+        "recoveryPointProperties": {
+          "$ref": "#/definitions/RecoveryPointProperties",
+          "description": "Properties of Recovery Point"
+        },
+        "recoveryPointTierDetails": {
+          "type": "array",
+          "description": "Recovery point tier information.",
+          "items": {
+            "$ref": "#/definitions/RecoveryPointTierInformation"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShareRecoveryPoint"
+    },
+    "AzureFileShareRestoreRequest": {
+      "type": "object",
+      "description": "AzureFileShare Restore Request",
+      "properties": {
+        "recoveryType": {
+          "$ref": "#/definitions/RecoveryType",
+          "description": "Type of this recovery."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "Source storage account ARM Id"
+        },
+        "copyOptions": {
+          "$ref": "#/definitions/CopyOptions",
+          "description": "Options to resolve copy conflicts."
+        },
+        "restoreRequestType": {
+          "$ref": "#/definitions/RestoreRequestType",
+          "description": "Restore Type (FullShareRestore or ItemLevelRestore)"
+        },
+        "restoreFileSpecs": {
+          "type": "array",
+          "description": "List of Source Files/Folders(which need to recover) and TargetFolderPath details",
+          "items": {
+            "$ref": "#/definitions/RestoreFileSpecs"
+          },
+          "x-ms-identifiers": []
+        },
+        "targetDetails": {
+          "$ref": "#/definitions/TargetAFSRestoreInfo",
+          "description": "Target File Share Details"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShareRestoreRequest"
+    },
+    "AzureFileShareType": {
+      "type": "string",
+      "description": "File Share type XSync or XSMB.",
+      "enum": [
+        "Invalid",
+        "XSMB",
+        "XSync"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFileShareType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "XSMB",
+            "value": "XSMB"
+          },
+          {
+            "name": "XSync",
+            "value": "XSync"
+          }
+        ]
+      }
+    },
+    "AzureFileshareProtectedItem": {
+      "type": "object",
+      "description": "Azure File Share workload-specific backup item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the fileshare represented by this backup item."
+        },
+        "protectionStatus": {
+          "type": "string",
+          "description": "Backup status of this backup item."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionState",
+          "description": "Backup state of this backup item."
+        },
+        "lastBackupStatus": {
+          "type": "string",
+          "description": "Last backup operation status. Possible values: Healthy, Unhealthy."
+        },
+        "lastBackupTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last backup operation on this backup item."
+        },
+        "kpisHealths": {
+          "type": "object",
+          "description": "Health details of different KPIs",
+          "additionalProperties": {
+            "$ref": "#/definitions/KPIResourceHealthDetails"
+          }
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureFileshareProtectedItemExtendedInfo",
+          "description": "Additional information with this backup item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureFileShareProtectedItem"
+    },
+    "AzureFileshareProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information about Azure File Share backup item.",
+      "properties": {
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this item in the service."
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of available backup copies associated with this backup item."
+        },
+        "policyState": {
+          "type": "string",
+          "description": "Indicates consistency of policy object and policy applied to this backup item."
+        },
+        "resourceState": {
+          "type": "string",
+          "description": "Indicates the state of this resource. Possible values are from enum ResourceState {Invalid, Active, SoftDeleted, Deleted}",
+          "readOnly": true
+        },
+        "resourceStateSyncTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The resource state sync time for this backup item.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureIaaSClassicComputeVMContainer": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing a classic virtual machine.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IaaSVMContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.ClassicCompute/virtualMachines"
+    },
+    "AzureIaaSClassicComputeVMProtectableItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing the Classic Compute VM.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IaaSVMProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.ClassicCompute/virtualMachines"
+    },
+    "AzureIaaSClassicComputeVMProtectedItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing the Classic Compute VM.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureIaaSVMProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.ClassicCompute/virtualMachines"
+    },
+    "AzureIaaSComputeVMContainer": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing an Azure Resource Manager virtual machine.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IaaSVMContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.Compute/virtualMachines"
+    },
+    "AzureIaaSComputeVMProtectableItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing the Azure Resource Manager VM.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IaaSVMProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.Compute/virtualMachines"
+    },
+    "AzureIaaSComputeVMProtectedItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item representing the Azure Resource Manager VM.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureIaaSVMProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.Compute/virtualMachines"
+    },
+    "AzureIaaSVMErrorInfo": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific error information.",
+      "properties": {
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Error code.",
+          "readOnly": true
+        },
+        "errorTitle": {
+          "type": "string",
+          "description": "Title: Typically, the entity that the error pertains to.",
+          "readOnly": true
+        },
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string.",
+          "readOnly": true
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations for above error code.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "AzureIaaSVMHealthDetails": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific Health Details.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceHealthDetails"
+        }
+      ]
+    },
+    "AzureIaaSVMJob": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific job object.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed during the execution of this job."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "Gets or sets the state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Error details on execution of this job.",
+          "items": {
+            "$ref": "#/definitions/AzureIaaSVMErrorInfo"
+          },
+          "x-ms-identifiers": [
+            "errorCode"
+          ]
+        },
+        "virtualMachineVersion": {
+          "type": "string",
+          "description": "Specifies whether the backup item is a Classic or an Azure Resource Manager VM."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureIaaSVMJobExtendedInfo",
+          "description": "Additional information for this job."
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Container name of the entity on which the current job is executing."
+        },
+        "isUserTriggered": {
+          "type": "boolean",
+          "description": "Indicated that whether the job is adhoc(true) or scheduled(false)"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureIaaSVMJob"
+    },
+    "AzureIaaSVMJobExtendedInfo": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific additional information for job.",
+      "properties": {
+        "tasksList": {
+          "type": "array",
+          "description": "List of tasks associated with this job.",
+          "items": {
+            "$ref": "#/definitions/AzureIaaSVMJobTaskDetails"
+          },
+          "x-ms-identifiers": [
+            "taskId"
+          ]
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "Job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "internalPropertyBag": {
+          "type": "object",
+          "description": "Job internal properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "progressPercentage": {
+          "type": "number",
+          "format": "double",
+          "description": "Indicates progress of the job. Null if it has not started or completed."
+        },
+        "estimatedRemainingDuration": {
+          "type": "string",
+          "description": "Time remaining for execution of this job."
+        },
+        "dynamicErrorMessage": {
+          "type": "string",
+          "description": "Non localized error message on job execution."
+        }
+      }
+    },
+    "AzureIaaSVMJobTaskDetails": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific job task details.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "The task display name."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time."
+        },
+        "instanceId": {
+          "type": "string",
+          "description": "The instanceId."
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed for task."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status."
+        },
+        "progressPercentage": {
+          "type": "number",
+          "format": "double",
+          "description": "Progress of the task."
+        },
+        "taskExecutionDetails": {
+          "type": "string",
+          "description": "Details about execution of the task.\neg: number of bytes transferred etc"
+        }
+      }
+    },
+    "AzureIaaSVMJobV2": {
+      "type": "object",
+      "description": "Azure IaaS VM workload-specific job object.",
+      "properties": {
+        "actionsInfo": {
+          "type": "array",
+          "description": "Gets or sets the state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Container name of the entity on which the current job is executing."
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed during the execution of this job."
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Error details on execution of this job.",
+          "items": {
+            "$ref": "#/definitions/AzureIaaSVMErrorInfo"
+          },
+          "x-ms-identifiers": [
+            "errorCode"
+          ]
+        },
+        "virtualMachineVersion": {
+          "type": "string",
+          "description": "Specifies whether the backup item is a Classic or an Azure Resource Manager VM."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureIaaSVMJobExtendedInfo",
+          "description": "Additional information for this job."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureIaaSVMJobV2"
+    },
+    "AzureIaaSVMProtectedItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the VM represented by this backup item.",
+          "readOnly": true
+        },
+        "virtualMachineId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the virtual machine represented by this item.",
+          "readOnly": true
+        },
+        "protectionStatus": {
+          "type": "string",
+          "description": "Backup status of this backup item."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionState",
+          "description": "Backup state of this backup item."
+        },
+        "healthStatus": {
+          "$ref": "#/definitions/HealthStatus",
+          "description": "Health status of protected item.",
+          "readOnly": true
+        },
+        "healthDetails": {
+          "type": "array",
+          "description": "Health details on this backup item.",
+          "items": {
+            "$ref": "#/definitions/AzureIaaSVMHealthDetails"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        },
+        "kpisHealths": {
+          "type": "object",
+          "description": "Health details of different KPIs",
+          "additionalProperties": {
+            "$ref": "#/definitions/KPIResourceHealthDetails"
+          }
+        },
+        "lastBackupStatus": {
+          "type": "string",
+          "description": "Last backup operation status."
+        },
+        "lastBackupTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last backup operation on this backup item.",
+          "readOnly": true
+        },
+        "protectedItemDataId": {
+          "type": "string",
+          "description": "Data ID of the protected item.",
+          "readOnly": true
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureIaaSVMProtectedItemExtendedInfo",
+          "description": "Additional information for this backup item."
+        },
+        "extendedProperties": {
+          "$ref": "#/definitions/ExtendedProperties",
+          "description": "Extended Properties for Azure IaasVM Backup."
+        },
+        "policyType": {
+          "type": "string",
+          "description": "Type of the policy used for protection",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureIaaSVMProtectedItem"
+    },
+    "AzureIaaSVMProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on Azure IaaS VM specific backup item.",
+      "properties": {
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item across all tiers."
+        },
+        "oldestRecoveryPointInVault": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item in vault tier"
+        },
+        "oldestRecoveryPointInArchive": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item in archive tier"
+        },
+        "newestRecoveryPointInArchive": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The latest backup copy available for this backup item in archive tier"
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of backup copies available for this backup item."
+        },
+        "policyInconsistent": {
+          "type": "boolean",
+          "description": "Specifies if backup policy associated with the backup item is inconsistent."
+        }
+      }
+    },
+    "AzureIaaSVMProtectionPolicy": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup policy.",
+      "properties": {
+        "instantRPDetails": {
+          "$ref": "#/definitions/InstantRPAdditionalDetails"
+        },
+        "schedulePolicy": {
+          "$ref": "#/definitions/SchedulePolicy",
+          "description": "Backup schedule specified as part of backup policy."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Retention policy with the details on backup copy retention ranges."
+        },
+        "tieringPolicy": {
+          "type": "object",
+          "description": "Tiering policy to automatically move RPs to another tier\nKey is Target Tier, defined in RecoveryPointTierType enum.\nTiering policy specifies the criteria to move RP to the target tier.",
+          "additionalProperties": {
+            "$ref": "#/definitions/TieringPolicy"
+          }
+        },
+        "instantRpRetentionRangeInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Instant RP retention policy range in days"
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "TimeZone optional input as string. For example: TimeZone = \"Pacific Standard Time\"."
+        },
+        "policyType": {
+          "$ref": "#/definitions/IAASVMPolicyType"
+        },
+        "snapshotConsistencyType": {
+          "$ref": "#/definitions/IaasVMSnapshotConsistencyType"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureIaasVM"
+    },
+    "AzureRecoveryServiceVaultProtectionIntent": {
+      "type": "object",
+      "description": "Azure Recovery Services Vault specific protection intent item.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionIntent"
+        }
+      ],
+      "x-ms-discriminator-value": "RecoveryServiceVaultItem"
+    },
+    "AzureResourceProtectionIntent": {
+      "type": "object",
+      "description": "IaaS VM specific backup protection intent item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the VM represented by this backup item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionIntent"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureResourceItem"
+    },
+    "AzureSQLAGWorkloadContainerProtectionContainer": {
+      "type": "object",
+      "description": "Container for SQL workloads under SQL Availability Group.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLAGWorkLoadContainer"
+    },
+    "AzureSqlContainer": {
+      "type": "object",
+      "description": "Azure Sql workload-specific container.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSqlContainer"
+    },
+    "AzureSqlProtectedItem": {
+      "type": "object",
+      "description": "Azure SQL workload-specific backup item.",
+      "properties": {
+        "protectedItemDataId": {
+          "type": "string",
+          "description": "Internal ID of a backup item. Used by Azure SQL Backup engine to contact Recovery Services."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectedItemState",
+          "description": "Backup state of the backed up item."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureSqlProtectedItemExtendedInfo",
+          "description": "Additional information for this backup item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "Microsoft.Sql/servers/databases"
+    },
+    "AzureSqlProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on Azure Sql specific protected item.",
+      "properties": {
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this item in the service."
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of available backup copies associated with this backup item."
+        },
+        "policyState": {
+          "type": "string",
+          "description": "State of the backup policy associated with this backup item."
+        }
+      }
+    },
+    "AzureSqlProtectionPolicy": {
+      "type": "object",
+      "description": "Azure SQL workload-specific backup policy.",
+      "properties": {
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Retention policy details."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureSql"
+    },
+    "AzureStorageContainer": {
+      "type": "object",
+      "description": "Azure Storage Account workload-specific container.",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "description": "Fully qualified ARM url."
+        },
+        "storageAccountVersion": {
+          "type": "string",
+          "description": "Storage account version."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "Resource group name of Recovery Services Vault."
+        },
+        "protectedItemCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of items backed up in this container."
+        },
+        "acquireStorageAccountLock": {
+          "$ref": "#/definitions/AcquireStorageAccountLock",
+          "description": "Whether storage account lock is to be acquired for this container or not."
+        },
+        "operationType": {
+          "$ref": "#/definitions/OperationType",
+          "description": "Re-Do Operation"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "StorageContainer"
+    },
+    "AzureStorageErrorInfo": {
+      "type": "object",
+      "description": "Azure storage specific error information",
+      "properties": {
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Error code."
+        },
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string."
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations for above error code.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AzureStorageJob": {
+      "type": "object",
+      "description": "Azure storage specific job.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed during the execution of this job."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "Gets or sets the state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Error details on execution of this job.",
+          "items": {
+            "$ref": "#/definitions/AzureStorageErrorInfo"
+          },
+          "x-ms-identifiers": [
+            "errorCode"
+          ]
+        },
+        "storageAccountName": {
+          "type": "string",
+          "description": "Specifies friendly name of the storage account."
+        },
+        "storageAccountVersion": {
+          "type": "string",
+          "description": "Specifies whether the Storage account is a Classic or an Azure Resource Manager Storage account."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureStorageJobExtendedInfo",
+          "description": "Additional information about the job."
+        },
+        "isUserTriggered": {
+          "type": "boolean",
+          "description": "Indicated that whether the job is adhoc(true) or scheduled(false)"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureStorageJob"
+    },
+    "AzureStorageJobExtendedInfo": {
+      "type": "object",
+      "description": "Azure Storage workload-specific additional information for job.",
+      "properties": {
+        "tasksList": {
+          "type": "array",
+          "description": "List of tasks for this job",
+          "items": {
+            "$ref": "#/definitions/AzureStorageJobTaskDetails"
+          },
+          "x-ms-identifiers": [
+            "taskId"
+          ]
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "Job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dynamicErrorMessage": {
+          "type": "string",
+          "description": "Non localized error message on job execution."
+        }
+      }
+    },
+    "AzureStorageJobTaskDetails": {
+      "type": "object",
+      "description": "Azure storage workload specific job task details.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "The task display name."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status."
+        }
+      }
+    },
+    "AzureStorageProtectableContainer": {
+      "type": "object",
+      "description": "Azure Storage-specific protectable containers",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectableContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "StorageContainer"
+    },
+    "AzureVMAppContainerProtectableContainer": {
+      "type": "object",
+      "description": "Azure workload-specific container",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectableContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "VMAppContainer"
+    },
+    "AzureVMAppContainerProtectionContainer": {
+      "type": "object",
+      "description": "Container for SQL workloads under Azure Virtual Machines.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "VMAppContainer"
+    },
+    "AzureVMResourceFeatureSupportRequest": {
+      "type": "object",
+      "description": "AzureResource(IaaS VM) Specific feature support request",
+      "properties": {
+        "vmSize": {
+          "type": "string",
+          "description": "Size of the resource: VM size(A/D series etc) in case of IaasVM"
+        },
+        "vmSku": {
+          "type": "string",
+          "description": "SKUs (Premium/Managed etc) in case of IaasVM"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FeatureSupportRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVMResourceBackup"
+    },
+    "AzureVMResourceFeatureSupportResponse": {
+      "type": "object",
+      "description": "Response for feature support requests for Azure IaasVm",
+      "properties": {
+        "supportStatus": {
+          "$ref": "#/definitions/SupportStatus",
+          "description": "Support status of feature"
+        }
+      }
+    },
+    "AzureVmWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item.",
+      "properties": {
+        "parentName": {
+          "type": "string",
+          "description": "Name for instance or AG"
+        },
+        "serverName": {
+          "type": "string",
+          "description": "Host/Cluster Name for instance or AG"
+        },
+        "isAutoProtectable": {
+          "type": "boolean",
+          "description": "Indicates if workload item is auto-protectable"
+        },
+        "subinquireditemcount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "For instance or AG, indicates number of DB's present"
+        },
+        "subWorkloadItemCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "For instance or AG, indicates number of DB's to be protected"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/WorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadItem"
+    },
+    "AzureVmWorkloadProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item.",
+      "properties": {
+        "parentName": {
+          "type": "string",
+          "description": "Name for instance or AG"
+        },
+        "parentUniqueName": {
+          "type": "string",
+          "description": "Parent Unique Name is added to provide the service formatted URI Name of the Parent\nOnly Applicable for data bases where the parent would be either Instance or a SQL AG."
+        },
+        "serverName": {
+          "type": "string",
+          "description": "Host/Cluster Name for instance or AG"
+        },
+        "isAutoProtectable": {
+          "type": "boolean",
+          "description": "Indicates if protectable item is auto-protectable"
+        },
+        "isAutoProtected": {
+          "type": "boolean",
+          "description": "Indicates if protectable item is auto-protected"
+        },
+        "subinquireditemcount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "For instance or AG, indicates number of DB's present"
+        },
+        "subprotectableitemcount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "For instance or AG, indicates number of DB's to be protected"
+        },
+        "prebackupvalidation": {
+          "$ref": "#/definitions/PreBackupValidation",
+          "description": "Pre-backup validation for protectable objects"
+        },
+        "isProtectable": {
+          "type": "boolean",
+          "description": "Indicates if item is protectable"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/WorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadProtectableItem"
+    },
+    "AzureVmWorkloadProtectedItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protected item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the DB represented by this backup item.",
+          "readOnly": true
+        },
+        "serverName": {
+          "type": "string",
+          "description": "Host/Cluster Name for instance or AG"
+        },
+        "parentName": {
+          "type": "string",
+          "description": "Parent name of the DB such as Instance or Availability Group."
+        },
+        "parentType": {
+          "type": "string",
+          "description": "Parent type of protected item, example: for a DB, standalone server or distributed"
+        },
+        "protectionStatus": {
+          "type": "string",
+          "description": "Backup status of this backup item.",
+          "readOnly": true
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionState",
+          "description": "Backup state of this backup item."
+        },
+        "lastBackupStatus": {
+          "$ref": "#/definitions/LastBackupStatus",
+          "description": "Last backup operation status. Possible values: Healthy, Unhealthy."
+        },
+        "lastBackupTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last backup operation on this backup item."
+        },
+        "lastBackupErrorDetail": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "Error details in last backup"
+        },
+        "protectedItemDataSourceId": {
+          "type": "string",
+          "description": "Data ID of the protected item."
+        },
+        "protectedItemHealthStatus": {
+          "$ref": "#/definitions/ProtectedItemHealthStatus",
+          "description": "Health status of the backup item, evaluated based on last heartbeat received"
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureVmWorkloadProtectedItemExtendedInfo",
+          "description": "Additional information for this backup item."
+        },
+        "kpisHealths": {
+          "type": "object",
+          "description": "Health details of different KPIs",
+          "additionalProperties": {
+            "$ref": "#/definitions/KPIResourceHealthDetails"
+          }
+        },
+        "nodesList": {
+          "type": "array",
+          "description": "List of the nodes in case of distributed container.",
+          "items": {
+            "$ref": "#/definitions/DistributedNodesInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadProtectedItem"
+    },
+    "AzureVmWorkloadProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on Azure Workload for SQL specific backup item.",
+      "properties": {
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item across all tiers."
+        },
+        "oldestRecoveryPointInVault": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item in vault tier"
+        },
+        "oldestRecoveryPointInArchive": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available for this backup item in archive tier"
+        },
+        "newestRecoveryPointInArchive": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The latest backup copy available for this backup item in archive tier"
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of backup copies available for this backup item."
+        },
+        "policyState": {
+          "type": "string",
+          "description": "Indicates consistency of policy object and policy applied to this backup item."
+        },
+        "recoveryModel": {
+          "type": "string",
+          "description": "Indicates consistency of policy object and policy applied to this backup item."
+        }
+      }
+    },
+    "AzureVmWorkloadProtectionPolicy": {
+      "type": "object",
+      "description": "Azure VM (Mercury) workload-specific backup policy.",
+      "properties": {
+        "workLoadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Type of workload for the backup management"
+        },
+        "settings": {
+          "$ref": "#/definitions/Settings",
+          "description": "Common settings for the backup management"
+        },
+        "subProtectionPolicy": {
+          "type": "array",
+          "description": "List of sub-protection policies which includes schedule and retention",
+          "items": {
+            "$ref": "#/definitions/SubProtectionPolicy"
+          },
+          "x-ms-identifiers": []
+        },
+        "makePolicyConsistent": {
+          "type": "boolean",
+          "description": "Fix the policy inconsistency"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkload"
+    },
+    "AzureVmWorkloadSAPAseDatabaseProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SAP ASE Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPAseDatabase"
+    },
+    "AzureVmWorkloadSAPAseDatabaseProtectedItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protected item representing SAP ASE Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadSAPAseDatabase"
+    },
+    "AzureVmWorkloadSAPAseDatabaseWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SAP ASE Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPAseDatabase"
+    },
+    "AzureVmWorkloadSAPAseSystemProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SAP ASE System.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPAseSystem"
+    },
+    "AzureVmWorkloadSAPAseSystemWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SAP ASE System.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPAseSystem"
+    },
+    "AzureVmWorkloadSAPHanaDBInstance": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SAP HANA Dbinstance.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPHanaDBInstance"
+    },
+    "AzureVmWorkloadSAPHanaDBInstanceProtectedItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protected item representing SAP HANA DBInstance.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadSAPHanaDBInstance"
+    },
+    "AzureVmWorkloadSAPHanaDatabaseProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SAP HANA Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPHanaDatabase"
+    },
+    "AzureVmWorkloadSAPHanaDatabaseProtectedItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protected item representing SAP HANA Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadSAPHanaDatabase"
+    },
+    "AzureVmWorkloadSAPHanaDatabaseWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SAP HANA Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPHanaDatabase"
+    },
+    "AzureVmWorkloadSAPHanaHSRProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing HANA HSR.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "HanaHSRContainer"
+    },
+    "AzureVmWorkloadSAPHanaSystemProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SAP HANA System.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPHanaSystem"
+    },
+    "AzureVmWorkloadSAPHanaSystemWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SAP HANA System.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SAPHanaSystem"
+    },
+    "AzureVmWorkloadSQLAvailabilityGroupProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SQL Availability Group.",
+      "properties": {
+        "nodesList": {
+          "type": "array",
+          "description": "List of the nodes in case of distributed container.",
+          "items": {
+            "$ref": "#/definitions/DistributedNodesInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLAvailabilityGroupContainer"
+    },
+    "AzureVmWorkloadSQLDatabaseProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SQL Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLDataBase"
+    },
+    "AzureVmWorkloadSQLDatabaseProtectedItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protected item representing SQL Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureVmWorkloadSQLDatabase"
+    },
+    "AzureVmWorkloadSQLDatabaseWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SQL Database.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLDataBase"
+    },
+    "AzureVmWorkloadSQLInstanceProtectableItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific protectable item representing SQL Instance.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLInstance"
+    },
+    "AzureVmWorkloadSQLInstanceWorkloadItem": {
+      "type": "object",
+      "description": "Azure VM workload-specific workload item representing SQL Instance.",
+      "properties": {
+        "dataDirectoryPaths": {
+          "type": "array",
+          "description": "Data Directory Paths for default directories",
+          "items": {
+            "$ref": "#/definitions/SQLDataDirectory"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureVmWorkloadItem"
+        }
+      ],
+      "x-ms-discriminator-value": "SQLInstance"
+    },
+    "AzureWorkloadAutoProtectionIntent": {
+      "type": "object",
+      "description": "Azure Recovery Services Vault specific protection intent item.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureRecoveryServiceVaultProtectionIntent"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadAutoProtectionIntent"
+    },
+    "AzureWorkloadBackupRequest": {
+      "type": "object",
+      "description": "AzureWorkload workload-specific backup request.",
+      "properties": {
+        "backupType": {
+          "$ref": "#/definitions/BackupType",
+          "description": "Type of backup, viz. Full, Differential, Log or CopyOnlyFull"
+        },
+        "enableCompression": {
+          "type": "boolean",
+          "description": "Bool for Compression setting"
+        },
+        "recoveryPointExpiryTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Backup copy will expire after the time specified (UTC)."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadBackupRequest"
+    },
+    "AzureWorkloadContainer": {
+      "type": "object",
+      "description": "Container for the workloads running inside Azure Compute or Classic Compute.",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM ID of the virtual machine represented by this Azure Workload Container"
+        },
+        "lastUpdatedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time stamp when this container was updated."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureWorkloadContainerExtendedInfo",
+          "description": "Additional details of a workload container."
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type for which registration was sent."
+        },
+        "operationType": {
+          "$ref": "#/definitions/OperationType",
+          "description": "Re-Do Operation"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadContainer"
+    },
+    "AzureWorkloadContainerAutoProtectionIntent": {
+      "type": "object",
+      "description": "Azure workload specific protection intent item.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionIntent"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadContainerAutoProtectionIntent"
+    },
+    "AzureWorkloadContainerExtendedInfo": {
+      "type": "object",
+      "description": "Extended information of the container.",
+      "properties": {
+        "hostServerName": {
+          "type": "string",
+          "description": "Host Os Name in case of Stand Alone and Cluster Name in case of distributed container."
+        },
+        "inquiryInfo": {
+          "$ref": "#/definitions/InquiryInfo",
+          "description": "Inquiry Status for the container."
+        },
+        "nodesList": {
+          "type": "array",
+          "description": "List of the nodes in case of distributed container.",
+          "items": {
+            "$ref": "#/definitions/DistributedNodesInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "AzureWorkloadErrorInfo": {
+      "type": "object",
+      "description": "Azure storage specific error information",
+      "properties": {
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Error code."
+        },
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string."
+        },
+        "errorTitle": {
+          "type": "string",
+          "description": "Title: Typically, the entity that the error pertains to."
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations for above error code.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "additionalDetails": {
+          "type": "string",
+          "description": "Additional details for above error code."
+        }
+      }
+    },
+    "AzureWorkloadJob": {
+      "type": "object",
+      "description": "Azure storage specific job.",
+      "properties": {
+        "workloadType": {
+          "type": "string",
+          "description": "Workload type of the job"
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed during the execution of this job."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "Gets or sets the state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Error details on execution of this job.",
+          "items": {
+            "$ref": "#/definitions/AzureWorkloadErrorInfo"
+          },
+          "x-ms-identifiers": [
+            "errorCode"
+          ]
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureWorkloadJobExtendedInfo",
+          "description": "Additional information about the job."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadJob"
+    },
+    "AzureWorkloadJobExtendedInfo": {
+      "type": "object",
+      "description": "Azure VM workload-specific additional information for job.",
+      "properties": {
+        "tasksList": {
+          "type": "array",
+          "description": "List of tasks for this job",
+          "items": {
+            "$ref": "#/definitions/AzureWorkloadJobTaskDetails"
+          },
+          "x-ms-identifiers": [
+            "taskId"
+          ]
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "Job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dynamicErrorMessage": {
+          "type": "string",
+          "description": "Non localized error message on job execution."
+        }
+      }
+    },
+    "AzureWorkloadJobTaskDetails": {
+      "type": "object",
+      "description": "Azure VM workload specific job task details.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "The task display name."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status."
+        }
+      }
+    },
+    "AzureWorkloadPointInTimeRecoveryPoint": {
+      "type": "object",
+      "description": "Recovery point specific to PointInTime",
+      "properties": {
+        "timeRanges": {
+          "type": "array",
+          "description": "List of log ranges",
+          "items": {
+            "$ref": "#/definitions/PointInTimeRange"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadPointInTimeRecoveryPoint"
+    },
+    "AzureWorkloadPointInTimeRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Hana -specific restore. Specifically for PointInTime/Log restore",
+      "properties": {
+        "pointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "PointInTime value"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadPointInTimeRestoreRequest"
+    },
+    "AzureWorkloadRecoveryPoint": {
+      "type": "object",
+      "description": "Workload specific recovery point, specifically encapsulates full/diff recovery point",
+      "properties": {
+        "recoveryPointTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC time at which recovery point was created"
+        },
+        "type": {
+          "$ref": "#/definitions/RestorePointType",
+          "description": "Type of restore point"
+        },
+        "recoveryPointTierDetails": {
+          "type": "array",
+          "description": "Recovery point tier information.",
+          "items": {
+            "$ref": "#/definitions/RecoveryPointTierInformationV2"
+          },
+          "x-ms-identifiers": []
+        },
+        "recoveryPointMoveReadinessInfo": {
+          "type": "object",
+          "description": "Eligibility of RP to be moved to another tier",
+          "additionalProperties": {
+            "$ref": "#/definitions/RecoveryPointMoveReadinessInfo"
+          }
+        },
+        "recoveryPointProperties": {
+          "$ref": "#/definitions/RecoveryPointProperties",
+          "description": "Properties of Recovery Point"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadRecoveryPoint"
+    },
+    "AzureWorkloadRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload-specific restore.",
+      "properties": {
+        "recoveryType": {
+          "$ref": "#/definitions/RecoveryType",
+          "description": "Type of this recovery."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the VM on which workload that was running is being recovered."
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "Workload specific property bag.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "targetInfo": {
+          "$ref": "#/definitions/TargetRestoreInfo",
+          "description": "Details of target database"
+        },
+        "recoveryMode": {
+          "$ref": "#/definitions/RecoveryMode",
+          "description": "Defines whether the current recovery mode is file restore or database restore"
+        },
+        "targetResourceGroupName": {
+          "type": "string",
+          "description": "Defines the Resource group of the Target VM"
+        },
+        "userAssignedManagedIdentityDetails": {
+          "$ref": "#/definitions/UserAssignedManagedIdentityDetails",
+          "description": "User Assigned managed identity details\nCurrently used for snapshot."
+        },
+        "snapshotRestoreParameters": {
+          "$ref": "#/definitions/SnapshotRestoreParameters",
+          "description": "Additional details for snapshot recovery\nCurrently used for snapshot for SAP Hana."
+        },
+        "targetVirtualMachineId": {
+          "type": "string",
+          "description": "This is the complete ARM Id of the target VM\nFor e.g. /subscriptions/{subId}/resourcegroups/{rg}/provider/Microsoft.Compute/virtualmachines/{vm}"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadRestoreRequest"
+    },
+    "AzureWorkloadSAPAsePointInTimeRecoveryPoint": {
+      "type": "object",
+      "description": "Recovery point specific to PointInTime in SAPAse",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadPointInTimeRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPAsePointInTimeRecoveryPoint"
+    },
+    "AzureWorkloadSAPAsePointInTimeRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Ase-specific restore. Specifically for PointInTime/Log restore",
+      "properties": {
+        "pointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "PointInTime value"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSAPAseRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPAsePointInTimeRestoreRequest"
+    },
+    "AzureWorkloadSAPAseRecoveryPoint": {
+      "type": "object",
+      "description": "SAPAse specific recoverypoint, specifically encapsulates full/diff recoverypoints",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPAseRecoveryPoint"
+    },
+    "AzureWorkloadSAPAseRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Ase-specific restore.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPAseRestoreRequest"
+    },
+    "AzureWorkloadSAPHanaPointInTimeRecoveryPoint": {
+      "type": "object",
+      "description": "Recovery point specific to PointInTime in SAPHana",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadPointInTimeRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaPointInTimeRecoveryPoint"
+    },
+    "AzureWorkloadSAPHanaPointInTimeRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Hana -specific restore. Specifically for PointInTime/Log restore",
+      "properties": {
+        "pointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "PointInTime value"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSAPHanaRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaPointInTimeRestoreRequest"
+    },
+    "AzureWorkloadSAPHanaPointInTimeRestoreWithRehydrateRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Hana-specific restore with integrated rehydration of recovery point.",
+      "properties": {
+        "recoveryPointRehydrationInfo": {
+          "$ref": "#/definitions/RecoveryPointRehydrationInfo",
+          "description": "RP Rehydration Info"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSAPHanaPointInTimeRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaPointInTimeRestoreWithRehydrateRequest"
+    },
+    "AzureWorkloadSAPHanaRecoveryPoint": {
+      "type": "object",
+      "description": "SAPHana specific recoverypoint, specifically encapsulates full/diff recoverypoints",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaRecoveryPoint"
+    },
+    "AzureWorkloadSAPHanaRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Hana-specific restore.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaRestoreRequest"
+    },
+    "AzureWorkloadSAPHanaRestoreWithRehydrateRequest": {
+      "type": "object",
+      "description": "AzureWorkload SAP Hana-specific restore with integrated rehydration of recovery point.",
+      "properties": {
+        "recoveryPointRehydrationInfo": {
+          "$ref": "#/definitions/RecoveryPointRehydrationInfo",
+          "description": "RP Rehydration Info"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSAPHanaRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSAPHanaRestoreWithRehydrateRequest"
+    },
+    "AzureWorkloadSQLAutoProtectionIntent": {
+      "type": "object",
+      "description": "Azure Workload SQL Auto Protection intent item.",
+      "properties": {
+        "workloadItemType": {
+          "$ref": "#/definitions/WorkloadItemType",
+          "description": "Workload item type of the item for which intent is to be set"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadAutoProtectionIntent"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLAutoProtectionIntent"
+    },
+    "AzureWorkloadSQLPointInTimeRecoveryPoint": {
+      "type": "object",
+      "description": "Recovery point specific to PointInTime",
+      "properties": {
+        "timeRanges": {
+          "type": "array",
+          "description": "List of log ranges",
+          "items": {
+            "$ref": "#/definitions/PointInTimeRange"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSQLRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLPointInTimeRecoveryPoint"
+    },
+    "AzureWorkloadSQLPointInTimeRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SQL -specific restore. Specifically for PointInTime/Log restore",
+      "properties": {
+        "pointInTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "PointInTime value"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSQLRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLPointInTimeRestoreRequest"
+    },
+    "AzureWorkloadSQLPointInTimeRestoreWithRehydrateRequest": {
+      "type": "object",
+      "description": "AzureWorkload SQL-specific restore with integrated rehydration of recovery point.",
+      "properties": {
+        "recoveryPointRehydrationInfo": {
+          "$ref": "#/definitions/RecoveryPointRehydrationInfo",
+          "description": "RP Rehydration Info"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSQLPointInTimeRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLPointInTimeRestoreWithRehydrateRequest"
+    },
+    "AzureWorkloadSQLRecoveryPoint": {
+      "type": "object",
+      "description": "SQL specific recoverypoint, specifically encapsulates full/diff recoverypoint along with extended info",
+      "properties": {
+        "extendedInfo": {
+          "$ref": "#/definitions/AzureWorkloadSQLRecoveryPointExtendedInfo",
+          "description": "Extended Info that provides data directory details. Will be populated in two cases:\nWhen a specific recovery point is accessed using GetRecoveryPoint\nOr when ListRecoveryPoints is called for Log RP only with ExtendedInfo query filter"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLRecoveryPoint"
+    },
+    "AzureWorkloadSQLRecoveryPointExtendedInfo": {
+      "type": "object",
+      "description": "Extended info class details",
+      "properties": {
+        "dataDirectoryTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC time at which data directory info was captured"
+        },
+        "dataDirectoryPaths": {
+          "type": "array",
+          "description": "List of data directory paths during restore operation.",
+          "items": {
+            "$ref": "#/definitions/SQLDataDirectory"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "AzureWorkloadSQLRestoreRequest": {
+      "type": "object",
+      "description": "AzureWorkload SQL -specific restore. Specifically for full/diff restore",
+      "properties": {
+        "shouldUseAlternateTargetLocation": {
+          "type": "boolean",
+          "description": "Default option set to true. If this is set to false, alternate data directory must be provided"
+        },
+        "isNonRecoverable": {
+          "type": "boolean",
+          "description": "SQL specific property where user can chose to set no-recovery when restore operation is tried"
+        },
+        "alternateDirectoryPaths": {
+          "type": "array",
+          "description": "Data directory details",
+          "items": {
+            "$ref": "#/definitions/SQLDataDirectoryMapping"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLRestoreRequest"
+    },
+    "AzureWorkloadSQLRestoreWithRehydrateRequest": {
+      "type": "object",
+      "description": "AzureWorkload SQL-specific restore with integrated rehydration of recovery point",
+      "properties": {
+        "recoveryPointRehydrationInfo": {
+          "$ref": "#/definitions/RecoveryPointRehydrationInfo",
+          "description": "RP Rehydration Info"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureWorkloadSQLRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureWorkloadSQLRestoreWithRehydrateRequest"
+    },
+    "BEKDetails": {
+      "type": "object",
+      "description": "BEK is bitlocker encryption key.",
+      "properties": {
+        "secretUrl": {
+          "type": "string",
+          "description": "Secret is BEK."
+        },
+        "secretVaultId": {
+          "type": "string",
+          "description": "ID of the Key Vault where this Secret is stored."
+        },
+        "secretData": {
+          "type": "string",
+          "description": "BEK data."
+        }
+      }
+    },
+    "BMSBackupEngineQueryObject": {
+      "type": "object",
+      "description": "Query parameters to fetch list of backup engines.",
+      "properties": {
+        "expand": {
+          "type": "string",
+          "description": "attribute to add extended info"
+        }
+      }
+    },
+    "BMSBackupEnginesQueryObject": {
+      "type": "object",
+      "description": "Query parameters to fetch list of backup engines.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for the backup engine."
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the backup engine."
+        },
+        "expand": {
+          "type": "string",
+          "description": "Attribute to add extended info."
+        }
+      }
+    },
+    "BMSBackupSummariesQueryObject": {
+      "type": "object",
+      "description": "Query parameters to fetch backup summaries.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "Backup management type for this container."
+        }
+      }
+    },
+    "BMSContainerQueryObject": {
+      "type": "object",
+      "description": "The query filters that can be used with the list containers API.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for this container."
+        },
+        "containerType": {
+          "$ref": "#/definitions/ContainerType",
+          "description": "Type of container for filter"
+        },
+        "backupEngineName": {
+          "type": "string",
+          "description": "Backup engine name"
+        },
+        "fabricName": {
+          "type": "string",
+          "description": "Fabric name for filter"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of registration of this container with the Recovery Services Vault."
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of this container."
+        }
+      },
+      "required": [
+        "backupManagementType"
+      ]
+    },
+    "BMSContainersInquiryQueryObject": {
+      "type": "object",
+      "description": "The query filters that can be used with the inquire container API.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for this container."
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type for this container."
+        }
+      }
+    },
+    "BMSRefreshContainersQueryObject": {
+      "type": "object",
+      "description": "The query filters that can be used with the refresh container API.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for this container."
+        }
+      }
+    },
+    "BMSWorkloadItemQueryObject": {
+      "type": "object",
+      "description": "Filters to list items that can be backed up.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type."
+        },
+        "workloadItemType": {
+          "$ref": "#/definitions/WorkloadItemType",
+          "description": "Workload Item type"
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type"
+        },
+        "protectionStatus": {
+          "$ref": "#/definitions/ProtectionStatus",
+          "description": "Backup status query parameter."
+        }
+      }
+    },
+    "BackupEngineBase": {
+      "type": "object",
+      "description": "The base backup engine class. All workload specific backup engines derive from this class.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the backup engine."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the backup engine."
+        },
+        "registrationStatus": {
+          "type": "string",
+          "description": "Registration status of the backup engine with the Recovery Services Vault."
+        },
+        "backupEngineState": {
+          "type": "string",
+          "description": "Status of the backup engine with the Recovery Services Vault. = {Active/Deleting/DeleteFailed}"
+        },
+        "healthStatus": {
+          "type": "string",
+          "description": "Backup status of the backup engine."
+        },
+        "backupEngineType": {
+          "$ref": "#/definitions/BackupEngineType",
+          "description": "Type of the backup engine."
+        },
+        "canReRegister": {
+          "type": "boolean",
+          "description": "Flag indicating if the backup engine be registered, once already registered."
+        },
+        "backupEngineId": {
+          "type": "string",
+          "description": "ID of the backup engine."
+        },
+        "dpmVersion": {
+          "type": "string",
+          "description": "Backup engine version"
+        },
+        "azureBackupAgentVersion": {
+          "type": "string",
+          "description": "Backup agent version"
+        },
+        "isAzureBackupAgentUpgradeAvailable": {
+          "type": "boolean",
+          "description": "To check if backup agent upgrade available"
+        },
+        "isDpmUpgradeAvailable": {
+          "type": "boolean",
+          "description": "To check if backup engine upgrade available"
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/BackupEngineExtendedInfo",
+          "description": "Extended info of the backupengine"
+        }
+      },
+      "discriminator": "backupEngineType",
+      "required": [
+        "backupEngineType"
+      ]
+    },
+    "BackupEngineBaseResource": {
+      "type": "object",
+      "description": "The base backup engine class. All workload specific backup engines derive from this class.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupEngineBase",
+          "description": "BackupEngineBaseResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BackupEngineBaseResourceList": {
+      "type": "object",
+      "description": "List of BackupEngineBase resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/BackupEngineBaseResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "BackupEngineExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on backup engine.",
+      "properties": {
+        "databaseName": {
+          "type": "string",
+          "description": "Database name of backup engine."
+        },
+        "protectedItemsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of protected items in the backup engine."
+        },
+        "protectedServersCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of protected servers in the backup engine."
+        },
+        "diskCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of disks in the backup engine."
+        },
+        "usedDiskSpace": {
+          "type": "number",
+          "format": "double",
+          "description": "Disk space used in the backup engine."
+        },
+        "availableDiskSpace": {
+          "type": "number",
+          "format": "double",
+          "description": "Disk space currently available in the backup engine."
+        },
+        "refreshedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last refresh time in the backup engine."
+        },
+        "azureProtectedInstances": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Protected instances in the backup engine."
+        }
+      }
+    },
+    "BackupEngineType": {
+      "type": "string",
+      "description": "Type of the backup engine.",
+      "enum": [
+        "Invalid",
+        "DpmBackupEngine",
+        "AzureBackupServerEngine"
+      ],
+      "x-ms-enum": {
+        "name": "BackupEngineType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "DpmBackupEngine",
+            "value": "DpmBackupEngine"
+          },
+          {
+            "name": "AzureBackupServerEngine",
+            "value": "AzureBackupServerEngine"
+          }
+        ]
+      }
+    },
+    "BackupFabricResource": {
+      "type": "object",
+      "description": "Backup Fabric virtual resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the BackupFabricResource",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "BackupItemType": {
+      "type": "string",
+      "description": "Type of backup items associated with this container.",
+      "enum": [
+        "Invalid",
+        "VM",
+        "FileFolder",
+        "AzureSqlDb",
+        "SQLDB",
+        "Exchange",
+        "Sharepoint",
+        "VMwareVM",
+        "SystemState",
+        "Client",
+        "GenericDataSource",
+        "SQLDataBase",
+        "AzureFileShare",
+        "SAPHanaDatabase",
+        "SAPAseDatabase",
+        "SAPHanaDBInstance"
+      ],
+      "x-ms-enum": {
+        "name": "BackupItemType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "VM",
+            "value": "VM"
+          },
+          {
+            "name": "FileFolder",
+            "value": "FileFolder"
+          },
+          {
+            "name": "AzureSqlDb",
+            "value": "AzureSqlDb"
+          },
+          {
+            "name": "SQLDB",
+            "value": "SQLDB"
+          },
+          {
+            "name": "Exchange",
+            "value": "Exchange"
+          },
+          {
+            "name": "Sharepoint",
+            "value": "Sharepoint"
+          },
+          {
+            "name": "VMwareVM",
+            "value": "VMwareVM"
+          },
+          {
+            "name": "SystemState",
+            "value": "SystemState"
+          },
+          {
+            "name": "Client",
+            "value": "Client"
+          },
+          {
+            "name": "GenericDataSource",
+            "value": "GenericDataSource"
+          },
+          {
+            "name": "SQLDataBase",
+            "value": "SQLDataBase"
+          },
+          {
+            "name": "AzureFileShare",
+            "value": "AzureFileShare"
+          },
+          {
+            "name": "SAPHanaDatabase",
+            "value": "SAPHanaDatabase"
+          },
+          {
+            "name": "SAPAseDatabase",
+            "value": "SAPAseDatabase"
+          },
+          {
+            "name": "SAPHanaDBInstance",
+            "value": "SAPHanaDBInstance"
+          }
+        ]
+      }
+    },
+    "BackupManagementType": {
+      "type": "string",
+      "description": "Backup management type to execute the current job.",
+      "enum": [
+        "Invalid",
+        "AzureIaasVM",
+        "MAB",
+        "DPM",
+        "AzureBackupServer",
+        "AzureSql",
+        "AzureStorage",
+        "AzureWorkload",
+        "DefaultBackup"
+      ],
+      "x-ms-enum": {
+        "name": "BackupManagementType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "AzureIaasVM",
+            "value": "AzureIaasVM"
+          },
+          {
+            "name": "MAB",
+            "value": "MAB"
+          },
+          {
+            "name": "DPM",
+            "value": "DPM"
+          },
+          {
+            "name": "AzureBackupServer",
+            "value": "AzureBackupServer"
+          },
+          {
+            "name": "AzureSql",
+            "value": "AzureSql"
+          },
+          {
+            "name": "AzureStorage",
+            "value": "AzureStorage"
+          },
+          {
+            "name": "AzureWorkload",
+            "value": "AzureWorkload"
+          },
+          {
+            "name": "DefaultBackup",
+            "value": "DefaultBackup"
+          }
+        ]
+      }
+    },
+    "BackupManagementUsage": {
+      "type": "object",
+      "description": "Backup management usages of a vault.",
+      "properties": {
+        "unit": {
+          "$ref": "#/definitions/UsagesUnit",
+          "description": "Unit of the usage."
+        },
+        "quotaPeriod": {
+          "type": "string",
+          "description": "Quota period of usage."
+        },
+        "nextResetTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Next reset time of usage."
+        },
+        "currentValue": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Current value of usage."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Limit of usage."
+        },
+        "name": {
+          "$ref": "#/definitions/NameInfo",
+          "description": "Name of usage."
+        }
+      }
+    },
+    "BackupManagementUsageList": {
+      "type": "object",
+      "description": "Backup management usage for vault.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of backup management usages for the given vault.",
+          "items": {
+            "$ref": "#/definitions/BackupManagementUsage"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "BackupRequest": {
+      "type": "object",
+      "description": "Base class for backup request. Workload-specific backup requests are derived from this class.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "BackupRequestResource": {
+      "type": "object",
+      "description": "Base class for backup request. Workload-specific backup requests are derived from this class.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/BackupRequest",
+          "description": "BackupRequestResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "BackupResourceConfig": {
+      "type": "object",
+      "description": "The resource storage details.",
+      "properties": {
+        "storageModelType": {
+          "$ref": "#/definitions/StorageType",
+          "description": "Storage type"
+        },
+        "storageType": {
+          "$ref": "#/definitions/StorageType",
+          "description": "Storage type."
+        },
+        "storageTypeState": {
+          "$ref": "#/definitions/StorageTypeState",
+          "description": "Locked or Unlocked. Once a machine is registered against a resource, the storageTypeState is always Locked."
+        },
+        "crossRegionRestoreFlag": {
+          "type": "boolean",
+          "description": "Opt in details of Cross Region Restore feature."
+        },
+        "dedupState": {
+          "$ref": "#/definitions/DedupState",
+          "description": "Vault Dedup state"
+        },
+        "xcoolState": {
+          "$ref": "#/definitions/XcoolState",
+          "description": "Vault x-cool state"
+        }
+      }
+    },
+    "BackupResourceConfigResource": {
+      "type": "object",
+      "description": "The resource storage details.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupResourceConfig",
+          "description": "BackupResourceConfigResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BackupResourceEncryptionConfig": {
+      "type": "object",
+      "properties": {
+        "encryptionAtRestType": {
+          "$ref": "#/definitions/EncryptionAtRestType",
+          "description": "Encryption At Rest Type"
+        },
+        "keyUri": {
+          "type": "string",
+          "description": "Key Vault Key URI"
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "Key Vault Subscription Id"
+        },
+        "lastUpdateStatus": {
+          "$ref": "#/definitions/LastUpdateStatus"
+        },
+        "infrastructureEncryptionState": {
+          "$ref": "#/definitions/InfrastructureEncryptionState"
+        }
+      }
+    },
+    "BackupResourceEncryptionConfigExtended": {
+      "type": "object",
+      "properties": {
+        "userAssignedIdentity": {
+          "type": "string",
+          "description": "User Assigned Identity Id"
+        },
+        "useSystemAssignedIdentity": {
+          "type": "boolean",
+          "description": "bool to indicate whether to use system Assigned Identity or not"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupResourceEncryptionConfig"
+        }
+      ]
+    },
+    "BackupResourceEncryptionConfigExtendedResource": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupResourceEncryptionConfigExtended",
+          "description": "The properties of the backup resource encryption config extended resource"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BackupResourceEncryptionConfigResource": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupResourceEncryptionConfig",
+          "description": "The properties of the backup resource encryption config"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "BackupResourceVaultConfig": {
+      "type": "object",
+      "description": "Backup resource vault config details.",
+      "properties": {
+        "storageModelType": {
+          "$ref": "#/definitions/StorageType",
+          "description": "Storage type."
+        },
+        "storageType": {
+          "$ref": "#/definitions/StorageType",
+          "description": "Storage type."
+        },
+        "storageTypeState": {
+          "$ref": "#/definitions/StorageTypeState",
+          "description": "Locked or Unlocked. Once a machine is registered against a resource, the storageTypeState is always Locked."
+        },
+        "enhancedSecurityState": {
+          "$ref": "#/definitions/EnhancedSecurityState",
+          "description": "Enabled or Disabled."
+        },
+        "softDeleteFeatureState": {
+          "$ref": "#/definitions/SoftDeleteFeatureState",
+          "description": "Soft Delete feature state"
+        },
+        "softDeleteRetentionPeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Soft delete retention period in days"
+        },
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "description": "ResourceGuard Operation Requests",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isSoftDeleteFeatureStateEditable": {
+          "type": "boolean",
+          "description": "This flag is no longer in use. Please use 'softDeleteFeatureState' to set the soft delete state for the vault"
+        }
+      }
+    },
+    "BackupResourceVaultConfigResource": {
+      "type": "object",
+      "description": "Backup resource vault config details.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackupResourceVaultConfig",
+          "description": "BackupResourceVaultConfigResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BackupStatusRequest": {
+      "type": "object",
+      "description": "BackupStatus request.",
+      "properties": {
+        "resourceType": {
+          "$ref": "#/definitions/DataSourceType",
+          "description": "Container Type - VM, SQLPaaS, DPM, AzureFileShare..."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Entire ARM resource id of the resource"
+        },
+        "poLogicalName": {
+          "type": "string",
+          "description": "Protectable Item Logical Name"
+        }
+      }
+    },
+    "BackupStatusResponse": {
+      "type": "object",
+      "description": "BackupStatus response.",
+      "properties": {
+        "protectionStatus": {
+          "$ref": "#/definitions/ProtectionStatus",
+          "description": "Specifies whether the container is registered or not"
+        },
+        "vaultId": {
+          "type": "string",
+          "description": "Specifies the arm resource id of the vault"
+        },
+        "fabricName": {
+          "$ref": "#/definitions/FabricName",
+          "description": "Specifies the fabric name - Azure or AD"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Specifies the product specific container name. E.g. iaasvmcontainer;iaasvmcontainer;csname;vmname."
+        },
+        "protectedItemName": {
+          "type": "string",
+          "description": "Specifies the product specific ds name. E.g. vm;iaasvmcontainer;csname;vmname."
+        },
+        "errorCode": {
+          "type": "string",
+          "description": "ErrorCode in case of intent failed"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "ErrorMessage in case of intent failed."
+        },
+        "policyName": {
+          "type": "string",
+          "description": "Specifies the policy name which is used for protection"
+        },
+        "registrationStatus": {
+          "type": "string",
+          "description": "Container registration status"
+        },
+        "protectedItemsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of protected items"
+        },
+        "acquireStorageAccountLock": {
+          "$ref": "#/definitions/AcquireStorageAccountLock",
+          "description": "Specifies whether the storage account lock has been acquired or not"
+        }
+      }
+    },
+    "BackupType": {
+      "type": "string",
+      "description": "Type of backup, viz. Full, Differential, Log or CopyOnlyFull",
+      "enum": [
+        "Invalid",
+        "Full",
+        "Differential",
+        "Log",
+        "CopyOnlyFull",
+        "Incremental",
+        "SnapshotFull",
+        "SnapshotCopyOnlyFull"
+      ],
+      "x-ms-enum": {
+        "name": "BackupType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Full",
+            "value": "Full"
+          },
+          {
+            "name": "Differential",
+            "value": "Differential"
+          },
+          {
+            "name": "Log",
+            "value": "Log"
+          },
+          {
+            "name": "CopyOnlyFull",
+            "value": "CopyOnlyFull"
+          },
+          {
+            "name": "Incremental",
+            "value": "Incremental"
+          },
+          {
+            "name": "SnapshotFull",
+            "value": "SnapshotFull"
+          },
+          {
+            "name": "SnapshotCopyOnlyFull",
+            "value": "SnapshotCopyOnlyFull"
+          }
+        ]
+      }
+    },
+    "BmspoQueryObject": {
+      "type": "object",
+      "description": "Filters to list items that can be backed up.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type."
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Full name of the container whose Protectable Objects should be returned."
+        },
+        "status": {
+          "type": "string",
+          "description": "Backup status query parameter."
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name."
+        }
+      }
+    },
+    "BmsrpQueryObject": {
+      "type": "object",
+      "description": "Filters to list backup copies.",
+      "properties": {
+        "startDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Backup copies created after this time."
+        },
+        "endDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Backup copies created before this time."
+        },
+        "restorePointQueryType": {
+          "$ref": "#/definitions/RestorePointQueryType",
+          "description": "RestorePoint type"
+        },
+        "extendedInfo": {
+          "type": "boolean",
+          "description": "In Get Recovery Point, it tells whether extended information about recovery point is asked."
+        },
+        "moveReadyRPOnly": {
+          "type": "boolean",
+          "description": "Whether the RP can be moved to another tier"
+        },
+        "includeSoftDeletedRP": {
+          "type": "boolean",
+          "description": "Flag to indicate whether Soft Deleted RPs should be included/excluded from result."
+        }
+      }
+    },
+    "ClientDiscoveryDisplay": {
+      "type": "object",
+      "description": "Localized display information of an operation.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Name of the provider for display purposes"
+        },
+        "resource": {
+          "type": "string",
+          "description": "ResourceType for which this Operation can be performed."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Operations Name itself."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the operation having details of what operation is about."
+        }
+      }
+    },
+    "ClientDiscoveryForLogSpecification": {
+      "type": "object",
+      "description": "Class to represent shoebox log specification in json client discovery.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name for shoebox log specification."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Localized display name"
+        },
+        "blobDuration": {
+          "type": "string",
+          "description": "blob duration of shoebox log specification"
+        }
+      }
+    },
+    "ClientDiscoveryForProperties": {
+      "type": "object",
+      "description": "Class to represent shoebox properties in json client discovery.",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/ClientDiscoveryForServiceSpecification",
+          "description": "Operation properties."
+        }
+      }
+    },
+    "ClientDiscoveryForServiceSpecification": {
+      "type": "object",
+      "description": "Class to represent shoebox service specification in json client discovery.",
+      "properties": {
+        "logSpecifications": {
+          "type": "array",
+          "description": "List of log specifications of this operation.",
+          "items": {
+            "$ref": "#/definitions/ClientDiscoveryForLogSpecification"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ClientDiscoveryResponse": {
+      "type": "object",
+      "description": "Operations List response which contains list of available APIs.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of available operations.",
+          "items": {
+            "$ref": "#/definitions/ClientDiscoveryValueForSingleApi"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Link to the next chunk of Response."
+        }
+      }
+    },
+    "ClientDiscoveryValueForSingleApi": {
+      "type": "object",
+      "description": "Available operation details.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the Operation."
+        },
+        "display": {
+          "$ref": "#/definitions/ClientDiscoveryDisplay",
+          "description": "Contains the localized display information for this particular operation"
+        },
+        "origin": {
+          "type": "string",
+          "description": "The intended executor of the operation;governs the display of the operation in the RBAC UX and the audit logs UX"
+        },
+        "properties": {
+          "$ref": "#/definitions/ClientDiscoveryForProperties",
+          "description": "ShoeBox properties for the given operation."
+        }
+      }
+    },
+    "ClientScriptForConnect": {
+      "type": "object",
+      "description": "Client script details for file / folder restore.",
+      "properties": {
+        "scriptContent": {
+          "type": "string",
+          "description": "File content of the client script for file / folder restore."
+        },
+        "scriptExtension": {
+          "type": "string",
+          "description": "File extension of the client script for file / folder restore - .ps1 , .sh , etc."
+        },
+        "osType": {
+          "type": "string",
+          "description": "OS type - Windows, Linux etc. for which this file / folder restore client script works."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of Executable from where to source the content. If this is not null then ScriptContent should not be used"
+        },
+        "scriptNameSuffix": {
+          "type": "string",
+          "description": "Mandatory suffix that should be added to the name of script that is given for download to user.\nIf its null or empty then , ignore it."
+        }
+      }
+    },
+    "CloudError": {
+      "type": "object",
+      "description": "An error response from the Container Instance service.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/CloudErrorBody",
+          "description": "The error object."
+        }
+      }
+    },
+    "CloudErrorBody": {
+      "type": "object",
+      "description": "An error response from the Container Instance service.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the particular error. For example, the name of the property in error.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "A list of additional details about the error.",
+          "items": {
+            "$ref": "#/definitions/CloudErrorBody"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "code"
+          ]
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorAdditionalInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ContainerIdentityInfo": {
+      "type": "object",
+      "description": "Container identity information",
+      "properties": {
+        "uniqueName": {
+          "type": "string",
+          "description": "Unique name of the container"
+        },
+        "aadTenantId": {
+          "type": "string",
+          "description": "Protection container identity - AAD Tenant"
+        },
+        "servicePrincipalClientId": {
+          "type": "string",
+          "description": "Protection container identity - AAD Service Principal"
+        },
+        "audience": {
+          "type": "string",
+          "description": "Protection container identity - Audience"
+        }
+      }
+    },
+    "ContainerType": {
+      "type": "string",
+      "description": "Type of container for filter",
+      "enum": [
+        "Invalid",
+        "Unknown",
+        "IaasVMContainer",
+        "IaasVMServiceContainer",
+        "DPMContainer",
+        "AzureBackupServerContainer",
+        "MABContainer",
+        "Cluster",
+        "AzureSqlContainer",
+        "Windows",
+        "VCenter",
+        "VMAppContainer",
+        "SQLAGWorkLoadContainer",
+        "StorageContainer",
+        "GenericContainer",
+        "HanaHSRContainer"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "IaasVMContainer",
+            "value": "IaasVMContainer"
+          },
+          {
+            "name": "IaasVMServiceContainer",
+            "value": "IaasVMServiceContainer"
+          },
+          {
+            "name": "DPMContainer",
+            "value": "DPMContainer"
+          },
+          {
+            "name": "AzureBackupServerContainer",
+            "value": "AzureBackupServerContainer"
+          },
+          {
+            "name": "MABContainer",
+            "value": "MABContainer"
+          },
+          {
+            "name": "Cluster",
+            "value": "Cluster"
+          },
+          {
+            "name": "AzureSqlContainer",
+            "value": "AzureSqlContainer"
+          },
+          {
+            "name": "Windows",
+            "value": "Windows"
+          },
+          {
+            "name": "VCenter",
+            "value": "VCenter"
+          },
+          {
+            "name": "VMAppContainer",
+            "value": "VMAppContainer"
+          },
+          {
+            "name": "SQLAGWorkLoadContainer",
+            "value": "SQLAGWorkLoadContainer"
+          },
+          {
+            "name": "StorageContainer",
+            "value": "StorageContainer"
+          },
+          {
+            "name": "GenericContainer",
+            "value": "GenericContainer"
+          },
+          {
+            "name": "HanaHSRContainer",
+            "value": "HanaHSRContainer"
+          }
+        ]
+      }
+    },
+    "CopyOptions": {
+      "type": "string",
+      "description": "Options to resolve copy conflicts.",
+      "enum": [
+        "Invalid",
+        "CreateCopy",
+        "Skip",
+        "Overwrite",
+        "FailOnConflict"
+      ],
+      "x-ms-enum": {
+        "name": "CopyOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "CreateCopy",
+            "value": "CreateCopy"
+          },
+          {
+            "name": "Skip",
+            "value": "Skip"
+          },
+          {
+            "name": "Overwrite",
+            "value": "Overwrite"
+          },
+          {
+            "name": "FailOnConflict",
+            "value": "FailOnConflict"
+          }
+        ]
+      }
+    },
+    "CreateMode": {
+      "type": "string",
+      "description": "Create mode to indicate recovery of existing soft deleted data source or creation of new data source.",
+      "enum": [
+        "Invalid",
+        "Default",
+        "Recover"
+      ],
+      "x-ms-enum": {
+        "name": "CreateMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Default",
+            "value": "Default"
+          },
+          {
+            "name": "Recover",
+            "value": "Recover"
+          }
+        ]
+      }
+    },
+    "DPMContainerExtendedInfo": {
+      "type": "object",
+      "description": "Additional information of the DPMContainer.",
+      "properties": {
+        "lastRefreshedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last refresh time of the DPMContainer."
+        }
+      }
+    },
+    "DPMProtectedItem": {
+      "type": "object",
+      "description": "Additional information on Backup engine specific backup item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the managed item"
+        },
+        "backupEngineName": {
+          "type": "string",
+          "description": "Backup Management server protecting this backup item"
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectedItemState",
+          "description": "Protection state of the backup engine"
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/DPMProtectedItemExtendedInfo",
+          "description": "Extended info of the backup item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "DPMProtectedItem"
+    },
+    "DPMProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information of DPM Protected item.",
+      "properties": {
+        "protectableObjectLoadPath": {
+          "type": "object",
+          "description": "Attribute to provide information on various DBs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "protected": {
+          "type": "boolean",
+          "description": "To check if backup item is disk protected."
+        },
+        "isPresentOnCloud": {
+          "type": "boolean",
+          "description": "To check if backup item is cloud protected."
+        },
+        "lastBackupStatus": {
+          "type": "string",
+          "description": "Last backup status information on backup item."
+        },
+        "lastRefreshedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last refresh time on backup item."
+        },
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Oldest cloud recovery point time."
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "cloud recovery point count."
+        },
+        "onPremiseOldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Oldest disk recovery point time."
+        },
+        "onPremiseLatestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "latest disk recovery point time."
+        },
+        "onPremiseRecoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "disk recovery point count."
+        },
+        "isCollocated": {
+          "type": "boolean",
+          "description": "To check if backup item is collocated."
+        },
+        "protectionGroupName": {
+          "type": "string",
+          "description": "Protection group name of the backup item."
+        },
+        "diskStorageUsedInBytes": {
+          "type": "string",
+          "description": "Used Disk storage in bytes."
+        },
+        "totalDiskStorageSizeInBytes": {
+          "type": "string",
+          "description": "total Disk storage in bytes."
+        }
+      }
+    },
+    "DailyRetentionFormat": {
+      "type": "object",
+      "description": "Daily retention format.",
+      "properties": {
+        "daysOfTheMonth": {
+          "type": "array",
+          "description": "List of days of the month.",
+          "items": {
+            "$ref": "#/definitions/Day"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "DailyRetentionSchedule": {
+      "type": "object",
+      "description": "Daily retention schedule.",
+      "properties": {
+        "retentionTimes": {
+          "type": "array",
+          "description": "Retention times of retention policy.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "retentionDuration": {
+          "$ref": "#/definitions/RetentionDuration",
+          "description": "Retention duration of retention Policy."
+        }
+      }
+    },
+    "DailySchedule": {
+      "type": "object",
+      "properties": {
+        "scheduleRunTimes": {
+          "type": "array",
+          "description": "List of times of day this schedule has to be run.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "DataMoveLevel": {
+      "type": "string",
+      "description": "DataMove Level",
+      "enum": [
+        "Invalid",
+        "Vault",
+        "Container"
+      ],
+      "x-ms-enum": {
+        "name": "DataMoveLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Vault",
+            "value": "Vault"
+          },
+          {
+            "name": "Container",
+            "value": "Container"
+          }
+        ]
+      }
+    },
+    "DataSourceType": {
+      "type": "string",
+      "description": "Type of workload this item represents.",
+      "enum": [
+        "Invalid",
+        "VM",
+        "FileFolder",
+        "AzureSqlDb",
+        "SQLDB",
+        "Exchange",
+        "Sharepoint",
+        "VMwareVM",
+        "SystemState",
+        "Client",
+        "GenericDataSource",
+        "SQLDataBase",
+        "AzureFileShare",
+        "SAPHanaDatabase",
+        "SAPAseDatabase",
+        "SAPHanaDBInstance"
+      ],
+      "x-ms-enum": {
+        "name": "DataSourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "VM",
+            "value": "VM"
+          },
+          {
+            "name": "FileFolder",
+            "value": "FileFolder"
+          },
+          {
+            "name": "AzureSqlDb",
+            "value": "AzureSqlDb"
+          },
+          {
+            "name": "SQLDB",
+            "value": "SQLDB"
+          },
+          {
+            "name": "Exchange",
+            "value": "Exchange"
+          },
+          {
+            "name": "Sharepoint",
+            "value": "Sharepoint"
+          },
+          {
+            "name": "VMwareVM",
+            "value": "VMwareVM"
+          },
+          {
+            "name": "SystemState",
+            "value": "SystemState"
+          },
+          {
+            "name": "Client",
+            "value": "Client"
+          },
+          {
+            "name": "GenericDataSource",
+            "value": "GenericDataSource"
+          },
+          {
+            "name": "SQLDataBase",
+            "value": "SQLDataBase"
+          },
+          {
+            "name": "AzureFileShare",
+            "value": "AzureFileShare"
+          },
+          {
+            "name": "SAPHanaDatabase",
+            "value": "SAPHanaDatabase"
+          },
+          {
+            "name": "SAPAseDatabase",
+            "value": "SAPAseDatabase"
+          },
+          {
+            "name": "SAPHanaDBInstance",
+            "value": "SAPHanaDBInstance"
+          }
+        ]
+      }
+    },
+    "Day": {
+      "type": "object",
+      "description": "Day of the week.",
+      "properties": {
+        "date": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Date of the month"
+        },
+        "isLast": {
+          "type": "boolean",
+          "description": "Whether Date is last date of month"
+        }
+      }
+    },
+    "DayOfWeek": {
+      "type": "string",
+      "enum": [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday"
+      ],
+      "x-ms-enum": {
+        "name": "DayOfWeek",
+        "modelAsString": false
+      }
+    },
+    "DedupState": {
+      "type": "string",
+      "description": "Vault Dedup state",
+      "enum": [
+        "Invalid",
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "DedupState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "DiskExclusionProperties": {
+      "type": "object",
+      "properties": {
+        "diskLunList": {
+          "type": "array",
+          "description": "List of Disks' Logical Unit Numbers (LUN) to be used for VM Protection.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "isInclusionList": {
+          "type": "boolean",
+          "description": "Flag to indicate whether DiskLunList is to be included/ excluded from backup."
+        }
+      }
+    },
+    "DiskInformation": {
+      "type": "object",
+      "description": "Disk information",
+      "properties": {
+        "lun": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "DistributedNodesInfo": {
+      "type": "object",
+      "description": "This is used to represent the various nodes of the distributed container.",
+      "properties": {
+        "nodeName": {
+          "type": "string",
+          "description": "Name of the node under a distributed container."
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of this Node.\nFailed | Succeeded"
+        },
+        "errorDetail": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "Error Details if the Status is non-success."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM resource id of the node"
+        }
+      }
+    },
+    "DpmBackupEngine": {
+      "type": "object",
+      "description": "Data Protection Manager (DPM) specific backup engine.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupEngineBase"
+        }
+      ],
+      "x-ms-discriminator-value": "DpmBackupEngine"
+    },
+    "DpmContainer": {
+      "type": "object",
+      "description": "DPM workload-specific protection container.",
+      "properties": {
+        "canReRegister": {
+          "type": "boolean",
+          "description": "Specifies whether the container is re-registrable."
+        },
+        "containerId": {
+          "type": "string",
+          "description": "ID of container."
+        },
+        "protectedItemCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of protected items in the BackupEngine"
+        },
+        "dpmAgentVersion": {
+          "type": "string",
+          "description": "Backup engine Agent version"
+        },
+        "dpmServers": {
+          "type": "array",
+          "description": "List of BackupEngines protecting the container",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upgradeAvailable": {
+          "type": "boolean",
+          "description": "To check if upgrade available"
+        },
+        "protectionStatus": {
+          "type": "string",
+          "description": "Protection status of the container."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/DPMContainerExtendedInfo",
+          "description": "Extended Info of the container."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "DPMContainer"
+    },
+    "DpmErrorInfo": {
+      "type": "object",
+      "description": "DPM workload-specific error information.",
+      "properties": {
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string."
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations for above error code.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DpmJob": {
+      "type": "object",
+      "description": "DPM workload-specific job object.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed for job."
+        },
+        "dpmServerName": {
+          "type": "string",
+          "description": "DPM server name managing the backup item or backup job."
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Name of cluster/server protecting current backup item, if any."
+        },
+        "containerType": {
+          "type": "string",
+          "description": "Type of container."
+        },
+        "workloadType": {
+          "type": "string",
+          "description": "Type of backup item."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "The state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "The errors.",
+          "items": {
+            "$ref": "#/definitions/DpmErrorInfo"
+          },
+          "x-ms-identifiers": []
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/DpmJobExtendedInfo",
+          "description": "Additional information for this job."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "DpmJob"
+    },
+    "DpmJobExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on the DPM workload-specific job.",
+      "properties": {
+        "tasksList": {
+          "type": "array",
+          "description": "List of tasks associated with this job.",
+          "items": {
+            "$ref": "#/definitions/DpmJobTaskDetails"
+          },
+          "x-ms-identifiers": [
+            "taskId"
+          ]
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "The job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dynamicErrorMessage": {
+          "type": "string",
+          "description": "Non localized error message on job execution."
+        }
+      }
+    },
+    "DpmJobTaskDetails": {
+      "type": "object",
+      "description": "DPM workload-specific job task details.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "The task display name."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time."
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed for task."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status."
+        }
+      }
+    },
+    "EncryptionAtRestType": {
+      "type": "string",
+      "description": "Encryption At Rest Type",
+      "enum": [
+        "Invalid",
+        "MicrosoftManaged",
+        "CustomerManaged"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionAtRestType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "MicrosoftManaged",
+            "value": "MicrosoftManaged"
+          },
+          {
+            "name": "CustomerManaged",
+            "value": "CustomerManaged"
+          }
+        ]
+      }
+    },
+    "EncryptionDetails": {
+      "type": "object",
+      "description": "Details needed if the VM was encrypted at the time of backup.",
+      "properties": {
+        "encryptionEnabled": {
+          "type": "boolean",
+          "description": "Identifies whether this backup copy represents an encrypted VM at the time of backup."
+        },
+        "kekUrl": {
+          "type": "string",
+          "description": "Key Url."
+        },
+        "secretKeyUrl": {
+          "type": "string",
+          "description": "Secret Url."
+        },
+        "kekVaultId": {
+          "type": "string",
+          "description": "ID of Key Vault where KEK is stored."
+        },
+        "secretKeyVaultId": {
+          "type": "string",
+          "description": "ID of Key Vault where Secret is stored."
+        }
+      }
+    },
+    "EnhancedSecurityState": {
+      "type": "string",
+      "description": "Enabled or Disabled.",
+      "enum": [
+        "Invalid",
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EnhancedSecurityState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "description": "Error Detail class which encapsulates Code, Message and Recommendations.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Error Message related to the Code.",
+          "readOnly": true
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of recommendation strings.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ExportJobsOperationResultInfo": {
+      "type": "object",
+      "description": "This class is used to send blob details after exporting jobs.",
+      "properties": {
+        "blobUrl": {
+          "type": "string",
+          "description": "URL of the blob into which the serialized string of list of jobs is exported."
+        },
+        "blobSasKey": {
+          "type": "string",
+          "description": "SAS key to access the blob. It expires in 15 mins."
+        },
+        "excelFileBlobUrl": {
+          "type": "string",
+          "description": "URL of the blob into which the ExcelFile is uploaded."
+        },
+        "excelFileBlobSasKey": {
+          "type": "string",
+          "description": "SAS key to access the blob. It expires in 15 mins."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationResultInfoBase"
+        }
+      ],
+      "x-ms-discriminator-value": "ExportJobsOperationResultInfo"
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "The extended location of Recovery point where VM was present.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the extended location."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the extended location. Possible values include: 'EdgeZone'"
+        }
+      }
+    },
+    "ExtendedProperties": {
+      "type": "object",
+      "description": "Extended Properties for Azure IaasVM Backup.",
+      "properties": {
+        "diskExclusionProperties": {
+          "$ref": "#/definitions/DiskExclusionProperties",
+          "description": "Extended Properties for Disk Exclusion."
+        },
+        "linuxVmApplicationName": {
+          "type": "string",
+          "description": "Linux VM name"
+        }
+      }
+    },
+    "FabricName": {
+      "type": "string",
+      "description": "Specifies the fabric name - Azure or AD",
+      "enum": [
+        "Invalid",
+        "Azure"
+      ],
+      "x-ms-enum": {
+        "name": "FabricName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Azure",
+            "value": "Azure"
+          }
+        ]
+      }
+    },
+    "FeatureSupportRequest": {
+      "type": "object",
+      "description": "Base class for feature request",
+      "properties": {
+        "featureType": {
+          "type": "string",
+          "description": "backup support feature type."
+        }
+      },
+      "discriminator": "featureType",
+      "required": [
+        "featureType"
+      ]
+    },
+    "FetchTieringCostInfoForRehydrationRequest": {
+      "type": "object",
+      "description": "Request parameters for fetching cost info of rehydration",
+      "properties": {
+        "containerName": {
+          "type": "string",
+          "description": "Name of the protected item container"
+        },
+        "protectedItemName": {
+          "type": "string",
+          "description": "Name of the protectedItemName"
+        },
+        "recoveryPointId": {
+          "type": "string",
+          "description": "ID of the backup copy for rehydration cost info needs to be fetched."
+        },
+        "rehydrationPriority": {
+          "$ref": "#/definitions/RehydrationPriority",
+          "description": "Rehydration Priority"
+        }
+      },
+      "required": [
+        "containerName",
+        "protectedItemName",
+        "recoveryPointId",
+        "rehydrationPriority"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/FetchTieringCostInfoRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "FetchTieringCostInfoForRehydrationRequest"
+    },
+    "FetchTieringCostInfoRequest": {
+      "type": "object",
+      "description": "Base class for tiering cost request.\nSpecific cost request types are derived from this class.",
+      "properties": {
+        "sourceTierType": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "Source tier for the request"
+        },
+        "targetTierType": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "target tier for the request"
+        },
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "sourceTierType",
+        "targetTierType",
+        "objectType"
+      ]
+    },
+    "FetchTieringCostSavingsInfoForPolicyRequest": {
+      "type": "object",
+      "description": "Request parameters for tiering cost info for policy",
+      "properties": {
+        "policyName": {
+          "type": "string",
+          "description": "Name of the backup policy for which the cost savings information is requested"
+        }
+      },
+      "required": [
+        "policyName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/FetchTieringCostInfoRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "FetchTieringCostSavingsInfoForPolicyRequest"
+    },
+    "FetchTieringCostSavingsInfoForProtectedItemRequest": {
+      "type": "object",
+      "description": "Request parameters for tiering cost info for protected item",
+      "properties": {
+        "containerName": {
+          "type": "string",
+          "description": "Name of the protected item container"
+        },
+        "protectedItemName": {
+          "type": "string",
+          "description": "Name of the protectedItemName"
+        }
+      },
+      "required": [
+        "containerName",
+        "protectedItemName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/FetchTieringCostInfoRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "FetchTieringCostSavingsInfoForProtectedItemRequest"
+    },
+    "FetchTieringCostSavingsInfoForVaultRequest": {
+      "type": "object",
+      "description": "Request parameters for tiering cost info for vault",
+      "allOf": [
+        {
+          "$ref": "#/definitions/FetchTieringCostInfoRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "FetchTieringCostSavingsInfoForVaultRequest"
+    },
+    "GenericContainer": {
+      "type": "object",
+      "description": "Base class for generic container of backup items",
+      "properties": {
+        "fabricName": {
+          "type": "string",
+          "description": "Name of the container's fabric"
+        },
+        "extendedInformation": {
+          "$ref": "#/definitions/GenericContainerExtendedInfo",
+          "description": "Extended information (not returned in List container API calls)"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericContainer"
+    },
+    "GenericContainerExtendedInfo": {
+      "type": "object",
+      "description": "Container extended information",
+      "properties": {
+        "rawCertData": {
+          "type": "string",
+          "description": "Public key of container cert"
+        },
+        "containerIdentityInfo": {
+          "$ref": "#/definitions/ContainerIdentityInfo",
+          "description": "Container identity information"
+        },
+        "serviceEndpoints": {
+          "type": "object",
+          "description": "Azure Backup Service Endpoints for the container",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GenericProtectedItem": {
+      "type": "object",
+      "description": "Base class for backup items.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the container."
+        },
+        "policyState": {
+          "type": "string",
+          "description": "Indicates consistency of policy object and policy applied to this backup item."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionState",
+          "description": "Backup state of this backup item."
+        },
+        "protectedItemId": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Data Plane Service ID of the protected item."
+        },
+        "sourceAssociations": {
+          "type": "object",
+          "description": "Loosely coupled (type, value) associations (example - parent of a protected item)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fabricName": {
+          "type": "string",
+          "description": "Name of this backup item's fabric."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericProtectedItem"
+    },
+    "GenericProtectionPolicy": {
+      "type": "object",
+      "description": "Azure VM (Mercury) workload-specific backup policy.",
+      "properties": {
+        "subProtectionPolicy": {
+          "type": "array",
+          "description": "List of sub-protection policies which includes schedule and retention",
+          "items": {
+            "$ref": "#/definitions/SubProtectionPolicy"
+          },
+          "x-ms-identifiers": []
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "TimeZone optional input as string. For example: TimeZone = \"Pacific Standard Time\"."
+        },
+        "fabricName": {
+          "type": "string",
+          "description": "Name of this policy's fabric."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericProtectionPolicy"
+    },
+    "GenericRecoveryPoint": {
+      "type": "object",
+      "description": "Generic backup copy.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the backup copy."
+        },
+        "recoveryPointType": {
+          "type": "string",
+          "description": "Type of the backup copy."
+        },
+        "recoveryPointTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which this backup copy was created."
+        },
+        "recoveryPointAdditionalInfo": {
+          "type": "string",
+          "description": "Additional information associated with this backup copy."
+        },
+        "recoveryPointProperties": {
+          "$ref": "#/definitions/RecoveryPointProperties",
+          "description": "Properties of Recovery Point"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "GenericRecoveryPoint"
+    },
+    "GetProtectedItemQueryObject": {
+      "type": "object",
+      "description": "Filters to list backup items.",
+      "properties": {
+        "expand": {
+          "type": "string",
+          "description": "Specifies if the additional information should be provided for this item."
+        }
+      }
+    },
+    "HealthState": {
+      "type": "string",
+      "description": "Health State for the backed up item.",
+      "enum": [
+        "Passed",
+        "ActionRequired",
+        "ActionSuggested",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "HealthState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Passed",
+            "value": "Passed"
+          },
+          {
+            "name": "ActionRequired",
+            "value": "ActionRequired"
+          },
+          {
+            "name": "ActionSuggested",
+            "value": "ActionSuggested"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          }
+        ]
+      }
+    },
+    "HealthStatus": {
+      "type": "string",
+      "description": "Health status of protected item.",
+      "enum": [
+        "Passed",
+        "ActionRequired",
+        "ActionSuggested",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "HealthStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Passed",
+            "value": "Passed"
+          },
+          {
+            "name": "ActionRequired",
+            "value": "ActionRequired"
+          },
+          {
+            "name": "ActionSuggested",
+            "value": "ActionSuggested"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          }
+        ]
+      }
+    },
+    "HourlySchedule": {
+      "type": "object",
+      "properties": {
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Interval at which backup needs to be triggered. For hourly the value\ncan be 4/6/8/12"
+        },
+        "scheduleWindowStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "To specify start time of the backup window"
+        },
+        "scheduleWindowDuration": {
+          "type": "integer",
+          "format": "int32",
+          "description": "To specify duration of the backup window"
+        }
+      }
+    },
+    "HttpStatusCode": {
+      "type": "string",
+      "description": "HTTP Status Code of the operation.",
+      "enum": [
+        "Continue",
+        "SwitchingProtocols",
+        "OK",
+        "Created",
+        "Accepted",
+        "NonAuthoritativeInformation",
+        "NoContent",
+        "ResetContent",
+        "PartialContent",
+        "MultipleChoices",
+        "Ambiguous",
+        "MovedPermanently",
+        "Moved",
+        "Found",
+        "Redirect",
+        "SeeOther",
+        "RedirectMethod",
+        "NotModified",
+        "UseProxy",
+        "Unused",
+        "TemporaryRedirect",
+        "RedirectKeepVerb",
+        "BadRequest",
+        "Unauthorized",
+        "PaymentRequired",
+        "Forbidden",
+        "NotFound",
+        "MethodNotAllowed",
+        "NotAcceptable",
+        "ProxyAuthenticationRequired",
+        "RequestTimeout",
+        "Conflict",
+        "Gone",
+        "LengthRequired",
+        "PreconditionFailed",
+        "RequestEntityTooLarge",
+        "RequestUriTooLong",
+        "UnsupportedMediaType",
+        "RequestedRangeNotSatisfiable",
+        "ExpectationFailed",
+        "UpgradeRequired",
+        "InternalServerError",
+        "NotImplemented",
+        "BadGateway",
+        "ServiceUnavailable",
+        "GatewayTimeout",
+        "HttpVersionNotSupported"
+      ],
+      "x-ms-enum": {
+        "name": "HttpStatusCode",
+        "modelAsString": false
+      }
+    },
+    "IAASVMPolicyType": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "V1",
+        "V2"
+      ],
+      "x-ms-enum": {
+        "name": "IAASVMPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "V1",
+            "value": "V1"
+          },
+          {
+            "name": "V2",
+            "value": "V2"
+          }
+        ]
+      }
+    },
+    "ILRRequest": {
+      "type": "object",
+      "description": "Parameters to Provision ILR API.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "ILRRequestResource": {
+      "type": "object",
+      "description": "Parameters to Provision ILR API.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/ILRRequest",
+          "description": "ILRRequestResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "IaaSVMContainer": {
+      "type": "object",
+      "description": "IaaS VM workload-specific container.",
+      "properties": {
+        "virtualMachineId": {
+          "type": "string",
+          "description": "Fully qualified ARM url of the virtual machine represented by this Azure IaaS VM container."
+        },
+        "virtualMachineVersion": {
+          "type": "string",
+          "description": "Specifies whether the container represents a Classic or an Azure Resource Manager VM."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "Resource group name of Recovery Services Vault."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMContainer"
+    },
+    "IaaSVMProtectableItem": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup item.",
+      "properties": {
+        "virtualMachineId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the virtual machine."
+        },
+        "virtualMachineVersion": {
+          "type": "string",
+          "description": "Specifies whether the container represents a Classic or an Azure Resource Manager VM."
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "Resource group name of Recovery Services Vault."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/WorkloadProtectableItem"
+        }
+      ],
+      "x-ms-discriminator-value": "IaaSVMProtectableItem"
+    },
+    "IaasVMBackupRequest": {
+      "type": "object",
+      "description": "IaaS VM workload-specific backup request.",
+      "properties": {
+        "recoveryPointExpiryTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Backup copy will expire after the time specified (UTC)."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BackupRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMBackupRequest"
+    },
+    "IaasVMILRRegistrationRequest": {
+      "type": "object",
+      "description": "Restore files/folders from a backup copy of IaaS VM.",
+      "properties": {
+        "recoveryPointId": {
+          "type": "string",
+          "description": "ID of the IaaS VM backup copy from where the files/folders have to be restored."
+        },
+        "virtualMachineId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the virtual machine whose the files / folders have to be restored."
+        },
+        "initiatorName": {
+          "type": "string",
+          "description": "iSCSI initiator name."
+        },
+        "renewExistingRegistration": {
+          "type": "boolean",
+          "description": "Whether to renew existing registration with the iSCSI server."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ILRRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMILRRegistrationRequest"
+    },
+    "IaasVMRecoveryPoint": {
+      "type": "object",
+      "description": "IaaS VM workload specific backup copy.",
+      "properties": {
+        "recoveryPointType": {
+          "type": "string",
+          "description": "Type of the backup copy."
+        },
+        "recoveryPointTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time at which this backup copy was created."
+        },
+        "recoveryPointAdditionalInfo": {
+          "type": "string",
+          "description": "Additional information associated with this backup copy."
+        },
+        "sourceVMStorageType": {
+          "type": "string",
+          "description": "Storage type of the VM whose backup copy is created."
+        },
+        "isSourceVMEncrypted": {
+          "type": "boolean",
+          "description": "Identifies whether the VM was encrypted when the backup copy is created."
+        },
+        "keyAndSecret": {
+          "$ref": "#/definitions/KeyAndSecretDetails",
+          "description": "Required details for recovering an encrypted VM. Applicable only when IsSourceVMEncrypted is true."
+        },
+        "isInstantIlrSessionActive": {
+          "type": "boolean",
+          "description": "Is the session to recover items from this backup copy still active."
+        },
+        "recoveryPointTierDetails": {
+          "type": "array",
+          "description": "Recovery point tier information.",
+          "items": {
+            "$ref": "#/definitions/RecoveryPointTierInformationV2"
+          },
+          "x-ms-identifiers": []
+        },
+        "isManagedVirtualMachine": {
+          "type": "boolean",
+          "description": "Whether VM is with Managed Disks"
+        },
+        "virtualMachineSize": {
+          "type": "string",
+          "description": "Virtual Machine Size"
+        },
+        "originalStorageAccountOption": {
+          "type": "boolean",
+          "description": "Original Storage Account Option"
+        },
+        "osType": {
+          "type": "string",
+          "description": "OS type"
+        },
+        "recoveryPointDiskConfiguration": {
+          "$ref": "#/definitions/RecoveryPointDiskConfiguration",
+          "description": "Disk configuration"
+        },
+        "zones": {
+          "type": "array",
+          "description": "Identifies the zone of the VM at the time of backup. Applicable only for zone-pinned Vms",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recoveryPointMoveReadinessInfo": {
+          "type": "object",
+          "description": "Eligibility of RP to be moved to another tier",
+          "additionalProperties": {
+            "$ref": "#/definitions/RecoveryPointMoveReadinessInfo"
+          }
+        },
+        "securityType": {
+          "type": "string",
+          "description": "Security Type of the Disk"
+        },
+        "recoveryPointProperties": {
+          "$ref": "#/definitions/RecoveryPointProperties",
+          "description": "Properties of Recovery Point"
+        },
+        "isPrivateAccessEnabledOnAnyDisk": {
+          "type": "boolean",
+          "description": "This flag denotes if any of the disks in the VM are using Private access network setting"
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "Extended location of the VM recovery point,\nshould be null if VM is in public cloud"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RecoveryPoint"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMRecoveryPoint"
+    },
+    "IaasVMRestoreRequest": {
+      "type": "object",
+      "description": "IaaS VM workload-specific restore.",
+      "properties": {
+        "recoveryPointId": {
+          "type": "string",
+          "description": "ID of the backup copy to be recovered."
+        },
+        "recoveryType": {
+          "$ref": "#/definitions/RecoveryType",
+          "description": "Type of this recovery."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the VM which is being recovered."
+        },
+        "targetVirtualMachineId": {
+          "type": "string",
+          "description": "This is the complete ARM Id of the VM that will be created.\nFor e.g. /subscriptions/{subId}/resourcegroups/{rg}/provider/Microsoft.Compute/virtualmachines/{vm}"
+        },
+        "targetResourceGroupId": {
+          "type": "string",
+          "description": "This is the ARM Id of the resource group that you want to create for this Virtual machine and other artifacts.\nFor e.g. /subscriptions/{subId}/resourcegroups/{rg}"
+        },
+        "storageAccountId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the storage account to which the VM has to be restored."
+        },
+        "virtualNetworkId": {
+          "type": "string",
+          "description": "This is the virtual network Id of the vnet that will be attached to the virtual machine.\nUser will be validated for join action permissions in the linked access."
+        },
+        "subnetId": {
+          "type": "string",
+          "description": "Subnet ID, is the subnet ID associated with the to be restored VM. For Classic VMs it would be\n{VnetID}/Subnet/{SubnetName} and, for the Azure Resource Manager VMs it would be ARM resource ID used to represent\nthe subnet."
+        },
+        "targetDomainNameId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the domain name to be associated to the VM being restored. This applies only to Classic\nVirtual Machines."
+        },
+        "region": {
+          "type": "string",
+          "description": "Region in which the virtual machine is restored."
+        },
+        "affinityGroup": {
+          "type": "string",
+          "description": "Affinity group associated to VM to be restored. Used only for Classic Compute Virtual Machines."
+        },
+        "createNewCloudService": {
+          "type": "boolean",
+          "description": "Should a new cloud service be created while restoring the VM. If this is false, VM will be restored to the same\ncloud service as it was at the time of backup."
+        },
+        "originalStorageAccountOption": {
+          "type": "boolean",
+          "description": "Original Storage Account Option"
+        },
+        "encryptionDetails": {
+          "$ref": "#/definitions/EncryptionDetails",
+          "description": "Details needed if the VM was encrypted at the time of backup."
+        },
+        "restoreDiskLunList": {
+          "type": "array",
+          "description": "List of Disk LUNs for partial restore",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "restoreWithManagedDisks": {
+          "type": "boolean",
+          "description": "Flag to denote of an Unmanaged disk VM should be restored with Managed disks."
+        },
+        "diskEncryptionSetId": {
+          "type": "string",
+          "description": "DiskEncryptionSet's ID - needed if the VM needs to be encrypted at rest during restore with customer managed key."
+        },
+        "zones": {
+          "type": "array",
+          "description": "Target zone where the VM and its disks should be restored.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityInfo": {
+          "$ref": "#/definitions/IdentityInfo",
+          "description": "Managed Identity information required to access customer storage account."
+        },
+        "identityBasedRestoreDetails": {
+          "$ref": "#/definitions/IdentityBasedRestoreDetails",
+          "description": "IaaS VM workload specific restore details for restores using managed identity."
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "Target extended location where the VM should be restored,\nshould be null if restore is to be done in public cloud"
+        },
+        "securedVMDetails": {
+          "$ref": "#/definitions/SecuredVMDetails",
+          "description": "Stores Secured VM Details"
+        },
+        "targetDiskNetworkAccessSettings": {
+          "$ref": "#/definitions/TargetDiskNetworkAccessSettings",
+          "description": "Specifies target network access settings for disks of VM to be restored,"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMRestoreRequest"
+    },
+    "IaasVMRestoreWithRehydrationRequest": {
+      "type": "object",
+      "description": "IaaS VM workload-specific restore with integrated rehydration of recovery point.",
+      "properties": {
+        "recoveryPointRehydrationInfo": {
+          "$ref": "#/definitions/RecoveryPointRehydrationInfo",
+          "description": "RP Rehydration Info"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/IaasVMRestoreRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "IaasVMRestoreWithRehydrationRequest"
+    },
+    "IaasVMSnapshotConsistencyType": {
+      "type": "string",
+      "enum": [
+        "OnlyCrashConsistent"
+      ],
+      "x-ms-enum": {
+        "name": "IaasVMSnapshotConsistencyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OnlyCrashConsistent",
+            "value": "OnlyCrashConsistent"
+          }
+        ]
+      }
+    },
+    "IdentityBasedRestoreDetails": {
+      "type": "object",
+      "description": "IaaS VM workload specific restore details for restores using managed identity",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "Gets the class type."
+        },
+        "targetStorageAccountId": {
+          "type": "string",
+          "description": "Fully qualified ARM ID of the target storage account."
+        }
+      }
+    },
+    "IdentityInfo": {
+      "type": "object",
+      "description": "Encapsulates Managed Identity related information",
+      "properties": {
+        "isSystemAssignedIdentity": {
+          "type": "boolean",
+          "description": "To differentiate if the managed identity is system assigned or user assigned"
+        },
+        "managedIdentityResourceId": {
+          "type": "string",
+          "description": "Managed Identity Resource Id\nOptional: Might not be required in the case of system assigned managed identity"
+        }
+      }
+    },
+    "InfrastructureEncryptionState": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "InfrastructureEncryptionState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "InquiryInfo": {
+      "type": "object",
+      "description": "Details about inquired protectable items under a given container.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Inquiry Status for this container such as\nInProgress | Failed | Succeeded"
+        },
+        "errorDetail": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "Error Details if the Status is non-success."
+        },
+        "inquiryDetails": {
+          "type": "array",
+          "description": "Inquiry Details which will have workload specific details.\nFor e.g. - For SQL and oracle this will contain different details.",
+          "items": {
+            "$ref": "#/definitions/WorkloadInquiryDetails"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "InquiryStatus": {
+      "type": "string",
+      "description": "Status of protectable item, i.e. InProgress,Succeeded,Failed",
+      "enum": [
+        "Invalid",
+        "Success",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "InquiryStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Success",
+            "value": "Success"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "InquiryValidation": {
+      "type": "object",
+      "description": "Validation for inquired protectable items under a given container.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status for the Inquiry Validation."
+        },
+        "errorDetail": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "Error Detail in case the status is non-success."
+        },
+        "additionalDetail": {
+          "type": "string",
+          "description": "Error Additional Detail in case the status is non-success.",
+          "readOnly": true
+        },
+        "protectableItemCount": {
+          "description": "Dictionary to store the count of ProtectableItems with key POType.",
+          "readOnly": true
+        }
+      }
+    },
+    "InstantItemRecoveryTarget": {
+      "type": "object",
+      "description": "Target details for file / folder restore.",
+      "properties": {
+        "clientScripts": {
+          "type": "array",
+          "description": "List of client scripts.",
+          "items": {
+            "$ref": "#/definitions/ClientScriptForConnect"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "InstantRPAdditionalDetails": {
+      "type": "object",
+      "properties": {
+        "azureBackupRGNamePrefix": {
+          "type": "string"
+        },
+        "azureBackupRGNameSuffix": {
+          "type": "string"
+        }
+      }
+    },
+    "IntentItemType": {
+      "type": "string",
+      "description": "Type of workload this item represents",
+      "enum": [
+        "Invalid",
+        "SQLInstance",
+        "SQLAvailabilityGroupContainer"
+      ],
+      "x-ms-enum": {
+        "name": "IntentItemType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "SQLInstance",
+            "value": "SQLInstance"
+          },
+          {
+            "name": "SQLAvailabilityGroupContainer",
+            "value": "SQLAvailabilityGroupContainer"
+          }
+        ]
+      }
+    },
+    "Job": {
+      "type": "object",
+      "description": "Defines workload agnostic properties for a job.",
+      "properties": {
+        "entityFriendlyName": {
+          "type": "string",
+          "description": "Friendly name of the entity on which the current job is executing."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type to execute the current job."
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation name."
+        },
+        "status": {
+          "type": "string",
+          "description": "Job status."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time."
+        },
+        "activityId": {
+          "type": "string",
+          "description": "ActivityId of job."
+        },
+        "jobType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "jobType",
+      "required": [
+        "jobType"
+      ]
+    },
+    "JobOperationType": {
+      "type": "string",
+      "description": "Type of operation.",
+      "enum": [
+        "Invalid",
+        "Register",
+        "UnRegister",
+        "ConfigureBackup",
+        "Backup",
+        "Restore",
+        "DisableBackup",
+        "DeleteBackupData",
+        "CrossRegionRestore",
+        "Undelete",
+        "UpdateCustomerManagedKey"
+      ],
+      "x-ms-enum": {
+        "name": "JobOperationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Register",
+            "value": "Register"
+          },
+          {
+            "name": "UnRegister",
+            "value": "UnRegister"
+          },
+          {
+            "name": "ConfigureBackup",
+            "value": "ConfigureBackup"
+          },
+          {
+            "name": "Backup",
+            "value": "Backup"
+          },
+          {
+            "name": "Restore",
+            "value": "Restore"
+          },
+          {
+            "name": "DisableBackup",
+            "value": "DisableBackup"
+          },
+          {
+            "name": "DeleteBackupData",
+            "value": "DeleteBackupData"
+          },
+          {
+            "name": "CrossRegionRestore",
+            "value": "CrossRegionRestore"
+          },
+          {
+            "name": "Undelete",
+            "value": "Undelete"
+          },
+          {
+            "name": "UpdateCustomerManagedKey",
+            "value": "UpdateCustomerManagedKey"
+          }
+        ]
+      }
+    },
+    "JobQueryObject": {
+      "type": "object",
+      "description": "Filters to list the jobs.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/JobStatus",
+          "description": "Status of the job."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the job."
+        },
+        "operation": {
+          "$ref": "#/definitions/JobOperationType",
+          "description": "Type of operation."
+        },
+        "jobId": {
+          "type": "string",
+          "description": "JobID represents the job uniquely."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Job has started at this time. Value is in UTC."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Job has ended at this time. Value is in UTC."
+        }
+      }
+    },
+    "JobResource": {
+      "type": "object",
+      "description": "Defines workload agnostic properties for a job.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/Job",
+          "description": "JobResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "JobResourceList": {
+      "type": "object",
+      "description": "List of Job resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/JobResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "JobStatus": {
+      "type": "string",
+      "description": "Status of the job.",
+      "enum": [
+        "Invalid",
+        "InProgress",
+        "Completed",
+        "Failed",
+        "CompletedWithWarnings",
+        "Cancelled",
+        "Cancelling"
+      ],
+      "x-ms-enum": {
+        "name": "JobStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "CompletedWithWarnings",
+            "value": "CompletedWithWarnings"
+          },
+          {
+            "name": "Cancelled",
+            "value": "Cancelled"
+          },
+          {
+            "name": "Cancelling",
+            "value": "Cancelling"
+          }
+        ]
+      }
+    },
+    "JobSupportedAction": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "Cancellable",
+        "Retriable"
+      ],
+      "x-ms-enum": {
+        "name": "JobSupportedAction",
+        "modelAsString": false
+      }
+    },
+    "KEKDetails": {
+      "type": "object",
+      "description": "KEK is encryption key for BEK.",
+      "properties": {
+        "keyUrl": {
+          "type": "string",
+          "description": "Key is KEK."
+        },
+        "keyVaultId": {
+          "type": "string",
+          "description": "Key Vault ID where this Key is stored."
+        },
+        "keyBackupData": {
+          "type": "string",
+          "description": "KEK data."
+        }
+      }
+    },
+    "KPIResourceHealthDetails": {
+      "type": "object",
+      "description": "KPI Resource Health Details",
+      "properties": {
+        "resourceHealthStatus": {
+          "$ref": "#/definitions/ResourceHealthStatus",
+          "description": "Resource Health Status"
+        },
+        "resourceHealthDetails": {
+          "type": "array",
+          "description": "Resource Health Status",
+          "items": {
+            "$ref": "#/definitions/ResourceHealthDetails"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        }
+      }
+    },
+    "KeyAndSecretDetails": {
+      "type": "object",
+      "description": "BEK is bitlocker key.\nKEK is encryption key for BEK\nIf the VM was encrypted then we will store following details :\n1. Secret(BEK) - Url + Backup Data + vaultId.\n2. Key(KEK) - Url + Backup Data + vaultId.\n3. EncryptionMechanism\nBEK and KEK can potentially have different vault ids.",
+      "properties": {
+        "kekDetails": {
+          "$ref": "#/definitions/KEKDetails",
+          "description": "KEK is encryption key for BEK."
+        },
+        "bekDetails": {
+          "$ref": "#/definitions/BEKDetails",
+          "description": "BEK is bitlocker encryption key."
+        },
+        "encryptionMechanism": {
+          "type": "string",
+          "description": "Encryption mechanism: None/ SinglePass/ DoublePass"
+        }
+      }
+    },
+    "LastBackupStatus": {
+      "type": "string",
+      "description": "Last backup operation status. Possible values: Healthy, Unhealthy.",
+      "enum": [
+        "Invalid",
+        "Healthy",
+        "Unhealthy",
+        "IRPending"
+      ],
+      "x-ms-enum": {
+        "name": "LastBackupStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Healthy",
+            "value": "Healthy"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy"
+          },
+          {
+            "name": "IRPending",
+            "value": "IRPending"
+          }
+        ]
+      }
+    },
+    "LastUpdateStatus": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "NotEnabled",
+        "PartiallySucceeded",
+        "PartiallyFailed",
+        "Failed",
+        "Succeeded",
+        "Initialized",
+        "FirstInitialization"
+      ],
+      "x-ms-enum": {
+        "name": "LastUpdateStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "NotEnabled",
+            "value": "NotEnabled"
+          },
+          {
+            "name": "PartiallySucceeded",
+            "value": "PartiallySucceeded"
+          },
+          {
+            "name": "PartiallyFailed",
+            "value": "PartiallyFailed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Initialized",
+            "value": "Initialized"
+          },
+          {
+            "name": "FirstInitialization",
+            "value": "FirstInitialization"
+          }
+        ]
+      }
+    },
+    "ListRecoveryPointsRecommendedForMoveRequest": {
+      "type": "object",
+      "description": "ListRecoveryPointsRecommendedForMoveRequest Request",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "Gets the class type."
+        },
+        "excludedRPList": {
+          "type": "array",
+          "description": "List of Recovery Points excluded from Move",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LogSchedulePolicy": {
+      "type": "object",
+      "description": "Log policy schedule.",
+      "properties": {
+        "scheduleFrequencyInMins": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frequency of the log schedule operation of this policy in minutes."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SchedulePolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "LogSchedulePolicy"
+    },
+    "LongTermRetentionPolicy": {
+      "type": "object",
+      "description": "Long term retention policy.",
+      "properties": {
+        "dailySchedule": {
+          "$ref": "#/definitions/DailyRetentionSchedule",
+          "description": "Daily retention schedule of the protection policy."
+        },
+        "weeklySchedule": {
+          "$ref": "#/definitions/WeeklyRetentionSchedule",
+          "description": "Weekly retention schedule of the protection policy."
+        },
+        "monthlySchedule": {
+          "$ref": "#/definitions/MonthlyRetentionSchedule",
+          "description": "Monthly retention schedule of the protection policy."
+        },
+        "yearlySchedule": {
+          "$ref": "#/definitions/YearlyRetentionSchedule",
+          "description": "Yearly retention schedule of the protection policy."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RetentionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "LongTermRetentionPolicy"
+    },
+    "LongTermSchedulePolicy": {
+      "type": "object",
+      "description": "Long term policy schedule.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SchedulePolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "LongTermSchedulePolicy"
+    },
+    "MABContainerHealthDetails": {
+      "type": "object",
+      "description": "MAB workload-specific Health Details.",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Health Code"
+        },
+        "title": {
+          "type": "string",
+          "description": "Health Title"
+        },
+        "message": {
+          "type": "string",
+          "description": "Health Message"
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "Health Recommended Actions",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MabContainer": {
+      "type": "object",
+      "description": "Container with items backed up using MAB backup engine.",
+      "properties": {
+        "canReRegister": {
+          "type": "boolean",
+          "description": "Can the container be registered one more time."
+        },
+        "containerId": {
+          "type": "integer",
+          "format": "int64",
+          "description": "ContainerID represents the container."
+        },
+        "protectedItemCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of items backed up in this container."
+        },
+        "agentVersion": {
+          "type": "string",
+          "description": "Agent version of this container."
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/MabContainerExtendedInfo",
+          "description": "Additional information for this container"
+        },
+        "mabContainerHealthDetails": {
+          "type": "array",
+          "description": "Health details on this mab container.",
+          "items": {
+            "$ref": "#/definitions/MABContainerHealthDetails"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        },
+        "containerHealthState": {
+          "type": "string",
+          "description": "Health state of mab container."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionContainer"
+        }
+      ],
+      "x-ms-discriminator-value": "Windows"
+    },
+    "MabContainerExtendedInfo": {
+      "type": "object",
+      "description": "Additional information of the container.",
+      "properties": {
+        "lastRefreshedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time stamp when this container was refreshed."
+        },
+        "backupItemType": {
+          "$ref": "#/definitions/BackupItemType",
+          "description": "Type of backup items associated with this container."
+        },
+        "backupItems": {
+          "type": "array",
+          "description": "List of backup items associated with this container.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policyName": {
+          "type": "string",
+          "description": "Backup policy associated with this container."
+        },
+        "lastBackupStatus": {
+          "type": "string",
+          "description": "Latest backup status of this container."
+        }
+      }
+    },
+    "MabErrorInfo": {
+      "type": "object",
+      "description": "MAB workload-specific error information.",
+      "properties": {
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string.",
+          "readOnly": true
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "MabFileFolderProtectedItem": {
+      "type": "object",
+      "description": "MAB workload-specific backup item.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of this backup item."
+        },
+        "computerName": {
+          "type": "string",
+          "description": "Name of the computer associated with this backup item."
+        },
+        "lastBackupStatus": {
+          "type": "string",
+          "description": "Status of last backup operation."
+        },
+        "lastBackupTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last backup operation on this backup item."
+        },
+        "protectionState": {
+          "type": "string",
+          "description": "Protected, ProtectionStopped, IRPending or ProtectionError"
+        },
+        "deferredDeleteSyncTimeInUTC": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Sync time for deferred deletion in UTC"
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/MabFileFolderProtectedItemExtendedInfo",
+          "description": "Additional information with this backup item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectedItem"
+        }
+      ],
+      "x-ms-discriminator-value": "MabFileFolderProtectedItem"
+    },
+    "MabFileFolderProtectedItemExtendedInfo": {
+      "type": "object",
+      "description": "Additional information on the backed up item.",
+      "properties": {
+        "lastRefreshedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last time when the agent data synced to service."
+        },
+        "oldestRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The oldest backup copy available."
+        },
+        "recoveryPointCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of backup copies associated with the backup item."
+        }
+      }
+    },
+    "MabJob": {
+      "type": "object",
+      "description": "MAB workload-specific job.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time taken by job to run."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "The state/actions applicable on jobs like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "mabServerName": {
+          "type": "string",
+          "description": "Name of server protecting the DS."
+        },
+        "mabServerType": {
+          "$ref": "#/definitions/MabServerType",
+          "description": "Server type of MAB container."
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type of backup item."
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "The errors.",
+          "items": {
+            "$ref": "#/definitions/MabErrorInfo"
+          },
+          "x-ms-identifiers": []
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/MabJobExtendedInfo",
+          "description": "Additional information on the job."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "MabJob"
+    },
+    "MabJobExtendedInfo": {
+      "type": "object",
+      "description": "Additional information for the MAB workload-specific job.",
+      "properties": {
+        "tasksList": {
+          "type": "array",
+          "description": "List of tasks for this job.",
+          "items": {
+            "$ref": "#/definitions/MabJobTaskDetails"
+          },
+          "x-ms-identifiers": [
+            "taskId"
+          ]
+        },
+        "propertyBag": {
+          "type": "object",
+          "description": "The job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dynamicErrorMessage": {
+          "type": "string",
+          "description": "Non localized error message specific to this job."
+        }
+      }
+    },
+    "MabJobTaskDetails": {
+      "type": "object",
+      "description": "MAB workload-specific job task details.",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "The task display name."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time."
+        },
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed for task."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status."
+        }
+      }
+    },
+    "MabProtectionPolicy": {
+      "type": "object",
+      "description": "Mab container-specific backup policy.",
+      "properties": {
+        "schedulePolicy": {
+          "$ref": "#/definitions/SchedulePolicy",
+          "description": "Backup schedule of backup policy."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Retention policy details."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProtectionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "MAB"
+    },
+    "MabServerType": {
+      "type": "string",
+      "description": "Server type of MAB container.",
+      "enum": [
+        "Invalid",
+        "Unknown",
+        "IaasVMContainer",
+        "IaasVMServiceContainer",
+        "DPMContainer",
+        "AzureBackupServerContainer",
+        "MABContainer",
+        "Cluster",
+        "AzureSqlContainer",
+        "Windows",
+        "VCenter",
+        "VMAppContainer",
+        "SQLAGWorkLoadContainer",
+        "StorageContainer",
+        "GenericContainer"
+      ],
+      "x-ms-enum": {
+        "name": "MabServerType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          },
+          {
+            "name": "IaasVMContainer",
+            "value": "IaasVMContainer"
+          },
+          {
+            "name": "IaasVMServiceContainer",
+            "value": "IaasVMServiceContainer"
+          },
+          {
+            "name": "DPMContainer",
+            "value": "DPMContainer"
+          },
+          {
+            "name": "AzureBackupServerContainer",
+            "value": "AzureBackupServerContainer"
+          },
+          {
+            "name": "MABContainer",
+            "value": "MABContainer"
+          },
+          {
+            "name": "Cluster",
+            "value": "Cluster"
+          },
+          {
+            "name": "AzureSqlContainer",
+            "value": "AzureSqlContainer"
+          },
+          {
+            "name": "Windows",
+            "value": "Windows"
+          },
+          {
+            "name": "VCenter",
+            "value": "VCenter"
+          },
+          {
+            "name": "VMAppContainer",
+            "value": "VMAppContainer"
+          },
+          {
+            "name": "SQLAGWorkLoadContainer",
+            "value": "SQLAGWorkLoadContainer"
+          },
+          {
+            "name": "StorageContainer",
+            "value": "StorageContainer"
+          },
+          {
+            "name": "GenericContainer",
+            "value": "GenericContainer"
+          }
+        ]
+      }
+    },
+    "MonthOfYear": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+      ],
+      "x-ms-enum": {
+        "name": "MonthOfYear",
+        "modelAsString": false
+      }
+    },
+    "MonthlyRetentionSchedule": {
+      "type": "object",
+      "description": "Monthly retention schedule.",
+      "properties": {
+        "retentionScheduleFormatType": {
+          "$ref": "#/definitions/RetentionScheduleFormat",
+          "description": "Retention schedule format type for monthly retention policy."
+        },
+        "retentionScheduleDaily": {
+          "$ref": "#/definitions/DailyRetentionFormat",
+          "description": "Daily retention format for monthly retention policy."
+        },
+        "retentionScheduleWeekly": {
+          "$ref": "#/definitions/WeeklyRetentionFormat",
+          "description": "Weekly retention format for monthly retention policy."
+        },
+        "retentionTimes": {
+          "type": "array",
+          "description": "Retention times of retention policy.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "retentionDuration": {
+          "$ref": "#/definitions/RetentionDuration",
+          "description": "Retention duration of retention Policy."
+        }
+      }
+    },
+    "MoveRPAcrossTiersRequest": {
+      "type": "object",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "Gets the class type."
+        },
+        "sourceTierType": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "Source tier from where RP needs to be moved"
+        },
+        "targetTierType": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "Target tier where RP needs to be moved"
+        }
+      }
+    },
+    "NameInfo": {
+      "type": "object",
+      "description": "The name of usage.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Value of usage."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "Localized value of usage."
+        }
+      }
+    },
+    "OperationResultInfo": {
+      "type": "object",
+      "description": "Operation result info.",
+      "properties": {
+        "jobList": {
+          "type": "array",
+          "description": "List of jobs created by this operation.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationResultInfoBase"
+        }
+      ],
+      "x-ms-discriminator-value": "OperationResultInfo"
+    },
+    "OperationResultInfoBase": {
+      "type": "object",
+      "description": "Base class for operation result info.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "OperationResultInfoBaseResource": {
+      "type": "object",
+      "description": "Base class for operation result info.",
+      "properties": {
+        "operation": {
+          "$ref": "#/definitions/OperationResultInfoBase",
+          "description": "OperationResultInfoBaseResource operation"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationWorkerResponse"
+        }
+      ]
+    },
+    "OperationStatus": {
+      "type": "object",
+      "description": "Operation status.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the operation."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the operation."
+        },
+        "status": {
+          "$ref": "#/definitions/OperationStatusValues",
+          "description": "Operation status."
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Operation start time. Format: ISO-8601."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Operation end time. Format: ISO-8601."
+        },
+        "error": {
+          "$ref": "#/definitions/OperationStatusError",
+          "description": "Error information related to this operation."
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationStatusExtendedInfo",
+          "description": "Additional information associated with this operation."
+        }
+      }
+    },
+    "OperationStatusError": {
+      "type": "object",
+      "description": "Error information associated with operation status call.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code of the operation failure."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message displayed if the operation failure."
+        }
+      }
+    },
+    "OperationStatusExtendedInfo": {
+      "type": "object",
+      "description": "Base class for additional information of operation status.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "OperationStatusJobExtendedInfo": {
+      "type": "object",
+      "description": "Operation status job extended info.",
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "ID of the job created for this protected item."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationStatusExtendedInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "OperationStatusJobExtendedInfo"
+    },
+    "OperationStatusJobsExtendedInfo": {
+      "type": "object",
+      "description": "Operation status extended info for list of jobs.",
+      "properties": {
+        "jobIds": {
+          "type": "array",
+          "description": "IDs of the jobs created for the protected item.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "failedJobsError": {
+          "type": "object",
+          "description": "Stores all the failed jobs along with the corresponding error codes.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationStatusExtendedInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "OperationStatusJobsExtendedInfo"
+    },
+    "OperationStatusProvisionILRExtendedInfo": {
+      "type": "object",
+      "description": "Operation status extended info for ILR provision action.",
+      "properties": {
+        "recoveryTarget": {
+          "$ref": "#/definitions/InstantItemRecoveryTarget",
+          "description": "Target details for file / folder restore."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationStatusExtendedInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "OperationStatusProvisionILRExtendedInfo"
+    },
+    "OperationStatusValidateOperationExtendedInfo": {
+      "type": "object",
+      "description": "Operation status extended info for ValidateOperation action.",
+      "properties": {
+        "validateOperationResponse": {
+          "$ref": "#/definitions/ValidateOperationResponse",
+          "description": "Gets the validation operation response"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OperationStatusExtendedInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "OperationStatusValidateOperationExtendedInfo"
+    },
+    "OperationStatusValues": {
+      "type": "string",
+      "description": "Operation status.",
+      "enum": [
+        "Invalid",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "OperationStatusValues",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      }
+    },
+    "OperationType": {
+      "type": "string",
+      "description": "Re-Do Operation",
+      "enum": [
+        "Invalid",
+        "Register",
+        "Reregister",
+        "Rehydrate"
+      ],
+      "x-ms-enum": {
+        "name": "OperationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Register",
+            "value": "Register"
+          },
+          {
+            "name": "Reregister",
+            "value": "Reregister"
+          },
+          {
+            "name": "Rehydrate",
+            "value": "Rehydrate"
+          }
+        ]
+      }
+    },
+    "OperationWorkerResponse": {
+      "type": "object",
+      "description": "This is the base class for operation result responses.",
+      "properties": {
+        "statusCode": {
+          "$ref": "#/definitions/HttpStatusCode",
+          "description": "HTTP Status Code of the operation."
+        },
+        "headers": {
+          "type": "object",
+          "description": "HTTP headers associated with this operation.",
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
+    "OverwriteOptions": {
+      "type": "string",
+      "description": "Can Overwrite if Target DataBase already exists",
+      "enum": [
+        "Invalid",
+        "FailOnConflict",
+        "Overwrite"
+      ],
+      "x-ms-enum": {
+        "name": "OverwriteOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "FailOnConflict",
+            "value": "FailOnConflict"
+          },
+          {
+            "name": "Overwrite",
+            "value": "Overwrite"
+          }
+        ]
+      }
+    },
+    "PointInTimeRange": {
+      "type": "object",
+      "description": "Provides details for log ranges",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start time of the time range for log recovery."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End time of the time range for log recovery."
+        }
+      }
+    },
+    "PolicyType": {
+      "type": "string",
+      "description": "Type of backup policy type",
+      "enum": [
+        "Invalid",
+        "Full",
+        "Differential",
+        "Log",
+        "CopyOnlyFull",
+        "Incremental",
+        "SnapshotFull",
+        "SnapshotCopyOnlyFull"
+      ],
+      "x-ms-enum": {
+        "name": "PolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Full",
+            "value": "Full"
+          },
+          {
+            "name": "Differential",
+            "value": "Differential"
+          },
+          {
+            "name": "Log",
+            "value": "Log"
+          },
+          {
+            "name": "CopyOnlyFull",
+            "value": "CopyOnlyFull"
+          },
+          {
+            "name": "Incremental",
+            "value": "Incremental"
+          },
+          {
+            "name": "SnapshotFull",
+            "value": "SnapshotFull"
+          },
+          {
+            "name": "SnapshotCopyOnlyFull",
+            "value": "SnapshotCopyOnlyFull"
+          }
+        ]
+      }
+    },
+    "PreBackupValidation": {
+      "type": "object",
+      "description": "Pre-backup validation for Azure VM Workload provider.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/InquiryStatus",
+          "description": "Status of protectable item, i.e. InProgress,Succeeded,Failed"
+        },
+        "code": {
+          "type": "string",
+          "description": "Error code of protectable item"
+        },
+        "message": {
+          "type": "string",
+          "description": "Message corresponding to the error code for the protectable item"
+        }
+      }
+    },
+    "PreValidateEnableBackupRequest": {
+      "type": "object",
+      "description": "Contract to validate if backup can be enabled on the given resource in a given vault and given configuration.\nIt will validate followings\n1. Vault capacity\n2. VM is already protected\n3. Any VM related configuration passed in properties.",
+      "properties": {
+        "resourceType": {
+          "$ref": "#/definitions/DataSourceType",
+          "description": "ProtectedItem Type- VM, SqlDataBase, AzureFileShare etc"
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "ARM Virtual Machine Id"
+        },
+        "vaultId": {
+          "type": "string",
+          "description": "ARM id of the Recovery Services Vault"
+        },
+        "properties": {
+          "type": "string",
+          "description": "Configuration of VM if any needs to be validated like OS type etc"
+        }
+      }
+    },
+    "PreValidateEnableBackupResponse": {
+      "type": "object",
+      "description": "Response contract for enable backup validation request",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ValidationStatus",
+          "description": "Validation Status"
+        },
+        "errorCode": {
+          "type": "string",
+          "description": "Response error code"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Response error message"
+        },
+        "recommendation": {
+          "type": "string",
+          "description": "Recommended action for user"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Specifies the product specific container name. E.g. iaasvmcontainer;iaasvmcontainer;rgname;vmname. This is required\nfor portal"
+        },
+        "protectedItemName": {
+          "type": "string",
+          "description": "Specifies the product specific ds name. E.g. vm;iaasvmcontainer;rgname;vmname. This is required for portal"
+        }
+      }
+    },
+    "PrepareDataMoveRequest": {
+      "type": "object",
+      "description": "Prepare DataMove Request",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "ARM Id of target vault"
+        },
+        "targetRegion": {
+          "type": "string",
+          "description": "Target Region"
+        },
+        "dataMoveLevel": {
+          "$ref": "#/definitions/DataMoveLevel",
+          "description": "DataMove Level"
+        },
+        "sourceContainerArmIds": {
+          "type": "array",
+          "description": "Source Container ArmIds\nThis needs to be populated only if DataMoveLevel is set to container",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignoreMoved": {
+          "type": "boolean",
+          "description": "Ignore the artifacts which are already moved."
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "targetRegion",
+        "dataMoveLevel"
+      ]
+    },
+    "PrepareDataMoveResponse": {
+      "type": "object",
+      "description": "Prepare DataMove Response",
+      "properties": {
+        "correlationId": {
+          "type": "string",
+          "description": "Co-relationId for move operation"
+        },
+        "sourceVaultProperties": {
+          "type": "object",
+          "description": "Source Vault Properties",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/VaultStorageConfigOperationResultResponse"
+        }
+      ],
+      "x-ms-discriminator-value": "PrepareDataMoveResponse"
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The Private Endpoint network resource that is linked to the Private Endpoint connection",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Gets or sets id"
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "Private Endpoint Connection Response Properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets or sets provisioning state of the private endpoint connection"
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "Gets or sets private endpoint associated with the private endpoint connection"
+        },
+        "groupIds": {
+          "type": "array",
+          "description": "Group Ids for the Private Endpoint",
+          "items": {
+            "$ref": "#/definitions/VaultSubResourceType"
+          }
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "Gets or sets private link service connection state"
+        }
+      }
+    },
+    "PrivateEndpointConnectionResource": {
+      "type": "object",
+      "description": "Private Endpoint Connection Response Properties",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnection",
+          "description": "PrivateEndpointConnectionResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionStatus": {
+      "type": "string",
+      "description": "Gets or sets the status",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "Private Link Service Connection State",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateEndpointConnectionStatus",
+          "description": "Gets or sets the status"
+        },
+        "description": {
+          "type": "string",
+          "description": "Gets or sets description"
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "Gets or sets actions required"
+        }
+      }
+    },
+    "ProtectableContainer": {
+      "type": "object",
+      "description": "Protectable Container Class.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the container."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the container."
+        },
+        "protectableContainerType": {
+          "$ref": "#/definitions/ProtectableContainerType",
+          "description": "Type of the container. The value of this property for\n1. Compute Azure VM is Microsoft.Compute/virtualMachines\n2. Classic Compute Azure VM is Microsoft.ClassicCompute/virtualMachines"
+        },
+        "healthStatus": {
+          "type": "string",
+          "description": "Status of health of the container."
+        },
+        "containerId": {
+          "type": "string",
+          "description": "Fabric Id of the container such as ARM Id."
+        }
+      },
+      "discriminator": "protectableContainerType",
+      "required": [
+        "protectableContainerType"
+      ]
+    },
+    "ProtectableContainerResource": {
+      "type": "object",
+      "description": "Protectable Container Class.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/ProtectableContainer",
+          "description": "ProtectableContainerResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ProtectableContainerResourceList": {
+      "type": "object",
+      "description": "List of ProtectableContainer resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ProtectableContainerResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ProtectableContainerType": {
+      "type": "string",
+      "description": "Type of the container. The value of this property for\n1. Compute Azure VM is Microsoft.Compute/virtualMachines\n2. Classic Compute Azure VM is Microsoft.ClassicCompute/virtualMachines",
+      "enum": [
+        "Invalid",
+        "Unknown",
+        "IaasVMContainer",
+        "IaasVMServiceContainer",
+        "DPMContainer",
+        "AzureBackupServerContainer",
+        "MABContainer",
+        "Cluster",
+        "AzureSqlContainer",
+        "Windows",
+        "VCenter",
+        "VMAppContainer",
+        "SQLAGWorkLoadContainer",
+        "StorageContainer",
+        "GenericContainer",
+        "Microsoft.ClassicCompute/virtualMachines",
+        "Microsoft.Compute/virtualMachines",
+        "AzureWorkloadContainer"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectableContainerType",
+        "modelAsString": false
+      }
+    },
+    "ProtectedItem": {
+      "type": "object",
+      "description": "Base class for backup items.",
+      "properties": {
+        "protectedItemType": {
+          "type": "string",
+          "description": "backup item type."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the backed up item.",
+          "readOnly": true
+        },
+        "workloadType": {
+          "$ref": "#/definitions/DataSourceType",
+          "description": "Type of workload this item represents.",
+          "readOnly": true
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Unique name of container"
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM ID of the resource to be backed up."
+        },
+        "policyId": {
+          "type": "string",
+          "description": "ID of the backup policy with which this item is backed up."
+        },
+        "lastRecoveryPoint": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the last (latest) backup copy was created for this backup item."
+        },
+        "backupSetName": {
+          "type": "string",
+          "description": "Name of the backup set the backup item belongs to"
+        },
+        "createMode": {
+          "$ref": "#/definitions/CreateMode",
+          "description": "Create mode to indicate recovery of existing soft deleted data source or creation of new data source."
+        },
+        "deferredDeleteTimeInUTC": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time for deferred deletion in UTC"
+        },
+        "isScheduledForDeferredDelete": {
+          "type": "boolean",
+          "description": "Flag to identify whether the DS is scheduled for deferred delete"
+        },
+        "deferredDeleteTimeRemaining": {
+          "type": "string",
+          "description": "Time remaining before the DS marked for deferred delete is permanently deleted"
+        },
+        "isDeferredDeleteScheduleUpcoming": {
+          "type": "boolean",
+          "description": "Flag to identify whether the deferred deleted DS is to be purged soon"
+        },
+        "isRehydrate": {
+          "type": "boolean",
+          "description": "Flag to identify that deferred deleted DS is to be moved into Pause state"
+        },
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isArchiveEnabled": {
+          "type": "boolean",
+          "description": "Flag to identify whether datasource is protected in archive"
+        },
+        "policyName": {
+          "type": "string",
+          "description": "Name of the policy used for protection"
+        },
+        "softDeleteRetentionPeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Soft delete retention period in days"
+        },
+        "vaultId": {
+          "type": "string",
+          "description": "ID of the vault which protects this item",
+          "readOnly": true
+        }
+      },
+      "discriminator": "protectedItemType",
+      "required": [
+        "protectedItemType"
+      ]
+    },
+    "ProtectedItemHealthStatus": {
+      "type": "string",
+      "description": "Health status of the backup item, evaluated based on last heartbeat received",
+      "enum": [
+        "Invalid",
+        "Healthy",
+        "Unhealthy",
+        "NotReachable",
+        "IRPending"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectedItemHealthStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Healthy",
+            "value": "Healthy"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy"
+          },
+          {
+            "name": "NotReachable",
+            "value": "NotReachable"
+          },
+          {
+            "name": "IRPending",
+            "value": "IRPending"
+          }
+        ]
+      }
+    },
+    "ProtectedItemQueryObject": {
+      "type": "object",
+      "description": "Filters to list backup items.",
+      "properties": {
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health State for the backed up item."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for the backed up item."
+        },
+        "itemType": {
+          "$ref": "#/definitions/DataSourceType",
+          "description": "Type of workload this item represents."
+        },
+        "policyName": {
+          "type": "string",
+          "description": "Backup policy name associated with the backup item."
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Name of the container."
+        },
+        "backupEngineName": {
+          "type": "string",
+          "description": "Backup Engine name"
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of protected item"
+        },
+        "fabricName": {
+          "type": "string",
+          "description": "Name of the fabric."
+        },
+        "backupSetName": {
+          "type": "string",
+          "description": "Name of the backup set."
+        }
+      }
+    },
+    "ProtectedItemResource": {
+      "type": "object",
+      "description": "Base class for backup items.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProtectedItem",
+          "description": "ProtectedItemResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProtectedItemResourceList": {
+      "type": "object",
+      "description": "List of ProtectedItem resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ProtectedItemResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ProtectedItemState": {
+      "type": "string",
+      "description": "Backup state of the backed up item.",
+      "enum": [
+        "Invalid",
+        "IRPending",
+        "Protected",
+        "ProtectionError",
+        "ProtectionStopped",
+        "ProtectionPaused",
+        "BackupsSuspended"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectedItemState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "IRPending",
+            "value": "IRPending"
+          },
+          {
+            "name": "Protected",
+            "value": "Protected"
+          },
+          {
+            "name": "ProtectionError",
+            "value": "ProtectionError"
+          },
+          {
+            "name": "ProtectionStopped",
+            "value": "ProtectionStopped"
+          },
+          {
+            "name": "ProtectionPaused",
+            "value": "ProtectionPaused"
+          },
+          {
+            "name": "BackupsSuspended",
+            "value": "BackupsSuspended"
+          }
+        ]
+      }
+    },
+    "ProtectionContainer": {
+      "type": "object",
+      "description": "Base class for container with backup items. Containers with specific workloads are derived from this class.",
+      "properties": {
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the container."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the container."
+        },
+        "registrationStatus": {
+          "type": "string",
+          "description": "Status of registration of the container with the Recovery Services Vault."
+        },
+        "healthStatus": {
+          "type": "string",
+          "description": "Status of health of the container."
+        },
+        "containerType": {
+          "$ref": "#/definitions/ProtectableContainerType",
+          "description": "Type of the container. The value of this property for: 1. Compute Azure VM is Microsoft.Compute/virtualMachines 2.\nClassic Compute Azure VM is Microsoft.ClassicCompute/virtualMachines 3. Windows machines (like MAB, DPM etc) is\nWindows 4. Azure SQL instance is AzureSqlContainer. 5. Storage containers is StorageContainer. 6. Azure workload\nBackup is VMAppContainer"
+        },
+        "protectableObjectType": {
+          "type": "string",
+          "description": "Type of the protectable object associated with this container"
+        }
+      },
+      "discriminator": "containerType",
+      "required": [
+        "containerType"
+      ]
+    },
+    "ProtectionContainerResource": {
+      "type": "object",
+      "description": "Base class for container with backup items. Containers with specific workloads are derived from this class.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProtectionContainer",
+          "description": "ProtectionContainerResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProtectionContainerResourceList": {
+      "type": "object",
+      "description": "List of ProtectionContainer resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ProtectionContainerResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ProtectionIntent": {
+      "type": "object",
+      "description": "Base class for backup ProtectionIntent.",
+      "properties": {
+        "protectionIntentItemType": {
+          "$ref": "#/definitions/ProtectionIntentItemType",
+          "description": "backup protectionIntent type."
+        },
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Type of backup management for the backed up item."
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM ID of the resource to be backed up."
+        },
+        "itemId": {
+          "type": "string",
+          "description": "ID of the item which is getting protected, In case of Azure Vm , it is ProtectedItemId"
+        },
+        "policyId": {
+          "type": "string",
+          "description": "ID of the backup policy with which this item is backed up."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionStatus",
+          "description": "Backup state of this backup item."
+        }
+      },
+      "discriminator": "protectionIntentItemType",
+      "required": [
+        "protectionIntentItemType"
+      ]
+    },
+    "ProtectionIntentItemType": {
+      "type": "string",
+      "description": "backup protectionIntent type.",
+      "enum": [
+        "Invalid",
+        "AzureResourceItem",
+        "RecoveryServiceVaultItem",
+        "AzureWorkloadContainerAutoProtectionIntent",
+        "AzureWorkloadAutoProtectionIntent",
+        "AzureWorkloadSQLAutoProtectionIntent"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectionIntentItemType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "AzureResourceItem",
+            "value": "AzureResourceItem"
+          },
+          {
+            "name": "RecoveryServiceVaultItem",
+            "value": "RecoveryServiceVaultItem"
+          },
+          {
+            "name": "AzureWorkloadContainerAutoProtectionIntent",
+            "value": "AzureWorkloadContainerAutoProtectionIntent"
+          },
+          {
+            "name": "AzureWorkloadAutoProtectionIntent",
+            "value": "AzureWorkloadAutoProtectionIntent"
+          },
+          {
+            "name": "AzureWorkloadSQLAutoProtectionIntent",
+            "value": "AzureWorkloadSQLAutoProtectionIntent"
+          }
+        ]
+      }
+    },
+    "ProtectionIntentQueryObject": {
+      "type": "object",
+      "description": "Filters to list protection intent.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for the backed up item"
+        },
+        "itemType": {
+          "$ref": "#/definitions/IntentItemType",
+          "description": "Type of workload this item represents"
+        },
+        "parentName": {
+          "type": "string",
+          "description": "Parent name of the intent"
+        },
+        "itemName": {
+          "type": "string",
+          "description": "Item name of the intent"
+        }
+      }
+    },
+    "ProtectionIntentResource": {
+      "type": "object",
+      "description": "Base class for backup ProtectionIntent.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProtectionIntent",
+          "description": "ProtectionIntentResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProtectionIntentResourceList": {
+      "type": "object",
+      "description": "List of ProtectionIntent resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ProtectionIntentResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ProtectionPolicy": {
+      "type": "object",
+      "description": "Base class for backup policy. Workload-specific backup policies are derived from this class.",
+      "properties": {
+        "protectedItemsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items associated with this policy."
+        },
+        "backupManagementType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        },
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "description": "ResourceGuard Operation Requests",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "discriminator": "backupManagementType",
+      "required": [
+        "backupManagementType"
+      ]
+    },
+    "ProtectionPolicyQueryObject": {
+      "type": "object",
+      "description": "Filters the list backup policies API.",
+      "properties": {
+        "backupManagementType": {
+          "$ref": "#/definitions/BackupManagementType",
+          "description": "Backup management type for the backup policy."
+        },
+        "fabricName": {
+          "type": "string",
+          "description": "Fabric name for filter"
+        },
+        "workloadType": {
+          "$ref": "#/definitions/WorkloadType",
+          "description": "Workload type for the backup policy."
+        }
+      }
+    },
+    "ProtectionPolicyResource": {
+      "type": "object",
+      "description": "Base class for backup policy. Workload-specific backup policies are derived from this class.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProtectionPolicy",
+          "description": "ProtectionPolicyResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProtectionPolicyResourceList": {
+      "type": "object",
+      "description": "List of ProtectionPolicy resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ProtectionPolicyResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ProtectionState": {
+      "type": "string",
+      "description": "Backup state of this backup item.",
+      "enum": [
+        "Invalid",
+        "IRPending",
+        "Protected",
+        "ProtectionError",
+        "ProtectionStopped",
+        "ProtectionPaused",
+        "BackupsSuspended"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectionState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "IRPending",
+            "value": "IRPending"
+          },
+          {
+            "name": "Protected",
+            "value": "Protected"
+          },
+          {
+            "name": "ProtectionError",
+            "value": "ProtectionError"
+          },
+          {
+            "name": "ProtectionStopped",
+            "value": "ProtectionStopped"
+          },
+          {
+            "name": "ProtectionPaused",
+            "value": "ProtectionPaused"
+          },
+          {
+            "name": "BackupsSuspended",
+            "value": "BackupsSuspended"
+          }
+        ]
+      }
+    },
+    "ProtectionStatus": {
+      "type": "string",
+      "description": "Specifies whether the container is registered or not",
+      "enum": [
+        "Invalid",
+        "NotProtected",
+        "Protecting",
+        "Protected",
+        "ProtectionFailed"
+      ],
+      "x-ms-enum": {
+        "name": "ProtectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "NotProtected",
+            "value": "NotProtected"
+          },
+          {
+            "name": "Protecting",
+            "value": "Protecting"
+          },
+          {
+            "name": "Protected",
+            "value": "Protected"
+          },
+          {
+            "name": "ProtectionFailed",
+            "value": "ProtectionFailed"
+          }
+        ]
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Gets or sets provisioning state of the private endpoint connection",
+      "enum": [
+        "Succeeded",
+        "Deleting",
+        "Failed",
+        "Pending"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending"
+          }
+        ]
+      }
+    },
+    "RecoveryMode": {
+      "type": "string",
+      "description": "Defines whether the current recovery mode is file restore or database restore",
+      "enum": [
+        "Invalid",
+        "FileRecovery",
+        "WorkloadRecovery",
+        "SnapshotAttach",
+        "RecoveryUsingSnapshot",
+        "SnapshotAttachAndRecover"
+      ],
+      "x-ms-enum": {
+        "name": "RecoveryMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "FileRecovery",
+            "value": "FileRecovery"
+          },
+          {
+            "name": "WorkloadRecovery",
+            "value": "WorkloadRecovery"
+          },
+          {
+            "name": "SnapshotAttach",
+            "value": "SnapshotAttach"
+          },
+          {
+            "name": "RecoveryUsingSnapshot",
+            "value": "RecoveryUsingSnapshot"
+          },
+          {
+            "name": "SnapshotAttachAndRecover",
+            "value": "SnapshotAttachAndRecover"
+          }
+        ]
+      }
+    },
+    "RecoveryPoint": {
+      "type": "object",
+      "description": "Base class for backup copies. Workload-specific backup copies are derived from this class.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "RecoveryPointDiskConfiguration": {
+      "type": "object",
+      "description": "Disk configuration",
+      "properties": {
+        "numberOfDisksIncludedInBackup": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of disks included in backup"
+        },
+        "numberOfDisksAttachedToVm": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of disks attached to the VM"
+        },
+        "includedDiskList": {
+          "type": "array",
+          "description": "Information of disks included in backup",
+          "items": {
+            "$ref": "#/definitions/DiskInformation"
+          },
+          "x-ms-identifiers": []
+        },
+        "excludedDiskList": {
+          "type": "array",
+          "description": "Information of disks excluded from backup",
+          "items": {
+            "$ref": "#/definitions/DiskInformation"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "RecoveryPointMoveReadinessInfo": {
+      "type": "object",
+      "properties": {
+        "isReadyForMove": {
+          "type": "boolean"
+        },
+        "additionalInfo": {
+          "type": "string"
+        }
+      }
+    },
+    "RecoveryPointProperties": {
+      "type": "object",
+      "description": "Properties of Recovery Point",
+      "properties": {
+        "expiryTime": {
+          "type": "string",
+          "description": "Expiry time of Recovery Point in UTC."
+        },
+        "ruleName": {
+          "type": "string",
+          "description": "Rule name tagged on Recovery Point that governs life cycle"
+        },
+        "isSoftDeleted": {
+          "type": "boolean",
+          "description": "Bool to indicate whether RP is in soft delete state or not"
+        }
+      }
+    },
+    "RecoveryPointRehydrationInfo": {
+      "type": "object",
+      "description": "RP Rehydration Info",
+      "properties": {
+        "rehydrationRetentionDuration": {
+          "type": "string",
+          "description": "How long the rehydrated RP should be kept\nShould be ISO8601 Duration format e.g. \"P7D\""
+        },
+        "rehydrationPriority": {
+          "$ref": "#/definitions/RehydrationPriority",
+          "description": "Rehydration Priority"
+        }
+      }
+    },
+    "RecoveryPointResource": {
+      "type": "object",
+      "description": "Base class for backup copies. Workload-specific backup copies are derived from this class.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RecoveryPoint",
+          "description": "RecoveryPointResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RecoveryPointResourceList": {
+      "type": "object",
+      "description": "List of RecoveryPoint resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/RecoveryPointResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "RecoveryPointTierInformation": {
+      "type": "object",
+      "description": "Recovery point tier information.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "Recovery point tier type."
+        },
+        "status": {
+          "$ref": "#/definitions/RecoveryPointTierStatus",
+          "description": "Recovery point tier status."
+        },
+        "extendedInfo": {
+          "type": "object",
+          "description": "Recovery point tier status.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RecoveryPointTierInformationV2": {
+      "type": "object",
+      "description": "RecoveryPoint Tier Information V2",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RecoveryPointTierType",
+          "description": "Recovery point tier type."
+        },
+        "status": {
+          "$ref": "#/definitions/RecoveryPointTierStatus",
+          "description": "Recovery point tier status."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RecoveryPointTierInformation"
+        }
+      ]
+    },
+    "RecoveryPointTierStatus": {
+      "type": "string",
+      "description": "Recovery point tier status.",
+      "enum": [
+        "Invalid",
+        "Valid",
+        "Disabled",
+        "Deleted",
+        "Rehydrated"
+      ],
+      "x-ms-enum": {
+        "name": "RecoveryPointTierStatus",
+        "modelAsString": true
+      }
+    },
+    "RecoveryPointTierType": {
+      "type": "string",
+      "description": "Recovery point tier type.",
+      "enum": [
+        "Invalid",
+        "InstantRP",
+        "HardenedRP",
+        "ArchivedRP"
+      ],
+      "x-ms-enum": {
+        "name": "RecoveryPointTierType",
+        "modelAsString": false
+      }
+    },
+    "RecoveryType": {
+      "type": "string",
+      "description": "Type of this recovery.",
+      "enum": [
+        "Invalid",
+        "OriginalLocation",
+        "AlternateLocation",
+        "RestoreDisks",
+        "Offline"
+      ],
+      "x-ms-enum": {
+        "name": "RecoveryType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "OriginalLocation",
+            "value": "OriginalLocation"
+          },
+          {
+            "name": "AlternateLocation",
+            "value": "AlternateLocation"
+          },
+          {
+            "name": "RestoreDisks",
+            "value": "RestoreDisks"
+          },
+          {
+            "name": "Offline",
+            "value": "Offline"
+          }
+        ]
+      }
+    },
+    "RehydrationPriority": {
+      "type": "string",
+      "description": "Rehydration Priority",
+      "enum": [
+        "Standard",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "RehydrationPriority",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "High",
+            "value": "High"
+          }
+        ]
+      }
+    },
+    "ResourceGuardOperationDetail": {
+      "type": "object",
+      "properties": {
+        "vaultCriticalOperation": {
+          "type": "string"
+        },
+        "defaultResourceRequest": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceGuardProxyBase": {
+      "type": "object",
+      "properties": {
+        "resourceGuardResourceId": {
+          "type": "string"
+        },
+        "resourceGuardOperationDetails": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardOperationDetail"
+          },
+          "x-ms-identifiers": []
+        },
+        "lastUpdatedTime": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceGuardResourceId"
+      ]
+    },
+    "ResourceGuardProxyBaseResource": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ResourceGuardProxyBase",
+          "description": "ResourceGuardProxyBaseResource properties"
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ResourceGuardProxyBaseResourceList": {
+      "type": "object",
+      "description": "List of ResourceGuardProxyBase resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/ResourceGuardProxyBaseResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "ResourceHealthDetails": {
+      "type": "object",
+      "description": "Health Details for backup items.",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Health Code",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "description": "Health Title",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Health Message",
+          "readOnly": true
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "Health Recommended Actions",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ResourceHealthStatus": {
+      "type": "string",
+      "description": "Resource Health Status",
+      "enum": [
+        "Healthy",
+        "TransientDegraded",
+        "PersistentDegraded",
+        "TransientUnhealthy",
+        "PersistentUnhealthy",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceHealthStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Healthy",
+            "value": "Healthy"
+          },
+          {
+            "name": "TransientDegraded",
+            "value": "TransientDegraded"
+          },
+          {
+            "name": "PersistentDegraded",
+            "value": "PersistentDegraded"
+          },
+          {
+            "name": "TransientUnhealthy",
+            "value": "TransientUnhealthy"
+          },
+          {
+            "name": "PersistentUnhealthy",
+            "value": "PersistentUnhealthy"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          }
+        ]
+      }
+    },
+    "ResourceList": {
+      "type": "object",
+      "description": "Base for all lists of resources.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The URI to fetch the next page of resources, with each API call returning up to 200 resources per page. Use ListNext() to fetch the next page if the total number of resources exceeds 200."
+        }
+      }
+    },
+    "RestoreFileSpecs": {
+      "type": "object",
+      "description": "Restore file specs like file path, type and target folder path info.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Source File/Folder path"
+        },
+        "fileSpecType": {
+          "type": "string",
+          "description": "Indicates what the Path variable stands for"
+        },
+        "targetFolderPath": {
+          "type": "string",
+          "description": "Destination folder path in target FileShare"
+        }
+      }
+    },
+    "RestorePointQueryType": {
+      "type": "string",
+      "description": "RestorePoint type",
+      "enum": [
+        "Invalid",
+        "Full",
+        "Log",
+        "Differential",
+        "FullAndDifferential",
+        "All",
+        "Incremental",
+        "SnapshotFull",
+        "SnapshotCopyOnlyFull"
+      ],
+      "x-ms-enum": {
+        "name": "RestorePointQueryType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Full",
+            "value": "Full"
+          },
+          {
+            "name": "Log",
+            "value": "Log"
+          },
+          {
+            "name": "Differential",
+            "value": "Differential"
+          },
+          {
+            "name": "FullAndDifferential",
+            "value": "FullAndDifferential"
+          },
+          {
+            "name": "All",
+            "value": "All"
+          },
+          {
+            "name": "Incremental",
+            "value": "Incremental"
+          },
+          {
+            "name": "SnapshotFull",
+            "value": "SnapshotFull"
+          },
+          {
+            "name": "SnapshotCopyOnlyFull",
+            "value": "SnapshotCopyOnlyFull"
+          }
+        ]
+      }
+    },
+    "RestorePointType": {
+      "type": "string",
+      "description": "Type of restore point",
+      "enum": [
+        "Invalid",
+        "Full",
+        "Log",
+        "Differential",
+        "Incremental",
+        "SnapshotFull",
+        "SnapshotCopyOnlyFull"
+      ],
+      "x-ms-enum": {
+        "name": "RestorePointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Full",
+            "value": "Full"
+          },
+          {
+            "name": "Log",
+            "value": "Log"
+          },
+          {
+            "name": "Differential",
+            "value": "Differential"
+          },
+          {
+            "name": "Incremental",
+            "value": "Incremental"
+          },
+          {
+            "name": "SnapshotFull",
+            "value": "SnapshotFull"
+          },
+          {
+            "name": "SnapshotCopyOnlyFull",
+            "value": "SnapshotCopyOnlyFull"
+          }
+        ]
+      }
+    },
+    "RestoreRequest": {
+      "type": "object",
+      "description": "Base class for restore request. Workload-specific restore requests are derived from this class.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        },
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "description": "ResourceGuardOperationRequests on which LAC check will be performed",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "RestoreRequestResource": {
+      "type": "object",
+      "description": "Base class for restore request. Workload-specific restore requests are derived from this class.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/RestoreRequest",
+          "description": "RestoreRequestResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "RestoreRequestType": {
+      "type": "string",
+      "description": "Restore Type (FullShareRestore or ItemLevelRestore)",
+      "enum": [
+        "Invalid",
+        "FullShareRestore",
+        "ItemLevelRestore"
+      ],
+      "x-ms-enum": {
+        "name": "RestoreRequestType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "FullShareRestore",
+            "value": "FullShareRestore"
+          },
+          {
+            "name": "ItemLevelRestore",
+            "value": "ItemLevelRestore"
+          }
+        ]
+      }
+    },
+    "RetentionDuration": {
+      "type": "object",
+      "description": "Retention duration.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Count of duration types. Retention duration is obtained by the counting the duration type Count times.\nFor example, when Count = 3 and DurationType = Weeks, retention duration will be three weeks."
+        },
+        "durationType": {
+          "$ref": "#/definitions/RetentionDurationType",
+          "description": "Retention duration type of retention policy."
+        }
+      }
+    },
+    "RetentionDurationType": {
+      "type": "string",
+      "description": "Retention duration type of retention policy.",
+      "enum": [
+        "Invalid",
+        "Days",
+        "Weeks",
+        "Months",
+        "Years"
+      ],
+      "x-ms-enum": {
+        "name": "RetentionDurationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Days",
+            "value": "Days"
+          },
+          {
+            "name": "Weeks",
+            "value": "Weeks"
+          },
+          {
+            "name": "Months",
+            "value": "Months"
+          },
+          {
+            "name": "Years",
+            "value": "Years"
+          }
+        ]
+      }
+    },
+    "RetentionPolicy": {
+      "type": "object",
+      "description": "Base class for retention policy.",
+      "properties": {
+        "retentionPolicyType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "retentionPolicyType",
+      "required": [
+        "retentionPolicyType"
+      ]
+    },
+    "RetentionScheduleFormat": {
+      "type": "string",
+      "description": "Retention schedule format type for monthly retention policy.",
+      "enum": [
+        "Invalid",
+        "Daily",
+        "Weekly"
+      ],
+      "x-ms-enum": {
+        "name": "RetentionScheduleFormat",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Daily",
+            "value": "Daily"
+          },
+          {
+            "name": "Weekly",
+            "value": "Weekly"
+          }
+        ]
+      }
+    },
+    "SQLDataDirectory": {
+      "type": "object",
+      "description": "SQLDataDirectory info",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/SQLDataDirectoryType",
+          "description": "Type of data directory mapping"
+        },
+        "path": {
+          "type": "string",
+          "description": "File path"
+        },
+        "logicalName": {
+          "type": "string",
+          "description": "Logical name of the file"
+        }
+      }
+    },
+    "SQLDataDirectoryMapping": {
+      "type": "object",
+      "description": "Encapsulates information regarding data directory",
+      "properties": {
+        "mappingType": {
+          "$ref": "#/definitions/SQLDataDirectoryType",
+          "description": "Type of data directory mapping"
+        },
+        "sourceLogicalName": {
+          "type": "string",
+          "description": "Restore source logical name path"
+        },
+        "sourcePath": {
+          "type": "string",
+          "description": "Restore source path"
+        },
+        "targetPath": {
+          "type": "string",
+          "description": "Target path"
+        }
+      }
+    },
+    "SQLDataDirectoryType": {
+      "type": "string",
+      "description": "Type of data directory mapping",
+      "enum": [
+        "Invalid",
+        "Data",
+        "Log"
+      ],
+      "x-ms-enum": {
+        "name": "SQLDataDirectoryType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Data",
+            "value": "Data"
+          },
+          {
+            "name": "Log",
+            "value": "Log"
+          }
+        ]
+      }
+    },
+    "SchedulePolicy": {
+      "type": "object",
+      "description": "Base class for backup schedule.",
+      "properties": {
+        "schedulePolicyType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "schedulePolicyType",
+      "required": [
+        "schedulePolicyType"
+      ]
+    },
+    "ScheduleRunType": {
+      "type": "string",
+      "description": "Frequency of the schedule operation of this policy.",
+      "enum": [
+        "Invalid",
+        "Daily",
+        "Weekly",
+        "Hourly"
+      ],
+      "x-ms-enum": {
+        "name": "ScheduleRunType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Daily",
+            "value": "Daily"
+          },
+          {
+            "name": "Weekly",
+            "value": "Weekly"
+          },
+          {
+            "name": "Hourly",
+            "value": "Hourly"
+          }
+        ]
+      }
+    },
+    "SecuredVMDetails": {
+      "type": "object",
+      "description": "Restore request parameters for Secured VMs",
+      "properties": {
+        "securedVMOsDiskEncryptionSetId": {
+          "type": "string",
+          "description": "Gets or Sets Disk Encryption Set Id for Secured VM OS Disk"
+        }
+      }
+    },
+    "SecurityPinBase": {
+      "type": "object",
+      "description": "Base class for get security pin request body",
+      "properties": {
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "description": "ResourceGuard Operation Requests",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "type": "object",
+      "description": "Common settings field for backup management",
+      "properties": {
+        "timeZone": {
+          "type": "string",
+          "description": "TimeZone optional input as string. For example: TimeZone = \"Pacific Standard Time\"."
+        },
+        "issqlcompression": {
+          "type": "boolean",
+          "description": "SQL compression flag"
+        },
+        "isCompression": {
+          "type": "boolean",
+          "description": "Workload compression flag. This has been added so that 'isSqlCompression'\nwill be deprecated once clients upgrade to consider this flag."
+        },
+        "vdiSettings": {
+          "$ref": "#/definitions/VdiSettings",
+          "description": "VDI (Virtual Device Interface) settings used while taking backups. Currently applicable to SQL workload only."
+        }
+      }
+    },
+    "SimpleRetentionPolicy": {
+      "type": "object",
+      "description": "Simple policy retention.",
+      "properties": {
+        "retentionDuration": {
+          "$ref": "#/definitions/RetentionDuration",
+          "description": "Retention duration of the protection policy."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RetentionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "SimpleRetentionPolicy"
+    },
+    "SimpleSchedulePolicy": {
+      "type": "object",
+      "description": "Simple policy schedule.",
+      "properties": {
+        "scheduleRunFrequency": {
+          "$ref": "#/definitions/ScheduleRunType",
+          "description": "Frequency of the schedule operation of this policy."
+        },
+        "scheduleRunDays": {
+          "type": "array",
+          "description": "List of days of week this schedule has to be run.",
+          "items": {
+            "$ref": "#/definitions/DayOfWeek"
+          }
+        },
+        "scheduleRunTimes": {
+          "type": "array",
+          "description": "List of times of day this schedule has to be run.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "hourlySchedule": {
+          "$ref": "#/definitions/HourlySchedule",
+          "description": "Hourly Schedule of this Policy"
+        },
+        "scheduleWeeklyFrequency": {
+          "type": "integer",
+          "format": "int32",
+          "description": "At every number weeks this schedule has to be run."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SchedulePolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "SimpleSchedulePolicy"
+    },
+    "SimpleSchedulePolicyV2": {
+      "type": "object",
+      "description": "The V2 policy schedule for IaaS that supports hourly backups.",
+      "properties": {
+        "scheduleRunFrequency": {
+          "$ref": "#/definitions/ScheduleRunType",
+          "description": "Frequency of the schedule operation of this policy."
+        },
+        "hourlySchedule": {
+          "$ref": "#/definitions/HourlySchedule",
+          "description": "hourly schedule of this policy"
+        },
+        "dailySchedule": {
+          "$ref": "#/definitions/DailySchedule",
+          "description": "Daily schedule of this policy"
+        },
+        "weeklySchedule": {
+          "$ref": "#/definitions/WeeklySchedule",
+          "description": "Weekly schedule of this policy"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SchedulePolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "SimpleSchedulePolicyV2"
+    },
+    "SnapshotBackupAdditionalDetails": {
+      "type": "object",
+      "description": "Snapshot Backup related fields for WorkloadType SaPHanaSystem",
+      "properties": {
+        "instantRpRetentionRangeInDays": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "instantRPDetails": {
+          "type": "string"
+        },
+        "userAssignedManagedIdentityDetails": {
+          "$ref": "#/definitions/UserAssignedManagedIdentityDetails",
+          "description": "User assigned managed identity details"
+        }
+      }
+    },
+    "SnapshotRestoreParameters": {
+      "type": "object",
+      "description": "Encapsulates information regarding snapshot recovery for SAP Hana",
+      "properties": {
+        "skipAttachAndMount": {
+          "type": "boolean"
+        },
+        "logPointInTimeForDBRecovery": {
+          "type": "string"
+        }
+      }
+    },
+    "SoftDeleteFeatureState": {
+      "type": "string",
+      "description": "Soft Delete feature state",
+      "enum": [
+        "Invalid",
+        "Enabled",
+        "Disabled",
+        "AlwaysON"
+      ],
+      "x-ms-enum": {
+        "name": "SoftDeleteFeatureState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "AlwaysON",
+            "value": "AlwaysON"
+          }
+        ]
+      }
+    },
+    "StorageType": {
+      "type": "string",
+      "description": "Storage type",
+      "enum": [
+        "Invalid",
+        "GeoRedundant",
+        "LocallyRedundant",
+        "ZoneRedundant",
+        "ReadAccessGeoZoneRedundant"
+      ],
+      "x-ms-enum": {
+        "name": "StorageType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "GeoRedundant",
+            "value": "GeoRedundant"
+          },
+          {
+            "name": "LocallyRedundant",
+            "value": "LocallyRedundant"
+          },
+          {
+            "name": "ZoneRedundant",
+            "value": "ZoneRedundant"
+          },
+          {
+            "name": "ReadAccessGeoZoneRedundant",
+            "value": "ReadAccessGeoZoneRedundant"
+          }
+        ]
+      }
+    },
+    "StorageTypeState": {
+      "type": "string",
+      "description": "Locked or Unlocked. Once a machine is registered against a resource, the storageTypeState is always Locked.",
+      "enum": [
+        "Invalid",
+        "Locked",
+        "Unlocked"
+      ],
+      "x-ms-enum": {
+        "name": "StorageTypeState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Locked",
+            "value": "Locked"
+          },
+          {
+            "name": "Unlocked",
+            "value": "Unlocked"
+          }
+        ]
+      }
+    },
+    "SubProtectionPolicy": {
+      "type": "object",
+      "description": "Sub-protection policy which includes schedule and retention",
+      "properties": {
+        "policyType": {
+          "$ref": "#/definitions/PolicyType",
+          "description": "Type of backup policy type"
+        },
+        "schedulePolicy": {
+          "$ref": "#/definitions/SchedulePolicy",
+          "description": "Backup schedule specified as part of backup policy."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Retention policy with the details on backup copy retention ranges."
+        },
+        "tieringPolicy": {
+          "type": "object",
+          "description": "Tiering policy to automatically move RPs to another tier.\nKey is Target Tier, defined in RecoveryPointTierType enum.\nTiering policy specifies the criteria to move RP to the target tier.",
+          "additionalProperties": {
+            "$ref": "#/definitions/TieringPolicy"
+          }
+        },
+        "snapshotBackupAdditionalDetails": {
+          "$ref": "#/definitions/SnapshotBackupAdditionalDetails",
+          "description": "Snapshot Backup related fields for WorkloadType SaPHanaSystem"
+        }
+      }
+    },
+    "SupportStatus": {
+      "type": "string",
+      "description": "Support status of feature",
+      "enum": [
+        "Invalid",
+        "Supported",
+        "DefaultOFF",
+        "DefaultON",
+        "NotSupported"
+      ],
+      "x-ms-enum": {
+        "name": "SupportStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Supported",
+            "value": "Supported"
+          },
+          {
+            "name": "DefaultOFF",
+            "value": "DefaultOFF"
+          },
+          {
+            "name": "DefaultON",
+            "value": "DefaultON"
+          },
+          {
+            "name": "NotSupported",
+            "value": "NotSupported"
+          }
+        ]
+      }
+    },
+    "TargetAFSRestoreInfo": {
+      "type": "object",
+      "description": "Target Azure File Share Info.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "File share name"
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "Target file share resource ARM ID"
+        }
+      }
+    },
+    "TargetDiskNetworkAccessOption": {
+      "type": "string",
+      "description": "Network access settings to be used for restored disks",
+      "enum": [
+        "SameAsOnSourceDisks",
+        "EnablePrivateAccessForAllDisks",
+        "EnablePublicAccessForAllDisks"
+      ],
+      "x-ms-enum": {
+        "name": "TargetDiskNetworkAccessOption",
+        "modelAsString": false
+      }
+    },
+    "TargetDiskNetworkAccessSettings": {
+      "type": "object",
+      "description": "Specifies target network access settings for disks of VM to be restored.",
+      "properties": {
+        "targetDiskNetworkAccessOption": {
+          "$ref": "#/definitions/TargetDiskNetworkAccessOption",
+          "description": "Network access settings to be used for restored disks"
+        },
+        "targetDiskAccessId": {
+          "type": "string",
+          "description": "Gets or sets the ARM resource ID of the target disk access to be used when TargetDiskNetworkAccessOption is set to TargetDiskNetworkAccessOption.UseNew"
+        }
+      }
+    },
+    "TargetRestoreInfo": {
+      "type": "object",
+      "description": "Details about target workload during restore operation.",
+      "properties": {
+        "overwriteOption": {
+          "$ref": "#/definitions/OverwriteOptions",
+          "description": "Can Overwrite if Target DataBase already exists"
+        },
+        "containerId": {
+          "type": "string",
+          "description": "Resource Id name of the container in which Target DataBase resides"
+        },
+        "databaseName": {
+          "type": "string",
+          "description": "Database name InstanceName/DataBaseName for SQL or System/DbName for SAP Hana"
+        },
+        "targetDirectoryForFileRestore": {
+          "type": "string",
+          "description": "Target directory location for restore as files."
+        }
+      }
+    },
+    "TieringCostInfo": {
+      "type": "object",
+      "description": "Base class for tiering cost response",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "TieringCostRehydrationInfo": {
+      "type": "object",
+      "description": "Response parameters for tiering cost info for rehydration",
+      "properties": {
+        "rehydrationSizeInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Rehydration size in bytes"
+        },
+        "retailRehydrationCostPerGBPerMonth": {
+          "type": "number",
+          "format": "double",
+          "description": "Source tier to target tier rehydration cost per GB per month"
+        }
+      },
+      "required": [
+        "rehydrationSizeInBytes",
+        "retailRehydrationCostPerGBPerMonth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TieringCostInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "TieringCostRehydrationInfo"
+    },
+    "TieringCostSavingInfo": {
+      "type": "object",
+      "description": "Response parameters for tiering cost info for savings",
+      "properties": {
+        "sourceTierSizeReductionInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Source tier size reduction in bytes after moving all the recommended backup points to target tier"
+        },
+        "targetTierSizeIncreaseInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Target tier size increase in bytes after moving all the recommended backup points to target tier"
+        },
+        "retailSourceTierCostPerGBPerMonth": {
+          "type": "number",
+          "format": "double",
+          "description": "Source tier retail cost per GB per month"
+        },
+        "retailTargetTierCostPerGBPerMonth": {
+          "type": "number",
+          "format": "double",
+          "description": "Target tier retail cost per GB per month"
+        }
+      },
+      "required": [
+        "sourceTierSizeReductionInBytes",
+        "targetTierSizeIncreaseInBytes",
+        "retailSourceTierCostPerGBPerMonth",
+        "retailTargetTierCostPerGBPerMonth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TieringCostInfo"
+        }
+      ],
+      "x-ms-discriminator-value": "TieringCostSavingInfo"
+    },
+    "TieringMode": {
+      "type": "string",
+      "description": "Tiering Mode to control automatic tiering of recovery points. Supported values are:\n1. TierRecommended: Tier all recovery points recommended to be tiered\n2. TierAfter: Tier all recovery points after a fixed period, as specified in duration + durationType below.\n3. DoNotTier: Do not tier any recovery points",
+      "enum": [
+        "Invalid",
+        "TierRecommended",
+        "TierAfter",
+        "DoNotTier"
+      ],
+      "x-ms-enum": {
+        "name": "TieringMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "TierRecommended",
+            "value": "TierRecommended"
+          },
+          {
+            "name": "TierAfter",
+            "value": "TierAfter"
+          },
+          {
+            "name": "DoNotTier",
+            "value": "DoNotTier"
+          }
+        ]
+      }
+    },
+    "TieringPolicy": {
+      "type": "object",
+      "description": "Tiering Policy for a target tier.\nIf the policy is not specified for a given target tier, service retains the existing configured tiering policy for that tier",
+      "properties": {
+        "tieringMode": {
+          "$ref": "#/definitions/TieringMode",
+          "description": "Tiering Mode to control automatic tiering of recovery points. Supported values are:\n1. TierRecommended: Tier all recovery points recommended to be tiered\n2. TierAfter: Tier all recovery points after a fixed period, as specified in duration + durationType below.\n3. DoNotTier: Do not tier any recovery points"
+        },
+        "duration": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of days/weeks/months/years to retain backups in current tier before tiering.\nUsed only if TieringMode is set to TierAfter"
+        },
+        "durationType": {
+          "$ref": "#/definitions/RetentionDurationType",
+          "description": "Retention duration type: days/weeks/months/years\nUsed only if TieringMode is set to TierAfter"
+        }
+      }
+    },
+    "TokenInformation": {
+      "type": "object",
+      "description": "The token information details.",
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "Token value."
+        },
+        "expiryTimeInUtcTicks": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Expiry time of token."
+        },
+        "securityPIN": {
+          "type": "string",
+          "description": "Security PIN"
+        }
+      }
+    },
+    "TriggerDataMoveRequest": {
+      "type": "object",
+      "description": "Trigger DataMove Request",
+      "properties": {
+        "sourceResourceId": {
+          "type": "string",
+          "description": "ARM Id of source vault"
+        },
+        "sourceRegion": {
+          "type": "string",
+          "description": "Source Region"
+        },
+        "dataMoveLevel": {
+          "$ref": "#/definitions/DataMoveLevel",
+          "description": "DataMove Level"
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Correlation Id"
+        },
+        "sourceContainerArmIds": {
+          "type": "array",
+          "description": "Source Container ArmIds",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pauseGC": {
+          "type": "boolean",
+          "description": "Pause GC"
+        }
+      },
+      "required": [
+        "sourceResourceId",
+        "sourceRegion",
+        "dataMoveLevel",
+        "correlationId"
+      ]
+    },
+    "Type": {
+      "type": "string",
+      "description": "Backup management type for this container.",
+      "enum": [
+        "Invalid",
+        "BackupProtectedItemCountSummary",
+        "BackupProtectionContainerCountSummary"
+      ],
+      "x-ms-enum": {
+        "name": "Type",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "BackupProtectedItemCountSummary",
+            "value": "BackupProtectedItemCountSummary"
+          },
+          {
+            "name": "BackupProtectionContainerCountSummary",
+            "value": "BackupProtectionContainerCountSummary"
+          }
+        ]
+      }
+    },
+    "UnlockDeleteRequest": {
+      "type": "object",
+      "description": "Request body of unlock delete API.",
+      "properties": {
+        "resourceGuardOperationRequests": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resourceToBeDeleted": {
+          "type": "string"
+        }
+      }
+    },
+    "UnlockDeleteResponse": {
+      "type": "object",
+      "description": "Response of Unlock Delete API.",
+      "properties": {
+        "unlockDeleteExpiryTime": {
+          "type": "string",
+          "description": "This is the time when unlock delete privileges will get expired."
+        }
+      }
+    },
+    "UsagesUnit": {
+      "type": "string",
+      "description": "Unit of the usage.",
+      "enum": [
+        "Count",
+        "Bytes",
+        "Seconds",
+        "Percent",
+        "CountPerSecond",
+        "BytesPerSecond"
+      ],
+      "x-ms-enum": {
+        "name": "UsagesUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Count",
+            "value": "Count"
+          },
+          {
+            "name": "Bytes",
+            "value": "Bytes"
+          },
+          {
+            "name": "Seconds",
+            "value": "Seconds"
+          },
+          {
+            "name": "Percent",
+            "value": "Percent"
+          },
+          {
+            "name": "CountPerSecond",
+            "value": "CountPerSecond"
+          },
+          {
+            "name": "BytesPerSecond",
+            "value": "BytesPerSecond"
+          }
+        ]
+      }
+    },
+    "UserAssignedIdentityProperties": {
+      "type": "object",
+      "description": "User assigned managed identity properties",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the assigned identity."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of the assigned identity."
+        }
+      }
+    },
+    "UserAssignedManagedIdentityDetails": {
+      "type": "object",
+      "description": "User assigned managed identity details",
+      "properties": {
+        "identityArmId": {
+          "type": "string",
+          "description": "The ARM id of the assigned identity."
+        },
+        "identityName": {
+          "type": "string",
+          "description": "The name of the assigned identity."
+        },
+        "userAssignedIdentityProperties": {
+          "$ref": "#/definitions/UserAssignedIdentityProperties",
+          "description": "User assigned managed identity properties"
+        }
+      }
+    },
+    "ValidateIaasVMRestoreOperationRequest": {
+      "type": "object",
+      "description": "AzureRestoreValidation request.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValidateRestoreOperationRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "ValidateIaasVMRestoreOperationRequest"
+    },
+    "ValidateOperationRequest": {
+      "type": "object",
+      "description": "Base class for validate operation request.",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "ValidateOperationRequestResource": {
+      "type": "object",
+      "description": "Base class for validate operation request.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Recovery point ID."
+        },
+        "properties": {
+          "$ref": "#/definitions/ValidateOperationRequest",
+          "description": "ValidateOperationRequestResource properties"
+        }
+      },
+      "required": [
+        "id",
+        "properties"
+      ]
+    },
+    "ValidateOperationResponse": {
+      "type": "object",
+      "description": "Base class for validate operation response.",
+      "properties": {
+        "validationResults": {
+          "type": "array",
+          "description": "Gets the validation result",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        }
+      }
+    },
+    "ValidateOperationsResponse": {
+      "type": "object",
+      "properties": {
+        "validateOperationResponse": {
+          "$ref": "#/definitions/ValidateOperationResponse",
+          "description": "Base class for validate operation response."
+        }
+      }
+    },
+    "ValidateRestoreOperationRequest": {
+      "type": "object",
+      "description": "AzureRestoreValidation request.",
+      "properties": {
+        "restoreRequest": {
+          "$ref": "#/definitions/RestoreRequest",
+          "description": "Sets restore request to be validated"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ValidateOperationRequest"
+        }
+      ],
+      "x-ms-discriminator-value": "ValidateRestoreOperationRequest"
+    },
+    "ValidationStatus": {
+      "type": "string",
+      "description": "Validation Status",
+      "enum": [
+        "Invalid",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ValidationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "VaultJob": {
+      "type": "object",
+      "description": "Vault level Job",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "Time elapsed during the execution of this job."
+        },
+        "actionsInfo": {
+          "type": "array",
+          "description": "Gets or sets the state/actions applicable on this job like cancel/retry.",
+          "items": {
+            "$ref": "#/definitions/JobSupportedAction"
+          }
+        },
+        "errorDetails": {
+          "type": "array",
+          "description": "Error details on execution of this job.",
+          "items": {
+            "$ref": "#/definitions/VaultJobErrorInfo"
+          },
+          "x-ms-identifiers": [
+            "errorCode"
+          ]
+        },
+        "extendedInfo": {
+          "$ref": "#/definitions/VaultJobExtendedInfo",
+          "description": "Additional information about the job."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Job"
+        }
+      ],
+      "x-ms-discriminator-value": "VaultJob"
+    },
+    "VaultJobErrorInfo": {
+      "type": "object",
+      "description": "Vault Job specific error information",
+      "properties": {
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Error code."
+        },
+        "errorString": {
+          "type": "string",
+          "description": "Localized error string."
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of localized recommendations for above error code.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VaultJobExtendedInfo": {
+      "type": "object",
+      "description": "Vault Job for CMK - has CMK specific info.",
+      "properties": {
+        "propertyBag": {
+          "type": "object",
+          "description": "Job properties.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VaultResource": {
+      "type": "object",
+      "description": "Vault resource in Recovery Service.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the VaultResource",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "VaultRetentionPolicy": {
+      "type": "object",
+      "description": "Vault retention policy for AzureFileShare",
+      "properties": {
+        "vaultRetention": {
+          "$ref": "#/definitions/RetentionPolicy",
+          "description": "Base class for retention policy."
+        },
+        "snapshotRetentionInDays": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "vaultRetention",
+        "snapshotRetentionInDays"
+      ]
+    },
+    "VaultStorageConfigOperationResultResponse": {
+      "type": "object",
+      "description": "Operation result response for Vault Storage Config",
+      "properties": {
+        "objectType": {
+          "type": "string",
+          "description": "This property will be used as the discriminator for deciding the specific types in the polymorphic chain of types."
+        }
+      },
+      "discriminator": "objectType",
+      "required": [
+        "objectType"
+      ]
+    },
+    "VaultSubResourceType": {
+      "type": "string",
+      "description": "GroupId for the PrivateEndpointConnection - AzureBackup, AzureBackup_secondary or AzureSiteRecovery",
+      "enum": [
+        "AzureBackup",
+        "AzureBackup_secondary",
+        "AzureSiteRecovery"
+      ],
+      "x-ms-enum": {
+        "name": "VaultSubResourceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureBackup",
+            "value": "AzureBackup"
+          },
+          {
+            "name": "AzureBackup_secondary",
+            "value": "AzureBackup_secondary"
+          },
+          {
+            "name": "AzureSiteRecovery",
+            "value": "AzureSiteRecovery"
+          }
+        ]
+      }
+    },
+    "VdiSettings": {
+      "type": "object",
+      "description": "VDI settings used while taking backups. Controls multi-stream VDI behavior for SQL workloads.",
+      "properties": {
+        "isMultiVdiSupportEnabled": {
+          "type": "boolean",
+          "description": "Flag to indicate whether multi-stream VDI backup is enabled for the workload."
+        },
+        "noOfVdiStreams": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of VDI streams to use when multi-VDI is enabled. Allowed range is 1 to 32.",
+          "minimum": 1,
+          "maximum": 32
+        }
+      }
+    },
+    "WeekOfMonth": {
+      "type": "string",
+      "enum": [
+        "First",
+        "Second",
+        "Third",
+        "Fourth",
+        "Last",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "WeekOfMonth",
+        "modelAsString": false
+      }
+    },
+    "WeeklyRetentionFormat": {
+      "type": "object",
+      "description": "Weekly retention format.",
+      "properties": {
+        "daysOfTheWeek": {
+          "type": "array",
+          "description": "List of days of the week.",
+          "items": {
+            "$ref": "#/definitions/DayOfWeek"
+          }
+        },
+        "weeksOfTheMonth": {
+          "type": "array",
+          "description": "List of weeks of month.",
+          "items": {
+            "$ref": "#/definitions/WeekOfMonth"
+          }
+        }
+      }
+    },
+    "WeeklyRetentionSchedule": {
+      "type": "object",
+      "description": "Weekly retention schedule.",
+      "properties": {
+        "daysOfTheWeek": {
+          "type": "array",
+          "description": "List of days of week for weekly retention policy.",
+          "items": {
+            "$ref": "#/definitions/DayOfWeek"
+          }
+        },
+        "retentionTimes": {
+          "type": "array",
+          "description": "Retention times of retention policy.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "retentionDuration": {
+          "$ref": "#/definitions/RetentionDuration",
+          "description": "Retention duration of retention Policy."
+        }
+      }
+    },
+    "WeeklySchedule": {
+      "type": "object",
+      "properties": {
+        "scheduleRunDays": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DayOfWeek"
+          }
+        },
+        "scheduleRunTimes": {
+          "type": "array",
+          "description": "List of times of day this schedule has to be run.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "WorkloadInquiryDetails": {
+      "type": "object",
+      "description": "Details of an inquired protectable item.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the Workload such as SQL, Oracle etc."
+        },
+        "itemCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Contains the protectable item Count inside this Container."
+        },
+        "inquiryValidation": {
+          "$ref": "#/definitions/InquiryValidation",
+          "description": "Inquiry validation such as permissions and other backup validations."
+        }
+      }
+    },
+    "WorkloadItem": {
+      "type": "object",
+      "description": "Base class for backup item. Workload-specific backup items are derived from this class.",
+      "properties": {
+        "backupManagementType": {
+          "type": "string",
+          "description": "Type of backup management to backup an item."
+        },
+        "workloadType": {
+          "type": "string",
+          "description": "Type of workload for the backup management"
+        },
+        "workloadItemType": {
+          "type": "string",
+          "description": "Type of the backup item."
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the backup item."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionStatus",
+          "description": "State of the back up item."
+        }
+      },
+      "discriminator": "workloadItemType",
+      "required": [
+        "workloadItemType"
+      ]
+    },
+    "WorkloadItemResource": {
+      "type": "object",
+      "description": "Base class for backup item. Workload-specific backup items are derived from this class.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/WorkloadItem",
+          "description": "WorkloadItemResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "WorkloadItemResourceList": {
+      "type": "object",
+      "description": "List of WorkloadItem resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/WorkloadItemResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "WorkloadItemType": {
+      "type": "string",
+      "description": "Workload item type of the item for which intent is to be set",
+      "enum": [
+        "Invalid",
+        "SQLInstance",
+        "SQLDataBase",
+        "SAPHanaSystem",
+        "SAPHanaDatabase",
+        "SAPAseSystem",
+        "SAPAseDatabase",
+        "SAPHanaDBInstance"
+      ],
+      "x-ms-enum": {
+        "name": "WorkloadItemType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "SQLInstance",
+            "value": "SQLInstance"
+          },
+          {
+            "name": "SQLDataBase",
+            "value": "SQLDataBase"
+          },
+          {
+            "name": "SAPHanaSystem",
+            "value": "SAPHanaSystem"
+          },
+          {
+            "name": "SAPHanaDatabase",
+            "value": "SAPHanaDatabase"
+          },
+          {
+            "name": "SAPAseSystem",
+            "value": "SAPAseSystem"
+          },
+          {
+            "name": "SAPAseDatabase",
+            "value": "SAPAseDatabase"
+          },
+          {
+            "name": "SAPHanaDBInstance",
+            "value": "SAPHanaDBInstance"
+          }
+        ]
+      }
+    },
+    "WorkloadProtectableItem": {
+      "type": "object",
+      "description": "Base class for backup item. Workload-specific backup items are derived from this class.",
+      "properties": {
+        "backupManagementType": {
+          "type": "string",
+          "description": "Type of backup management to backup an item."
+        },
+        "workloadType": {
+          "type": "string",
+          "description": "Type of workload for the backup management"
+        },
+        "protectableItemType": {
+          "type": "string",
+          "description": "Type of the backup item."
+        },
+        "friendlyName": {
+          "type": "string",
+          "description": "Friendly name of the backup item."
+        },
+        "protectionState": {
+          "$ref": "#/definitions/ProtectionStatus",
+          "description": "State of the back up item."
+        }
+      },
+      "discriminator": "protectableItemType",
+      "required": [
+        "protectableItemType"
+      ]
+    },
+    "WorkloadProtectableItemResource": {
+      "type": "object",
+      "description": "Base class for backup item. Workload-specific backup items are derived from this class.",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "eTag": {
+          "type": "string",
+          "description": "Optional ETag."
+        },
+        "properties": {
+          "$ref": "#/definitions/WorkloadProtectableItem",
+          "description": "WorkloadProtectableItemResource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "WorkloadProtectableItemResourceList": {
+      "type": "object",
+      "description": "List of WorkloadProtectableItem resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of resources.",
+          "items": {
+            "$ref": "#/definitions/WorkloadProtectableItemResource"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceList"
+        }
+      ]
+    },
+    "WorkloadType": {
+      "type": "string",
+      "description": "Type of workload for the backup management",
+      "enum": [
+        "Invalid",
+        "VM",
+        "FileFolder",
+        "AzureSqlDb",
+        "SQLDB",
+        "Exchange",
+        "Sharepoint",
+        "VMwareVM",
+        "SystemState",
+        "Client",
+        "GenericDataSource",
+        "SQLDataBase",
+        "AzureFileShare",
+        "SAPHanaDatabase",
+        "SAPAseDatabase",
+        "SAPHanaDBInstance"
+      ],
+      "x-ms-enum": {
+        "name": "WorkloadType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "VM",
+            "value": "VM"
+          },
+          {
+            "name": "FileFolder",
+            "value": "FileFolder"
+          },
+          {
+            "name": "AzureSqlDb",
+            "value": "AzureSqlDb"
+          },
+          {
+            "name": "SQLDB",
+            "value": "SQLDB"
+          },
+          {
+            "name": "Exchange",
+            "value": "Exchange"
+          },
+          {
+            "name": "Sharepoint",
+            "value": "Sharepoint"
+          },
+          {
+            "name": "VMwareVM",
+            "value": "VMwareVM"
+          },
+          {
+            "name": "SystemState",
+            "value": "SystemState"
+          },
+          {
+            "name": "Client",
+            "value": "Client"
+          },
+          {
+            "name": "GenericDataSource",
+            "value": "GenericDataSource"
+          },
+          {
+            "name": "SQLDataBase",
+            "value": "SQLDataBase"
+          },
+          {
+            "name": "AzureFileShare",
+            "value": "AzureFileShare"
+          },
+          {
+            "name": "SAPHanaDatabase",
+            "value": "SAPHanaDatabase"
+          },
+          {
+            "name": "SAPAseDatabase",
+            "value": "SAPAseDatabase"
+          },
+          {
+            "name": "SAPHanaDBInstance",
+            "value": "SAPHanaDBInstance"
+          }
+        ]
+      }
+    },
+    "XcoolState": {
+      "type": "string",
+      "description": "Vault x-cool state",
+      "enum": [
+        "Invalid",
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "XcoolState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Invalid",
+            "value": "Invalid"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "YearlyRetentionSchedule": {
+      "type": "object",
+      "description": "Yearly retention schedule.",
+      "properties": {
+        "retentionScheduleFormatType": {
+          "$ref": "#/definitions/RetentionScheduleFormat",
+          "description": "Retention schedule format for yearly retention policy."
+        },
+        "monthsOfYear": {
+          "type": "array",
+          "description": "List of months of year of yearly retention policy.",
+          "items": {
+            "$ref": "#/definitions/MonthOfYear"
+          }
+        },
+        "retentionScheduleDaily": {
+          "$ref": "#/definitions/DailyRetentionFormat",
+          "description": "Daily retention format for yearly retention policy."
+        },
+        "retentionScheduleWeekly": {
+          "$ref": "#/definitions/WeeklyRetentionFormat",
+          "description": "Weekly retention format for yearly retention policy."
+        },
+        "retentionTimes": {
+          "type": "array",
+          "description": "Retention times of retention policy.",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "retentionDuration": {
+          "$ref": "#/definitions/RetentionDuration",
+          "description": "Retention duration of retention Policy."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupFeature_Validate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupFeature_Validate.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "featureType": "AzureVMResourceBackup",
+      "vmSize": "Basic_A0",
+      "vmSku": "Premium"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "supportStatus": "DefaultOFF"
+      }
+    }
+  },
+  "operationId": "FeatureSupport_Validate",
+  "title": "Check Azure Vm Backup Feature Support"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupPolicies_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupPolicies_List.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultPolicy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 30,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2017-12-05T19:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2017-12-05T19:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            }
+          },
+          {
+            "name": "testPolicy1",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2018-01-24T02:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupProtectableItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupProtectableItems_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectableItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "friendlyName": "iaasvm-1",
+              "protectableItemType": "Microsoft.ClassicCompute/virtualMachines",
+              "protectionState": "NotProtected",
+              "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "workloadType": "VM"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectableItems_List",
+  "title": "List protectable items with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupProtectedItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/BackupProtectedItems_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM' and itemType eq 'VM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "containerName": "iaasvmcontainer;iaasvm-rg;iaasvm-1",
+              "friendlyName": "iaasvm-1",
+              "healthStatus": "Passed",
+              "lastBackupStatus": "Completed",
+              "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+              "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+              "policyId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+              "policyType": "V2",
+              "protectedItemDataId": "636482643132986882",
+              "protectedItemType": "Microsoft.ClassicCompute/virtualMachines",
+              "protectionState": "Protected",
+              "protectionStatus": "Healthy",
+              "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+              "workloadType": "VM"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectedItems_List",
+  "title": "List protected items with backupManagementType filter as AzureIaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ClassicCompute_ProtectedItem_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ClassicCompute_ProtectedItem_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainer;iaasvm-rg;iaasvm-1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainer;iaasvm-rg;iaasvm-1",
+          "friendlyName": "iaasvm-1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "policyType": "V1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.ClassicCompute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.ClassicCompute/virtualMachines/iaasvm-1",
+          "workloadType": "VM"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItems_Get",
+  "title": "Get Protected Classic Virtual Machine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Compute_ProtectedItem_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Compute_ProtectedItem_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;iaasvm-rg;iaasvm-1/protectedItems/VM;iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;iaasvm-rg;iaasvm-1",
+          "friendlyName": "iaasvm-1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": "2017-11-22T12:25:32.048723Z",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "policyType": "V2",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.Compute/virtualMachines/iaasvm-1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/providers/Microsoft.Compute/virtualMachines/iaasvm-1",
+          "workloadType": "VM"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItems_Get",
+  "title": "Get Protected Virtual Machine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ConfigureProtection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ConfigureProtection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "policyId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+        "protectedItemType": "Microsoft.Compute/virtualMachines",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectedItems_CreateOrUpdate",
+  "title": "Enable Protection on Azure IaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/GetBackupStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/GetBackupStatus.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Compute/VirtualMachines/testVm",
+      "resourceType": "VM"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "containerName": "iaasvmcontainer;iaasvmcontainerv2;testRg;testVm",
+        "errorCode": "Success",
+        "errorMessage": "ErrorMessage",
+        "fabricName": "Azure",
+        "policyName": "myPolicy",
+        "protectedItemName": "vm;iaasvmcontainerv2;testRg;testVm",
+        "protectionStatus": "Protected",
+        "vaultId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/Vaults/testVault"
+      }
+    }
+  },
+  "operationId": "BackupStatus_Get",
+  "title": "Get Azure Virtual Machine Backup Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectedItemOperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectedItemOperationResults.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "Protected",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectedItemOperationResults_Get",
+  "title": "Get Operation Results of Protected Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectedItemOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectedItemOperationStatus.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "2017-10-29T06:04:18.207325Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "jobId": "00000000-0000-0000-0000-000000000000",
+          "objectType": "OperationStatusJobExtendedInfo"
+        },
+        "startTime": "2017-10-29T06:04:18.207325Z",
+        "status": "Succeeded"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProtectedItemOperationStatuses_Get",
+  "title": "Get Operation Status of Protected Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionIntent_CreateOrUpdate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionIntent_CreateOrUpdate.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+    "parameters": {
+      "properties": {
+        "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+        "protectionIntentItemType": "AzureResourceItem",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/chamsrgtest/providers/Microsoft.Compute/virtualMachines/chamscandel"
+      }
+    },
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+        "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/vm;iaasvmcontainerv2;chamsrgtest;chamscandel",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+          "protectionIntentItemType": "AzureResourceItem",
+          "protectionState": "Protected"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_CreateOrUpdate",
+  "title": "Create or Update Azure Vm Protection Intent"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionIntent_Validate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionIntent_Validate.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "azureRegion": "southeastasia",
+    "parameters": {
+      "properties": "",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/arunaupgrade/providers/Microsoft.Compute/VirtualMachines/upgrade1",
+      "resourceType": "VM",
+      "vaultId": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/Vaults/myVault"
+    },
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "containerName": "iaasvmcontainer;iaasvmcontainerv2;arunaupgrade;upgrade1",
+        "errorCode": "VirtualMachineAlreadyProtected",
+        "errorMessage": "Virtual machine with same name and same resource group is already protected. Please select `Disable' choice above for backup and go to backup item corresponding to this VM in the vault",
+        "protectedItemName": "vm;iaasvmcontainerv2;arunaupgrade;upgrade1",
+        "recommendation": "Please do not enable protection again.",
+        "status": "Failed"
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_Validate",
+  "title": "Validate Enable Protection on Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Complex.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Complex.json
@@ -1,0 +1,183 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 2,
+              "durationType": "Months"
+            },
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Wednesday",
+                "Thursday"
+              ],
+              "weeksOfTheMonth": [
+                "First",
+                "Third"
+              ]
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Monday",
+              "Wednesday",
+              "Thursday"
+            ],
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "February",
+              "November"
+            ],
+            "retentionDuration": {
+              "count": 4,
+              "durationType": "Years"
+            },
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Monday",
+                "Thursday"
+              ],
+              "weeksOfTheMonth": [
+                "Fourth"
+              ]
+            },
+            "retentionTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunDays": [
+            "Monday",
+            "Wednesday",
+            "Thursday"
+          ],
+          "scheduleRunFrequency": "Weekly",
+          "scheduleRunTimes": [
+            "2018-01-24T10:00:00Z"
+          ]
+        },
+        "timeZone": "Pacific Standard Time"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 2,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Wednesday",
+                  "Thursday"
+                ],
+                "weeksOfTheMonth": [
+                  "First",
+                  "Third"
+                ]
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Monday",
+                "Wednesday",
+                "Thursday"
+              ],
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "February",
+                "November"
+              ],
+              "retentionDuration": {
+                "count": 4,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Monday",
+                  "Thursday"
+                ],
+                "weeksOfTheMonth": [
+                  "Fourth"
+                ]
+              },
+              "retentionTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunDays": [
+              "Monday",
+              "Wednesday",
+              "Thursday"
+            ],
+            "scheduleRunFrequency": "Weekly",
+            "scheduleRunTimes": [
+              "2018-01-24T10:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Full Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Simple.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_CreateOrUpdate_Simple.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2018-01-24T02:00:00Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy"
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2018-01-24T02:00:00Z"
+          ]
+        },
+        "timeZone": "Pacific Standard Time"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Simple Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_Delete.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionPolicies_Delete",
+  "title": "Delete Azure Vm Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicies_Get.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_Get",
+  "title": "Get Azure IaasVm Protection Policy Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicyOperationResults_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicyOperationResults_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "protectedItemsCount": 1,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2018-01-24T02:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicyOperationResults_Get",
+  "title": "Get Protection Policy Operation Results"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicyOperationStatuses_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ProtectionPolicyOperationStatuses_Get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "GetProtectionPolicyOperationStatus",
+        "endTime": "2018-01-24T12:57:32.1142968Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "failedJobsError": {},
+          "jobIds": [
+            "00000000-0000-0000-0000-000000000000"
+          ],
+          "objectType": "OperationStatusJobsExtendedInfo"
+        },
+        "startTime": "2018-01-24T12:57:32.1142968Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "ProtectionPolicyOperationStatuses_Get",
+  "title": "Get Protection Policy Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Provision_Ilr.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Provision_Ilr.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "initiatorName": "Hello World",
+        "objectType": "IaasVMILRRegistrationRequest",
+        "recoveryPointId": "38823086363464",
+        "renewExistingRegistration": true,
+        "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/pysdktestrg/providers/Microsoft.Compute/virtualMachines/pysdktestv2vm1"
+      }
+    },
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "recoveryPointId": "1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ItemLevelRecoveryConnections_Provision",
+  "title": "Provision Instant Item Level Recovery for Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPointsRecommendedForMove_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPointsRecommendedForMove_List.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "parameters": {
+      "excludedRPList": [
+        "348916168024334",
+        "348916168024335"
+      ],
+      "objectType": "ListRecoveryPointsRecommendedForMoveRequest"
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "22244821112382",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/22244821112382",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2017-12-21T22:48:25.4353958Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1"
+            }
+          },
+          {
+            "name": "24977149827250",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/24977149827250",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "ArchivedRP",
+                  "extendedInfo": {
+                    "RehydratedRPExpiryTime": "2020-12-21T22:48:25.4353958Z"
+                  },
+                  "status": "Rehydrated"
+                }
+              ],
+              "recoveryPointTime": "2017-12-20T22:49:44.3317945Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1",
+              "zones": [
+                "1"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RecoveryPointsRecommendedForMove_List",
+  "title": "Get Protected Azure Vm Recovery Points Recommended for Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPoints_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPoints_Get.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "recoveryPointId": "26083826328862",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "26083826328862",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/26083826328862",
+        "properties": {
+          "isInstantIlrSessionActive": false,
+          "isManagedVirtualMachine": true,
+          "isPrivateAccessEnabledOnAnyDisk": true,
+          "isSourceVMEncrypted": false,
+          "objectType": "IaasVMRecoveryPoint",
+          "originalStorageAccountOption": false,
+          "recoveryPointAdditionalInfo": "",
+          "recoveryPointMoveReadinessInfo": {
+            "ArchivedRP": {
+              "isReadyForMove": true
+            }
+          },
+          "recoveryPointTierDetails": [
+            {
+              "type": "HardenedRP",
+              "status": "Valid"
+            }
+          ],
+          "recoveryPointTime": "2017-11-22T22:32:46.6088472Z",
+          "recoveryPointType": "CrashConsistent",
+          "sourceVMStorageType": "NormalStorage",
+          "virtualMachineSize": "Standard_D1",
+          "zones": [
+            "1"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "RecoveryPoints_Get",
+  "title": "Get Azure Vm Recovery Point Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPoints_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/RecoveryPoints_List.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "fabricName": "Azure",
+    "protectedItemName": "VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall",
+    "resourceGroupName": "rshhtestmdvmrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rshvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "22244821112382",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/22244821112382",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "Archive": {
+                  "isReadyForMove": true
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2017-12-21T22:48:25.4353958Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1"
+            }
+          },
+          {
+            "name": "24977149827250",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rshhtestmdvmrg/providers/Microsoft.RecoveryServices/vaults/rshvault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/protectedItems/VM;iaasvmcontainerv2;rshhtestmdvmrg;rshmdvmsmall/recoveryPoints/24977149827250",
+            "properties": {
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isPrivateAccessEnabledOnAnyDisk": true,
+              "isSourceVMEncrypted": false,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "additionalInfo": "Recovery point cannot be moved to archive tier since it has already been moved.",
+                  "isReadyForMove": false
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Deleted"
+                },
+                {
+                  "type": "ArchivedRP",
+                  "extendedInfo": {
+                    "RehydratedRPExpiryTime": "2020-12-21T22:48:25.4353958Z"
+                  },
+                  "status": "Rehydrated"
+                }
+              ],
+              "recoveryPointTime": "2017-12-20T22:49:44.3317945Z",
+              "recoveryPointType": "CrashConsistent",
+              "sourceVMStorageType": "NormalStorage",
+              "virtualMachineSize": "Standard_D1",
+              "zones": [
+                "1"
+              ]
+            }
+          },
+          {
+            "name": "70477518625276",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/FijiValidation-asr-microsoftrrdclab3-408/providers/Microsoft.RecoveryServices/vaults/testVault408/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;fijivalidation-asr-microsoftrrdclab3-408;vm408/protectedItems/VM;iaasvmcontainerv2;fijivalidation-asr-microsoftrrdclab3-408;vm408/recoveryPoints/70477518625276",
+            "properties": {
+              "extendedLocation": {
+                "name": "microsoftrrdclab3",
+                "type": "EdgeZone"
+              },
+              "isInstantIlrSessionActive": false,
+              "isManagedVirtualMachine": true,
+              "isPrivateAccessEnabledOnAnyDisk": false,
+              "isSourceVMEncrypted": true,
+              "objectType": "IaasVMRecoveryPoint",
+              "originalStorageAccountOption": false,
+              "osType": "Windows",
+              "recoveryPointAdditionalInfo": "",
+              "recoveryPointMoveReadinessInfo": {
+                "ArchivedRP": {
+                  "additionalInfo": "We're still determining if this Recovery Point can be moved.. Please check again after some time.",
+                  "isReadyForMove": false
+                }
+              },
+              "recoveryPointTierDetails": [
+                {
+                  "type": "InstantRP",
+                  "status": "Valid"
+                },
+                {
+                  "type": "HardenedRP",
+                  "status": "Valid"
+                }
+              ],
+              "recoveryPointTime": "2023-09-22T20:02:00.1225746Z",
+              "recoveryPointType": "CrashConsistent",
+              "securityType": "None",
+              "sourceVMStorageType": "PremiumVMOnPartialPremiumStorage",
+              "virtualMachineSize": "Standard_D2s_v3"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "RecoveryPoints_List",
+  "title": "Get Protected Azure Vm Recovery Points"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Revoke_Ilr.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/Revoke_Ilr.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "recoveryPointId": "1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/protectedItems/vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ItemLevelRecoveryConnections_Revoke",
+  "title": "Revoke Instant Item Level Recovery for Azure Vm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/StopProtection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/StopProtection.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "protectedItemType": "Microsoft.Compute/virtualMachines",
+        "protectionState": "ProtectionStopped",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "containerName": "iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+          "friendlyName": "netvmtestv2vm1",
+          "healthStatus": "Passed",
+          "lastBackupStatus": "Completed",
+          "lastBackupTime": "2018-01-22T12:25:32.048723Z",
+          "lastRecoveryPoint": null,
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupPolicies/testPolicy1",
+          "protectedItemDataId": "636482643132986882",
+          "protectedItemType": "Microsoft.Compute/virtualMachines",
+          "protectionState": "ProtectionStopped",
+          "protectionStatus": "Healthy",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "virtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "workloadType": "VM"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectedItems_CreateOrUpdate",
+  "title": "Stop Protection with retain data on Azure IaasVm"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": true
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": true
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreRequest with identityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreWithRehydrationRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ALR_IaasVMRestoreWithRehydrationRequest.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": false,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "objectType": "IaasVMRestoreWithRehydrationRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryPointRehydrationInfo": {
+          "rehydrationPriority": "High",
+          "rehydrationRetentionDuration": "P7D"
+        },
+        "recoveryType": "AlternateLocation",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Storage/storageAccounts/testingAccount",
+        "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet/subnets/default",
+        "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2",
+        "targetVirtualMachineId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg2/providers/Microsoft.Compute/virtualmachines/RSMDALRVM981435",
+        "virtualNetworkId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Network/virtualNetworks/testNet"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore to New Azure IaasVm with IaasVMRestoreWithRehydrationRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ResourceGuardEnabled.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_ResourceGuardEnabled.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "resourceGuardOperationRequests": [
+          "/subscriptions/063bf7bc-e4dc-4cde-8840-8416fbd7921e/resourcegroups/ankurRG1/providers/Microsoft.DataProtection/resourceGuards/RG341/triggerRestoreRequests/default"
+        ],
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore with Resource Guard Enabled"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount",
+        "targetDiskNetworkAccessSettings": {
+          "targetDiskAccessId": "/subscriptions/e7a191f5-713c-4bdb-b5e4-cf3dd90230ef/resourceGroups/arpja/providers/Microsoft.Compute/diskAccesses/arpja-diskaccess-ccy",
+          "targetDiskNetworkAccessOption": "EnablePrivateAccessForAllDisks"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreRequest_IdentityBasedRestoreDetails.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "identityBasedRestoreDetails": {
+          "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        },
+        "identityInfo": {
+          "isSystemAssignedIdentity": false,
+          "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+        },
+        "objectType": "IaasVMRestoreRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreRequest with IdentityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreWithRehydrationRequest.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerRestore_RestoreDisks_IaasVMRestoreWithRehydrationRequest.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "createNewCloudService": true,
+        "encryptionDetails": {
+          "encryptionEnabled": false
+        },
+        "objectType": "IaasVMRestoreWithRehydrationRequest",
+        "originalStorageAccountOption": false,
+        "recoveryPointId": "348916168024334",
+        "recoveryPointRehydrationInfo": {
+          "rehydrationPriority": "Standard",
+          "rehydrationRetentionDuration": "P7D"
+        },
+        "recoveryType": "RestoreDisks",
+        "region": "southeastasia",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+        "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-09-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Restores_Trigger",
+  "title": "Restore Disks with IaasVMRestoreWithRehydrationRequest"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerValidateOperation_RestoreDisk.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/TriggerValidateOperation_RestoreDisk.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupValidateOperationsStatuses/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupValidateOperationResults/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Retry-After": 10
+      }
+    }
+  },
+  "operationId": "ValidateOperation_Trigger",
+  "title": "Trigger Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/IaaS_v2_daily.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/IaaS_v2_daily.json
@@ -1,0 +1,193 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "instantRpRetentionRangeInDays": 30,
+        "policyType": "V2",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 180,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "dailySchedule": {
+            "scheduleRunTimes": [
+              "2018-01-24T10:00:00Z"
+            ]
+          },
+          "schedulePolicyType": "SimpleSchedulePolicyV2",
+          "scheduleRunFrequency": "Daily"
+        },
+        "snapshotConsistencyType": "OnlyCrashConsistent",
+        "timeZone": "India Standard Time"
+      }
+    },
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 180,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "dailySchedule": {
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Daily"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "India Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operations/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Enhanced Azure Vm Protection Policy with daily backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/IaaS_v2_hourly.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/IaaS_v2_hourly.json
@@ -1,0 +1,193 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "instantRpRetentionRangeInDays": 30,
+        "policyType": "V2",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 180,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-12-17T08:00:00+00:00"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "hourlySchedule": {
+            "interval": 4,
+            "scheduleWindowDuration": 16,
+            "scheduleWindowStartTime": "2021-12-17T08:00:00Z"
+          },
+          "schedulePolicyType": "SimpleSchedulePolicyV2",
+          "scheduleRunFrequency": "Hourly"
+        },
+        "snapshotConsistencyType": "OnlyCrashConsistent",
+        "timeZone": "India Standard Time"
+      }
+    },
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 180,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-12-17T08:00:00+00:00"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "hourlySchedule": {
+              "interval": 4,
+              "scheduleWindowDuration": 16,
+              "scheduleWindowStartTime": "2021-12-17T08:00:00Z"
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Hourly"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "India Standard Time"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operations/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample/operationResults/00000000-0000-0000-0000-000000000000?api-version=2020-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Enhanced Azure Vm Protection Policy with Hourly backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/v2-Get-Policy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/v2-Get-Policy.json
@@ -1,0 +1,50 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "policyName": "v2-daily-sample",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "v2-daily-sample",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-sample",
+        "properties": {
+          "backupManagementType": "AzureIaasVM",
+          "instantRpRetentionRangeInDays": 30,
+          "policyType": "V2",
+          "protectedItemsCount": 0,
+          "resourceGuardOperationRequests": null,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 1,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2018-01-24T02:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy"
+          },
+          "schedulePolicy": {
+            "dailySchedule": {
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            },
+            "schedulePolicyType": "SimpleSchedulePolicyV2",
+            "scheduleRunFrequency": "Daily"
+          },
+          "snapshotConsistencyType": "OnlyCrashConsistent",
+          "timeZone": "Pacific Standard Time"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_Get",
+  "title": "Get Azure IaasVm Enhanced Protection Policy Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/v2-List-Policies.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/V2Policy/v2-List-Policies.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureIaasVM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DefaultPolicy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/DefaultPolicy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 30,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2017-12-05T19:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2017-12-05T19:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            }
+          },
+          {
+            "name": "testPolicy1",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunFrequency": "Daily",
+                "scheduleRunTimes": [
+                  "2018-01-24T02:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          },
+          {
+            "name": "v2-daily-policy",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/v2-daily-policy",
+            "properties": {
+              "backupManagementType": "AzureIaasVM",
+              "protectedItemsCount": 0,
+              "retentionPolicy": {
+                "dailySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Days"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T02:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "dailySchedule": {
+                  "scheduleRunTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "schedulePolicyType": "SimpleSchedulePolicyV2",
+                "scheduleRunFrequency": "Daily"
+              },
+              "timeZone": "Pacific Standard Time"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureIaasVm with both V1 and V2 policies"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperationResults.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupValidateOperationsStatuses/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupValidateOperationResults/00000000-0000-0000-0000-000000000000?api-version=2022-03-01",
+        "Retry-After": 10
+      }
+    }
+  },
+  "operationId": "ValidateOperationResults_Get",
+  "title": "Get Operation Results of Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperationStatus.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "2017-10-29T06:04:18.207325Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "objectType": "OperationStatusValidateOperationExtendedInfo",
+          "validateOperationResponse": {
+            "validationResults": [
+              {
+                "code": "UserErrorCoreCountSubscriptionQuotaReached",
+                "message": "Core Count subscription quota has been reached.",
+                "recommendations": [
+                  "Contact Azure support to increase the limits."
+                ]
+              }
+            ]
+          }
+        },
+        "startTime": "2017-10-29T06:04:18.207325Z",
+        "status": "Succeeded"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ValidateOperationStatuses_Get",
+  "title": "Get Operation Status of Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperation_RestoreDisk.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperation_RestoreDisk.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1",
+          "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operation_Validate",
+  "title": "Validate Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperation_RestoreDisk_IdentityBasedRestoreDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureIaasVm/ValidateOperation_RestoreDisk_IdentityBasedRestoreDetails.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testRG;testvmName",
+    "fabricName": "Azure",
+    "parameters": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testVault/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;testRG;testvmName/protectedItems/VM;iaasvmcontainerv2;testRG;testvmName/recoveryPoints/348916168024334",
+      "properties": {
+        "objectType": "ValidateIaasVMRestoreOperationRequest",
+        "restoreRequest": {
+          "createNewCloudService": true,
+          "encryptionDetails": {
+            "encryptionEnabled": false
+          },
+          "identityBasedRestoreDetails": {
+            "targetStorageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testingRg/providers/Microsoft.Storage/storageAccounts/testAccount"
+          },
+          "identityInfo": {
+            "isSystemAssignedIdentity": false,
+            "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/asmaskarRG1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/asmaskartestmsi"
+          },
+          "objectType": "IaasVMRestoreRequest",
+          "originalStorageAccountOption": false,
+          "recoveryPointId": "348916168024334",
+          "recoveryType": "RestoreDisks",
+          "region": "southeastasia",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.Compute/virtualMachines/netvmtestv2vm1"
+        }
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testRG;testvmName",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "validateOperationResponse": {
+          "validationResults": [
+            {
+              "code": "UserErrorCoreCountSubscriptionQuotaReached",
+              "message": "Core Count subscription quota has been reached.",
+              "recommendations": [
+                "Contact Azure support to increase the limits."
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operation_Validate",
+  "title": "Validate Operation with identityBasedRestoreDetails"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectableContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectableContainers_List.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureStorage' and workloadType eq 'AzureFileShare'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;storage;test-rg;testst",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectableContainers/StorageContainer;storage;test-rg;teststorage",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/teststorage",
+              "friendlyName": "teststorage",
+              "healthStatus": "Healthy",
+              "protectableContainerType": "StorageContainer"
+            }
+          },
+          {
+            "name": "StorageContainer;ClassicStorage;test-rg;teststorage",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectableContainers/StorageContainer;ClassicStorage;test-rg;teststorage",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ClassicStorage/storageAccounts/teststorage",
+              "friendlyName": "teststorage",
+              "healthStatus": "Healthy",
+              "protectableContainerType": "StorageContainer"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProtectableContainers_List",
+  "title": "List protectable items with backupManagementType filter as AzureStorage"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Inquire.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Inquire.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "storagecontainer;Storage;test-rg;teststorage",
+    "fabricName": "Azure",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Inquire",
+  "title": "Inquire Azure Storage Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Inquire_Result.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Inquire_Result.json
@@ -1,0 +1,67 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;testRG;testSQL",
+    "fabricName": "Azure",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VMAppContainer;Compute;testRG;testSQL",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "containerType": "VMAppContainer",
+          "extendedInfo": {
+            "hostServerName": "testsql",
+            "inquiryInfo": {
+              "errorDetail": {
+                "code": "Success",
+                "message": "Not Available",
+                "recommendations": [
+                  "Not Available"
+                ]
+              },
+              "inquiryDetails": [
+                {
+                  "type": "sql",
+                  "inquiryValidation": {
+                    "errorDetail": {
+                      "code": "Success",
+                      "message": "Not Available",
+                      "recommendations": [
+                        "Not Available"
+                      ]
+                    },
+                    "status": "Success"
+                  },
+                  "itemCount": 14
+                }
+              ],
+              "status": "Success"
+            },
+            "nodesList": []
+          },
+          "friendlyName": "testSQL",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.Compute/virtualMachines/testSQL",
+          "workloadType": null
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainerOperationResults_Get",
+  "title": "Get Azure Storage Protection Container Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;Storage;testrg;suchandrtestsa125",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+            "id": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourcegroups/testrg/providers/microsoft.recoveryservices/vaults/suchandr-test-vault-wcus/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;testrg;suchandrtestsa125",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerType": "StorageContainer",
+              "friendlyName": "suchandrtestsa125",
+              "healthStatus": "Healthy",
+              "protectedItemCount": 2,
+              "registrationStatus": "Registered",
+              "sourceResourceId": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/suchandrtestsa125"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectionContainers_List",
+  "title": "List Backup Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Register.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionContainers_Register.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "acquireStorageAccountLock": "Acquire",
+        "backupManagementType": "AzureStorage",
+        "containerType": "StorageContainer",
+        "friendlyName": "swaggertestsa",
+        "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/SwaggerTestRg/providers/Microsoft.Storage/storageAccounts/swaggertestsa"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa",
+        "properties": {
+          "acquireStorageAccountLock": "Acquire",
+          "backupManagementType": "AzureStorage",
+          "containerType": "StorageContainer",
+          "friendlyName": "swaggertestsa",
+          "healthStatus": "Healthy",
+          "protectedItemCount": 0,
+          "registrationStatus": "Registered",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/SwaggerTestRg/providers/Microsoft.Storage/storageAccounts/swaggertestsa"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2019-05-13-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;SwaggerTestRg;swaggertestsa/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Register",
+  "title": "RegisterAzure Storage ProtectionContainers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Daily.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Daily.json
@@ -1,0 +1,182 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Days"
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": [
+              "2021-09-29T08:00:00.000Z"
+            ]
+          }
+        },
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2021-09-29T08:00:00.000Z"
+          ]
+        },
+        "timeZone": "UTC",
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "dailyPolicy2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dailyPolicy2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 5,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T08:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2021-09-29T08:00:00Z"
+            ],
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "UTC"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/dailyPolicy2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Daily Azure Storage Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hardened.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hardened.json
@@ -1,0 +1,189 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "schedulePolicy": {
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Daily",
+          "scheduleRunTimes": [
+            "2023-07-18T09:30:00.000Z"
+          ]
+        },
+        "timeZone": "UTC",
+        "vaultRetentionPolicy": {
+          "snapshotRetentionInDays": 5,
+          "vaultRetention": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 30,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleDaily": null,
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2023-07-18T09:30:00.000Z"
+              ]
+            }
+          }
+        },
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "newPolicyV2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "newPolicyV2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "schedulePolicy": {
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Daily",
+            "scheduleRunTimes": [
+              "2023-07-18T09:30:00.000Z"
+            ]
+          },
+          "timeZone": "UTC",
+          "vaultRetentionPolicy": {
+            "snapshotRetentionInDays": 5,
+            "vaultRetention": {
+              "dailySchedule": {
+                "retentionDuration": {
+                  "count": 30,
+                  "durationType": "Days"
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "monthlySchedule": {
+                "retentionDuration": {
+                  "count": 60,
+                  "durationType": "Months"
+                },
+                "retentionScheduleDaily": null,
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "First"
+                  ]
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "retentionPolicyType": "LongTermRetentionPolicy",
+              "weeklySchedule": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "retentionDuration": {
+                  "count": 12,
+                  "durationType": "Weeks"
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              },
+              "yearlySchedule": {
+                "monthsOfYear": [
+                  "January"
+                ],
+                "retentionDuration": {
+                  "count": 10,
+                  "durationType": "Years"
+                },
+                "retentionScheduleDaily": null,
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "First"
+                  ]
+                },
+                "retentionTimes": [
+                  "2023-07-18T09:30:00.000Z"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2/operations/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicyV2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Azure Storage Vault Standard Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hourly.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/ProtectionPolicies_CreateOrUpdate_Hourly.json
@@ -1,0 +1,178 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "retentionPolicy": {
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Days"
+            },
+            "retentionTimes": null
+          },
+          "monthlySchedule": {
+            "retentionDuration": {
+              "count": 60,
+              "durationType": "Months"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": null
+          },
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "weeklySchedule": {
+            "daysOfTheWeek": [
+              "Sunday"
+            ],
+            "retentionDuration": {
+              "count": 12,
+              "durationType": "Weeks"
+            },
+            "retentionTimes": null
+          },
+          "yearlySchedule": {
+            "monthsOfYear": [
+              "January"
+            ],
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Years"
+            },
+            "retentionScheduleDaily": null,
+            "retentionScheduleFormatType": "Weekly",
+            "retentionScheduleWeekly": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "weeksOfTheMonth": [
+                "First"
+              ]
+            },
+            "retentionTimes": null
+          }
+        },
+        "schedulePolicy": {
+          "hourlySchedule": {
+            "interval": 4,
+            "scheduleWindowDuration": 12,
+            "scheduleWindowStartTime": "2021-09-29T08:00:00.000Z"
+          },
+          "schedulePolicyType": "SimpleSchedulePolicy",
+          "scheduleRunFrequency": "Hourly"
+        },
+        "timeZone": "UTC",
+        "workLoadType": "AzureFileShare"
+      }
+    },
+    "policyName": "newPolicy2",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "swaggertestvault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "newPolicy2",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2",
+        "properties": {
+          "backupManagementType": "AzureStorage",
+          "protectedItemsCount": 0,
+          "retentionPolicy": {
+            "dailySchedule": {
+              "retentionDuration": {
+                "count": 5,
+                "durationType": "Days"
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "monthlySchedule": {
+              "retentionDuration": {
+                "count": 60,
+                "durationType": "Months"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "retentionPolicyType": "LongTermRetentionPolicy",
+            "weeklySchedule": {
+              "daysOfTheWeek": [
+                "Sunday"
+              ],
+              "retentionDuration": {
+                "count": 12,
+                "durationType": "Weeks"
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            },
+            "yearlySchedule": {
+              "monthsOfYear": [
+                "January"
+              ],
+              "retentionDuration": {
+                "count": 10,
+                "durationType": "Years"
+              },
+              "retentionScheduleFormatType": "Weekly",
+              "retentionScheduleWeekly": {
+                "daysOfTheWeek": [
+                  "Sunday"
+                ],
+                "weeksOfTheMonth": [
+                  "First"
+                ]
+              },
+              "retentionTimes": [
+                "2021-09-29T20:00:00Z"
+              ]
+            }
+          },
+          "schedulePolicy": {
+            "hourlySchedule": {
+              "interval": 4,
+              "scheduleWindowDuration": 12,
+              "scheduleWindowStartTime": "2021-09-29T08:00:00Z"
+            },
+            "schedulePolicyType": "SimpleSchedulePolicy",
+            "scheduleRunFrequency": "Hourly",
+            "scheduleWeeklyFrequency": 0
+          },
+          "timeZone": "UTC"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/swaggertestvault/backupPolicies/newPolicy2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Hourly Azure Storage Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/SoftDeletedContainers_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureStorage/SoftDeletedContainers_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "StorageContainer;Storage;testrg;suchandrtestsa125",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+            "id": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourcegroups/testrg/providers/microsoft.recoveryservices/vaults/suchandr-test-vault-wcus/backupFabrics/Azure/protectionContainers/StorageContainer;Storage;testrg;suchandrtestsa125",
+            "properties": {
+              "backupManagementType": "AzureStorage",
+              "containerType": "StorageContainer",
+              "friendlyName": "suchandrtestsa125",
+              "healthStatus": "Healthy",
+              "protectedItemCount": 2,
+              "registrationStatus": "SoftDeleted",
+              "sourceResourceId": "/subscriptions/172424a4-d65f-421e-a8de-197d98aabeba/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/suchandrtestsa125"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DeletedProtectionContainers_List",
+  "title": "List Backup Protection Containers"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupPolicies_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupPolicies_List.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "HourlyLogBackup",
+            "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/HourlyLogBackup",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "protectedItemsCount": 0,
+              "settings": {
+                "issqlcompression": false,
+                "timeZone": "UTC"
+              },
+              "subProtectionPolicy": [
+                {
+                  "policyType": "Full",
+                  "retentionPolicy": {
+                    "dailySchedule": {
+                      "retentionDuration": {
+                        "count": 30,
+                        "durationType": "Days"
+                      },
+                      "retentionTimes": [
+                        "2017-12-05T19:00:00Z"
+                      ]
+                    },
+                    "retentionPolicyType": "LongTermRetentionPolicy"
+                  },
+                  "schedulePolicy": {
+                    "schedulePolicyType": "SimpleSchedulePolicy",
+                    "scheduleRunFrequency": "Daily",
+                    "scheduleRunTimes": [
+                      "2017-12-05T19:00:00Z"
+                    ],
+                    "scheduleWeeklyFrequency": 0
+                  }
+                },
+                {
+                  "policyType": "Log",
+                  "retentionPolicy": {
+                    "retentionDuration": {
+                      "count": 30,
+                      "durationType": "Days"
+                    },
+                    "retentionPolicyType": "SimpleRetentionPolicy"
+                  },
+                  "schedulePolicy": {
+                    "scheduleFrequencyInMins": 60,
+                    "schedulePolicyType": "LogSchedulePolicy"
+                  }
+                }
+              ],
+              "workLoadType": "SQLDataBase"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupPolicies_List",
+  "title": "List protection policies with backupManagementType filter as AzureWorkload"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_Delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "249D9B07-D2EF-4202-AA64-65F35418564E",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "ProtectionIntent_Delete",
+  "title": "Delete Protection intent from item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_Get.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "intentObjectName": "249D9B07-D2EF-4202-AA64-65F35418564E",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "249D9B07-D2EF-4202-AA64-65F35418564E",
+        "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/249D9B07-D2EF-4202-AA64-65F35418564E",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "itemId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupProtectionContainer/VMAppContainer;Compute;testVmName/backupProtectableItems/SQLInstance;MSSQLSERVER",
+          "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+          "protectionIntentItemType": "AzureWorkloadContainerAutoProtectionIntent"
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionIntent_Get",
+  "title": "Get ProtectionIntent for an item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupProtectionIntent_List.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {},
+    "resourceGroupName": "myRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "myVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "249D9B07-D2EF-4202-AA64-65F35418564E",
+            "type": "Microsoft.RecoveryServices/vaults/backupProtectionIntent",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupFabrics/Azure/backupProtectionIntent/249D9B07-D2EF-4202-AA64-65F35418564E",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "itemId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupProtectionContainer/VMAppContainer;Compute;testVmName/backupProtectableItems/SQLInstance;MSSQLSERVER",
+              "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/myVault/backupPolicies/myPolicy",
+              "protectionIntentItemType": "AzureWorkloadContainerAutoProtectionIntent"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupProtectionIntent_List",
+  "title": "List protection intent with backupManagementType filter"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupWorkloadItems_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/BackupWorkloadItems_List.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;bvtdtestag;sqlserver-1",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "suchandr-seacan-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "SQLInstance;MSSQLSERVER",
+            "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/items",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/testRg/providers/Microsoft.RecoveryServices/vaults/suchandr-seacan-rsv/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;bvtdtestag;sqlserver-1/protectableItems/SQLInstance;MSSQLSERVER",
+            "properties": {
+              "backupManagementType": "AzureWorkload",
+              "dataDirectoryPaths": [
+                {
+                  "type": "Data",
+                  "path": "F:\\DATA\\"
+                },
+                {
+                  "type": "Log",
+                  "path": "F:\\LOG\\"
+                }
+              ],
+              "friendlyName": "MSSQLSERVER",
+              "isAutoProtectable": true,
+              "parentName": "MSSQLSERVER",
+              "protectionState": "NotProtected",
+              "serverName": "sqlserver-1.contoso.com",
+              "subWorkloadItemCount": 3,
+              "subinquireditemcount": 0,
+              "workloadItemType": "SQLInstance",
+              "workloadType": "SQL"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupWorkloadItems_List",
+  "title": "List Workload Items in Container"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionContainers_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionContainers_Get.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "$filter": "backupManagementType eq 'AzureWorkload'",
+    "api-version": "2026-06-01",
+    "containerName": "VMAppContainer;Compute;testRG;testSQL",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "VMAppContainer;Compute;testRG;testSQL",
+        "type": "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;testRG;testSQL",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "containerType": "VMAppContainer",
+          "extendedInfo": {
+            "hostServerName": "testsql",
+            "inquiryInfo": {
+              "errorDetail": {
+                "code": "Success",
+                "message": "Not Available",
+                "recommendations": [
+                  "Not Available"
+                ]
+              },
+              "inquiryDetails": [
+                {
+                  "type": "sql",
+                  "inquiryValidation": {
+                    "errorDetail": {
+                      "code": "Success",
+                      "message": "Not Available",
+                      "recommendations": [
+                        "Not Available"
+                      ]
+                    },
+                    "status": "Success"
+                  },
+                  "itemCount": 14
+                }
+              ],
+              "status": "Success"
+            },
+            "nodesList": []
+          },
+          "friendlyName": "testSQL",
+          "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.Compute/virtualMachines/testSQL",
+          "workloadType": null
+        }
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Get",
+  "title": "Get Protection Container Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionContainers_Unregister.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionContainers_Unregister.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "storagecontainer;Storage;test-rg;teststorage",
+    "fabricName": "Azure",
+    "resourceGroupName": "testRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.RecoveryServices/vaults/testvault/backupFabrics/Azure/protectionContainers/storagecontainer;Storage;test-rg;teststorage/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainers_Unregister",
+  "title": "Unregister Protection Container"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_Complex.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_Complex.json
@@ -1,0 +1,262 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureWorkload",
+        "settings": {
+          "issqlcompression": false,
+          "timeZone": "Pacific Standard Time"
+        },
+        "subProtectionPolicy": [
+          {
+            "policyType": "Full",
+            "retentionPolicy": {
+              "monthlySchedule": {
+                "retentionDuration": {
+                  "count": 1,
+                  "durationType": "Months"
+                },
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "Second"
+                  ]
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              },
+              "retentionPolicyType": "LongTermRetentionPolicy",
+              "weeklySchedule": {
+                "daysOfTheWeek": [
+                  "Sunday",
+                  "Tuesday"
+                ],
+                "retentionDuration": {
+                  "count": 2,
+                  "durationType": "Weeks"
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              },
+              "yearlySchedule": {
+                "monthsOfYear": [
+                  "January",
+                  "June",
+                  "December"
+                ],
+                "retentionDuration": {
+                  "count": 1,
+                  "durationType": "Years"
+                },
+                "retentionScheduleFormatType": "Weekly",
+                "retentionScheduleWeekly": {
+                  "daysOfTheWeek": [
+                    "Sunday"
+                  ],
+                  "weeksOfTheMonth": [
+                    "Last"
+                  ]
+                },
+                "retentionTimes": [
+                  "2018-01-24T10:00:00Z"
+                ]
+              }
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Sunday",
+                "Tuesday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Differential",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 8,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Friday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2018-01-24T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Log",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "scheduleFrequencyInMins": 60,
+              "schedulePolicyType": "LogSchedulePolicy"
+            }
+          }
+        ],
+        "workLoadType": "SQLDataBase"
+      }
+    },
+    "policyName": "testPolicy1",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPolicy1",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "protectedItemsCount": 0,
+          "settings": {
+            "issqlcompression": false,
+            "timeZone": "Pacific Standard Time"
+          },
+          "subProtectionPolicy": [
+            {
+              "policyType": "Full",
+              "retentionPolicy": {
+                "monthlySchedule": {
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Months"
+                  },
+                  "retentionScheduleFormatType": "Weekly",
+                  "retentionScheduleWeekly": {
+                    "daysOfTheWeek": [
+                      "Sunday"
+                    ],
+                    "weeksOfTheMonth": [
+                      "Second"
+                    ]
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "retentionPolicyType": "LongTermRetentionPolicy",
+                "weeklySchedule": {
+                  "daysOfTheWeek": [
+                    "Sunday",
+                    "Tuesday"
+                  ],
+                  "retentionDuration": {
+                    "count": 2,
+                    "durationType": "Weeks"
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                },
+                "yearlySchedule": {
+                  "monthsOfYear": [
+                    "January",
+                    "June",
+                    "December"
+                  ],
+                  "retentionDuration": {
+                    "count": 1,
+                    "durationType": "Years"
+                  },
+                  "retentionScheduleFormatType": "Weekly",
+                  "retentionScheduleWeekly": {
+                    "daysOfTheWeek": [
+                      "Sunday"
+                    ],
+                    "weeksOfTheMonth": [
+                      "Last"
+                    ]
+                  },
+                  "retentionTimes": [
+                    "2018-01-24T10:00:00Z"
+                  ]
+                }
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Sunday",
+                  "Tuesday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2018-01-24T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Differential",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 8,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Friday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2018-01-24T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Log",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 7,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "scheduleFrequencyInMins": 60,
+                "schedulePolicyType": "LogSchedulePolicy"
+              }
+            }
+          ],
+          "workLoadType": "SQLDataBase"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operations/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/testPolicy1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update Full Azure Workload Protection Policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "backupManagementType": "AzureWorkload",
+        "settings": {
+          "issqlcompression": false,
+          "isCompression": true,
+          "timeZone": "Pacific Standard Time",
+          "vdiSettings": {
+            "isMultiVdiSupportEnabled": true,
+            "noOfVdiStreams": 8
+          }
+        },
+        "subProtectionPolicy": [
+          {
+            "policyType": "Full",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 30,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "schedulePolicyType": "SimpleSchedulePolicy",
+              "scheduleRunDays": [
+                "Sunday"
+              ],
+              "scheduleRunFrequency": "Weekly",
+              "scheduleRunTimes": [
+                "2026-06-01T10:00:00Z"
+              ]
+            }
+          },
+          {
+            "policyType": "Log",
+            "retentionPolicy": {
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              },
+              "retentionPolicyType": "SimpleRetentionPolicy"
+            },
+            "schedulePolicy": {
+              "scheduleFrequencyInMins": 60,
+              "schedulePolicyType": "LogSchedulePolicy"
+            }
+          }
+        ],
+        "workLoadType": "SQLDataBase"
+      }
+    },
+    "policyName": "sqlMultiVdiPolicy",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "sqlMultiVdiPolicy",
+        "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy",
+        "properties": {
+          "backupManagementType": "AzureWorkload",
+          "protectedItemsCount": 0,
+          "settings": {
+            "issqlcompression": false,
+            "isCompression": true,
+            "timeZone": "Pacific Standard Time",
+            "vdiSettings": {
+              "isMultiVdiSupportEnabled": true,
+              "noOfVdiStreams": 8
+            }
+          },
+          "subProtectionPolicy": [
+            {
+              "policyType": "Full",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 30,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "schedulePolicyType": "SimpleSchedulePolicy",
+                "scheduleRunDays": [
+                  "Sunday"
+                ],
+                "scheduleRunFrequency": "Weekly",
+                "scheduleRunTimes": [
+                  "2026-06-01T10:00:00Z"
+                ],
+                "scheduleWeeklyFrequency": 0
+              }
+            },
+            {
+              "policyType": "Log",
+              "retentionPolicy": {
+                "retentionDuration": {
+                  "count": 7,
+                  "durationType": "Days"
+                },
+                "retentionPolicyType": "SimpleRetentionPolicy"
+              },
+              "schedulePolicy": {
+                "scheduleFrequencyInMins": 60,
+                "schedulePolicyType": "LogSchedulePolicy"
+              }
+            }
+          ],
+          "workLoadType": "SQLDataBase"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy/operations/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupPolicies/sqlMultiVdiPolicy/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-06-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionPolicies_CreateOrUpdate",
+  "title": "Create or Update SQL Azure Workload Protection Policy with multi-VDI streaming enabled"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/BackupDataMoveOperationStatus_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/BackupDataMoveOperationStatus_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "GetOperationStatus",
+  "title": "Get OperationStatus"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/PrepareDataMoveOperationResult_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/PrepareDataMoveOperationResult_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "PrepareDataMoveResponse"
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/operationResult/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSPrepareDataMoveOperationResult_Get",
+  "title": "Get operation result for PrepareDataMove"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/PrepareDataMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/PrepareDataMove_Post.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "dataMoveLevel": "Vault",
+      "targetRegion": "USGov Virginia",
+      "targetResourceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/targetRG/providers/Microsoft.RecoveryServices/vaults/target-rsv"
+    },
+    "resourceGroupName": "sourceRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/backupDataMove/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/prepareDataMove/operationResult/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSPrepareDataMove",
+  "title": "Prepare Data Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/TriggerDataMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupDataMove/TriggerDataMove_Post.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "correlationId": "MTg2OTcyMzM4NzYyMjc1NDY3Nzs1YmUzYmVmNi04YjJiLTRhOTItOTllYi01NTM0MDllYjk2NjE=",
+      "dataMoveLevel": "Vault",
+      "sourceRegion": "USGov Iowa",
+      "sourceResourceId": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv"
+    },
+    "resourceGroupName": "targetRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "target-rsv"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceRG/providers/Microsoft.RecoveryServices/vaults/source-rsv/backupStorageConfig/vaultStorageConfig/backupDataMove/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2020-07-01-preview",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "BMSTriggerDataMove",
+  "title": "Trigger Data Move"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupResourceEncryptionConfig_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupResourceEncryptionConfig_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "rishgrp",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "rishTestVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "backupResourceEncryptionConfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupEncryptionConfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rishgrp/providers/Microsoft.RecoveryServicesBVTD2/vaults/rishTestVault/backupEncryptionConfigs/backupResourceEncryptionConfig",
+        "properties": {
+          "encryptionAtRestType": "CustomerManaged",
+          "infrastructureEncryptionState": "Disabled",
+          "keyUri": "https://gktestkv1.vault.azure.net/keys/Test1/ed2e8cdc7f86477ebf0c6462b504a9ed",
+          "lastUpdateStatus": "Succeeded",
+          "subscriptionId": "1a2311d9-66f5-47d3-a9fb-7a37da63934b",
+          "useSystemAssignedIdentity": false,
+          "userAssignedIdentity": "/subscriptions/85bf5e8c-3084-4f42-add2-746ebb7e97b2/resourcegroups/defaultrg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/examplemsi"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceEncryptionConfigs_Get",
+  "title": "Get Vault Encryption Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupResourceEncryptionConfig_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/BackupResourceEncryptionConfig_Put.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "encryptionAtRestType": "CustomerManaged",
+        "infrastructureEncryptionState": "true",
+        "keyUri": "https://gktestkv1.vault.azure.net/keys/Test1/ed2e8cdc7f86477ebf0c6462b504a9ed",
+        "subscriptionId": "1a2311d9-66f5-47d3-a9fb-7a37da63934b"
+      }
+    },
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "source-rsv"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "BackupResourceEncryptionConfigs_Update",
+  "title": "Update Vault Encryption Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupProtectedItem_UsageSummary_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupProtectedItem_UsageSummary_Get.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "$filter": "type eq 'BackupProtectedItemCountSummary'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Azure Virtual Machine",
+              "value": "AzureIaasVM"
+            },
+            "currentValue": 7,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Agent",
+              "value": "MAB"
+            },
+            "currentValue": 3,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Server",
+              "value": "AzureBackupServer"
+            },
+            "currentValue": 1,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Storage (Azure Files)",
+              "value": "AzureStorage"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "SQL in Azure VM",
+              "value": "AzureWorkload"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupUsageSummaries_List",
+  "title": "Get Protected Items Usages Summary"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupProtectionContainers_UsageSummary_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupProtectionContainers_UsageSummary_Get.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "$filter": "type eq 'BackupProtectionContainerCountSummary'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Azure Backup Server",
+              "value": "AzureBackupServer"
+            },
+            "currentValue": 2,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "Azure Backup Agent",
+              "value": "MAB"
+            },
+            "currentValue": 3,
+            "limit": -1,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "SQL in Azure VM",
+              "value": "AzureWorkload"
+            },
+            "currentValue": 1,
+            "limit": -1,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupUsageSummaries_List",
+  "title": "Get Protected Containers Usages Summary"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Get.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Get",
+  "title": "Get Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Patch.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Patch.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "enhancedSecurityState": "Enabled"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Update",
+  "title": "Update Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupResourceVaultConfigs_Put.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "enhancedSecurityState": "Enabled",
+        "softDeleteFeatureState": "Enabled"
+      }
+    },
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/SwaggerTest/backupconfig/vaultconfig",
+        "properties": {
+          "enhancedSecurityState": "Enabled",
+          "softDeleteFeatureState": "Enabled"
+        }
+      }
+    }
+  },
+  "operationId": "BackupResourceVaultConfigs_Put",
+  "title": "Update Vault Security Config"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupSecurityPin_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupSecurityPin_Get.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "SwaggerTest"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "expiryTimeInUtcTicks": 636495150137443100,
+        "securityPIN": "200432",
+        "token": "200432"
+      }
+    }
+  },
+  "operationId": "SecurityPINs_Get",
+  "title": "Get Vault Security Pin"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Get.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultstorageconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupstorageconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupstorageconfig/vaultstorageconfig",
+        "properties": {
+          "storageModelType": "GeoRedundant",
+          "storageType": "GeoRedundant",
+          "storageTypeState": "Locked"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Get",
+  "title": "Get Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Patch.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Patch.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "storageType": "LocallyRedundant",
+        "storageTypeState": "Unlocked"
+      }
+    },
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Patch",
+  "title": "Update Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Put.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/BackupStorageConfig_Put.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "storageType": "LocallyRedundant",
+        "storageTypeState": "Unlocked"
+      }
+    },
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "vaultstorageconfig",
+        "type": "Microsoft.RecoveryServices/vaults/backupstorageconfig",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupstorageconfig/vaultstorageconfig",
+        "properties": {
+          "storageModelType": "LocallyRedundant",
+          "storageType": "LocallyRedundant",
+          "storageTypeState": "Unlocked"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupResourceStorageConfigsNonCRR_Update",
+  "title": "Update Vault Storage Configuration"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/CancelJobOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/CancelJobOperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "JobOperationResults_Get",
+  "title": "Cancel Job Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ExportJobsOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ExportJobsOperationResult.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "headers": {},
+        "operation": {
+          "blobSasKey": "?sv=2014-02-14&sr=b&sig=<sas_signature>&st=2017-11-29T07%3A53%3A34Z&se=2017-11-29T08%3A03%3A34Z&sp=r",
+          "blobUrl": "https://azureblob.blob.core.windows.net/reportcontainer/exportjobsreportc00000000-0000-0000-0000-000000000000",
+          "objectType": "ExportJobsOperationResultInfo"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "body": {
+        "headers": {
+          "Location": [
+            "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01"
+          ],
+          "Retry-After": [
+            "60"
+          ]
+        },
+        "operation": {
+          "objectType": "ExportJobsOperationResultInfo"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ExportJobsOperationResults_Get",
+  "title": "Export Jobs Operation Results"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/GetJobDetails.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/GetJobDetails.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+        "properties": {
+          "activityId": "00000000-0000-0000-0000-000000000000",
+          "backupManagementType": "AzureIaasVM",
+          "duration": "PT9.8782791S",
+          "entityFriendlyName": "testvm",
+          "extendedInfo": {
+            "propertyBag": {
+              "VM Name": "testvm"
+            },
+            "tasksList": [
+              {
+                "duration": "PT0S",
+                "status": "InProgress",
+                "taskId": "Take Snapshot"
+              },
+              {
+                "duration": "PT0S",
+                "status": "NotStarted",
+                "taskId": "Transfer data to vault"
+              }
+            ]
+          },
+          "jobType": "AzureIaaSVMJob",
+          "operation": "Backup",
+          "startTime": "2017-08-03T05:31:07.014604Z",
+          "status": "InProgress",
+          "virtualMachineVersion": "Compute"
+        }
+      }
+    }
+  },
+  "operationId": "JobDetails_Get",
+  "title": "Get Job Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobs.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobs.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          },
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT31.3066291S",
+              "endTime": "2017-08-03T05:31:03.7553376Z",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "ConfigureBackup",
+              "startTime": "2017-08-03T05:30:32.4487085Z",
+              "status": "Completed",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List All Jobs"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobsWithAllSupportedFilters.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobsWithAllSupportedFilters.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "$filter": "startTime eq '2016-01-01 00:00:00 AM' and endTime eq '2017-11-29 00:00:00 AM' and operation eq 'Backup' and backupManagementType eq 'AzureIaasVM' and status eq 'InProgress'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List Jobs With Filters"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobsWithStartTimeAndEndTimeFilters.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ListJobsWithStartTimeAndEndTimeFilters.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "$filter": "startTime eq '2016-01-01 00:00:00 AM' and endTime eq '2017-11-29 00:00:00 AM'",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs?api-version=2017-07-01&%24filter=startTime+eq+%272016-01-01+00%3a00%3a00+AM%27+and+endTime+eq+%272017-11-29+00%3a00%3a00+AM%27&%24skiptoken=%3c%3fxml+version%3d%221.0%22+encoding%3d%22utf-16%22%3f%3e%0d%0a%3cContinuationToken%3e%0d%0a++%3cContinuationToken%3e%0d%0a++++%3cVersion%3e2.0%3c%2fVersion%3e%0d%0a++++%3cType%3eTable%3c%2fType%3e%0d%0a++++%3cNextPartitionKey%3e1!28!NzI5MTk0OTM1MDkwNjEwODQzMA--%3c%2fNextPartitionKey%3e%0d%0a++++%3cNextRowKey%3e1!108!am9ic3N0YXJ0dGltZWluZGV4XzBfMjUxODkxNDYzNTI2NjE5Nzg5OF8wXzYwOWZkM2JmLTU4MzctNDFkYi1iMjExLTY1MzliNDNlZjM1OA--%3c%2fNextRowKey%3e%0d%0a++++%3cTargetLocation%3ePrimary%3c%2fTargetLocation%3e%0d%0a++%3c%2fContinuationToken%3e%0d%0a%3c%2fContinuationToken%3e",
+        "value": [
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT12.4272909S",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "Backup",
+              "startTime": "2017-08-03T05:31:07.014604Z",
+              "status": "InProgress",
+              "virtualMachineVersion": "Compute"
+            }
+          },
+          {
+            "name": "00000000-0000-0000-0000-000000000000",
+            "type": "Microsoft.RecoveryServices/vaults/backupJobs",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000",
+            "properties": {
+              "activityId": "00000000-0000-0000-0000-000000000000",
+              "backupManagementType": "AzureIaasVM",
+              "duration": "PT31.3066291S",
+              "endTime": "2017-08-03T05:31:03.7553376Z",
+              "entityFriendlyName": "testvm",
+              "jobType": "AzureIaaSVMJob",
+              "operation": "ConfigureBackup",
+              "startTime": "2017-08-03T05:30:32.4487085Z",
+              "status": "Completed",
+              "virtualMachineVersion": "Compute"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupJobs_List",
+  "title": "List Jobs With Time Filter"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "iaasvmcontainer;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "fabricName": "Azure",
+    "protectedItemName": "vm;iaasvmcontainerv2;pysdktestrg;pysdktestv2vm1",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperations/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectedItems_Delete",
+  "title": "Delete Protection from Azure Virtual Machine"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete_OperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete_OperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperations/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/PythonSDKBackupTestRg/providers/Microsoft.RecoveryServices/vaults/PySDKBackupTestRsVault/backupOperationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "BackupOperationResults_Get",
+  "title": "Get Result for Protected Item Delete Operation"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete_OperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/ProtectedItem_Delete_OperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "PythonSDKBackupTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "PySDKBackupTestRsVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "00000000-0000-0000-0000-000000000000",
+        "endTime": "0001-01-01T00:00:00.00000Z",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "startTime": "2017-08-03T06:52:53.886027Z",
+        "status": "InProgress"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "BackupOperationStatuses_Get",
+  "title": "Get Protected Item Delete Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/RefreshContainers.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/RefreshContainers.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "ProtectionContainers_Refresh",
+  "title": "Trigger Azure Vm Discovery"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/RefreshContainers_OperationResults.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/RefreshContainers_OperationResults.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "fabricName": "Azure",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupFabrics/Azure/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ProtectionContainerRefreshOperationResults_Get",
+  "title": "Azure Vm Discovery Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerBackup_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerBackup_Post.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;testrg;v1win2012r",
+    "fabricName": "Azure",
+    "parameters": {
+      "properties": {
+        "objectType": "IaasVMBackupRequest"
+      }
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;testrg;v1win2012r",
+    "resourceGroupName": "linuxRsVaultRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "linuxRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/linuxRsVaultRG/providers/Microsoft.RecoveryServices/vaults/linuxRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;testrg;v1win2012r/protectedItems/VM;iaasvmcontainer;testrg;v1win2012r/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Location": "https://management.azure.com/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/linuxRsVaultRG/providers/Microsoft.RecoveryServices/vaults/linuxRsVault/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainer;testrg;v1win2012r/protectedItems/VM;iaasvmcontainer;testrg;v1win2012r/operationResults/00000000-0000-0000-0000-000000000000?api-version=2016-12-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Backups_Trigger",
+  "title": "Trigger Backup"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerCancelJob.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerCancelJob.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "jobName": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/00000000-0000-0000-0000-000000000000/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "JobCancellations_Trigger",
+  "title": "Cancel Job"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerExportJobs.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Common/TriggerExportJobs.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SwaggerTestRg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "NetSDKTestRsVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SwaggerTestRg/providers/Microsoft.RecoveryServices/vaults/NetSDKTestRsVault/backupJobs/operationResults/00000000-0000-0000-0000-000000000000?api-version=2017-07-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "Jobs_Export",
+  "title": "Export Jobs"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Dpm/BackupEngines_Get.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Dpm/BackupEngines_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "backupEngineName": "testServer",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testServer",
+        "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+        "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer",
+        "properties": {
+          "azureBackupAgentVersion": "2.0.9532.0",
+          "backupEngineState": "Active",
+          "backupEngineType": "DpmBackupEngine",
+          "dpmVersion": "5.1.348.0",
+          "extendedInfo": {
+            "availableDiskSpace": 50,
+            "diskCount": 5,
+            "protectedItemsCount": 35,
+            "protectedServersCount": 21,
+            "usedDiskSpace": 20
+          },
+          "friendlyName": "testServer",
+          "isAzureBackupAgentUpgradeAvailable": false,
+          "isDpmUpgradeAvailable": false,
+          "registrationStatus": "Registered"
+        }
+      }
+    }
+  },
+  "operationId": "BackupEngines_Get",
+  "title": "Get Dpm/AzureBackupServer/Lajolla Backup Engine Details"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Dpm/BackupEngines_List.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/Dpm/BackupEngines_List.json
@@ -1,0 +1,62 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "testRG",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testServer1",
+            "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer1",
+            "properties": {
+              "azureBackupAgentVersion": "2.0.9532.0",
+              "backupEngineState": "Active",
+              "backupEngineType": "DpmBackupEngine",
+              "dpmVersion": "5.1.348.0",
+              "extendedInfo": {
+                "availableDiskSpace": 50,
+                "diskCount": 5,
+                "protectedItemsCount": 35,
+                "protectedServersCount": 21,
+                "usedDiskSpace": 20
+              },
+              "friendlyName": "testServer1",
+              "isAzureBackupAgentUpgradeAvailable": false,
+              "isDpmUpgradeAvailable": false,
+              "registrationStatus": "Registered"
+            }
+          },
+          {
+            "name": "testServer5",
+            "type": "Microsoft.RecoveryServices/vaults/backupEngines",
+            "id": "/Subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRG/providers/Microsoft.RecoveryServices/vaults/testVault/backupEngines/testServer5",
+            "properties": {
+              "azureBackupAgentVersion": "2.0.9530.0",
+              "backupEngineState": "Active",
+              "backupEngineType": "DpmBackupEngine",
+              "dpmVersion": "5.1.348.0",
+              "extendedInfo": {
+                "availableDiskSpace": 50,
+                "diskCount": 5,
+                "protectedItemsCount": 35,
+                "protectedServersCount": 21,
+                "usedDiskSpace": 20
+              },
+              "friendlyName": "testServer5",
+              "isAzureBackupAgentUpgradeAvailable": false,
+              "isDpmUpgradeAvailable": false,
+              "registrationStatus": "Registered"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BackupEngines_List",
+  "title": "List Dpm/AzureBackupServer/Lajolla Backup Engines"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ListOperations.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ListOperations.json
@@ -1,0 +1,465 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "microsoft.recoveryservices/vaults/usages/read",
+            "display": {
+              "description": "Returns usage details for a Recovery Services Vault.",
+              "operation": "Recovery Services Vault usage details.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Usage"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupUsageSummaries/read",
+            "display": {
+              "description": "Returns summaries for Protected Items and Protected Servers for a Recovery Services .",
+              "operation": "Recovery Services Protected Items and Protected Servers usage summaries details.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Usages Summaries"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/storageConfig/read",
+            "display": {
+              "description": "Returns Storage Configuration for Recovery Services Vault.",
+              "operation": "Get Resource Storage Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Storage Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/storageConfig/write",
+            "display": {
+              "description": "Updates Storage Configuration for Recovery Services Vault.",
+              "operation": "Write Resource Storage Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Storage Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupconfig/vaultconfig/read",
+            "display": {
+              "description": "Returns Configuration for Recovery Services Vault.",
+              "operation": "Get Resource Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupconfig/vaultconfig/write",
+            "display": {
+              "description": "Updates Configuration for Recovery Services Vault.",
+              "operation": "Update Resource Config",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Vault Config"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/tokenInfo/read",
+            "display": {
+              "description": "Returns token information for Recovery Services Vault.",
+              "operation": "Get Vault Token Info",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Token Info"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupSecurityPIN/read",
+            "display": {
+              "description": "Returns Security PIN Information for Recovery Services Vault.",
+              "operation": "Get Security PIN Info",
+              "provider": "microsoft.recoveryservices",
+              "resource": "SecurityPINInfo"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupManagementMetaData/read",
+            "display": {
+              "description": "Returns Backup Management Metadata for Recovery Services Vault.",
+              "operation": "Get Backup Management Metadata",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Management Metadata"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupOperationResults/read",
+            "display": {
+              "description": "Returns Backup Operation Result for Recovery Services Vault.",
+              "operation": "Get Backup Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupOperations/read",
+            "display": {
+              "description": "Returns Backup Operation Status for Recovery Services Vault.",
+              "operation": "Get Backup Operation Status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/read",
+            "display": {
+              "description": "Returns all Job Objects",
+              "operation": "Get Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/cancel/action",
+            "display": {
+              "description": "Cancel the Job",
+              "operation": "Cancel Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobsExport/action",
+            "display": {
+              "description": "Export Jobs",
+              "operation": "Export Jobs",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Export Backup Jobs"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobs/operationResults/read",
+            "display": {
+              "description": "Returns the Result of Job Operation.",
+              "operation": "Get Job Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Jobs Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupJobsExport/operationResults/read",
+            "display": {
+              "description": "Returns the Result of Export Job Operation.",
+              "operation": "Get Export Job Operation Result",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Export Backup Jobs Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/read",
+            "display": {
+              "description": "Get Recovery Points for Protected Items.",
+              "operation": "Get Recovery Points",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action",
+            "display": {
+              "description": "Restore Recovery Points for Protected Items.",
+              "operation": "Restore Recovery Points",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/provisionInstantItemRecovery/action",
+            "display": {
+              "description": "Provision Instant Item Recovery for Protected Item",
+              "operation": "Provision Instant Item Recovery for Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/revokeInstantItemRecovery/action",
+            "display": {
+              "description": "Revoke Instant Item Recovery for Protected Item",
+              "operation": "Revoke Instant Item Recovery for Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Recovery Points"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/read",
+            "display": {
+              "description": "Returns all Protection Policies",
+              "operation": "Get Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/write",
+            "display": {
+              "description": "Creates Protection Policy",
+              "operation": "Create Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/delete",
+            "display": {
+              "description": "Delete a Protection Policy",
+              "operation": "Delete Protection Policy",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policies"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/operationResults/read",
+            "display": {
+              "description": "Get Results of Policy Operation.",
+              "operation": "Get Policy Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policy Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPolicies/operationsStatus/read",
+            "display": {
+              "description": "Get Status of Policy Operation.",
+              "operation": "Get Policy Operation Status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Policy Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/read",
+            "display": {
+              "description": "Returns object details of the Protected Item",
+              "operation": "Get Protected Item Details",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectedItems/read",
+            "display": {
+              "description": "Returns the list of all Protected Items.",
+              "operation": "Get All Protected Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/write",
+            "display": {
+              "description": "Create a backup Protected Item",
+              "operation": "Create Backup Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/delete",
+            "display": {
+              "description": "Deletes Protected Item",
+              "operation": "Delete Protected Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/operationResults/read",
+            "display": {
+              "description": "Gets Result of Operation Performed on Protected Items.",
+              "operation": "Get Protected Items Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Item Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/operationsStatus/read",
+            "display": {
+              "description": "Returns the status of Operation performed on Protected Items.",
+              "operation": "Get Protected Items operation status",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Item Operation Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/protectedItems/backup/action",
+            "display": {
+              "description": "Performs Backup for Protected Item.",
+              "operation": "Backup Protected Item",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protected Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectableItems/read",
+            "display": {
+              "description": "Returns list of all Protectable Items.",
+              "operation": "Get Protectable Items",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Protectable Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/refreshContainers/read",
+            "display": {
+              "description": "Refreshes the container list",
+              "operation": "Refresh container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Refresh Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/operationResults/read",
+            "display": {
+              "description": "Returns status of the operation",
+              "operation": "Get Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Refresh Containers Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupProtectionContainers/read",
+            "display": {
+              "description": "Returns all containers belonging to the subscription",
+              "operation": "Get Containers In Subscription",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Protection Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/read",
+            "display": {
+              "description": "Returns all registered containers",
+              "operation": "Get Registered Container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/operationResults/read",
+            "display": {
+              "description": "Gets result of Operation performed on Protection Container.",
+              "operation": "Get Container Operation Results",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers Operation Results"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupEngines",
+            "display": {
+              "description": "Returns all the backup management servers registered with vault.",
+              "operation": "List of backup management servers.",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Engines"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupStatus",
+            "display": {
+              "description": "Check Backup Status for Recovery Services Vaults",
+              "operation": "Check Backup Status for Vault",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Backup Status"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupPreValidateProtection",
+            "display": {
+              "description": "",
+              "operation": "Pre Validate Enable Protection",
+              "provider": "microsoft.recoveryservices",
+              "resource": "PreValidate Protection"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupValidateFeatures",
+            "display": {
+              "description": "Validate Features",
+              "operation": "Validate Features",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Validate Features"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/backupProtectionIntent/write",
+            "display": {
+              "description": "Create a backup Protection Intent",
+              "operation": "Create backup Protection Intent",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Intent"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/{fabricName}/protectionContainers/{containerName}/items/read",
+            "display": {
+              "description": "Get all items in a container",
+              "operation": "Get all items in a container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Workload Items"
+            },
+            "origin": "user"
+          },
+          {
+            "name": "microsoft.recoveryservices/vaults/backupFabrics/protectionContainers/inquire/action",
+            "display": {
+              "description": "Get all items in a container",
+              "operation": "Get all items in a container",
+              "provider": "microsoft.recoveryservices",
+              "resource": "Protection Containers Inquire"
+            },
+            "origin": "user"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "ListOperations"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/DeletePrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/DeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/6c48fa17-39c7-45f1-90ac-47a587128ace/resourceGroups/backupadminrg/providers/Microsoft.RecoveryServices/Vaults/demo-pevault-2/privateEndpointConnections/autoapprovalpeecy4.3679789459502941542.backup.5ede856d-d9f0-461e-a15b-370c84525817/operationsStatus/2908a25d-8036-48d2-bdcc-fdce26b9771f?api-versi",
+        "Retry-After": "60"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateEndpointConnection_Delete",
+  "title": "Delete PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/GetPrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/GetPrivateEndpointConnection.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Pending"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnection_Get",
+  "title": "Get PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/GetPrivateEndpointConnectionOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/GetPrivateEndpointConnectionOperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "PrivateEndpoint_GetOperationStatus",
+  "title": "Get OperationStatus"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/PutPrivateEndpointConnection.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/PrivateEndpointConnection/PutPrivateEndpointConnection.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "groupIds": [
+          "AzureBackup_secondary"
+        ],
+        "privateEndpoint": {
+          "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+        },
+        "privateLinkServiceConnectionState": {
+          "description": "Approved by johndoe@company.com",
+          "status": "Approved"
+        },
+        "provisioningState": "Succeeded"
+      }
+    },
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "gaallatestpe1.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "type": "Microsoft.RecoveryServices/vaults/privateEndpointConnections",
+        "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.RecoveryServicesBVTD2/vaults/gaallavaultbvtd2msi/privateEndpointConnections/gaallatestpe3.3592346090307038890.backup.5704c932-249a-490b-a142-1396838cd3b",
+        "properties": {
+          "groupIds": [
+            "AzureBackup_secondary"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/04cf684a-d41f-4550-9f70-7708a3a2283b/resourceGroups/gaallaRG/providers/Microsoft.Network/privateEndpoints/gaallatestpe3"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Approved by johndoe@company.com",
+            "status": "Approved"
+          },
+          "provisioningState": "Pending"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/6c48fa17-39c7-45f1-90ac-47a587128ace/resourceGroups/backupadminrg/providers/Microsoft.RecoveryServices/Vaults/demo-pevault-2/privateEndpointConnections/autoapprovalpeecy4.3679789459502941542.backup.5ede856d-d9f0-461e-a15b-370c84525817/operationsStatus/2908a25d-8036-48d2-bdcc-fdce26b9771f?api-versi",
+        "Retry-After": "60"
+      }
+    }
+  },
+  "operationId": "PrivateEndpointConnection_Put",
+  "title": "Update PrivateEndpointConnection"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/DeleteResourceGuardProxy.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ResourceGuardProxy_Delete",
+  "title": "Delete ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/GetResourceGuardProxy.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "swaggerExample",
+        "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+        "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "properties": {
+          "description": "Please take JIT access before performing any of the critical operation",
+          "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+          "resourceGuardOperationDetails": [
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/resourceguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+        }
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_Get",
+  "title": "Get ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/ListResourceGuardProxy.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "resourceGroupName": "SampleResourceGroup",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "swaggerExample",
+            "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+            "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+            "properties": {
+              "description": "Please take JIT access before performing any of the critical operation",
+              "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+              "resourceGuardOperationDetails": [
+                {
+                  "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+                  "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+                },
+                {
+                  "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+                  "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+                }
+              ],
+              "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxies_Get",
+  "title": "Get VaultGuardProxies"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/PutResourceGuardProxy.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "properties": {
+        "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+      }
+    },
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "swaggerExample",
+        "type": "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies",
+        "id": "/backupmanagement/resources/sampleVault/backupResourceGuardProxies/swaggerExample",
+        "properties": {
+          "description": "Please take JIT access before performing any of the critical operation",
+          "lastUpdatedTime": "2021-02-11T12:20:47.8210031Z",
+          "resourceGuardOperationDetails": [
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteResourceGuardProxyRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/deleteResourceGuardProxyRequests"
+            },
+            {
+              "defaultResourceRequest": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/disableSoftDeleteRequests/default",
+              "vaultCriticalOperation": "Microsoft.DataProtection/resourceGuards/disableSoftDeleteRequests"
+            }
+          ],
+          "resourceGuardResourceId": "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew"
+        }
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_Put",
+  "title": "Create ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/ResourceGuardProxyCRUD/UnlockDeleteResourceGuardProxy.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "resourceGuardOperationRequests": [
+        "/subscriptions/c999d45b-944f-418c-a0d8-c3fcfd1802c8/resourceGroups/vaultguardRGNew/providers/Microsoft.DataProtection/resourceGuards/VaultGuardTestNew/deleteProtectedItemRequests/default"
+      ],
+      "resourceToBeDeleted": "/subscriptions/62b829ee-7936-40c9-a1c9-47a93f9f3965/resourceGroups/gaallarg/providers/Microsoft.RecoveryServices/vaults/MercuryCrrVault/backupFabrics/Azure/protectionContainers/VMAppContainer;compute;crrtestrg;crrtestvm/protectedItems/SQLDataBase;mssqlserver;testdb"
+    },
+    "resourceGroupName": "SampleResourceGroup",
+    "resourceGuardProxyName": "swaggerExample",
+    "subscriptionId": "0b352192-dcac-4cc7-992e-a96190ccc68c",
+    "vaultName": "sampleVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "unlockDeleteExpiryTime": "2021-02-11T13:12:27.7870742Z"
+      }
+    }
+  },
+  "operationId": "ResourceGuardProxy_UnlockDelete",
+  "title": "UnlockDelete ResourceGuardProxy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForPolicy.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForPolicy.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "objectType": "FetchTieringCostSavingsInfoForPolicyRequest",
+      "policyName": "monthly",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for policy"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForProtectedItem.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForProtectedItem.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "objectType": "FetchTieringCostSavingsInfoForProtectedItemRequest",
+      "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for protected item"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForRehydrate.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForRehydrate.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "objectType": "FetchTieringCostInfoForRehydrationRequest",
+      "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+      "recoveryPointId": "1222343434",
+      "rehydrationPriority": "High",
+      "sourceTierType": "ArchivedRP",
+      "targetTierType": "HardenedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostRehydrationInfo",
+        "rehydrationSizeInBytes": 1204000,
+        "retailRehydrationCostPerGBPerMonth": 0.02
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the rehydration cost for recovery point"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForVault.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/FetchTieringCostForVault.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "parameters": {
+      "objectType": "FetchTieringCostSavingsInfoForVaultRequest",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupTieringCost/default/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "FetchTieringCost_Post",
+  "title": "Get the tiering savings cost info for vault"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/GetTieringCostOperationResult.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/GetTieringCostOperationResult.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "objectType": "TieringCostSavingInfo",
+        "retailSourceTierCostPerGBPerMonth": 0.02,
+        "retailTargetTierCostPerGBPerMonth": 0.003,
+        "sourceTierSizeReductionInBytes": 1204000,
+        "targetTierSizeIncreaseInBytes": 1892
+      }
+    }
+  },
+  "operationId": "GetTieringCostOperationResult_Get",
+  "title": "Fetch Tiering Cost Operation Result"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/GetTieringCostOperationStatus.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TieringCost/GetTieringCostOperationStatus.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "operationId": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+    "api-version": "2026-06-01",
+    "privateEndpointConnectionName": "gaallatestpe2.5704c932-249a-490b-a142-1396838cd3b",
+    "resourceGroupName": "gaallaRG",
+    "subscriptionId": "04cf684a-d41f-4550-9f70-7708a3a2283b",
+    "vaultName": "gaallavaultbvtd2msi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "endTime": "2020-02-27T11:59:47.5901592Z",
+        "id": "0f48183b-0a44-4dca-aec1-bba5daab888a",
+        "startTime": "2020-02-27T11:59:47.5901592Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "TieringCostOperationStatus_Get",
+  "title": "Fetch Tiering Cost Operation Status"
+}

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TriggerRecoveryPointMove_Post.json
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/stable/2026-06-01/examples/TriggerRecoveryPointMove_Post.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "containerName": "IaasVMContainer;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "fabricName": "Azure",
+    "parameters": {
+      "objectType": "MoveRPAcrossTiersRequest",
+      "sourceTierType": "HardenedRP",
+      "targetTierType": "ArchivedRP"
+    },
+    "protectedItemName": "VM;iaasvmcontainerv2;netsdktestrg;netvmtestv2vm1",
+    "recoveryPointId": "348916168024334",
+    "resourceGroupName": "netsdktestrg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "vaultName": "testVault"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationsStatus/00000000-0000-0000-0000-000000000000?api-version=2026-02-01",
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/netsdktestrg/providers/Microsoft.RecoveryServices/vaults/testVault/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/protectedItems/vm;iaasVMContainerV2;netsdktestrg;netvmtestv2vm1/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-02-01",
+        "Retry-After": 60
+      }
+    }
+  },
+  "operationId": "MoveRecoveryPoint",
+  "title": "Trigger RP Move Operation"
+}


### PR DESCRIPTION
## ARM API Information (Control Plane)
- **MSFTInternal -> ResourceProvider Name:** Microsoft.RecoveryServices
- **OperationId(s) affected:** ProtectionPolicies_CreateOrUpdate
- **Brief description:** Adds an optional `vdiSettings` field to `Settings` (used by AzureWorkload backup policy) plus a new `VdiSettings` model exposing `isMultiVdiSupportEnabled` and `noOfVdiStreams` (range 1–32). Surfaces multi-stream VDI behavior for SQL workload backups via PowerShell / Az SDKs.
- **Linked service PR:** [BMS PR 15544233](https://msazure.visualstudio.com/One/_git/Mgmt-RecoverySvcs-BackupMgmt/pullrequest/15544233)

## Changeset

| File | Change |
|---|---|
| `main.tsp` | Append `v2026_06_01: "2026-06-01"` to `Versions` enum |
| `models.tsp` | `import "@typespec/versioning"`; extend `model Settings` with `@added(Versions.v2026_06_01) vdiSettings?: VdiSettings`; add new `model VdiSettings { isMultiVdiSupportEnabled?: boolean; @minValue(1) @maxValue(32) noOfVdiStreams?: int32 }` (also `@added`) |
| `readme.md` | Bump top `tag:` and `package-activestamp` to `package-2026-06-01`; insert new tag section referencing `stable/2026-06-01/bms.json` |
| `stable/2026-06-01/` | New stable folder copied from `stable/2026-02-01/` with `api-version` rewritten everywhere |
| `stable/2026-06-01/examples/AzureWorkload/ProtectionPolicies_CreateOrUpdate_SqlWithMultiVdi.json` | New example covering `vdiSettings` block on a SQL policy |

## API version cadence rationale
Latest stable on `main` is `2026-02-01`. Per the team cadence (stable cut at the **start of a new month**, preview at end of month), the next stable slot is `2026-06-01`. This feature is GA-ready per the linked BMS PR (no preview gating requested), so it lands directly in stable. Newer-stable carry-forward: examples are copied verbatim from `stable/2026-02-01/` and the `api-version` field is bulk-rewritten — no functional changes beyond the multi-VDI addition.

## Validation
- `npx tsp compile .` → ✅ "Compilation completed successfully." (no errors, no warnings)
- Cross-check before edit: `grep -r "vdiSettings|VdiSettings|isMultiVdiSupportEnabled|noOfVdiStreams" specification/recoveryservicesbackup` → 0 hits (no accidental backport)
- Generated `stable/2026-06-01/bms.json` contains `VdiSettings` definition + `vdiSettings` property on `Settings`. `stable/2026-02-01/bms.json` is unchanged (0 hits for VdiSettings).
- Range constraint `[1, 32]` emitted into the JSON schema via `@minValue` / `@maxValue`.

## Known follow-ups (intentionally left for review feedback)
1. **`@opExample` wiring** — the new `SqlWithMultiVdi.json` is in the examples folder but is not yet wired to `ProtectionPolicies_CreateOrUpdate` via an `@opExample` decorator in TypeSpec. Will add if reviewers prefer it explicitly bound; otherwise will rely on operationId-based linter discovery.
2. **Workload restriction encoding** — multi-VDI is a SQL-only feature today. Currently enforced at runtime (service-side). Open question: should we encode it as a discriminator constraint in TypeSpec, or leave docs-only?
3. **Default values** — `isMultiVdiSupportEnabled` defaults to `false` and `noOfVdiStreams` defaults to `1` (service-side). Should we add `@doc` blocks calling this out explicitly, or leave to PowerShell help text?

## Notes for reviewers
- This is a **stable** version bump, not preview — the BMS feature has GA approval.
- No breaking changes — `vdiSettings` is optional.
- No companion bump needed in `recoveryservices` / `recoveryservicessiterecovery` for this scope (workload-policy-local change). General cross-RP version bump for `Microsoft.RecoveryServices` will be tracked separately if/when needed.
- Sister change for PowerShell CLI (`Az.RecoveryServices` backup module) and .NET SDK (`Azure.ResourceManager.RecoveryServicesBackup`) will follow the SDK release-plan flow on eng.ms once this merges.

🤖 Drafted with the [`#bms-swagger-pr-from-service-pr`](https://github.com/hiaga/copilot-skills) Copilot CLI skill from the linked service PR.
