### PR TITLE
[Do NOT Merge]Address ARM API review feedback for snapshot immutability policy

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Disk.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Disk.tsp
@@ -69,12 +69,10 @@ interface Disks {
   #suppress "@azure-tools/typespec-azure-resource-manager/no-response-body" "For backward compatibility"
   createOrUpdate is ComputeResourceCreateOrReplaceAsync<
     Disk,
-    Response =
-      | ArmResourceUpdatedResponse<Disk>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Disk> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: Disk;
-        })
+    Response = ArmResourceUpdatedResponse<Disk> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Disk> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: Disk;
+    })
   >;
 
   /**
@@ -85,12 +83,10 @@ interface Disks {
   update is ComputeCustomPatchAsync<
     Disk,
     DiskUpdate,
-    Response =
-      | ArmResponse<Disk>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Disk> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: Disk;
-        })
+    Response = ArmResponse<Disk> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Disk> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: Disk;
+    })
   >;
 
   /**
@@ -129,20 +125,16 @@ interface Disks {
   >;
 }
 
-@@doc(
-  Disk.name,
+@@doc(Disk.name,
   "The name of the managed disk that is being created. The name can't be changed after the disk is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters."
 );
 @@doc(Disk.properties, "Disk resource properties.");
-@@doc(
-  Disks.createOrUpdate::parameters.resource,
+@@doc(Disks.createOrUpdate::parameters.resource,
   "Disk object supplied in the body of the Put disk operation."
 );
-@@doc(
-  Disks.update::parameters.properties,
+@@doc(Disks.update::parameters.properties,
   "Disk object supplied in the body of the Patch disk operation."
 );
-@@doc(
-  Disks.grantAccess::parameters.body,
+@@doc(Disks.grantAccess::parameters.body,
   "Access data object supplied in the body of the get disk access operation."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskAccess.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskAccess.tsp
@@ -44,12 +44,10 @@ interface DiskAccesses {
   #suppress "@azure-tools/typespec-azure-resource-manager/no-response-body" "For backward compatibility"
   createOrUpdate is ComputeResourceCreateOrReplaceAsync<
     DiskAccess,
-    Response =
-      | ArmResourceUpdatedResponse<DiskAccess>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskAccess> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: DiskAccess;
-        })
+    Response = ArmResourceUpdatedResponse<DiskAccess> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskAccess> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: DiskAccess;
+    })
   >;
 
   /**
@@ -60,12 +58,10 @@ interface DiskAccesses {
   update is ComputeCustomPatchAsync<
     DiskAccess,
     DiskAccessUpdate,
-    Response =
-      | ArmResponse<DiskAccess>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskAccess> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: DiskAccess;
-        })
+    Response = ArmResponse<DiskAccess> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskAccess> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: DiskAccess;
+    })
   >;
 
   /**
@@ -101,16 +97,13 @@ interface DiskAccesses {
   >;
 }
 
-@@doc(
-  DiskAccess.name,
+@@doc(DiskAccess.name,
   "The name of the disk access resource that is being created. The name can't be changed after the disk encryption set is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters."
 );
 @@doc(DiskAccess.properties, "");
-@@doc(
-  DiskAccesses.createOrUpdate::parameters.resource,
+@@doc(DiskAccesses.createOrUpdate::parameters.resource,
   "disk access object supplied in the body of the Put disk access operation."
 );
-@@doc(
-  DiskAccesses.update::parameters.properties,
+@@doc(DiskAccesses.update::parameters.properties,
   "disk access object supplied in the body of the Patch disk access operation."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskEncryptionSet.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskEncryptionSet.tsp
@@ -44,12 +44,10 @@ interface DiskEncryptionSets {
   #suppress "@azure-tools/typespec-azure-resource-manager/no-response-body" "For backward compatibility"
   createOrUpdate is ComputeResourceCreateOrReplaceAsync<
     DiskEncryptionSet,
-    Response =
-      | ArmResourceUpdatedResponse<DiskEncryptionSet>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskEncryptionSet> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: DiskEncryptionSet;
-        })
+    Response = ArmResourceUpdatedResponse<DiskEncryptionSet> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskEncryptionSet> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: DiskEncryptionSet;
+    })
   >;
 
   /**
@@ -60,12 +58,10 @@ interface DiskEncryptionSets {
   update is ComputeCustomPatchAsync<
     DiskEncryptionSet,
     DiskEncryptionSetUpdate,
-    Response =
-      | ArmResponse<DiskEncryptionSet>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskEncryptionSet> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: DiskEncryptionSet;
-        })
+    Response = ArmResponse<DiskEncryptionSet> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = DiskEncryptionSet> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: DiskEncryptionSet;
+    })
   >;
 
   /**
@@ -106,16 +102,13 @@ interface DiskEncryptionSets {
   >;
 }
 
-@@doc(
-  DiskEncryptionSet.name,
+@@doc(DiskEncryptionSet.name,
   "The name of the disk encryption set that is being created. The name can't be changed after the disk encryption set is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters."
 );
 @@doc(DiskEncryptionSet.properties, "");
-@@doc(
-  DiskEncryptionSets.createOrUpdate::parameters.resource,
+@@doc(DiskEncryptionSets.createOrUpdate::parameters.resource,
   "disk encryption set object supplied in the body of the Put disk encryption set operation."
 );
-@@doc(
-  DiskEncryptionSets.update::parameters.properties,
+@@doc(DiskEncryptionSets.update::parameters.properties,
   "disk encryption set object supplied in the body of the Patch disk encryption set operation."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskRestorePoint.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/DiskRestorePoint.tsp
@@ -101,11 +101,9 @@ interface DiskRestorePoints {
 }
 
 @@doc(DiskRestorePoint.name, "The name of the disk restore point created.");
-@@doc(
-  DiskRestorePoint.properties,
+@@doc(DiskRestorePoint.properties,
   "Properties of an incremental disk restore point"
 );
-@@doc(
-  DiskRestorePoints.grantAccess::parameters.body,
+@@doc(DiskRestorePoints.grantAccess::parameters.body,
   "Access data object supplied in the body of the get disk access operation."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/PrivateEndpointConnection.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/PrivateEndpointConnection.tsp
@@ -46,12 +46,10 @@ interface PrivateEndpointConnections {
   @operationId("DiskAccesses_UpdateAPrivateEndpointConnection")
   updateAPrivateEndpointConnection is ComputeResourceCreateOrReplaceAsync<
     PrivateEndpointConnection,
-    Response =
-      | ArmResourceUpdatedResponse<PrivateEndpointConnection>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = PrivateEndpointConnection> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: PrivateEndpointConnection;
-        })
+    Response = ArmResourceUpdatedResponse<PrivateEndpointConnection> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = PrivateEndpointConnection> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: PrivateEndpointConnection;
+    })
   >;
 
   /**
@@ -76,12 +74,10 @@ interface PrivateEndpointConnections {
   >;
 }
 
-@@doc(
-  PrivateEndpointConnection.name,
+@@doc(PrivateEndpointConnection.name,
   "The name of the private endpoint connection."
 );
 @@doc(PrivateEndpointConnection.properties, "Resource properties.");
-@@doc(
-  PrivateEndpointConnections.updateAPrivateEndpointConnection::parameters.resource,
+@@doc(PrivateEndpointConnections.updateAPrivateEndpointConnection::parameters.resource,
   "private endpoint connection object supplied in the body of the Put private endpoint connection operation."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
@@ -121,9 +121,7 @@ interface Snapshots {
   >;
 
   /**
-   * Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy
-   * with the specified duration and type. If the snapshot already has a locked policy, the request
-   * will be rejected. Use updateImmutabilityPolicyLock to lock an existing unlocked policy.
+   * Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy with the specified duration and type. If the snapshot already has a locked policy, the request will be rejected. Use updateImmutabilityPolicyLock to lock an immutability policy.
    */
   @added(Versions.v2026_03_02)
   @action("updateImmutabilityPolicy")
