### PR TITLE
Add @@clientName for RecordType in TrafficManager client.tsp

### DIFF
--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/client.tsp
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/client.tsp
@@ -165,6 +165,9 @@ op getReplace(
   "csharp"
 );
 @@clientName(ProfileStatus, "TrafficManagerProfileStatus", "csharp");
+@@clientName(RecordType, "TrafficManagerRecordType", "csharp");
+@@clientName(RecordType.AAAA, "Aaaa", "csharp");
+@@clientName(RecordType.CNAME, "Cname", "csharp");
 @@clientName(MonitorProtocol.HTTP, "Http", "csharp");
 @@clientName(MonitorProtocol.HTTPS, "Https", "csharp");
 @@clientName(MonitorProtocol.TCP, "Tcp", "csharp");


### PR DESCRIPTION
Addresses .NET SDK PR review feedback (Azure/azure-sdk-for-net#59107):

- Rename RecordType to TrafficManagerRecordType for csharp (avoid generic name)

- Rename RecordType.AAAA to Aaaa for csharp (.NET naming convention)

- Rename RecordType.CNAME to Cname for csharp (.NET naming convention)

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
