### PR TITLE
VoiceLive: 2026-06-01-preview API version patch

### DIFF
--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -713,10 +713,19 @@ union Modality {
 @usage(RequestUsage)
 model EouDetection {
   #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Keeping inline union to avoid breaking changes."
+  @typeChangedFrom(
+    Versions.v2026_06_01_preview,
+
+      | "semantic_detection_v1"
+      | "semantic_detection_v1_en"
+      | "semantic_detection_v1_multilingual"
+      | string
+  )
   `model`:
     | "semantic_detection_v1"
     | "semantic_detection_v1_en"
     | "semantic_detection_v1_multilingual"
+    | "smart_end_of_turn_detection"
     | string;
 }
 
@@ -774,6 +783,25 @@ model AzureSemanticDetectionMultilingual extends EouDetection {
   threshold_level?: EouThresholdLevel;
 
   /** Timeout in milliseconds. Recommended instead of `timeout`. */
+  @minValue(0)
+  timeout_ms?: int32;
+}
+
+/**
+ * Audio-based end-of-turn detection. Operates directly on the input audio
+ * stream rather than text. Use `threshold_level` and `timeout_ms` to tune
+ * detection.
+ */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_06_01_preview)
+@usage(RequestUsage)
+model SmartEndOfTurnDetection extends EouDetection {
+  `model`: "smart_end_of_turn_detection";
+
+  /** Threshold level setting. One of `low`, `medium`, `high`, or `default`. */
+  threshold_level?: EouThresholdLevel;
+
+  /** Timeout in milliseconds. */
   @minValue(0)
   timeout_ms?: int32;
 }

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -70,6 +70,10 @@ model RequestSession {
   /** Specifies which tools the model is allowed to call during the session. */
   tool_choice?: ToolChoice;
 
+  /** Whether the model is allowed to call tools in parallel. */
+  @added(Versions.v2026_06_01_preview)
+  parallel_tool_calls?: boolean = true;
+
   /** Controls the randomness of the model's output. Range: 0.0 to 1.0. Default is 0.7. */
   temperature?: float32;
 

--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -32,6 +32,14 @@ union ClientEventType {
   /** Sent by the client to initiate a WebRTC session with an SDP offer. */
   @added(Versions.v2026_06_01_preview)
   rtc_call_sdp_create: "rtc.call.sdp.create",
+
+  /** Streamed delta of input text content being appended to an item. */
+  @added(Versions.v2026_06_01_preview)
+  input_text_delta: "input_text.delta",
+
+  /** Signals that the streamed input text content for an item is complete. */
+  @added(Versions.v2026_06_01_preview)
+  input_text_done: "input_text.done",
 }
 
 /** Server event types used in VoiceLive protocol. */

--- a/specification/ai/data-plane/VoiceLive/items.tsp
+++ b/specification/ai/data-plane/VoiceLive/items.tsp
@@ -59,11 +59,12 @@ model InputAudioContentPart extends MessageContentPart {
 }
 
 /** Input image content part. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
 @added(Versions.v2026_01_01_preview)
 @usage(RequestUsage)
 model RequestImageContentPart extends ContentPart {
   type: ContentPartType.input_image;
-  url?: string;
+  image_url?: url;
   detail?: RequestImageContentPartDetail;
 }
 

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -161,6 +161,39 @@ model ClientEventInputAudioClear extends ClientEvent {
   type: ClientEventType.input_audio_clear;
 }
 
+/** Streams a delta of input text content into the specified item. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_06_01_preview)
+@usage(RequestUsage)
+model ClientEventInputTextDelta extends ClientEvent {
+  /** The event type, must be `input_text.delta`. */
+  type: ClientEventType.input_text_delta;
+
+  /** The ID of the item the text delta is being appended to. */
+  id: string;
+
+  /** The text delta to append. */
+  delta: string;
+
+  /** The index of the content part within the item the delta applies to. */
+  content_index?: int32 = 0;
+}
+
+/** Signals that the streamed input text content for the specified item is complete. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_06_01_preview)
+@usage(RequestUsage)
+model ClientEventInputTextDone extends ClientEvent {
+  /** The event type, must be `input_text.done`. */
+  type: ClientEventType.input_text_done;
+
+  /** The ID of the item whose text content has finished streaming. */
+  id: string;
+
+  /** The index of the content part within the item. */
+  content_index?: int32 = 0;
+}
+
 // Tool customization: establish custom, enriched discriminated type hierarchy
 /** The item to add to the conversation. */
 @usage(RequestUsage)

