### PR TITLE
Remove image and container_protocol_versions from HostedAgentDefinition

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -22369,27 +22369,6 @@
             },
             "description": "An array of tools the hosted agent's model may call while generating a response. You\ncan specify which tool to use by setting the `tool_choice` parameter."
           },
-          "container_protocol_versions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ProtocolVersionRecord"
-            },
-            "description": "The protocols that the agent supports for ingress communication of the containers.",
-            "example": [
-              {
-                "protocol": "responses",
-                "version": "v0.1.1"
-              },
-              {
-                "protocol": "invocations",
-                "version": "v0.0.1"
-              },
-              {
-                "protocol": "a2a",
-                "version": "v0.3.0"
-              }
-            ]
-          },
           "cpu": {
             "type": "string",
             "description": "The CPU configuration for the hosted agent.",
@@ -22410,11 +22389,6 @@
               "name": "LOG_LEVEL",
               "value": "debug"
             }
-          },
-          "image": {
-            "type": "string",
-            "description": "The image ID for the agent, applicable to image-based hosted agents.",
-            "example": "my-registry.azurecr.io/my-hosted-agent:latest"
           },
           "container_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -15216,18 +15216,6 @@ components:
           description: |-
             An array of tools the hosted agent's model may call while generating a response. You
             can specify which tool to use by setting the `tool_choice` parameter.
-        container_protocol_versions:
-          type: array
-          items:
-            $ref: '#/components/schemas/ProtocolVersionRecord'
-          description: The protocols that the agent supports for ingress communication of the containers.
-          example:
-            - protocol: responses
-              version: v0.1.1
-            - protocol: invocations
-              version: v0.0.1
-            - protocol: a2a
-              version: v0.3.0
         cpu:
           type: string
           description: The CPU configuration for the hosted agent.
@@ -15244,10 +15232,6 @@ components:
           example:
             name: LOG_LEVEL
             value: debug
-        image:
-          type: string
-          description: The image ID for the agent, applicable to image-based hosted agents.
-          example: my-registry.azurecr.io/my-hosted-agent:latest
         container_configuration:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -26466,27 +26466,6 @@
             },
             "description": "An array of tools the hosted agent's model may call while generating a response. You\ncan specify which tool to use by setting the `tool_choice` parameter."
           },
-          "container_protocol_versions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ProtocolVersionRecord"
-            },
-            "description": "The protocols that the agent supports for ingress communication of the containers.",
-            "example": [
-              {
-                "protocol": "responses",
-                "version": "v0.1.1"
-              },
-              {
-                "protocol": "invocations",
-                "version": "v0.0.1"
-              },
-              {
-                "protocol": "a2a",
-                "version": "v0.3.0"
-              }
-            ]
-          },
           "cpu": {
             "type": "string",
             "description": "The CPU configuration for the hosted agent.",
@@ -26507,11 +26486,6 @@
               "name": "LOG_LEVEL",
               "value": "debug"
             }
-          },
-          "image": {
-            "type": "string",
-            "description": "The image ID for the agent, applicable to image-based hosted agents.",
-            "example": "my-registry.azurecr.io/my-hosted-agent:latest"
           },
           "container_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -18004,18 +18004,6 @@ components:
           description: |-
             An array of tools the hosted agent's model may call while generating a response. You
             can specify which tool to use by setting the `tool_choice` parameter.
-        container_protocol_versions:
-          type: array
-          items:
-            $ref: '#/components/schemas/ProtocolVersionRecord'
-          description: The protocols that the agent supports for ingress communication of the containers.
-          example:
-            - protocol: responses
-              version: v0.1.1
-            - protocol: invocations
-              version: v0.0.1
-            - protocol: a2a
-              version: v0.3.0
         cpu:
           type: string
           description: The CPU configuration for the hosted agent.
@@ -18032,10 +18020,6 @@ components:
           example:
             name: LOG_LEVEL
             value: debug
-        image:
-          type: string
-          description: The image ID for the agent, applicable to image-based hosted agents.
-          example: my-registry.azurecr.io/my-hosted-agent:latest
         container_configuration:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -482,14 +482,6 @@ model HostedAgentDefinition extends AgentDefinition {
     """)
   tools?: OpenAI.Tool[];
 
-  @doc("The protocols that the agent supports for ingress communication of the containers.")
-  @example(#[
-    #{ protocol: "responses", version: "v0.1.1" },
-    #{ protocol: "invocations", version: "v0.0.1" },
-    #{ protocol: "a2a", version: "v0.3.0" }
-  ])
-  container_protocol_versions?: ProtocolVersionRecord[];
-
   /**
    * When specify the `cpu` and `memory`, the total CPU and memory allocated to all the containers in a container app must add up to one of the following combinations.
    * See [vCPU and memory allocation requirements](https://learn.microsoft.com/azure/container-apps/containers#allocations).
@@ -505,10 +497,6 @@ model HostedAgentDefinition extends AgentDefinition {
   @doc("Environment variables to set in the hosted agent container.")
   @example(#{ name: "LOG_LEVEL", value: "debug" })
   environment_variables?: Record<string>;
-
-  @doc("The image ID for the agent, applicable to image-based hosted agents.")
-  @example("my-registry.azurecr.io/my-hosted-agent:latest")
-  image?: string;
 
   @doc("Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.")
   @extension(


### PR DESCRIPTION
Per review feedback, instead of using `@removed(Versions.v1)`, remove the `image` and `container_protocol_versions` properties from `HostedAgentDefinition` entirely.

### Changes
- `specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp`: removed both properties (and their decorators) from the model.
- Regenerated `openapi3/v1` and `openapi3/virtual-public-preview` outputs to match the current TSP.

### Validation
- `tsp compile` succeeds.