### PR TITLE
Add ARM modeling lease for Microsoft.DeviceUpdate/DuDeviceRegistry

### DIFF
--- a/.github/arm-leases/deviceupdate/Microsoft.DeviceUpdate/DuDeviceRegistry/lease.yaml
+++ b/.github/arm-leases/deviceupdate/Microsoft.DeviceUpdate/DuDeviceRegistry/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.DeviceUpdate
+  startdate: "2026-05-21"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/migrate/Microsoft.Migrate/NetworkAssessments/lease.yaml
+++ b/.github/arm-leases/migrate/Microsoft.Migrate/NetworkAssessments/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.Migrate
+  startdate: "2026-05-21"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds a service-level ARM modeling lease for the new `DuDeviceRegistry` service folder being introduced under `Microsoft.DeviceUpdate`.

Companion to private PR Azure/azure-rest-api-specs-pr#28350 ("[ADU] - New service: LinkedAccounts, New API version: 2026-05-01-preview"), which adds a new service folder `specification/deviceupdate/resource-manager/Microsoft.DeviceUpdate/DuDeviceRegistry/`.

Without this lease, the ARM Modeling Review workflow would look for `.github/arm-leases/deviceupdate/Microsoft.DeviceUpdate/DuDeviceRegistry/lease.yaml`, fail to find it (only `duedge` and `duiothub` service leases were pre-staged), and keep `ARMModelingReviewRequired` on the PR.

Lease details:
- resource-provider: Microsoft.DeviceUpdate
- service folder: DuDeviceRegistry
- start: 2026-05-21
- duration: P180D
- reviewer: @vikeshi26