### PR TITLE
Rename Storage static website CSharp API

### DIFF
--- a/specification/storage/Storage.Management/client.tsp
+++ b/specification/storage/Storage.Management/client.tsp
@@ -203,6 +203,8 @@ using Microsoft.Storage;
 
 // Resource type renames for backward compatibility
 @@clientName(BlobServiceProperties, "BlobService", "csharp");
+@@clientName(StaticWebsite, "BlobServiceStaticWebsite", "csharp");
+@@clientName(StaticWebsite.enabled, "IsEnabled", "csharp");
 @@clientName(QueueServiceProperties, "QueueService", "csharp");
 @@clientName(TableServiceProperties, "TableService", "csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "This operation is pageable for .Net SDK"


### PR DESCRIPTION
Companion spec change for Azure/azure-sdk-for-net#59408.

Adds C# client-name customizations for Storage static website API review feedback:
- `StaticWebsite` -> `BlobServiceStaticWebsite`
- `StaticWebsite.enabled` -> `IsEnabled`

Original SDK review comments:
- https://github.com/Azure/azure-sdk-for-net/pull/59068#discussion_r3285566688
- https://github.com/Azure/azure-sdk-for-net/pull/59068#discussion_r3285567408