### PR TITLE
Add service-level lease for Microsoft.AzureResilienceManagement/AzureResilienceManagement

### DIFF
--- a/.github/arm-leases/azureresiliencemanagement/Microsoft.AzureResilienceManagement/AzureResilienceManagement/lease.yaml
+++ b/.github/arm-leases/azureresiliencemanagement/Microsoft.AzureResilienceManagement/AzureResilienceManagement/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.AzureResilienceManagement
+  startdate: "2026-05-21"
+  duration: P180D
+  reviewer: "@tejaswiminnu"


### PR DESCRIPTION
Adds a service-level ARM lease at `.github/arm-leases/azureresiliencemanagement/Microsoft.AzureResilienceManagement/AzureResilienceManagement/lease.yaml`.

The existing namespace-level lease at `.github/arm-leases/azureresiliencemanagement/Microsoft.AzureResilienceManagement/lease.yaml` is not picked up by the ARM Modeling Review workflow for PRs that introduce a new service group under the RP (e.g. #43285), because `checkLease` in `.github/workflows/src/arm-modeling-review/detect-arm-leases.js` builds the lease path including the service name and does not fall back to the namespace-only path.

Adding this service-level lease lets the ARM Modeling Review workflow auto-sign-off the AzureResilienceManagement onboarding PR.

- resource-provider: `Microsoft.AzureResilienceManagement`
- startdate: 2026-05-21
- duration: P180D
- reviewer: @tejaswiminnu