### PR TITLE
[Update for GA] Remove HostedAgents and AgentEndpoints preview gates for hosted agents GA

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -6,12 +6,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-alias AgentInvocationPreviewHeader = WithRequiredFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
-
-const AgentInvocationRequiredPreviews = #{
-  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
-};
-
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations")
 interface AgentInvocations {
@@ -21,12 +15,11 @@ interface AgentInvocations {
    */
   @get
   @route("/agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   getAgentInvocationOpenApiSpec is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       @header contentType: "application/json";
       @body spec: Record<unknown>;
@@ -38,7 +31,6 @@ interface AgentInvocations {
    */
   @post
   @route("/agents/{agent_name}/endpoint/protocols/invocations")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   createAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -52,7 +44,7 @@ interface AgentInvocations {
 
       /** The request body. */
       @body request: unknown;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Unique identifier for this invocation. */
       @header("x-agent-invocation-id") invocationId: string;
@@ -74,7 +66,6 @@ interface AgentInvocations {
    */
   @get
   @route("/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   getAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -82,7 +73,7 @@ interface AgentInvocations {
 
       /** The unique identifier of the invocation. */
       @path invocation_id: string;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */
       @header("x-agent-session-id") agentSessionId: string;
@@ -101,7 +92,6 @@ interface AgentInvocations {
    */
   @post
   @route("/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   cancelAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -115,7 +105,7 @@ interface AgentInvocations {
 
       /** Optional request body. */
       @body request?: unknown;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */
       @header("x-agent-session-id") agentSessionId: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -6,12 +6,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-alias AgentWebsocketPreviewHeader = WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
-
-const AgentWebsocketRequiredPreviews = #{
-  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
-};
-
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations WebSocket")
 @removed(Versions.v1)
@@ -26,7 +20,6 @@ interface AgentWebsocket {
    */
   @get
   @route("/agents/endpoint/protocols/invocations_ws")
-  @extension("x-ms-foundry-meta", AgentWebsocketRequiredPreviews)
   connectEndpointWebsocket is FoundryDataPlaneOperation<
     {
       /** The name of the project. */
@@ -39,11 +32,8 @@ interface AgentWebsocket {
       @query agent_session_id?: string;
 
       /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
-      @query(#{ explode: false, name: "foundry_features" })
-      foundry_features_query?: AgentDefinitionOptInKeys[] = #[
-        AgentDefinitionOptInKeys.hosted_agents_v1_preview
-      ];
-    } & AgentWebsocketPreviewHeader,
+
+    },
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */
       @header("x-agent-session-id") sessionId: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -27,12 +27,7 @@ interface AgentSessionFiles {
   #suppress "@azure-tools/typespec-azure-core/byos" "The file is targeting the per-session files mounted to a foundry agent"
   @put
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  uploadSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  uploadSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -56,12 +51,7 @@ interface AgentSessionFiles {
    */
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  downloadSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  downloadSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -81,12 +71,7 @@ interface AgentSessionFiles {
    */
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  listSessionFiles is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  listSessionFiles is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -106,12 +91,7 @@ interface AgentSessionFiles {
    */
   @delete
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  deleteSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  deleteSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -9,7 +9,6 @@ namespace Azure.AI.Projects;
 
 const AllConditionalAgentDefinitionPreviews = #{
   conditional_previews: #[
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
     AgentDefinitionOptInKeys.container_agents_v1_preview,
     AgentDefinitionOptInKeys.workflow_agents_v1_preview,
     AgentDefinitionOptInKeys.code_agents_v1_preview
@@ -28,12 +27,6 @@ model CreateAgentVersionRequest {
   @extension("x-ms-foundry-meta", AllConditionalAgentDefinitionPreviews)
   definition: AgentDefinition;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint reference for the agent.")
   blueprint_reference?: AgentBlueprintReference;
 }
@@ -82,21 +75,9 @@ model CreateAgentRequest {
 
   ...CreateAgentVersionRequest;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent")
   agent_endpoint?: AgentEndpointConfig;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("Optional agent card for the agent")
   agent_card?: AgentCard;
 }
@@ -105,10 +86,6 @@ model UpdateAgentRequest {
   ...CreateAgentVersionRequest;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model PatchAgentRequest {
   @doc("The endpoint configuration for the agent")
   agent_endpoint?: AgentEndpointConfig;
@@ -141,51 +118,21 @@ model AgentObject {
     latest: AgentVersionObject;
   };
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The endpoint configuration for the agent")
   agent_endpoint?: AgentEndpointConfig;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The instance identity of the agent")
   @visibility(Lifecycle.Read)
   instance_identity?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint_reference?: AgentBlueprintReference;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   agent_card?: AgentCard;
 }
 
@@ -221,42 +168,18 @@ model AgentVersionObject {
   @doc("Error details if the agent version provisioning failed.")
   error?: ApiError;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The instance identity of the agent")
   @visibility(Lifecycle.Read)
   instance_identity?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint_reference?: AgentBlueprintReference;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The unique GUID identifier of the agent.")
   @visibility(Lifecycle.Read)
   agent_guid?: string;
@@ -447,10 +370,6 @@ union CodeDependencyResolution {
 }
 
 @doc("The hosted agent definition.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model HostedAgentDefinition extends AgentDefinition {
   kind: AgentKind.hosted;
 
@@ -627,27 +546,15 @@ union ContainerLogKind {
   system: "system",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union VersionSelectorType {
   string,
   FixedRatio: "FixedRatio",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model VersionSelector {
   version_selection_rules: VersionSelectionRule[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model VersionSelectionRule {
   type: VersionSelectorType;
@@ -656,10 +563,6 @@ model VersionSelectionRule {
   agent_version: string;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model FixedRatioVersionSelectionRule extends VersionSelectionRule {
   type: VersionSelectorType.FixedRatio;
 
@@ -669,69 +572,37 @@ model FixedRatioVersionSelectionRule extends VersionSelectionRule {
   traffic_percentage: int32;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model EntraAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.Entra;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model BotServiceAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.BotService;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model BotServiceRbacAuthorizationScheme
   extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.BotServiceRbac;
 }
 
 @discriminator("kind")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model IsolationKeySource {
   kind: IsolationKeySourceKind;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model EntraIsolationKeySource extends IsolationKeySource {
   kind: IsolationKeySourceKind.Entra;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model HeaderIsolationKeySource extends IsolationKeySource {
   kind: IsolationKeySourceKind.Header;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentEndpointAuthorizationSchemeType {
   string,
   Entra: "Entra",
@@ -739,20 +610,12 @@ union AgentEndpointAuthorizationSchemeType {
   BotServiceRbac: "BotServiceRbac",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union IsolationKeySourceKind {
   string,
   Entra: "Entra",
   Header: "Header",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentEndpointConfig {
   @doc("The version selector of the agent endpoint determines how traffic is routed to different versions of the agent.")
   version_selector?: VersionSelector;
@@ -764,10 +627,6 @@ model AgentEndpointConfig {
   authorization_schemes?: AgentEndpointAuthorizationScheme[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentIdentity {
   @doc("The principal ID of the agent instance")
   principal_id: string;
@@ -776,28 +635,16 @@ model AgentIdentity {
   client_id: string;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentBlueprintReferenceType {
   string,
   ManagedAgentIdentityBlueprint: "ManagedAgentIdentityBlueprint",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model AgentBlueprintReference {
   type: AgentBlueprintReferenceType;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model ManagedAgentIdentityBlueprintReference extends AgentBlueprintReference {
   type: AgentBlueprintReferenceType.ManagedAgentIdentityBlueprint;
 
@@ -806,24 +653,12 @@ model ManagedAgentIdentityBlueprintReference extends AgentBlueprintReference {
 }
 
 /** A skill example string with a maximum length of 1024 characters. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @maxLength(1024)
 scalar AgentCardSkillExample extends string;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @maxLength(32)
 scalar AgentCardSkillTag extends string;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentCardSkill {
   @doc("a unique identifier for the skill")
   @maxLength(64)
@@ -848,10 +683,6 @@ model AgentCardSkill {
   examples?: AgentCardSkillExample[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentCard {
   @doc("The version of the agent card.")
   @maxLength(32)
@@ -941,10 +772,6 @@ model DownloadAgentCodeResponse {
 // ── Session Status ──────────────────────────────────────
 
 /** The status of an agent session. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentSessionStatus {
   string,
 
@@ -976,10 +803,6 @@ union AgentSessionStatus {
 // ── Version Indicator ───────────────────────────────────
 
 /** The type of version indicator used to determine the agent version backing a session. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union VersionIndicatorType {
   string,
 
@@ -989,10 +812,6 @@ union VersionIndicatorType {
 
 /** Base class for version indicators. Uses type discriminator for polymorphism. */
 @doc("Version indicator determining which agent version backs the session.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model VersionIndicator {
   /** The type of version indicator. */
@@ -1000,10 +819,6 @@ model VersionIndicator {
 }
 
 /** Version indicator that references a specific agent version by name. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model VersionRefIndicator extends VersionIndicator {
   /** Discriminator value for version_ref. */
   type: VersionIndicatorType.VersionRef;
@@ -1016,10 +831,6 @@ model VersionRefIndicator extends VersionIndicator {
 
 /** Represents an agent session resource. */
 @doc("An agent session providing a long-lived compute sandbox for hosted agent invocations.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentSessionResource {
   /** The session identifier. */
   agent_session_id: string;
@@ -1050,10 +861,6 @@ model AgentSessionResource {
 
 /** Request body for creating a new agent session. */
 @doc("Request to create a new agent session.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model CreateAgentSessionRequest {
   /** Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted. */
   agent_session_id?: string;
@@ -1066,10 +873,6 @@ model CreateAgentSessionRequest {
  * Known SSE event types emitted by the hosted agent session log stream.
  * Additional event types may be introduced in future versions.
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union SessionLogEventType {
   string,
 
@@ -1098,10 +901,6 @@ union SessionLogEventType {
  * data: {"timestamp":"2026-03-10T09:34:52.714Z","stream":"status","message":"Successfully connected to container"}
  * ```
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model SessionLogEvent {
   @doc("The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.")
   @example("log")
@@ -1114,10 +913,6 @@ model SessionLogEvent {
 // ── Telemetry Unions ────────────────────────────────────
 
 @doc("The kind of telemetry export endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryEndpointKind {
   string,
 
@@ -1126,10 +921,6 @@ union TelemetryEndpointKind {
 }
 
 @doc("The type of telemetry data to export.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryDataKind {
   string,
 
@@ -1144,10 +935,6 @@ union TelemetryDataKind {
 }
 
 @doc("The transport protocol for telemetry export.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryTransportProtocol {
   string,
 
@@ -1161,10 +948,6 @@ union TelemetryTransportProtocol {
 // ── Telemetry Auth (discriminated by "type") ────────────
 
 @doc("The type of authentication for a telemetry endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryEndpointAuthType {
   string,
 
@@ -1174,20 +957,12 @@ union TelemetryEndpointAuthType {
 
 @doc("Authentication configuration for a telemetry endpoint.")
 @discriminator("type")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryEndpointAuth {
   @doc("The authentication type.")
   type: TelemetryEndpointAuthType;
 }
 
 @doc("Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model HeaderTelemetryEndpointAuth extends TelemetryEndpointAuth {
   @doc("The authentication type, always 'header' for header-based secret authentication.")
   type: TelemetryEndpointAuthType.header;
@@ -1208,10 +983,6 @@ model HeaderTelemetryEndpointAuth extends TelemetryEndpointAuth {
 // ── Telemetry Config & Endpoint (discriminated by "kind") ─
 
 @doc("Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryConfig {
   @doc("Customer-supplied telemetry export endpoint configurations.")
   @minItems(1)
@@ -1221,10 +992,6 @@ model TelemetryConfig {
 
 @doc("A telemetry export endpoint configuration.")
 @discriminator("kind")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryEndpoint {
   @doc("The telemetry export endpoint kind.")
   kind: TelemetryEndpointKind;
@@ -1238,10 +1005,6 @@ model TelemetryEndpoint {
 }
 
 @doc("An OTLP (OpenTelemetry Protocol) telemetry export endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model OtlpTelemetryEndpoint extends TelemetryEndpoint {
   @doc("The endpoint kind, always 'OTLP' for OpenTelemetry Protocol endpoints.")
   kind: TelemetryEndpointKind.OTLP;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -288,14 +288,7 @@ interface Agents {
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" ""
   @patch(#{ implicitOptionality: true })
   @route("/agents/{agent_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  patchAgentObject is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  patchAgentObject is FoundryDataPlaneOperation<
     {
       /** The name of the agent to retrieve. */
       @path agent_name: string;
@@ -385,14 +378,7 @@ interface Agents {
    */
   @post
   @route("/agents/{agent_name}/endpoint/sessions")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  createSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  createSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent to create a session for. */
       @path agent_name: string;
@@ -407,14 +393,7 @@ interface Agents {
    */
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  getSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  getSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -431,14 +410,7 @@ interface Agents {
    */
   @delete
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  deleteSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  deleteSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -455,14 +427,7 @@ interface Agents {
   @get
   @route("/agents/{agent_name}/endpoint/sessions")
   @list
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  listSessions is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  listSessions is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -502,12 +467,7 @@ interface Agents {
    */
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  getSessionLogStream is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  getSessionLogStream is FoundryDataPlaneOperation<
     {
       /** The name of the hosted agent. */
       @path agent_name: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
@@ -8,10 +8,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model CreateOrUpdateManagedAgentIdentityBlueprintRequest {
   @doc("""
     The unique name that identifies the managed agent identity blueprint.

--- a/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/routes.tsp
@@ -13,14 +13,7 @@ namespace Azure.AI.Projects;
 interface ManagedAgentIdentityBlueprints {
   @put
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  createOrUpdateManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  createOrUpdateManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to create. */
       @path blueprint_name: string;
@@ -35,14 +28,7 @@ interface ManagedAgentIdentityBlueprints {
    */
   @get
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  getManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  getManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to retrieve. */
       @path blueprint_name: string;
@@ -55,14 +41,7 @@ interface ManagedAgentIdentityBlueprints {
    */
   @delete
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  deleteManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  deleteManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to delete. */
       @path blueprint_name: string;
@@ -72,14 +51,7 @@ interface ManagedAgentIdentityBlueprints {
 
   @get
   @route("/managedAgentIdentityBlueprints")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  listManagedAgentIdentityBlueprints is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  listManagedAgentIdentityBlueprints is FoundryDataPlaneOperation<
     {
       ...PageOrderQueryParameter;
       ...PageLimitQueryParameter;

--- a/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/servicepatterns.tsp
@@ -36,10 +36,8 @@ op FoundryDataPlaneOperation<
 
 /** Feature opt-in keys for agent definition operations supporting hosted or workflow agents. */
 union AgentDefinitionOptInKeys {
-  hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   container_agents_v1_preview: "ContainerAgents=V1Preview",
-  agent_endpoint_v1_preview: "AgentEndpoints=V1Preview",
 
   code_agents_v1_preview: "CodeAgents=V1Preview",
 }


### PR DESCRIPTION
## Summary

Remove `HostedAgents=V1Preview` and `AgentEndpoints=V1Preview` preview gates from hosted agent TypeSpec definitions to enable GA.

### Changes (8 files, -371 lines)

| File | Change |
|------|--------|
| `servicepatterns.tsp` | Remove `hosted_agents_v1_preview` and `agent_endpoint_v1_preview` from `AgentDefinitionOptInKeys` enum |
| `agents/models.tsp` | Remove 52 preview metadata extensions from models (HostedAgentDefinition, telemetry types, endpoint types, auth schemes, etc.). Add `agent_endpoint` and `agent_card` to `UpdateAgentRequest`. |
| `agents/routes.tsp` | Convert session CRUD, patchAgent, logstream from `FoundryDataPlanePreviewOperation` to `FoundryDataPlaneOperation` |
| `agents-invocations/routes.tsp` | Remove preview header/metadata from all 4 invocation operations |
| `agents-invocations_ws/routes.tsp` | Remove preview from websocket operation |
| `agents-session-files/routes.tsp` | Convert all 4 file operations to GA |
| `managed-blueprints/routes.tsp` | Convert all 4 blueprint operations to GA |
| `managed-blueprints/models.tsp` | Remove preview metadata |

### Kept as preview (separate GA tracks)
- `container_agents_v1_preview` (ContainerApp agents)
- `code_agents_v1_preview` (Code deploy agents)
- `workflow_agents_v1_preview` (Workflow agents)

### Additional: UpdateAgentRequest spec fix
Added `agent_endpoint?` and `agent_card?` to `UpdateAgentRequest` (matching `CreateAgentRequest`) so customers can update auth schemes via the primary update API.

Follows the same pattern as PR #43188 (Toolboxes GA).