### PR TITLE
Add zones property to InterconnectGroup resource

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/InterconnectGroup.tsp
@@ -44,6 +44,10 @@ model InterconnectGroup extends Common.Resource {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "etag is a standard envelope property on Network RP resources for optimistic concurrency"
   @visibility(Lifecycle.Read)
   etag?: string;
+
+  /** A list of availability zones denoting the resource needs to come from. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "zones is a standard envelope property on Network RP resources for availability zone support"
+  zones?: string[];
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-07-01/interconnectGroup.json
@@ -519,6 +519,13 @@
           "type": "string",
           "description": "A unique read-only string that changes whenever the resource is updated.",
           "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "allOf": [


### PR DESCRIPTION
Add availability zones support to the InterconnectGroup resource, following the same pattern as PublicIPAddress. This adds a zones?: string[] property to the InterconnectGroup model and regenerates the OpenAPI JSON.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
