### PR TITLE
Add ARM lease for Microsoft.AIGrounding

### DIFF
--- a/.github/arm-leases/aigrounding/Microsoft.AIGrounding/lease.yaml
+++ b/.github/arm-leases/aigrounding/Microsoft.AIGrounding/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.AIGrounding
+  startdate: "2026-05-20"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds an ARM lease for the `Microsoft.AIGrounding` resource provider.

- **Resource Provider:** Microsoft.AIGrounding
- **Start date:** 2026-05-20
- **Duration:** P180D
- **Reviewer:** @vikeshi26