--- a/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-01-01-preview/VoiceLive.json
@@ -2364,8 +2364,9 @@
       "type": "object",
       "description": "Input image content part.",
       "properties": {
-        "url": {
-          "type": "string"
+        "image_url": {
+          "type": "string",
+          "format": "uri"
         },
         "detail": {
           "$ref": "#/definitions/RequestImageContentPartDetail"

--- a/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
@@ -1447,6 +1447,61 @@
       ],
       "x-ms-discriminator-value": "input_audio.turn.start"
     },
+    "ClientEventInputTextDelta": {
+      "type": "object",
+      "description": "Streams a delta of input text content into the specified item.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the item the text delta is being appended to."
+        },
+        "delta": {
+          "type": "string",
+          "description": "The text delta to append."
+        },
+        "content_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the content part within the item the delta applies to.",
+          "default": 0
+        }
+      },
+      "required": [
+        "id",
+        "delta"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClientEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "input_text.delta"
+    },
+    "ClientEventInputTextDone": {
+      "type": "object",
+      "description": "Signals that the streamed input text content for the specified item is complete.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the item whose text content has finished streaming."
+        },
+        "content_index": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The index of the content part within the item.",
+          "default": 0
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClientEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "input_text.done"
+    },
     "ClientEventOutputAudioBufferClear": {
       "type": "object",
       "description": "Client request to clear the avatar output buffer.",
@@ -1574,7 +1629,9 @@
         "session.avatar.connect",
         "mcp_approval_response",
         "output_audio_buffer.clear",
-        "rtc.call.sdp.create"
+        "rtc.call.sdp.create",
+        "input_text.delta",
+        "input_text.done"
       ],
       "x-ms-enum": {
         "name": "ClientEventType",
@@ -1657,6 +1714,16 @@
             "name": "rtc_call_sdp_create",
             "value": "rtc.call.sdp.create",
             "description": "Sent by the client to initiate a WebRTC session with an SDP offer."
+          },
+          {
+            "name": "input_text_delta",
+            "value": "input_text.delta",
+            "description": "Streamed delta of input text content being appended to an item."
+          },
+          {
+            "name": "input_text_done",
+            "value": "input_text.done",
+            "description": "Signals that the streamed input text content for an item is complete."
           }
         ]
       }
@@ -1763,7 +1830,8 @@
           "enum": [
             "semantic_detection_v1",
             "semantic_detection_v1_en",
-            "semantic_detection_v1_multilingual"
+            "semantic_detection_v1_multilingual",
+            "smart_end_of_turn_detection"
           ],
           "x-ms-enum": {
             "modelAsString": true
@@ -2812,8 +2880,9 @@
       "type": "object",
       "description": "Input image content part.",
       "properties": {
-        "url": {
-          "type": "string"
+        "image_url": {
+          "type": "string",
+          "format": "uri"
         },
         "detail": {
           "$ref": "#/definitions/RequestImageContentPartDetail"
@@ -6250,6 +6319,28 @@
           }
         ]
       }
+    },
+    "SmartEndOfTurnDetection": {
+      "type": "object",
+      "description": "Audio-based end-of-turn detection. Operates directly on the input audio\nstream rather than text. Use `threshold_level` and `timeout_ms` to tune\ndetection.",
+      "properties": {
+        "threshold_level": {
+          "$ref": "#/definitions/EouThresholdLevel",
+          "description": "Threshold level setting. One of `low`, `medium`, `high`, or `default`."
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Timeout in milliseconds.",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EouDetection"
+        }
+      ],
+      "x-ms-discriminator-value": "smart_end_of_turn_detection"
     },
     "StaticInterimResponseConfig": {
       "type": "object",

--- a/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/preview/2026-06-01-preview/VoiceLive.json
@@ -3070,6 +3070,11 @@
           "$ref": "#/definitions/ToolChoice",
           "description": "Specifies which tools the model is allowed to call during the session."
         },
+        "parallel_tool_calls": {
+          "type": "boolean",
+          "description": "Whether the model is allowed to call tools in parallel.",
+          "default": true
+        },
         "temperature": {
           "type": "number",
           "format": "float",
@@ -3891,6 +3896,11 @@
         "tool_choice": {
           "$ref": "#/definitions/ToolChoice",
           "description": "Specifies which tools the model is allowed to call during the session."
+        },
+        "parallel_tool_calls": {
+          "type": "boolean",
+          "description": "Whether the model is allowed to call tools in parallel.",
+          "default": true
         },
         "temperature": {
           "type": "number",

--- a/specification/ai/data-plane/VoiceLive/stable/2026-04-10/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-04-10/VoiceLive.json
@@ -2618,8 +2618,9 @@
       "type": "object",
       "description": "Input image content part.",
       "properties": {
-        "url": {
-          "type": "string"
+        "image_url": {
+          "type": "string",
+          "format": "uri"
         },
         "detail": {
           "$ref": "#/definitions/RequestImageContentPartDetail"


### PR DESCRIPTION
## Summary

Patch to the in-flight VoiceLive 2026-06-01-preview API version, plus a cross-version bug fix for the image content part field name.

## Changes

1. **Bug fix — rename `RequestImageContentPart.url` → `image_url` (all API versions)**
   The original `url` field was never wired up server-side and never accepted by the service; the correct wire field name is `image_url`. Applied to all versions where `RequestImageContentPart` exists (2026-01-01-preview, 2026-04-10, 2026-06-01-preview). Type also tightened from `string` to `url`.

2. **`input_text.delta` / `input_text.done` client events** *(v2026-06-01-preview)*
   New `ClientEventInputTextDelta` and `ClientEventInputTextDone` events for streaming text input into a conversation item.

3. **`SmartEndOfTurnDetection` audio-based EOU variant** *(v2026-06-01-preview)*
   New EOU detection model with `model: "smart_end_of_turn_detection"` exposing `threshold_level` and `timeout_ms`. The new literal is added to the `EouDetection` discriminator inline union via `@typeChangedFrom` so older API versions are not affected.

4. **`parallel_tool_calls` session option** *(v2026-06-01-preview)*
   New optional `parallel_tool_calls` boolean (default `true`) on `SessionBase`, controlling whether the model may issue tool calls in parallel. Applies to both request and response session payloads.

## Validation

- `tsp compile` passes cleanly.
- `git diff` confirms older API versions only carry the `url` → `image_url` bug fix; all other changes are scoped to 2026-06-01-preview.
