### PR TITLE
Maintenance: Update Python client name for OperationDisplay and add ARM import

### DIFF
--- a/specification/maintenance/resource-manager/Microsoft.Maintenance/Maintenance/back-compatible.tsp
+++ b/specification/maintenance/resource-manager/Microsoft.Maintenance/Maintenance/back-compatible.tsp
@@ -1,4 +1,5 @@
 import "@azure-tools/typespec-client-generator-core";
+import "@azure-tools/typespec-azure-resource-manager";
 
 using Azure.ClientGenerator.Core;
 using Microsoft.Maintenance;
@@ -142,3 +143,9 @@ using Microsoft.Maintenance;
 );
 @@clientLocation(UpdatesOperationGroup.listParent, "Updates");
 @@clientLocation(UpdatesOperationGroup.list, "Updates");
+
+@@clientName(
+  Azure.ResourceManager.CommonTypes.OperationDisplay,
+  "OperationInfo",
+  "python"
+);


### PR DESCRIPTION
## Summary
Update the maintenance back-compatible TypeSpec configuration for Python SDK generation.

## Changes
- add the Azure Resource Manager TypeSpec import
- rename `Azure.ResourceManager.CommonTypes.OperationDisplay` to `OperationInfo` for the Python client generator

## Why
This keeps the Python client surface aligned with the intended customization for the maintenance spec.