### PR TITLE
Changed vector_store_ids from required to optional

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -2677,7 +2677,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
       "post": {
         "operationId": "Agents_stopSession",
-        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.\nReturns a failed session resource when the stop attempt fails.",
+        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -29871,8 +29871,7 @@
       "OpenAI.FileSearchTool": {
         "type": "object",
         "required": [
-          "type",
-          "vector_store_ids"
+          "type"
         ],
         "properties": {
           "type": {
@@ -29883,13 +29882,6 @@
             "description": "The type of the file search tool. Always `file_search`.",
             "x-stainless-const": true,
             "default": "file_search"
-          },
-          "vector_store_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "The IDs of the vector stores to search."
           },
           "max_num_results": {
             "allOf": [
@@ -29929,6 +29921,13 @@
               "$ref": "#/components/schemas/ToolConfig"
             },
             "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
+          },
+          "vector_store_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The IDs of the vector stores to search."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -1818,7 +1818,6 @@ paths:
       description: |-
         Stops a session.
         Returns 204 No Content when the stop succeeds.
-        Returns a failed session resource when the stop attempt fails.
       parameters:
         - name: Foundry-Features
           in: header
@@ -20413,7 +20412,6 @@ components:
       type: object
       required:
         - type
-        - vector_store_ids
       properties:
         type:
           type: string
@@ -20422,11 +20420,6 @@ components:
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
           default: file_search
-        vector_store_ids:
-          type: array
-          items:
-            type: string
-          description: The IDs of the vector stores to search.
         max_num_results:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -20453,6 +20446,11 @@ components:
             Per-tool configuration map. Keys are tool names or `*` (catch-all default).
             Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
+        vector_store_ids:
+          type: array
+          items:
+            type: string
+          description: The IDs of the vector stores to search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -2808,7 +2808,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
       "post": {
         "operationId": "Agents_stopSession",
-        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.\nReturns a failed session resource when the stop attempt fails.",
+        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -34148,8 +34148,7 @@
       "OpenAI.FileSearchTool": {
         "type": "object",
         "required": [
-          "type",
-          "vector_store_ids"
+          "type"
         ],
         "properties": {
           "type": {
@@ -34160,13 +34159,6 @@
             "description": "The type of the file search tool. Always `file_search`.",
             "x-stainless-const": true,
             "default": "file_search"
-          },
-          "vector_store_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "The IDs of the vector stores to search."
           },
           "max_num_results": {
             "allOf": [
@@ -34206,6 +34198,13 @@
               "$ref": "#/components/schemas/ToolConfig"
             },
             "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
+          },
+          "vector_store_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The IDs of the vector stores to search."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -1908,7 +1908,6 @@ paths:
       description: |-
         Stops a session.
         Returns 204 No Content when the stop succeeds.
-        Returns a failed session resource when the stop attempt fails.
       parameters:
         - name: Foundry-Features
           in: header
@@ -23325,7 +23324,6 @@ components:
       type: object
       required:
         - type
-        - vector_store_ids
       properties:
         type:
           type: string
@@ -23334,11 +23332,6 @@ components:
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
           default: file_search
-        vector_store_ids:
-          type: array
-          items:
-            type: string
-          description: The IDs of the vector stores to search.
         max_num_results:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -23365,6 +23358,11 @@ components:
             Per-tool configuration map. Keys are tool names or `*` (catch-all default).
             Resolution order: exact tool name match takes priority over `*`.
             Unknown tool names are silently ignored at runtime.
+        vector_store_ids:
+          type: array
+          items:
+            type: string
+          description: The IDs of the vector stores to search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -121,8 +121,12 @@ namespace Azure.AI.Projects {
   );
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@withoutOmittedProperties(OpenAI.FileSearchTool, "vector_store_ids");
   @@copyProperties(OpenAI.FileSearchTool,
     {
+      /** The IDs of the vector stores to search. */
+      vector_store_ids?: string[],
+
       ...ToolNameAndDescriptionExtension,
       ...ToolConfigExtension,
     }

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -1,4 +1,4 @@
-import "../memory-stores/models.tsp";
+ import "../memory-stores/models.tsp";
 
 using Azure.Core.Experimental;
 using TypeSpec.Versioning;
@@ -122,6 +122,7 @@ namespace Azure.AI.Projects {
 
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@withoutOmittedProperties(OpenAI.FileSearchTool, "vector_store_ids");
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(OpenAI.FileSearchTool,
     {
       /** The IDs of the vector stores to search. */


### PR DESCRIPTION


## Make `vector_store_ids` optional on `FileSearchTool`

**Description:**

Changes `vector_store_ids` from required to optional on `OpenAI.FileSearchTool` in the Foundry spec using `@@withoutOmittedProperties` + `@@copyProperties` override pattern.

This allows creating a `file_search` tool without pre-specifying vector store IDs upfront.