### PR TITLE
msi: add python service-dir in tspconfig

### DIFF
--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
@@ -13,6 +13,7 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
 
   "@azure-tools/typespec-python":
+    service-dir: "sdk/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-msi"
     namespace: "azure.mgmt.msi"
     generate-test: true


### PR DESCRIPTION
## Summary
- add `service-dir: "sdk/resources"` under `@azure-tools/typespec-python` in MSI `tspconfig.yaml`

## Why
- align Python SDK generation output path with expected Azure SDK service directory layout

## Files changed
- `specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml`
