### PR TITLE
Remove dataset source from data generation jobs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -3554,29 +3554,6 @@
             "explode": false
           },
           {
-            "name": "scenario",
-            "in": "query",
-            "required": false,
-            "description": "Filter data generation jobs by their scenario.",
-            "schema": {
-              "$ref": "#/components/schemas/DataGenerationJobScenario"
-            },
-            "explode": false
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "description": "Filter data generation jobs by their type.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DataGenerationJobType"
-              }
-            },
-            "explode": false
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -19059,7 +19059,6 @@
             "prompt": "#/components/schemas/PromptDataGenerationJobSource",
             "agent": "#/components/schemas/AgentDataGenerationJobSource",
             "traces": "#/components/schemas/TracesDataGenerationJobSource",
-            "dataset": "#/components/schemas/DatasetDataGenerationJobSource",
             "file": "#/components/schemas/FileDataGenerationJobSource"
           }
         },
@@ -19076,7 +19075,6 @@
               "prompt",
               "agent",
               "traces",
-              "dataset",
               "file"
             ]
           }
@@ -19212,40 +19210,6 @@
           }
         ],
         "description": "Dataset output for a data generation job."
-      },
-      "DatasetDataGenerationJobSource": {
-        "type": "object",
-        "required": [
-          "type",
-          "name"
-        ],
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities')."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "dataset"
-            ],
-            "description": "The source type for this source, which is Dataset."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the dataset."
-          },
-          "version": {
-            "type": "string",
-            "description": "The version of the dataset. If not specified, the latest version is used."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DataGenerationJobSource"
-          }
-        ],
-        "description": "Dataset source for data generation jobs — reference to a dataset."
       },
       "DatasetEvaluatorGenerationJobSource": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12730,7 +12730,6 @@ components:
           prompt: '#/components/schemas/PromptDataGenerationJobSource'
           agent: '#/components/schemas/AgentDataGenerationJobSource'
           traces: '#/components/schemas/TracesDataGenerationJobSource'
-          dataset: '#/components/schemas/DatasetDataGenerationJobSource'
           file: '#/components/schemas/FileDataGenerationJobSource'
       description: The base source model for data generation jobs.
     DataGenerationJobSourceType:
@@ -12741,7 +12740,6 @@ components:
             - prompt
             - agent
             - traces
-            - dataset
             - file
       description: The supported source types for data generation jobs.
     DataGenerationJobType:
@@ -12837,29 +12835,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOutput'
       description: Dataset output for a data generation job.
-    DatasetDataGenerationJobSource:
-      type: object
-      required:
-        - type
-        - name
-      properties:
-        description:
-          type: string
-          description: Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities').
-        type:
-          type: string
-          enum:
-            - dataset
-          description: The source type for this source, which is Dataset.
-        name:
-          type: string
-          description: The name of the dataset.
-        version:
-          type: string
-          description: The version of the dataset. If not specified, the latest version is used.
-      allOf:
-        - $ref: '#/components/schemas/DataGenerationJobSource'
-      description: Dataset source for data generation jobs — reference to a dataset.
     DatasetEvaluatorGenerationJobSource:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -2438,22 +2438,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: scenario
-          in: query
-          required: false
-          description: Filter data generation jobs by their scenario.
-          schema:
-            $ref: '#/components/schemas/DataGenerationJobScenario'
-          explode: false
-        - name: type
-          in: query
-          required: false
-          description: Filter data generation jobs by their type.
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/DataGenerationJobType'
-          explode: false
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -4620,29 +4620,6 @@
             "explode": false
           },
           {
-            "name": "scenario",
-            "in": "query",
-            "required": false,
-            "description": "Filter data generation jobs by their scenario.",
-            "schema": {
-              "$ref": "#/components/schemas/DataGenerationJobScenario"
-            },
-            "explode": false
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "description": "Filter data generation jobs by their type.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DataGenerationJobType"
-              }
-            },
-            "explode": false
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -22275,7 +22275,6 @@
             "prompt": "#/components/schemas/PromptDataGenerationJobSource",
             "agent": "#/components/schemas/AgentDataGenerationJobSource",
             "traces": "#/components/schemas/TracesDataGenerationJobSource",
-            "dataset": "#/components/schemas/DatasetDataGenerationJobSource",
             "file": "#/components/schemas/FileDataGenerationJobSource"
           }
         },
@@ -22292,7 +22291,6 @@
               "prompt",
               "agent",
               "traces",
-              "dataset",
               "file"
             ]
           }
@@ -22428,40 +22426,6 @@
           }
         ],
         "description": "Dataset output for a data generation job."