@@ -137,9 +135,7 @@ interface Snapshots {
   >;
 
   /**
-   * Locks the immutability policy of a snapshot. Once locked, the policy cannot be modified or
-   * removed until the lock period expires. The snapshot must already have an unlocked immutability
-   * policy configured via updateImmutabilityPolicy before it can be locked.
+   * Locks the immutability policy of a snapshot. Once locked, the policy cannot be reduced or removed until the lock period expires.
    */
   @added(Versions.v2026_03_02)
   @action("updateImmutabilityPolicyLock")

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
@@ -58,12 +58,10 @@ interface Snapshots {
   #suppress "@azure-tools/typespec-azure-resource-manager/no-response-body" "For backward compatibility"
   createOrUpdate is ComputeResourceCreateOrReplaceAsync<
     Snapshot,
-    Response =
-      | ArmResourceUpdatedResponse<Snapshot>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Snapshot> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: Snapshot;
-        })
+    Response = ArmResourceUpdatedResponse<Snapshot> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Snapshot> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: Snapshot;
+    })
   >;
 
   /**
@@ -74,12 +72,10 @@ interface Snapshots {
   update is ComputeCustomPatchAsync<
     Snapshot,
     SnapshotUpdate,
-    Response =
-      | ArmResourceUpdatedResponse<Snapshot>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Snapshot> &
-          Azure.Core.Foundations.RetryAfterHeader> & {
-          @bodyRoot _: Snapshot;
-        })
+    Response = ArmResourceUpdatedResponse<Snapshot> | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = Snapshot> &
+      Azure.Core.Foundations.RetryAfterHeader> & {
+      @bodyRoot _: Snapshot;
+    })
   >;
 
   /**
@@ -147,21 +143,17 @@ interface Snapshots {
   >;
 }
 
-@@doc(
-  Snapshot.name,
+@@doc(Snapshot.name,
   "The name of the snapshot that is being created. The name can't be changed after the snapshot is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The max name length is 80 characters."
 );
 @@doc(Snapshot.properties, "Snapshot resource properties.");
-@@doc(
-  Snapshots.createOrUpdate::parameters.resource,
+@@doc(Snapshots.createOrUpdate::parameters.resource,
   "Snapshot object supplied in the body of the Put disk operation."
 );
-@@doc(
-  Snapshots.update::parameters.properties,
+@@doc(Snapshots.update::parameters.properties,
   "Snapshot object supplied in the body of the Patch snapshot operation."
 );
-@@doc(
-  Snapshots.grantAccess::parameters.body,
+@@doc(Snapshots.grantAccess::parameters.body,
   "Access data object supplied in the body of the get snapshot access operation."
 );
 @@doc(Snapshots.updateImmutabilityPolicy::parameters.body,

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
@@ -121,25 +121,35 @@ interface Snapshots {
   >;
 
   /**
-   * Updates the immutability policy of a snapshot.
+   * Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy
+   * with the specified duration and type. If the snapshot already has a locked policy, the request
+   * will be rejected. Use updateImmutabilityPolicyLock to lock an existing unlocked policy.
    */
   @added(Versions.v2026_03_02)
   @action("updateImmutabilityPolicy")
   updateImmutabilityPolicy is ComputeResourceActionAsync<
     Snapshot,
     ImmutabilityPolicyData,
