### PR TITLE
Add Content-Disposition header to uploadFile operation of File KS

### DIFF
--- a/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceUploadKnowledgeSourceFile.json
+++ b/specification/search/data-plane/Search/examples/2026-05-01-preview/SearchServiceUploadKnowledgeSourceFile.json
@@ -6,6 +6,7 @@
     "api-version": "2026-05-01-preview",
     "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
     "sourceName": "ks-file-test",
+    "Content-Disposition": "attachment; filename=\"example.pdf\"",
     "file": "dGVzdCBmaWxlIGNvbnRlbnQ="
   },
   "responses": {

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceUploadKnowledgeSourceFile.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/examples/SearchServiceUploadKnowledgeSourceFile.json
@@ -6,6 +6,7 @@
     "api-version": "2026-05-01-preview",
     "x-ms-client-request-id": "00000000-0000-0000-0000-000000000000",
     "sourceName": "ks-file-test",
+    "Content-Disposition": "attachment; filename=\"example.pdf\"",
     "file": "dGVzdCBmaWxlIGNvbnRlbnQ="
   },
   "responses": {

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -3673,6 +3673,14 @@
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
           },
           {
+            "name": "Content-Disposition",
+            "in": "header",
+            "description": "The Content-Disposition header specifying the filename of the uploaded file.\nMust follow the format: `attachment; filename=\"<filename>\"`.\nFor example: `attachment; filename=\"installation-guide.pdf\"`.",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "contentDisposition"
+          },
+          {
             "$ref": "#/parameters/Azure.Core.ClientRequestIdHeader"
           },
           {

--- a/specification/search/data-plane/Search/routes-service.tsp
+++ b/specification/search/data-plane/Search/routes-service.tsp
@@ -925,6 +925,13 @@ interface KnowledgeSources {
       /** The content type of the request body. Must be application/octet-stream. */
       @header contentType: "application/octet-stream";
 
+      /**
+       * The Content-Disposition header specifying the filename of the uploaded file.
+       * Must follow the format: `attachment; filename="<filename>"`.
+       * For example: `attachment; filename="installation-guide.pdf"`.
+       */
+      @header("Content-Disposition") contentDisposition: string;
+
       /** The file content to upload. */
       @body file: bytes;
     },


### PR DESCRIPTION
Target for #42217

This pull request introduces support for specifying the filename of uploaded knowledge source files in the Azure Search API by requiring a `Content-Disposition` header. This header allows clients to indicate the intended filename for uploaded files, improving file handling and traceability.

**API contract and documentation updates:**

* Added a required `Content-Disposition` header parameter to the upload knowledge source file operation in `search.json`, including a detailed description and usage example.
* Updated the `KnowledgeSources` interface in `routes-service.tsp` to require the `Content-Disposition` header, with documentation on its format and example usage.

**Example updates:**

* Added the `Content-Disposition` header to the upload knowledge source file examples in both the preview and main example JSON files, demonstrating correct usage.