### PR TITLE
[Test][SQL] msi: add python service-dir in tspconfig

### DIFF
--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/tspconfig.yaml
@@ -13,6 +13,7 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
 
   "@azure-tools/typespec-python":
+    service-dir: "sdk/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-msi"
     namespace: "azure.mgmt.msi"
     generate-test: true


### PR DESCRIPTION
Test draft PR. Do not merge.

Changes:
- `specification/sql/resource-manager/Microsoft.Sql/SQL/tspconfig.yaml`: trim emitters to Python only (test).
- `specification/sql/resource-manager/Microsoft.Sql/SQL/main.tsp`: add `2025-03-01` API version (test).