-    Snapshot
+    Snapshot,
+    LroHeaders = ArmAsyncOperationHeader<FinalResult = Snapshot> &
+      ArmLroLocationHeader<FinalResult = Snapshot> &
+      Azure.Core.Foundations.RetryAfterHeader
   >;
 
   /**
-   * Updates the immutability policy lock of a snapshot.
+   * Locks the immutability policy of a snapshot. Once locked, the policy cannot be modified or
+   * removed until the lock period expires. The snapshot must already have an unlocked immutability
+   * policy configured via updateImmutabilityPolicy before it can be locked.
    */
   @added(Versions.v2026_03_02)
   @action("updateImmutabilityPolicyLock")
   updateImmutabilityPolicyLock is ComputeResourceActionAsync<
     Snapshot,
-    ImmutabilityPolicyData,
-    Snapshot
+    ImmutabilityPolicyLockData,
+    Snapshot,
+    LroHeaders = ArmAsyncOperationHeader<FinalResult = Snapshot> &
+      ArmLroLocationHeader<FinalResult = Snapshot> &
+      Azure.Core.Foundations.RetryAfterHeader
   >;
 }
 
@@ -162,3 +172,4 @@ interface Snapshots {
 @@doc(Snapshots.updateImmutabilityPolicyLock::parameters.body,
   "Immutability policy data supplied in the body of the update immutability policy lock operation."
 );
+

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/back-compatible.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/back-compatible.tsp
@@ -10,14 +10,12 @@ using ComputeDisk;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  PrivateLinkResource.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateLinkResource.properties
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  DiskEncryptionSetUpdate.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(DiskEncryptionSetUpdate.properties
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
@@ -25,8 +23,7 @@ using ComputeDisk;
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(SnapshotUpdate.properties);
 
 @@clientName(Disks.update, "Disks.update::parameters.properties", "disk");
-@@clientName(
-  Disks.grantAccess,
+@@clientName(Disks.grantAccess,
   "Disks.grantAccess::parameters.body",
   "grantAccessData"
 );
@@ -34,8 +31,7 @@ using ComputeDisk;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(Disk.properties);
 
-@@clientName(
-  DiskAccesses.update,
+@@clientName(DiskAccesses.update,
   "DiskAccesses.update::parameters.properties",
   "diskAccess"
 );
@@ -45,39 +41,32 @@ using ComputeDisk;
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  PrivateEndpointConnection.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(PrivateEndpointConnection.properties
 );
 
-@@clientName(
-  DiskEncryptionSets.update,
+@@clientName(DiskEncryptionSets.update,
   "DiskEncryptionSets.update::parameters.properties",
   "diskEncryptionSet"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  DiskEncryptionSet.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(DiskEncryptionSet.properties
 );
 
-@@clientName(
-  DiskRestorePoints.grantAccess,
+@@clientName(DiskRestorePoints.grantAccess,
   "DiskRestorePoints.grantAccess::parameters.body",
   "grantAccessData"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "@flattenProperty decorator is not recommended to use."
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Back compatibility"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  DiskRestorePoint.properties
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(DiskRestorePoint.properties
 );
 
-@@clientName(
-  Snapshots.update,
+@@clientName(Snapshots.update,
   "Snapshots.update::parameters.properties",
   "snapshot"
 );
-@@clientName(
-  Snapshots.grantAccess,
+@@clientName(Snapshots.grantAccess,
   "Snapshots.grantAccess::parameters.body",
   "grantAccessData"
 );
@@ -87,16 +76,13 @@ using ComputeDisk;
 
 @@clientName(DiskAccesses.createOrUpdate::parameters.resource, "diskAccess");
 @@clientName(DiskAccesses.update::parameters.properties, "diskAccess");
-@@clientName(
-  PrivateEndpointConnections.updateAPrivateEndpointConnection::parameters.resource,
+@@clientName(PrivateEndpointConnections.updateAPrivateEndpointConnection::parameters.resource,
   "privateEndpointConnection"
 );
-@@clientName(
-  DiskEncryptionSets.createOrUpdate::parameters.resource,
+@@clientName(DiskEncryptionSets.createOrUpdate::parameters.resource,
   "diskEncryptionSet"
 );
-@@clientName(
-  DiskEncryptionSets.update::parameters.properties,
+@@clientName(DiskEncryptionSets.update::parameters.properties,
   "diskEncryptionSet"
 );
 @@clientName(Disks.createOrUpdate::parameters.resource, "disk");
@@ -113,31 +99,26 @@ using ComputeDisk;
   "immutabilityPolicyData"
 );
 @@clientLocation(DiskRestorePoints.get, "DiskRestorePoint", "!csharp");
-@@clientLocation(
-  DiskRestorePoints.listByRestorePoint,
+@@clientLocation(DiskRestorePoints.listByRestorePoint,
   "DiskRestorePoint",
   "!csharp"
 );
 @@clientLocation(DiskRestorePoints.grantAccess, "DiskRestorePoint", "!csharp");
 @@clientLocation(DiskRestorePoints.revokeAccess, "DiskRestorePoint", "!csharp");
 
-@@clientLocation(
-  PrivateEndpointConnections.getAPrivateEndpointConnection,
+@@clientLocation(PrivateEndpointConnections.getAPrivateEndpointConnection,
   DiskAccesses,
   "!csharp"
 );
-@@clientLocation(
-  PrivateEndpointConnections.updateAPrivateEndpointConnection,
+@@clientLocation(PrivateEndpointConnections.updateAPrivateEndpointConnection,
   DiskAccesses,
   "!csharp"
 );
-@@clientLocation(
-  PrivateEndpointConnections.deleteAPrivateEndpointConnection,
+@@clientLocation(PrivateEndpointConnections.deleteAPrivateEndpointConnection,
   DiskAccesses,
   "!csharp"
 );
-@@clientLocation(
-  PrivateEndpointConnections.listPrivateEndpointConnections,
+@@clientLocation(PrivateEndpointConnections.listPrivateEndpointConnections,
   DiskAccesses,
   "!csharp"
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/client.tsp
@@ -4,8 +4,7 @@ import "@azure-tools/typespec-client-generator-core";
 using Azure.ClientGenerator.Core;
 using ComputeDisk;
 
-@@clientName(
-  DiskSecurityTypes.ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey,
+@@clientName(DiskSecurityTypes.ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey,
   "ConfidentialVMVmguestStateOnlyEncryptedWithPlatformKey",
   "go,javascript"
 );
@@ -13,8 +12,7 @@ using ComputeDisk;
 // Property name changes - diskIOPS properties should be lowercase "iops" for Java compatibility
 @@clientName(DiskProperties.diskIOPSReadWrite, "diskIopsReadWrite", "java");
 @@clientName(DiskProperties.diskIOPSReadOnly, "diskIopsReadOnly", "java");
-@@clientName(
-  DiskUpdateProperties.diskIOPSReadWrite,
+@@clientName(DiskUpdateProperties.diskIOPSReadWrite,
   "diskIopsReadWrite",
   "java"
 );
@@ -23,15 +21,13 @@ using ComputeDisk;
 // Property name changes - AccessUri SAS properties should be lowercase "sas" for Java compatibility
 @@clientName(AccessUri.accessSAS, "accessSas", "java");
 @@clientName(AccessUri.securityDataAccessSAS, "securityDataAccessSas", "java");
-@@clientName(
-  AccessUri.securityMetadataAccessSAS,
+@@clientName(AccessUri.securityMetadataAccessSAS,
   "securityMetadataAccessSas",
   "java"
 );
 
 // Property name changes - GrantAccessData SAS property should be lowercase "sas" for Java compatibility
-@@clientName(
-  GrantAccessData.getSecureVMGuestStateSAS,
+@@clientName(GrantAccessData.getSecureVMGuestStateSAS,
   "getSecureVMGuestStateSas",
   "java"
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
@@ -1920,11 +1920,9 @@ model SnapshotUpdateProperties {
 }
 
 @@doc(SnapshotList.value, "A list of snapshots.");
-@@doc(
-  ResourceUriList.nextLink,
+@@doc(ResourceUriList.nextLink,
   "The uri to fetch the next page of encrypted resources. Call ListNext() with this to fetch the next page of encrypted resources."
 );
-@@doc(
-  ResourceUriList.value,
+@@doc(ResourceUriList.value,
   "A list of IDs or Owner IDs of resources which are encrypted with the disk encryption set."
 );

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
@@ -1139,8 +1139,9 @@ model GrantAccessData {
 }
 
 /**
- * The state of the immutability policy.
+ * The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period.
  */
+@added(Versions.v2026_03_02)
 union ImmutabilityPolicyType {
   string,
 
@@ -1150,7 +1151,7 @@ union ImmutabilityPolicyType {
   Unlocked: "Unlocked",
 
   /**
-   * The snapshot immutability policy cannot be modified by any user until the lock period expires.
+   * The snapshot immutability policy duration cannot be reduced but can be extended. The policy cannot be removed until the lock period expires.
    */
   Locked: "Locked",
 }
@@ -1158,16 +1159,71 @@ union ImmutabilityPolicyType {
 /**
  * Data used for updating the immutability policy of a snapshot.
  */
+@added(Versions.v2026_03_02)
 model ImmutabilityPolicyData {
   /**
    * The immutability duration for the snapshot, in number of days.
    */
+  @minValue(1)
+  immutabilityDurationDays: int32;
+
+  /**
+   * The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period.
+   */
+  type: ImmutabilityPolicyType;
+}
+
+/**
+ * Data used for locking the immutability policy of a snapshot.
+ */
+@added(Versions.v2026_03_02)
+model ImmutabilityPolicyLockData {
+  /**
+   * The immutability duration for the snapshot, in number of days.
+   */
+  @minValue(0)
+  immutabilityDurationDays: int32;
+
+  /**
+   * The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period.
+   */
+  type: ImmutabilityPolicyType;
+}
+
+/**
+ * The immutability policy currently applied to a snapshot.
+ */
+@added(Versions.v2026_03_02)
+model ImmutabilityPolicy {
+  /**
+   * The immutability duration for the snapshot, in number of days.
+   */
+  @visibility(Lifecycle.Read)
   immutabilityDurationDays?: int32;
 
   /**
-   * The type of the immutability policy. Possible values include: 'Unlocked', 'Locked'.
+   * The type of the immutability policy.
    */
+  @visibility(Lifecycle.Read)
   type?: ImmutabilityPolicyType;
+
+  /**
+   * The time when the immutability policy was set on the snapshot.
+   */
+  @visibility(Lifecycle.Read)
+  policyStartTime?: utcDateTime;
+
+  /**
+   * The time when the immutability policy will expire on the snapshot.
+   */
+  @visibility(Lifecycle.Read)
+  policyExpirationTime?: utcDateTime;
+
+  /**
+   * Indicates whether the immutability policy has expired.
+   */
+  @visibility(Lifecycle.Read)
+  isPolicyExpired?: boolean;
 }
 
 /**
@@ -1815,6 +1871,13 @@ model SnapshotProperties {
   @visibility(Lifecycle.Read)
   @added(Versions.v2025_01_02)
   snapshotAccessState?: SnapshotAccessState;
+
+  /**
+   * The immutability policy currently applied to this snapshot. Present only when an immutability policy has been configured.
+   */
+  @visibility(Lifecycle.Read)
+  @added(Versions.v2026_03_02)
+  immutabilityPolicy?: ImmutabilityPolicy;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
@@ -2474,7 +2474,7 @@
         "tags": [
           "Snapshots"
         ],
-        "description": "Updates the immutability policy of a snapshot.",
+        "description": "Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy\nwith the specified duration and type. If the snapshot already has a locked policy, the request\nwill be rejected. Use updateImmutabilityPolicyLock to lock an existing unlocked policy.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -2512,6 +2512,10 @@
           "202": {
             "description": "Resource operation accepted.",
             "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
               "Location": {
                 "type": "string",
                 "description": "The Location header contains the URL where the status of the long running operation can be checked."
@@ -2536,7 +2540,7 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "azure-async-operation"
         },
         "x-ms-long-running-operation": true
       }
@@ -2547,7 +2551,7 @@
         "tags": [
           "Snapshots"
         ],
-        "description": "Updates the immutability policy lock of a snapshot.",
+        "description": "Locks the immutability policy of a snapshot. Once locked, the policy cannot be modified or\nremoved until the lock period expires. The snapshot must already have an unlocked immutability\npolicy configured via updateImmutabilityPolicy before it can be locked.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -2571,7 +2575,7 @@
             "description": "Immutability policy data supplied in the body of the update immutability policy lock operation.",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ImmutabilityPolicyData"
+              "$ref": "#/definitions/ImmutabilityPolicyLockData"
             }
           }
         ],
@@ -2585,6 +2589,10 @@
           "202": {
             "description": "Resource operation accepted.",
             "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
               "Location": {
                 "type": "string",
                 "description": "The Location header contains the URL where the status of the long running operation can be checked."
@@ -2609,7 +2617,7 @@
           }
         },
         "x-ms-long-running-operation-options": {
-          "final-state-via": "location"
+          "final-state-via": "azure-async-operation"
         },
         "x-ms-long-running-operation": true
       }
@@ -4206,6 +4214,40 @@
         }
       }
     },
+    "ImmutabilityPolicy": {
+      "type": "object",
+      "description": "The immutability policy currently applied to a snapshot.",
+      "properties": {
+        "immutabilityDurationDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The immutability duration for the snapshot, in number of days.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ImmutabilityPolicyType",
+          "description": "The type of the immutability policy.",
+          "readOnly": true
+        },
+        "policyStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the immutability policy was set on the snapshot.",
+          "readOnly": true
+        },
+        "policyExpirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time when the immutability policy will expire on the snapshot.",
+          "readOnly": true
+        },
+        "isPolicyExpired": {
+          "type": "boolean",
+          "description": "Indicates whether the immutability policy has expired.",
+          "readOnly": true
+        }
+      }
+    },
     "ImmutabilityPolicyData": {
       "type": "object",
       "description": "Data used for updating the immutability policy of a snapshot.",
@@ -4213,17 +4255,42 @@
         "immutabilityDurationDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The immutability duration for the snapshot, in number of days."
+          "description": "The immutability duration for the snapshot, in number of days.",
+          "minimum": 1
         },
         "type": {
           "$ref": "#/definitions/ImmutabilityPolicyType",
-          "description": "The type of the immutability policy. Possible values include: 'Unlocked', 'Locked'."
+          "description": "The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period."
         }
-      }
+      },
+      "required": [
+        "immutabilityDurationDays",
+        "type"
+      ]
+    },
+    "ImmutabilityPolicyLockData": {
+      "type": "object",
+      "description": "Data used for locking the immutability policy of a snapshot.",
+      "properties": {
+        "immutabilityDurationDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The immutability duration for the snapshot, in number of days.",
+          "minimum": 0
+        },
+        "type": {
+          "$ref": "#/definitions/ImmutabilityPolicyType",
+          "description": "The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period."
+        }
+      },
+      "required": [
+        "immutabilityDurationDays",
+        "type"
+      ]
     },
     "ImmutabilityPolicyType": {
       "type": "string",
-      "description": "The state of the immutability policy.",
+      "description": "The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period.",
       "enum": [
         "Unlocked",
         "Locked"
@@ -4240,7 +4307,7 @@
           {
             "name": "Locked",
             "value": "Locked",
-            "description": "The snapshot immutability policy cannot be modified by any user until the lock period expires."
+            "description": "The snapshot immutability policy duration cannot be reduced but can be extended. The policy cannot be removed until the lock period expires."
           }
         ]
       }
@@ -4787,6 +4854,11 @@
         "snapshotAccessState": {
           "$ref": "#/definitions/Common.SnapshotAccessState",
           "description": "The state of snapshot which determines the access availability of the snapshot.",
+          "readOnly": true
+        },
+        "immutabilityPolicy": {
+          "$ref": "#/definitions/ImmutabilityPolicy",
+          "description": "The immutability policy currently applied to this snapshot. Present only when an immutability policy has been configured.",
           "readOnly": true
         }
       },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
@@ -2474,7 +2474,7 @@
         "tags": [
           "Snapshots"
         ],
-        "description": "Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy\nwith the specified duration and type. If the snapshot already has a locked policy, the request\nwill be rejected. Use updateImmutabilityPolicyLock to lock an existing unlocked policy.",
+        "description": "Updates the immutability policy of a snapshot. Sets or extends an unlocked immutability policy with the specified duration and type. If the snapshot already has a locked policy, the request will be rejected. Use updateImmutabilityPolicyLock to lock an immutability policy.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -2551,7 +2551,7 @@
         "tags": [
           "Snapshots"
         ],
-        "description": "Locks the immutability policy of a snapshot. Once locked, the policy cannot be modified or\nremoved until the lock period expires. The snapshot must already have an unlocked immutability\npolicy configured via updateImmutabilityPolicy before it can be locked.",
+        "description": "Locks the immutability policy of a snapshot. Once locked, the policy cannot be reduced or removed until the lock period expires.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"


### PR DESCRIPTION

 - [Blocking 1] Discoverable state: Added a read-only immutabilityPolicy property to SnapshotProperties exposing policy state (duration, type, start/expiry times, expiration status) so GET responses, ARG, and Azure Policy can observe immutability state.
 - [Blocking 2] Required fields & validation: Made immutabilityDurationDays and type required in request bodies. Added @minValue(1) for unlock and  @minValue(0) for lock API. No @maxValue as the max is config-driven (currently 90 days, subject to change).
 - [Blocking 3] Action differentiation: Created separate ImmutabilityPolicyData and ImmutabilityPolicyLockData request models. Documented the state machine in action descriptions: updateImmutabilityPolicy sets/extends unlocked policies; updateImmutabilityPolicyLock sets/extends locked policies.

Warnings addressed:
 - [Warning 1] LRO headers: Added Azure-AsyncOperation header alongside Location and Retry-After for both async POST actions per RPC-Async-V1-06.
 - [Warning 2] Enum description: Fixed ImmutabilityPolicyType description from "state" to "type" with clarified semantics for Unlocked and Locked values.
 - [Warning 3] Suppression scope: ResourceNameRestriction suppression kept as-is — the suppression applies broadly to DiskRP.json as intended.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
