### PR TITLE
Refactor: replace KnowledgeBaseRetrievalActivityRecord inheritance with spread pattern (wire-level unchanged)

### DIFF
--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -467,6 +467,7 @@ model KnowledgeBaseRetrievalActivityRecord {
 model KnowledgeBaseSearchIndexActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.searchIndex;
 
@@ -493,9 +494,9 @@ model KnowledgeBaseSearchIndexActivityArguments {
 }
 
 /** Represents a azure blob retrieval activity record. */
-model KnowledgeBaseAzureBlobActivityRecord
-  extends KnowledgeBaseActivityRecord {
+model KnowledgeBaseAzureBlobActivityRecord extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.azureBlob;
 
@@ -515,6 +516,7 @@ model KnowledgeBaseAzureBlobActivityArguments {
 model KnowledgeBaseIndexedSharePointActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedSharePoint;
 
@@ -534,6 +536,7 @@ model KnowledgeBaseIndexedSharePointActivityArguments {
 model KnowledgeBaseIndexedOneLakeActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedOneLake;
 
@@ -548,9 +551,9 @@ model KnowledgeBaseIndexedOneLakeActivityArguments {
 }
 
 /** Represents a web retrieval activity record. */
-model KnowledgeBaseWebActivityRecord
-  extends KnowledgeBaseActivityRecord {
+model KnowledgeBaseWebActivityRecord extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.web;
 
@@ -582,6 +585,7 @@ model KnowledgeBaseWebActivityArguments {
 model KnowledgeBaseRemoteSharePointActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.remoteSharePoint;
 
@@ -603,9 +607,9 @@ model KnowledgeBaseRemoteSharePointActivityArguments {
 /** Represents a WorkIQ retrieval activity record. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
 @added(Versions.v2026_05_01_preview)
-model KnowledgeBaseWorkIQActivityRecord
-  extends KnowledgeBaseActivityRecord {
+model KnowledgeBaseWorkIQActivityRecord extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.workIQ;
 
@@ -627,6 +631,7 @@ model KnowledgeBaseWorkIQActivityArguments {
 model KnowledgeBaseFabricDataAgentActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.fabricDataAgent;
 
@@ -646,6 +651,7 @@ model KnowledgeBaseFabricDataAgentActivityArguments {
 model KnowledgeBaseFabricOntologyActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.fabricOntology;
 
@@ -662,9 +668,9 @@ model KnowledgeBaseFabricOntologyActivityArguments {
 
 /** Represents an MCP server retrieval activity record. */
 @added(Versions.v2026_05_01_preview)
-model KnowledgeBaseMcpServerActivityRecord
-  extends KnowledgeBaseActivityRecord {
+model KnowledgeBaseMcpServerActivityRecord extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.mcpServer;
 
@@ -685,9 +691,9 @@ model KnowledgeBaseMcpServerActivityArguments {
 
 /** Represents a File retrieval activity record. */
 @added(Versions.v2026_05_01_preview)
-model KnowledgeBaseFileActivityRecord
-  extends KnowledgeBaseActivityRecord {
+model KnowledgeBaseFileActivityRecord extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.file;
 
@@ -707,6 +713,7 @@ model KnowledgeBaseFileActivityArguments {
 model KnowledgeBaseIndexedSqlActivityRecord
   extends KnowledgeBaseActivityRecord {
   ...KnowledgeBaseRetrievalActivityRecord;
+
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedSql;
 

--- a/specification/search/data-plane/Search/models-knowledgebase.tsp
+++ b/specification/search/data-plane/Search/models-knowledgebase.tsp
@@ -447,11 +447,8 @@ model KnowledgeBaseActivityRecord {
   warning?: string;
 }
 
-/** Represents a retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-string-discriminator" "Inherits typed discriminator from base"
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-@discriminator("type")
-model KnowledgeBaseRetrievalActivityRecord extends KnowledgeBaseActivityRecord {
+/** Common fields for retrieval activity records. Used via spread in concrete retrieval models. */
+model KnowledgeBaseRetrievalActivityRecord {
   /** The knowledge source for the retrieval activity. */
   knowledgeSourceName?: string;
 
@@ -467,10 +464,9 @@ model KnowledgeBaseRetrievalActivityRecord extends KnowledgeBaseActivityRecord {
 }
 
 /** Represents a search index retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 model KnowledgeBaseSearchIndexActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.searchIndex;
 
@@ -497,10 +493,9 @@ model KnowledgeBaseSearchIndexActivityArguments {
 }
 
 /** Represents a azure blob retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 model KnowledgeBaseAzureBlobActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.azureBlob;
 
@@ -515,12 +510,11 @@ model KnowledgeBaseAzureBlobActivityArguments {
 }
 
 /** Represents a indexed SharePoint retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 @removed(Versions.v2026_04_01)
 model KnowledgeBaseIndexedSharePointActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedSharePoint;
 
@@ -537,10 +531,9 @@ model KnowledgeBaseIndexedSharePointActivityArguments {
 }
 
 /** Represents a indexed OneLake retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 model KnowledgeBaseIndexedOneLakeActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedOneLake;
 
@@ -555,10 +548,9 @@ model KnowledgeBaseIndexedOneLakeActivityArguments {
 }
 
 /** Represents a web retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 model KnowledgeBaseWebActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.web;
 
@@ -585,12 +577,11 @@ model KnowledgeBaseWebActivityArguments {
 }
 
 /** Represents a remote SharePoint retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 @removed(Versions.v2026_04_01)
 model KnowledgeBaseRemoteSharePointActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.remoteSharePoint;
 
@@ -610,12 +601,11 @@ model KnowledgeBaseRemoteSharePointActivityArguments {
 }
 
 /** Represents a WorkIQ retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 #suppress "@azure-tools/typespec-azure-core/casing-style" "WorkIQ is a product name where IQ is an acronym."
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseWorkIQActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.workIQ;
 
@@ -633,11 +623,10 @@ model KnowledgeBaseWorkIQActivityArguments {
 }
 
 /** Represents a Fabric Data Agent retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseFabricDataAgentActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.fabricDataAgent;
 
@@ -653,11 +642,10 @@ model KnowledgeBaseFabricDataAgentActivityArguments {
 }
 
 /** Represents a Fabric Ontology retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseFabricOntologyActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.fabricOntology;
 
@@ -673,11 +661,10 @@ model KnowledgeBaseFabricOntologyActivityArguments {
 }
 
 /** Represents an MCP server retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseMcpServerActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.mcpServer;
 
@@ -697,11 +684,10 @@ model KnowledgeBaseMcpServerActivityArguments {
 }
 
 /** Represents a File retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseFileActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.file;
 
@@ -717,11 +703,10 @@ model KnowledgeBaseFileActivityArguments {
 }
 
 /** Represents an indexed SQL retrieval activity record. */
-#suppress "@azure-tools/typespec-azure-core/no-multiple-discriminator" "Existing"
-#suppress "DISCRIMINATOR_VALUE_NOT_FOUND" "Multi-Level Discrimination"
 @added(Versions.v2026_05_01_preview)
 model KnowledgeBaseIndexedSqlActivityRecord
-  extends KnowledgeBaseRetrievalActivityRecord {
+  extends KnowledgeBaseActivityRecord {
+  ...KnowledgeBaseRetrievalActivityRecord;
   /** The discriminator value. */
   type: KnowledgeBaseActivityRecordType.indexedSql;
 

--- a/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2025-11-01-preview/search.json
@@ -9522,6 +9522,20 @@
       "type": "object",
       "description": "Represents a azure blob retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "azureBlobArguments": {
           "$ref": "#/definitions/KnowledgeBaseAzureBlobActivityArguments",
           "description": "The azure blob arguments for the retrieval activity."
@@ -9529,7 +9543,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "azureBlob"
@@ -9653,6 +9667,20 @@
       "type": "object",
       "description": "Represents a indexed OneLake retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "indexedOneLakeArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedOneLakeActivityArguments",
           "description": "The indexed OneLake arguments for the retrieval activity."
@@ -9660,7 +9688,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedOneLake"
@@ -9695,6 +9723,20 @@
       "type": "object",
       "description": "Represents a indexed SharePoint retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "indexedSharePointArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedSharePointActivityArguments",
           "description": "The indexed SharePoint arguments for the retrieval activity."
@@ -9702,7 +9744,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedSharePoint"
@@ -9996,6 +10038,20 @@
       "type": "object",
       "description": "Represents a remote SharePoint retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "remoteSharePointArguments": {
           "$ref": "#/definitions/KnowledgeBaseRemoteSharePointActivityArguments",
           "description": "The remote SharePoint arguments for the retrieval activity."
@@ -10003,7 +10059,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "remoteSharePoint"
@@ -10031,12 +10087,8 @@
     },
     "KnowledgeBaseRetrievalActivityRecord": {
       "type": "object",
-      "description": "Represents a retrieval activity record.",
+      "description": "Common fields for retrieval activity records. Used via spread in concrete retrieval models.",
       "properties": {
-        "type": {
-          "type": "string",
-          "description": "Discriminator property for KnowledgeBaseRetrievalActivityRecord."
-        },
         "knowledgeSourceName": {
           "type": "string",
           "description": "The knowledge source for the retrieval activity."
@@ -10051,16 +10103,7 @@
           "format": "int32",
           "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
         }
-      },
-      "discriminator": "type",
-      "required": [
-        "type"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
-        }
-      ]
+      }
     },
     "KnowledgeBaseRetrievalPartialResponse": {
       "type": "object",
@@ -10200,6 +10243,20 @@
       "type": "object",
       "description": "Represents a search index retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "searchIndexArguments": {
           "$ref": "#/definitions/KnowledgeBaseSearchIndexActivityArguments",
           "description": "The search index arguments for the retrieval activity."
@@ -10207,7 +10264,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "searchIndex"
@@ -10259,6 +10316,20 @@
       "type": "object",
       "description": "Represents a web retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "webArguments": {
           "$ref": "#/definitions/KnowledgeBaseWebActivityArguments",
           "description": "The web arguments for the retrieval activity."
@@ -10266,7 +10337,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "web"

--- a/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
+++ b/specification/search/data-plane/Search/preview/2026-05-01-preview/search.json
@@ -10247,6 +10247,24 @@
       "type": "object",
       "description": "Represents a azure blob retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "azureBlobArguments": {
           "$ref": "#/definitions/KnowledgeBaseAzureBlobActivityArguments",
           "description": "The azure blob arguments for the retrieval activity."
@@ -10254,7 +10272,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "azureBlob"
@@ -10368,6 +10386,24 @@
       "type": "object",
       "description": "Represents a Fabric Data Agent retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "fabricDataAgentArguments": {
           "$ref": "#/definitions/KnowledgeBaseFabricDataAgentActivityArguments",
           "description": "The Fabric Data Agent arguments for the retrieval activity."
@@ -10375,7 +10411,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "fabricDataAgent"
@@ -10414,6 +10450,24 @@
       "type": "object",
       "description": "Represents a Fabric Ontology retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "fabricOntologyArguments": {
           "$ref": "#/definitions/KnowledgeBaseFabricOntologyActivityArguments",
           "description": "The Fabric Ontology arguments for the retrieval activity."
@@ -10421,7 +10475,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "fabricOntology"
@@ -10460,6 +10514,24 @@
       "type": "object",
       "description": "Represents a File retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "fileArguments": {
           "$ref": "#/definitions/KnowledgeBaseFileActivityArguments",
           "description": "The File arguments for the retrieval activity."
@@ -10467,7 +10539,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "file"
@@ -10516,6 +10588,24 @@
       "type": "object",
       "description": "Represents a indexed OneLake retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "indexedOneLakeArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedOneLakeActivityArguments",
           "description": "The indexed OneLake arguments for the retrieval activity."
@@ -10523,7 +10613,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedOneLake"
@@ -10562,6 +10652,24 @@
       "type": "object",
       "description": "Represents a indexed SharePoint retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "indexedSharePointArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedSharePointActivityArguments",
           "description": "The indexed SharePoint arguments for the retrieval activity."
@@ -10569,7 +10677,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedSharePoint"
@@ -10608,6 +10716,24 @@
       "type": "object",
       "description": "Represents an indexed SQL retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "indexedSqlArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedSqlActivityArguments",
           "description": "The indexed SQL arguments for the retrieval activity."
@@ -10615,7 +10741,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedSql"
@@ -10655,6 +10781,24 @@
       "type": "object",
       "description": "Represents an MCP server retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "mcpServerArguments": {
           "$ref": "#/definitions/KnowledgeBaseMcpServerActivityArguments",
           "description": "The MCP server arguments for the retrieval activity."
@@ -10662,7 +10806,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "mcpServer"
@@ -11030,6 +11174,24 @@
       "type": "object",
       "description": "Represents a remote SharePoint retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "remoteSharePointArguments": {
           "$ref": "#/definitions/KnowledgeBaseRemoteSharePointActivityArguments",
           "description": "The remote SharePoint arguments for the retrieval activity."
@@ -11037,7 +11199,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "remoteSharePoint"
@@ -11065,12 +11227,8 @@
     },
     "KnowledgeBaseRetrievalActivityRecord": {
       "type": "object",
-      "description": "Represents a retrieval activity record.",
+      "description": "Common fields for retrieval activity records. Used via spread in concrete retrieval models.",
       "properties": {
-        "type": {
-          "type": "string",
-          "description": "Discriminator property for KnowledgeBaseRetrievalActivityRecord."
-        },
         "knowledgeSourceName": {
           "type": "string",
           "description": "The knowledge source for the retrieval activity."
@@ -11089,16 +11247,7 @@
           "$ref": "#/definitions/ImageServingStatistics",
           "description": "Statistics about image serving for this retrieval activity"
         }
-      },
-      "discriminator": "type",
-      "required": [
-        "type"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
-        }
-      ]
+      }
     },
     "KnowledgeBaseRetrievalPartialResponse": {
       "type": "object",
@@ -11252,6 +11401,24 @@
       "type": "object",
       "description": "Represents a search index retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "searchIndexArguments": {
           "$ref": "#/definitions/KnowledgeBaseSearchIndexActivityArguments",
           "description": "The search index arguments for the retrieval activity."
@@ -11259,7 +11426,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "searchIndex"
@@ -11315,6 +11482,24 @@
       "type": "object",
       "description": "Represents a web retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "webArguments": {
           "$ref": "#/definitions/KnowledgeBaseWebActivityArguments",
           "description": "The web arguments for the retrieval activity."
@@ -11322,7 +11507,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "web"
@@ -11362,6 +11547,24 @@
       "type": "object",
       "description": "Represents a WorkIQ retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
+        "imageServing": {
+          "$ref": "#/definitions/ImageServingStatistics",
+          "description": "Statistics about image serving for this retrieval activity"
+        },
         "workIQArguments": {
           "$ref": "#/definitions/KnowledgeBaseWorkIQActivityArguments",
           "description": "The WorkIQ arguments for the retrieval activity."
@@ -11369,7 +11572,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "workIQ"

--- a/specification/search/data-plane/Search/stable/2026-04-01/search.json
+++ b/specification/search/data-plane/Search/stable/2026-04-01/search.json
@@ -8832,6 +8832,20 @@
       "type": "object",
       "description": "Represents a azure blob retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "azureBlobArguments": {
           "$ref": "#/definitions/KnowledgeBaseAzureBlobActivityArguments",
           "description": "The azure blob arguments for the retrieval activity."
@@ -8839,7 +8853,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "azureBlob"
@@ -8963,6 +8977,20 @@
       "type": "object",
       "description": "Represents a indexed OneLake retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "indexedOneLakeArguments": {
           "$ref": "#/definitions/KnowledgeBaseIndexedOneLakeActivityArguments",
           "description": "The indexed OneLake arguments for the retrieval activity."
@@ -8970,7 +8998,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "indexedOneLake"
@@ -9214,12 +9242,8 @@
     },
     "KnowledgeBaseRetrievalActivityRecord": {
       "type": "object",
-      "description": "Represents a retrieval activity record.",
+      "description": "Common fields for retrieval activity records. Used via spread in concrete retrieval models.",
       "properties": {
-        "type": {
-          "type": "string",
-          "description": "Discriminator property for KnowledgeBaseRetrievalActivityRecord."
-        },
         "knowledgeSourceName": {
           "type": "string",
           "description": "The knowledge source for the retrieval activity."
@@ -9234,16 +9258,7 @@
           "format": "int32",
           "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
         }
-      },
-      "discriminator": "type",
-      "required": [
-        "type"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
-        }
-      ]
+      }
     },
     "KnowledgeBaseRetrievalPartialResponse": {
       "type": "object",
@@ -9368,6 +9383,20 @@
       "type": "object",
       "description": "Represents a search index retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "searchIndexArguments": {
           "$ref": "#/definitions/KnowledgeBaseSearchIndexActivityArguments",
           "description": "The search index arguments for the retrieval activity."
@@ -9375,7 +9404,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "searchIndex"
@@ -9427,6 +9456,20 @@
       "type": "object",
       "description": "Represents a web retrieval activity record.",
       "properties": {
+        "knowledgeSourceName": {
+          "type": "string",
+          "description": "The knowledge source for the retrieval activity."
+        },
+        "queryTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The query time for this retrieval activity."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The count of documents retrieved that were sufficiently relevant to pass the reranker threshold."
+        },
         "webArguments": {
           "$ref": "#/definitions/KnowledgeBaseWebActivityArguments",
           "description": "The web arguments for the retrieval activity."
@@ -9434,7 +9477,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/KnowledgeBaseRetrievalActivityRecord"
+          "$ref": "#/definitions/KnowledgeBaseActivityRecord"
         }
       ],
       "x-ms-discriminator-value": "web"


### PR DESCRIPTION
(Targeting #42217)

This pull request refactors the modeling of retrieval activity records in the knowledge base search API. The main change is to make `KnowledgeBaseRetrievalActivityRecord` a reusable set of common fields, rather than a base class with a discriminator. Now, all specific retrieval activity record models directly extend `KnowledgeBaseActivityRecord` and include the common retrieval fields via spreading. Additionally, the JSON schema definitions are updated to match this new structure and to add missing properties to the relevant models.

**Modeling and Inheritance Refactor:**
- Changed `KnowledgeBaseRetrievalActivityRecord` from an inherited model with a discriminator to a reusable model containing common fields, which are now spread into each concrete retrieval activity record model. All specific retrieval activity record models (like `KnowledgeBaseSearchIndexActivityRecord`, `KnowledgeBaseAzureBlobActivityRecord`, etc.) now extend `KnowledgeBaseActivityRecord` and include the retrieval fields via spreading, rather than inheritance. 

These changes simplify the model hierarchy, make the common retrieval fields more reusable, and ensure the JSON schema accurately reflects the intended data structure.