### PR TITLE
Remove temporary CSharp API version pins

### DIFF
--- a/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/tspconfig.yaml
+++ b/specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster/tspconfig.yaml
@@ -36,7 +36,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.MongoCluster"
-    api-version: "2025-09-01"
   "@azure-tools/typespec-ts":
     experimental-extensible-enums: true
     ignore-nullable-on-optional: false

--- a/specification/standbypool/StandbyPool.Management/tspconfig.yaml
+++ b/specification/standbypool/StandbyPool.Management/tspconfig.yaml
@@ -24,7 +24,6 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.StandbyPool"
-    api-version: "2025-10-01"
   "@azure-tools/typespec-ts":
     experimental-extensible-enums: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-standbypool"


### PR DESCRIPTION
## Summary

Remove the temporary C# management emitter `api-version` pins that were added in the access-cleanup PR after the paired .NET SDK PR was updated to the merged specs commit.

Affected specs:

- MongoCluster
- StandbyPool

## Validation

- `npx tsv specification/mongocluster/resource-manager/Microsoft.DocumentDB/MongoCluster`
- `npx tsv specification/standbypool/StandbyPool.Management`

## Related

- Follow-up to https://github.com/Azure/azure-rest-api-specs/pull/43362
- Paired SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/59350
