### PR TITLE
webpubsub: parameter reordering customization for Go/Python/JavaScript

### DIFF
--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -7,14 +7,12 @@ using Azure.Core;
 using Microsoft.SignalRService;
 using Http;
 
-@@clientName(
-  Microsoft.SignalRService,
+@@clientName(Microsoft.SignalRService,
   "WebPubSubManagementClient",
   "javascript,python"
 );
 
-@@clientDoc(
-  Microsoft.SignalRService.EventHandler.urlTemplate,
+@@clientDoc(Microsoft.SignalRService.EventHandler.urlTemplate,
   """
     Gets or sets the URL template for the event handler. The actual URL is calculated when the corresponding event is triggered. 
     The template supports predefined parameters syntax: `{event}`, `{hub}`, and KeyVault reference syntax `{&#64;Microsoft.KeyVault(SecretUri=_your_secret_identifier_)}` 
@@ -33,20 +31,19 @@ using Http;
 @@clientName(IPRule, "IpRule", "java");
 @@clientName(PrivateEndpointACL, "PrivateEndpointAcl", "java");
 @@clientName(Microsoft.SignalRService.WebPubSubResource, "ResourceInfo", "go");
-@@clientName(
-  Microsoft.SignalRService.WebPubSubResourceList,
-  "ResourceInfoList", "go");
+@@clientName(Microsoft.SignalRService.WebPubSubResourceList,
+  "ResourceInfoList",
+  "go"
+);
 @@clientName(EventHandler, "WebPubSubEventHandler", "csharp");
 @@clientName(WebPubSubRequestType.RESTAPI, "RestApi", "csharp");
 @@clientName(ProvisioningState, "WebPubSubProvisioningState", "csharp");
-@@clientName(
-  NameAvailabilityParameters,
+@@clientName(NameAvailabilityParameters,
   "WebPubSubNameAvailabilityContent",
   "csharp"
 );
 @@clientName(NameAvailabilityParameters.type, "ResourceType", "csharp");
-@@clientName(
-  RegenerateKeyParameters,
+@@clientName(RegenerateKeyParameters,
   "WebPubSubRegenerateKeyContent",
   "csharp"
 );
@@ -56,19 +53,16 @@ using Http;
 @@clientName(ACLAction, "AclAction", "csharp");
 @@clientName(PrivateEndpointACL, "PrivateEndpointAcl", "csharp");
 @@clientName(NetworkACL, "PublicNetworkAcls", "csharp");
-@@usage(
-  ShareablePrivateLinkResourceProperties,
+@@usage(ShareablePrivateLinkResourceProperties,
   Usage.input | Usage.output,
   "csharp"
 );
-@@clientName(
-  ShareablePrivateLinkResourceProperties,
+@@clientName(ShareablePrivateLinkResourceProperties,
   "ShareablePrivateLinkProperties",
   "csharp"
 );
 @@usage(ShareablePrivateLinkResourceType, Usage.input | Usage.output, "csharp");
-@@clientName(
-  ShareablePrivateLinkResourceType,
+@@clientName(ShareablePrivateLinkResourceType,
   "ShareablePrivateLinkType",
   "csharp"
 );
@@ -76,37 +70,31 @@ using Http;
 @@clientName(NameAvailability, "WebPubSubNameAvailability", "csharp");
 @@clientName(WebPubSubNetworkACLs, "WebPubSubNetworkAcls", "csharp");
 @@clientName(PrivateLinkResource, "WebPubSubPrivateLink", "csharp");
-@@clientName(
-  PrivateLinkResourceProperties.shareablePrivateLinkResourceTypes,
+@@clientName(PrivateLinkResourceProperties.shareablePrivateLinkResourceTypes,
   "ShareablePrivateLinkTypes",
   "csharp"
 );
-@@clientName(
-  PrivateLinkServiceConnectionStatus,
+@@clientName(PrivateLinkServiceConnectionStatus,
   "WebPubSubPrivateLinkServiceConnectionStatus",
   "csharp"
 );
-@@clientName(
-  SharedPrivateLinkResourceStatus,
+@@clientName(SharedPrivateLinkResourceStatus,
   "WebPubSubSharedPrivateLinkStatus",
   "csharp"
 );
 
 @@clientName(WebPubSubResource, "WebPubSub", "csharp");
 @@clientName(WebPubSubProperties.disableAadAuth, "IsAadAuthDisabled", "csharp");
-@@clientName(
-  WebPubSubTlsSettings.clientCertEnabled,
+@@clientName(WebPubSubTlsSettings.clientCertEnabled,
   "IsClientCertEnabled",
   "csharp"
 );
-@@clientName(
-  WebPubSubProperties.disableLocalAuth,
+@@clientName(WebPubSubProperties.disableLocalAuth,
   "IsLocalAuthDisabled",
   "csharp"
 );
 @@clientName(WebPubSubProperties.networkACLs, "NetworkAcls", "csharp");
-@@clientName(
-  PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
+@@clientName(PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
   "ConnectionState",
   "csharp"
 );
@@ -115,55 +103,45 @@ using Http;
 @@clientName(CustomDomain, "WebPubSubCustomDomain", "csharp");
 @@alternateType(ResourceReference.id, armResourceIdentifier, "csharp");
 @@alternateType(PrivateEndpoint.id, armResourceIdentifier, "csharp");
-@@clientName(
-  PrivateEndpointConnection,
+@@clientName(PrivateEndpointConnection,
   "WebPubSubPrivateEndpointConnection",
   "csharp"
 );
-@@clientName(
-  PrivateLinkServiceConnectionState,
+@@clientName(PrivateLinkServiceConnectionState,
   "WebPubSubPrivateLinkServiceConnectionState",
   "csharp"
 );
-@@clientName(
-  PrivateLinkServiceConnectionStatus,
+@@clientName(PrivateLinkServiceConnectionStatus,
   "WebPubSubPrivateLinkServiceConnectionStatus",
   "csharp"
 );
-@@alternateType(
-  SharedPrivateLinkResourceProperties.privateLinkResourceId,
+@@alternateType(SharedPrivateLinkResourceProperties.privateLinkResourceId,
   armResourceIdentifier,
   "csharp"
 );
 @@clientName(Replica, "WebPubSubReplica", "csharp");
-@@clientName(
-  ReplicaProperties.regionEndpointEnabled,
+@@clientName(ReplicaProperties.regionEndpointEnabled,
   "IsRegionEndpointEnabled",
   "csharp"
 );
-@@clientName(
-  WebPubSubProperties.regionEndpointEnabled,
+@@clientName(WebPubSubProperties.regionEndpointEnabled,
   "IsRegionEndpointEnabled",
   "csharp"
 );
-@@alternateType(
-  WebPubSubResource.identity,
+@@alternateType(WebPubSubResource.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
-@@alternateType(
-  Azure.ResourceManager.LocationParameter.location,
+@@alternateType(Azure.ResourceManager.LocationParameter.location,
   azureLocation,
   "csharp"
 );
-@@clientName(
-  WebPubSubOperationGroup.checkNameAvailability,
+@@clientName(WebPubSubOperationGroup.checkNameAvailability,
   "CheckWebPubSubNameAvailability",
   "csharp"
 );
 @@clientName(SharedPrivateLinkResource, "WebPubSubSharedPrivateLink", "csharp");
-@@clientName(
-  SharedPrivateLinkResourceStatus,
+@@clientName(SharedPrivateLinkResourceStatus,
   "WebPubSubSharedPrivateLinkStatus",
   "csharp"
 );
@@ -173,18 +151,15 @@ using Http;
 @@clientName(ResourceSku, "BillingInfoSku", "csharp");
 @@clientName(SkuCapacity, "WebPubSubSkuCapacity", "csharp");
 @@clientName(ScaleType, "WebPubSubScaleType", "csharp");
-@@clientName(
-  ApplicationFirewallSettings,
+@@clientName(ApplicationFirewallSettings,
   "WebPubSubApplicationFirewallSettings",
   "csharp"
 );
-@@clientName(
-  ClientConnectionCountRule,
+@@clientName(ClientConnectionCountRule,
   "WebPubSubClientConnectionCountRule",
   "csharp"
 );
-@@clientName(
-  ClientTrafficControlRule,
+@@clientName(ClientTrafficControlRule,
   "WebPubSubClientTrafficControlRule",
   "csharp"
 );
@@ -193,41 +168,34 @@ using Http;
 @@clientName(EventListenerEndpoint, "WebPubSubEventListenerEndpoint", "csharp");
 @@clientName(EventListenerFilter, "WebPubSubEventListenerFilter", "csharp");
 @@clientName(EventNameFilter, "WebPubSubEventNameFilter", "csharp");
-@@clientName(
-  GroupPresenceEventFilters,
+@@clientName(GroupPresenceEventFilters,
   "WebPubSubGroupPresenceEventFilters",
   "csharp"
 );
-@@clientName(
-  GroupPresenceEventName,
+@@clientName(GroupPresenceEventName,
   "WebPubSubGroupPresenceEventName",
   "csharp"
 );
 @@clientName(IPRule, "WebPubSubIPRule", "csharp");
 @@clientName(ServiceKind, "WebPubSubServiceKind", "csharp");
-@@clientName(
-  ThrottleByJwtCustomClaimRule,
+@@clientName(ThrottleByJwtCustomClaimRule,
   "WebPubSubThrottleByJwtCustomClaimRule",
   "csharp"
 );
-@@clientName(
-  ThrottleByJwtSignatureRule,
+@@clientName(ThrottleByJwtSignatureRule,
   "WebPubSubThrottleByJwtSignatureRule",
   "csharp"
 );
 @@clientName(ThrottleByUserIdRule, "WebPubSubThrottleByUserIdRule", "csharp");
-@@clientName(
-  TrafficThrottleByJwtCustomClaimRule,
+@@clientName(TrafficThrottleByJwtCustomClaimRule,
   "WebPubSubTrafficThrottleByJwtCustomClaimRule",
   "csharp"
 );
-@@clientName(
-  TrafficThrottleByJwtSignatureRule,
+@@clientName(TrafficThrottleByJwtSignatureRule,
   "WebPubSubTrafficThrottleByJwtSignatureRule",
   "csharp"
 );
-@@clientName(
-  TrafficThrottleByUserIdRule,
+@@clientName(TrafficThrottleByUserIdRule,
   "WebPubSubTrafficThrottleByUserIdRule",
   "csharp"
 );
@@ -237,8 +205,7 @@ using Http;
 @@alternateType(LiveTraceCategory.enabled, boolean, "csharp");
 @@clientName(LiveTraceConfiguration.enabled, "IsEnabled", "csharp");
 @@alternateType(LiveTraceConfiguration.enabled, boolean, "csharp");
-@@clientName(
-  WebPubSubResources.list,
+@@clientName(WebPubSubResources.list,
   "GetWebPubSubPrivateLinkResources",
   "csharp"
 );
@@ -273,7 +240,10 @@ op WebPubSubHubsGetCustomized(
   resourceName: string,
 ): WebPubSubHub;
 
-@@override(WebPubSubHubs.get, WebPubSubHubsGetCustomized, "go,python,javascript");
+@@override(WebPubSubHubs.get,
+  WebPubSubHubsGetCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -297,9 +267,10 @@ op WebPubSubHubsCreateOrUpdateCustomized(
   parameters: WebPubSubHub,
 ): void;
 
-@@override(
-  WebPubSubHubs.createOrUpdate,
-  WebPubSubHubsCreateOrUpdateCustomized, "go,python,javascript");
+@@override(WebPubSubHubs.createOrUpdate,
+  WebPubSubHubsCreateOrUpdateCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -320,7 +291,10 @@ op WebPubSubHubsDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(WebPubSubHubs.delete, WebPubSubHubsDeleteCustomized, "go,python,javascript");
+@@override(WebPubSubHubs.delete,
+  WebPubSubHubsDeleteCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -341,9 +315,10 @@ op PrivateEndpointConnectionsGetCustomized(
   resourceName: string,
 ): PrivateEndpointConnection;
 
-@@override(
-  PrivateEndpointConnections.get,
-  PrivateEndpointConnectionsGetCustomized, "go,python,javascript");
+@@override(PrivateEndpointConnections.get,
+  PrivateEndpointConnectionsGetCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -367,9 +342,10 @@ op PrivateEndpointConnectionsUpdateCustomized(
   parameters: PrivateEndpointConnection,
 ): PrivateEndpointConnection;
 
-@@override(
-  PrivateEndpointConnections.update,
-  PrivateEndpointConnectionsUpdateCustomized, "go,python,javascript");
+@@override(PrivateEndpointConnections.update,
+  PrivateEndpointConnectionsUpdateCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -390,15 +366,16 @@ op PrivateEndpointConnectionsDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(
-  PrivateEndpointConnections.delete,
-  PrivateEndpointConnectionsDeleteCustomized, "go,python,javascript");
+@@override(PrivateEndpointConnections.delete,
+  PrivateEndpointConnectionsDeleteCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
 op WebPubSubSharedPrivateLinkResourcesGetCustomized(
-  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.Legacy.Provider,
   ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
   ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
 
@@ -413,15 +390,16 @@ op WebPubSubSharedPrivateLinkResourcesGetCustomized(
   resourceName: string,
 ): SharedPrivateLinkResource;
 
-@@override(
-  WebPubSubSharedPrivateLinkResources.get,
-  WebPubSubSharedPrivateLinkResourcesGetCustomized, "go,python,javascript");
+@@override(WebPubSubSharedPrivateLinkResources.get,
+  WebPubSubSharedPrivateLinkResourcesGetCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
 op WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized(
-  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.Legacy.Provider,
   ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
   ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
 
@@ -439,15 +417,16 @@ op WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized(
   parameters: SharedPrivateLinkResource,
 ): void;
 
-@@override(
-  WebPubSubSharedPrivateLinkResources.createOrUpdate,
-  WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized, "go,python,javascript");
+@@override(WebPubSubSharedPrivateLinkResources.createOrUpdate,
+  WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized,
+  "go,python,javascript"
+);
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
 op WebPubSubSharedPrivateLinkResourcesDeleteCustomized(
-  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.Legacy.Provider,
   ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
   ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
 
@@ -462,6 +441,7 @@ op WebPubSubSharedPrivateLinkResourcesDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(
-  WebPubSubSharedPrivateLinkResources.delete,
-  WebPubSubSharedPrivateLinkResourcesDeleteCustomized, "go,python,javascript");
+@@override(WebPubSubSharedPrivateLinkResources.delete,
+  WebPubSubSharedPrivateLinkResourcesDeleteCustomized,
+  "go,python,javascript"
+);

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -5,6 +5,7 @@ using Azure.ClientGenerator.Core;
 using Azure.ClientGenerator.Core.Legacy;
 using Azure.Core;
 using Microsoft.SignalRService;
+using Http;
 
 @@clientName(
   Microsoft.SignalRService,
@@ -248,3 +249,235 @@ using Microsoft.SignalRService;
 @@markAsPageable(Replicas.listReplicaSkus, "csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Change the base type back to TrackedResource for backward compatibility"
 @@markAsPageable(WebPubSubResources.listSkus, "csharp");
+
+// =========================================================================
+// Go-only parameter reordering: preserve the original swagger order
+// (childName, resourceGroupName, resourceName, ...) instead of the
+// TypeSpec ARM default (resourceGroupName, resourceName, childName, ...).
+// =========================================================================
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubHubsGetCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<WebPubSubHub>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  hubName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): WebPubSubHub;
+
+@@override(WebPubSubHubs.get, WebPubSubHubsGetCustomized, "go");
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubHubsCreateOrUpdateCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<WebPubSubHub>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  hubName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+
+  @body
+  parameters: WebPubSubHub,
+): void;
+
+@@override(
+  WebPubSubHubs.createOrUpdate,
+  WebPubSubHubsCreateOrUpdateCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubHubsDeleteCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<WebPubSubHub>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  hubName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): void;
+
+@@override(WebPubSubHubs.delete, WebPubSubHubsDeleteCustomized, "go");
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op PrivateEndpointConnectionsGetCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<PrivateEndpointConnection>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  privateEndpointConnectionName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): PrivateEndpointConnection;
+
+@@override(
+  PrivateEndpointConnections.get,
+  PrivateEndpointConnectionsGetCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op PrivateEndpointConnectionsUpdateCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<PrivateEndpointConnection>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  privateEndpointConnectionName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+
+  @body
+  parameters: PrivateEndpointConnection,
+): PrivateEndpointConnection;
+
+@@override(
+  PrivateEndpointConnections.update,
+  PrivateEndpointConnectionsUpdateCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op PrivateEndpointConnectionsDeleteCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<PrivateEndpointConnection>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  privateEndpointConnectionName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): void;
+
+@@override(
+  PrivateEndpointConnections.delete,
+  PrivateEndpointConnectionsDeleteCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubSharedPrivateLinkResourcesGetCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  sharedPrivateLinkResourceName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): SharedPrivateLinkResource;
+
+@@override(
+  WebPubSubSharedPrivateLinkResources.get,
+  WebPubSubSharedPrivateLinkResourcesGetCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  sharedPrivateLinkResourceName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+
+  @body
+  parameters: SharedPrivateLinkResource,
+): void;
+
+@@override(
+  WebPubSubSharedPrivateLinkResources.createOrUpdate,
+  WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized,
+  "go"
+);
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+op WebPubSubSharedPrivateLinkResourcesDeleteCustomized(
+  ...Azure.ResourceManager.ProviderNamespace<SharedPrivateLinkResource>,
+  ...Azure.ResourceManager.CommonTypes.ApiVersionParameter,
+  ...Azure.ResourceManager.CommonTypes.SubscriptionIdParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  sharedPrivateLinkResourceName: string,
+
+  ...Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter,
+
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"
+  @path
+  resourceName: string,
+): void;
+
+@@override(
+  WebPubSubSharedPrivateLinkResources.delete,
+  WebPubSubSharedPrivateLinkResourcesDeleteCustomized,
+  "go"
+);

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -35,9 +35,7 @@ using Http;
 @@clientName(Microsoft.SignalRService.WebPubSubResource, "ResourceInfo", "go");
 @@clientName(
   Microsoft.SignalRService.WebPubSubResourceList,
-  "ResourceInfoList",
-  "go"
-);
+  "ResourceInfoList", "go");
 @@clientName(EventHandler, "WebPubSubEventHandler", "csharp");
 @@clientName(WebPubSubRequestType.RESTAPI, "RestApi", "csharp");
 @@clientName(ProvisioningState, "WebPubSubProvisioningState", "csharp");
@@ -275,7 +273,7 @@ op WebPubSubHubsGetCustomized(
   resourceName: string,
 ): WebPubSubHub;
 
-@@override(WebPubSubHubs.get, WebPubSubHubsGetCustomized, "go");
+@@override(WebPubSubHubs.get, WebPubSubHubsGetCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -301,9 +299,7 @@ op WebPubSubHubsCreateOrUpdateCustomized(
 
 @@override(
   WebPubSubHubs.createOrUpdate,
-  WebPubSubHubsCreateOrUpdateCustomized,
-  "go"
-);
+  WebPubSubHubsCreateOrUpdateCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -324,7 +320,7 @@ op WebPubSubHubsDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(WebPubSubHubs.delete, WebPubSubHubsDeleteCustomized, "go");
+@@override(WebPubSubHubs.delete, WebPubSubHubsDeleteCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -347,9 +343,7 @@ op PrivateEndpointConnectionsGetCustomized(
 
 @@override(
   PrivateEndpointConnections.get,
-  PrivateEndpointConnectionsGetCustomized,
-  "go"
-);
+  PrivateEndpointConnectionsGetCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -375,9 +369,7 @@ op PrivateEndpointConnectionsUpdateCustomized(
 
 @@override(
   PrivateEndpointConnections.update,
-  PrivateEndpointConnectionsUpdateCustomized,
-  "go"
-);
+  PrivateEndpointConnectionsUpdateCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -400,9 +392,7 @@ op PrivateEndpointConnectionsDeleteCustomized(
 
 @@override(
   PrivateEndpointConnections.delete,
-  PrivateEndpointConnectionsDeleteCustomized,
-  "go"
-);
+  PrivateEndpointConnectionsDeleteCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -425,9 +415,7 @@ op WebPubSubSharedPrivateLinkResourcesGetCustomized(
 
 @@override(
   WebPubSubSharedPrivateLinkResources.get,
-  WebPubSubSharedPrivateLinkResourcesGetCustomized,
-  "go"
-);
+  WebPubSubSharedPrivateLinkResourcesGetCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -453,9 +441,7 @@ op WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized(
 
 @@override(
   WebPubSubSharedPrivateLinkResources.createOrUpdate,
-  WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized,
-  "go"
-);
+  WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized, "go,python,javascript");
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -478,6 +464,4 @@ op WebPubSubSharedPrivateLinkResourcesDeleteCustomized(
 
 @@override(
   WebPubSubSharedPrivateLinkResources.delete,
-  WebPubSubSharedPrivateLinkResourcesDeleteCustomized,
-  "go"
-);
+  WebPubSubSharedPrivateLinkResourcesDeleteCustomized, "go,python,javascript");

--- a/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
+++ b/specification/webpubsub/resource-manager/Microsoft.SignalRService/SignalRService/client.tsp
@@ -7,12 +7,14 @@ using Azure.Core;
 using Microsoft.SignalRService;
 using Http;
 
-@@clientName(Microsoft.SignalRService,
+@@clientName(
+  Microsoft.SignalRService,
   "WebPubSubManagementClient",
   "javascript,python"
 );
 
-@@clientDoc(Microsoft.SignalRService.EventHandler.urlTemplate,
+@@clientDoc(
+  Microsoft.SignalRService.EventHandler.urlTemplate,
   """
     Gets or sets the URL template for the event handler. The actual URL is calculated when the corresponding event is triggered. 
     The template supports predefined parameters syntax: `{event}`, `{hub}`, and KeyVault reference syntax `{&#64;Microsoft.KeyVault(SecretUri=_your_secret_identifier_)}` 
@@ -31,19 +33,22 @@ using Http;
 @@clientName(IPRule, "IpRule", "java");
 @@clientName(PrivateEndpointACL, "PrivateEndpointAcl", "java");
 @@clientName(Microsoft.SignalRService.WebPubSubResource, "ResourceInfo", "go");
-@@clientName(Microsoft.SignalRService.WebPubSubResourceList,
+@@clientName(
+  Microsoft.SignalRService.WebPubSubResourceList,
   "ResourceInfoList",
   "go"
 );
 @@clientName(EventHandler, "WebPubSubEventHandler", "csharp");
 @@clientName(WebPubSubRequestType.RESTAPI, "RestApi", "csharp");
 @@clientName(ProvisioningState, "WebPubSubProvisioningState", "csharp");
-@@clientName(NameAvailabilityParameters,
+@@clientName(
+  NameAvailabilityParameters,
   "WebPubSubNameAvailabilityContent",
   "csharp"
 );
 @@clientName(NameAvailabilityParameters.type, "ResourceType", "csharp");
-@@clientName(RegenerateKeyParameters,
+@@clientName(
+  RegenerateKeyParameters,
   "WebPubSubRegenerateKeyContent",
   "csharp"
 );
@@ -53,16 +58,19 @@ using Http;
 @@clientName(ACLAction, "AclAction", "csharp");
 @@clientName(PrivateEndpointACL, "PrivateEndpointAcl", "csharp");
 @@clientName(NetworkACL, "PublicNetworkAcls", "csharp");
-@@usage(ShareablePrivateLinkResourceProperties,
+@@usage(
+  ShareablePrivateLinkResourceProperties,
   Usage.input | Usage.output,
   "csharp"
 );
-@@clientName(ShareablePrivateLinkResourceProperties,
+@@clientName(
+  ShareablePrivateLinkResourceProperties,
   "ShareablePrivateLinkProperties",
   "csharp"
 );
 @@usage(ShareablePrivateLinkResourceType, Usage.input | Usage.output, "csharp");
-@@clientName(ShareablePrivateLinkResourceType,
+@@clientName(
+  ShareablePrivateLinkResourceType,
   "ShareablePrivateLinkType",
   "csharp"
 );
@@ -70,31 +78,37 @@ using Http;
 @@clientName(NameAvailability, "WebPubSubNameAvailability", "csharp");
 @@clientName(WebPubSubNetworkACLs, "WebPubSubNetworkAcls", "csharp");
 @@clientName(PrivateLinkResource, "WebPubSubPrivateLink", "csharp");
-@@clientName(PrivateLinkResourceProperties.shareablePrivateLinkResourceTypes,
+@@clientName(
+  PrivateLinkResourceProperties.shareablePrivateLinkResourceTypes,
   "ShareablePrivateLinkTypes",
   "csharp"
 );
-@@clientName(PrivateLinkServiceConnectionStatus,
+@@clientName(
+  PrivateLinkServiceConnectionStatus,
   "WebPubSubPrivateLinkServiceConnectionStatus",
   "csharp"
 );
-@@clientName(SharedPrivateLinkResourceStatus,
+@@clientName(
+  SharedPrivateLinkResourceStatus,
   "WebPubSubSharedPrivateLinkStatus",
   "csharp"
 );
 
 @@clientName(WebPubSubResource, "WebPubSub", "csharp");
 @@clientName(WebPubSubProperties.disableAadAuth, "IsAadAuthDisabled", "csharp");
-@@clientName(WebPubSubTlsSettings.clientCertEnabled,
+@@clientName(
+  WebPubSubTlsSettings.clientCertEnabled,
   "IsClientCertEnabled",
   "csharp"
 );
-@@clientName(WebPubSubProperties.disableLocalAuth,
+@@clientName(
+  WebPubSubProperties.disableLocalAuth,
   "IsLocalAuthDisabled",
   "csharp"
 );
 @@clientName(WebPubSubProperties.networkACLs, "NetworkAcls", "csharp");
-@@clientName(PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
+@@clientName(
+  PrivateEndpointConnectionProperties.privateLinkServiceConnectionState,
   "ConnectionState",
   "csharp"
 );
@@ -103,45 +117,55 @@ using Http;
 @@clientName(CustomDomain, "WebPubSubCustomDomain", "csharp");
 @@alternateType(ResourceReference.id, armResourceIdentifier, "csharp");
 @@alternateType(PrivateEndpoint.id, armResourceIdentifier, "csharp");
-@@clientName(PrivateEndpointConnection,
+@@clientName(
+  PrivateEndpointConnection,
   "WebPubSubPrivateEndpointConnection",
   "csharp"
 );
-@@clientName(PrivateLinkServiceConnectionState,
+@@clientName(
+  PrivateLinkServiceConnectionState,
   "WebPubSubPrivateLinkServiceConnectionState",
   "csharp"
 );
-@@clientName(PrivateLinkServiceConnectionStatus,
+@@clientName(
+  PrivateLinkServiceConnectionStatus,
   "WebPubSubPrivateLinkServiceConnectionStatus",
   "csharp"
 );
-@@alternateType(SharedPrivateLinkResourceProperties.privateLinkResourceId,
+@@alternateType(
+  SharedPrivateLinkResourceProperties.privateLinkResourceId,
   armResourceIdentifier,
   "csharp"
 );
 @@clientName(Replica, "WebPubSubReplica", "csharp");
-@@clientName(ReplicaProperties.regionEndpointEnabled,
+@@clientName(
+  ReplicaProperties.regionEndpointEnabled,
   "IsRegionEndpointEnabled",
   "csharp"
 );
-@@clientName(WebPubSubProperties.regionEndpointEnabled,
+@@clientName(
+  WebPubSubProperties.regionEndpointEnabled,
   "IsRegionEndpointEnabled",
   "csharp"
 );
-@@alternateType(WebPubSubResource.identity,
+@@alternateType(
+  WebPubSubResource.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
-@@alternateType(Azure.ResourceManager.LocationParameter.location,
+@@alternateType(
+  Azure.ResourceManager.LocationParameter.location,
   azureLocation,
   "csharp"
 );
-@@clientName(WebPubSubOperationGroup.checkNameAvailability,
+@@clientName(
+  WebPubSubOperationGroup.checkNameAvailability,
   "CheckWebPubSubNameAvailability",
   "csharp"
 );
 @@clientName(SharedPrivateLinkResource, "WebPubSubSharedPrivateLink", "csharp");
-@@clientName(SharedPrivateLinkResourceStatus,
+@@clientName(
+  SharedPrivateLinkResourceStatus,
   "WebPubSubSharedPrivateLinkStatus",
   "csharp"
 );
@@ -151,15 +175,18 @@ using Http;
 @@clientName(ResourceSku, "BillingInfoSku", "csharp");
 @@clientName(SkuCapacity, "WebPubSubSkuCapacity", "csharp");
 @@clientName(ScaleType, "WebPubSubScaleType", "csharp");
-@@clientName(ApplicationFirewallSettings,
+@@clientName(
+  ApplicationFirewallSettings,
   "WebPubSubApplicationFirewallSettings",
   "csharp"
 );
-@@clientName(ClientConnectionCountRule,
+@@clientName(
+  ClientConnectionCountRule,
   "WebPubSubClientConnectionCountRule",
   "csharp"
 );
-@@clientName(ClientTrafficControlRule,
+@@clientName(
+  ClientTrafficControlRule,
   "WebPubSubClientTrafficControlRule",
   "csharp"
 );
@@ -168,34 +195,41 @@ using Http;
 @@clientName(EventListenerEndpoint, "WebPubSubEventListenerEndpoint", "csharp");
 @@clientName(EventListenerFilter, "WebPubSubEventListenerFilter", "csharp");
 @@clientName(EventNameFilter, "WebPubSubEventNameFilter", "csharp");
-@@clientName(GroupPresenceEventFilters,
+@@clientName(
+  GroupPresenceEventFilters,
   "WebPubSubGroupPresenceEventFilters",
   "csharp"
 );
-@@clientName(GroupPresenceEventName,
+@@clientName(
+  GroupPresenceEventName,
   "WebPubSubGroupPresenceEventName",
   "csharp"
 );
 @@clientName(IPRule, "WebPubSubIPRule", "csharp");
 @@clientName(ServiceKind, "WebPubSubServiceKind", "csharp");
-@@clientName(ThrottleByJwtCustomClaimRule,
+@@clientName(
+  ThrottleByJwtCustomClaimRule,
   "WebPubSubThrottleByJwtCustomClaimRule",
   "csharp"
 );
-@@clientName(ThrottleByJwtSignatureRule,
+@@clientName(
+  ThrottleByJwtSignatureRule,
   "WebPubSubThrottleByJwtSignatureRule",
   "csharp"
 );
 @@clientName(ThrottleByUserIdRule, "WebPubSubThrottleByUserIdRule", "csharp");
-@@clientName(TrafficThrottleByJwtCustomClaimRule,
+@@clientName(
+  TrafficThrottleByJwtCustomClaimRule,
   "WebPubSubTrafficThrottleByJwtCustomClaimRule",
   "csharp"
 );
-@@clientName(TrafficThrottleByJwtSignatureRule,
+@@clientName(
+  TrafficThrottleByJwtSignatureRule,
   "WebPubSubTrafficThrottleByJwtSignatureRule",
   "csharp"
 );
-@@clientName(TrafficThrottleByUserIdRule,
+@@clientName(
+  TrafficThrottleByUserIdRule,
   "WebPubSubTrafficThrottleByUserIdRule",
   "csharp"
 );
@@ -205,7 +239,8 @@ using Http;
 @@alternateType(LiveTraceCategory.enabled, boolean, "csharp");
 @@clientName(LiveTraceConfiguration.enabled, "IsEnabled", "csharp");
 @@alternateType(LiveTraceConfiguration.enabled, boolean, "csharp");
-@@clientName(WebPubSubResources.list,
+@@clientName(
+  WebPubSubResources.list,
   "GetWebPubSubPrivateLinkResources",
   "csharp"
 );
@@ -214,12 +249,6 @@ using Http;
 @@markAsPageable(Replicas.listReplicaSkus, "csharp");
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Change the base type back to TrackedResource for backward compatibility"
 @@markAsPageable(WebPubSubResources.listSkus, "csharp");
-
-// =========================================================================
-// Go-only parameter reordering: preserve the original swagger order
-// (childName, resourceGroupName, resourceName, ...) instead of the
-// TypeSpec ARM default (resourceGroupName, resourceName, childName, ...).
-// =========================================================================
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
@@ -240,7 +269,8 @@ op WebPubSubHubsGetCustomized(
   resourceName: string,
 ): WebPubSubHub;
 
-@@override(WebPubSubHubs.get,
+@@override(
+  WebPubSubHubs.get,
   WebPubSubHubsGetCustomized,
   "go,python,javascript"
 );
@@ -267,7 +297,8 @@ op WebPubSubHubsCreateOrUpdateCustomized(
   parameters: WebPubSubHub,
 ): void;
 
-@@override(WebPubSubHubs.createOrUpdate,
+@@override(
+  WebPubSubHubs.createOrUpdate,
   WebPubSubHubsCreateOrUpdateCustomized,
   "go,python,javascript"
 );
@@ -291,7 +322,8 @@ op WebPubSubHubsDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(WebPubSubHubs.delete,
+@@override(
+  WebPubSubHubs.delete,
   WebPubSubHubsDeleteCustomized,
   "go,python,javascript"
 );
@@ -315,7 +347,8 @@ op PrivateEndpointConnectionsGetCustomized(
   resourceName: string,
 ): PrivateEndpointConnection;
 
-@@override(PrivateEndpointConnections.get,
+@@override(
+  PrivateEndpointConnections.get,
   PrivateEndpointConnectionsGetCustomized,
   "go,python,javascript"
 );
@@ -342,7 +375,8 @@ op PrivateEndpointConnectionsUpdateCustomized(
   parameters: PrivateEndpointConnection,
 ): PrivateEndpointConnection;
 
-@@override(PrivateEndpointConnections.update,
+@@override(
+  PrivateEndpointConnections.update,
   PrivateEndpointConnectionsUpdateCustomized,
   "go,python,javascript"
 );
@@ -366,7 +400,8 @@ op PrivateEndpointConnectionsDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(PrivateEndpointConnections.delete,
+@@override(
+  PrivateEndpointConnections.delete,
   PrivateEndpointConnectionsDeleteCustomized,
   "go,python,javascript"
 );
@@ -390,7 +425,8 @@ op WebPubSubSharedPrivateLinkResourcesGetCustomized(
   resourceName: string,
 ): SharedPrivateLinkResource;
 
-@@override(WebPubSubSharedPrivateLinkResources.get,
+@@override(
+  WebPubSubSharedPrivateLinkResources.get,
   WebPubSubSharedPrivateLinkResourcesGetCustomized,
   "go,python,javascript"
 );
@@ -417,7 +453,8 @@ op WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized(
   parameters: SharedPrivateLinkResource,
 ): void;
 
-@@override(WebPubSubSharedPrivateLinkResources.createOrUpdate,
+@@override(
+  WebPubSubSharedPrivateLinkResources.createOrUpdate,
   WebPubSubSharedPrivateLinkResourcesCreateOrUpdateCustomized,
   "go,python,javascript"
 );
@@ -441,7 +478,8 @@ op WebPubSubSharedPrivateLinkResourcesDeleteCustomized(
   resourceName: string,
 ): void;
 
-@@override(WebPubSubSharedPrivateLinkResources.delete,
+@@override(
+  WebPubSubSharedPrivateLinkResources.delete,
   WebPubSubSharedPrivateLinkResourcesDeleteCustomized,
   "go,python,javascript"
 );


### PR DESCRIPTION
Preserve the original swagger SDK parameter order for webpubsub interfaces, restoring backward compatibility for Go, Python, and JavaScript SDK users of webpubsub.

After conversion to TypeSpec, the emitters generated operations with parameters in the TypeSpec ARM default order `(resourceGroupName, resourceName, childName, ...)`, which differs from the original swagger SDK order `(childName, resourceGroupName, resourceName, ...)`.

This PR adds `@@override` customizations scoped to `go,python,javascript` (following the pattern in #43159) to revert the parameter order for:
- `WebPubSubHubs.get / createOrUpdate / delete`
- `PrivateEndpointConnections.get / update / delete`
- `WebPubSubSharedPrivateLinkResources.get / createOrUpdate / delete`

Related Go SDK PR: https://github.com/Azure/azure-sdk-for-go/pull/26320