-      },
-      "DatasetDataGenerationJobSource": {
-        "type": "object",
-        "required": [
-          "type",
-          "name"
-        ],
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities')."
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "dataset"
-            ],
-            "description": "The source type for this source, which is Dataset."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the dataset."
-          },
-          "version": {
-            "type": "string",
-            "description": "The version of the dataset. If not specified, the latest version is used."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/DataGenerationJobSource"
-          }
-        ],
-        "description": "Dataset source for data generation jobs — reference to a dataset."
       },
       "DatasetEvaluationSuiteJobSource": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14912,7 +14912,6 @@ components:
           prompt: '#/components/schemas/PromptDataGenerationJobSource'
           agent: '#/components/schemas/AgentDataGenerationJobSource'
           traces: '#/components/schemas/TracesDataGenerationJobSource'
-          dataset: '#/components/schemas/DatasetDataGenerationJobSource'
           file: '#/components/schemas/FileDataGenerationJobSource'
       description: The base source model for data generation jobs.
     DataGenerationJobSourceType:
@@ -14923,7 +14922,6 @@ components:
             - prompt
             - agent
             - traces
-            - dataset
             - file
       description: The supported source types for data generation jobs.
     DataGenerationJobType:
@@ -15019,29 +15017,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/DataGenerationJobOutput'
       description: Dataset output for a data generation job.
-    DatasetDataGenerationJobSource:
-      type: object
-      required:
-        - type
-        - name
-      properties:
-        description:
-          type: string
-          description: Optional description of what this source represents — helps the pipeline interpret its content (e.g., 'Company refund policy document' or 'Describes the agent's core capabilities').
-        type:
-          type: string
-          enum:
-            - dataset
-          description: The source type for this source, which is Dataset.
-        name:
-          type: string
-          description: The name of the dataset.
-        version:
-          type: string
-          description: The version of the dataset. If not specified, the latest version is used.
-      allOf:
-        - $ref: '#/components/schemas/DataGenerationJobSource'
-      description: Dataset source for data generation jobs — reference to a dataset.
     DatasetEvaluationSuiteJobSource:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -3192,22 +3192,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: scenario
-          in: query
-          required: false
-          description: Filter data generation jobs by their scenario.
-          schema:
-            $ref: '#/components/schemas/DataGenerationJobScenario'
-          explode: false
-        - name: type
-          in: query
-          required: false
-          description: Filter data generation jobs by their type.
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/DataGenerationJobType'
-          explode: false
         - name: api-version
           in: query
           required: true

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp
@@ -217,9 +217,6 @@ union DataGenerationJobSourceType {
   @doc("Traces source — conversation traces from Application Insights.")
   traces: "traces",
 
-  @doc("Dataset source — reference to a dataset.")
-  dataset: "dataset",
-
   @doc("File source — Azure OpenAI file.")
   file: "file",
 }
@@ -246,11 +243,6 @@ model AgentDataGenerationJobSource extends DataGenerationJobSource {
 @doc("Traces source for data generation jobs — conversation traces from Application Insights.")
 model TracesDataGenerationJobSource extends DataGenerationJobSource {
   ...TracesJobSource;
-}
-
-@doc("Dataset source for data generation jobs — reference to a dataset.")
-model DatasetDataGenerationJobSource extends DataGenerationJobSource {
-  ...DatasetJobSource;
 }
 
 @doc("File source for data generation jobs — Azure OpenAI file input.")

--- a/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/routes.tsp
@@ -36,16 +36,7 @@ interface DataGenerationJobs {
   @extension("x-ms-foundry-meta", DataGenerationJobsRequiredPreviews)
   list is listJobsPreview<
     FoundryFeaturesOptInKeys.data_generation_jobs_v1_preview,
-    DataGenerationJob,
-    {
-      @doc("Filter data generation jobs by their scenario.")
-      @query
-      scenario?: DataGenerationJobScenario;
-
-      @doc("Filter data generation jobs by their type.")
-      @query(#{ explode: false })
-      type?: DataGenerationJobType[];
-    }
+    DataGenerationJob
   >;
 
   /**


### PR DESCRIPTION
Removes the `DatasetDataGenerationJobSource` model and the `dataset` member of the `DataGenerationJobSourceType` union from `specification/ai-foundry/data-plane/Foundry/src/data_generation_jobs/models.tsp`, and regenerates the corresponding openapi3 outputs.

## Changes
- `src/data_generation_jobs/models.tsp`: removed `dataset` union member and `DatasetDataGenerationJobSource` model definition.
- `openapi3/v1/microsoft-foundry-openapi3.{json,yaml}`: regenerated.
- `openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}`: regenerated.