### PR TITLE
Add python to clientName override for ChargeSummary.eTag to avoid SDK breaking

### DIFF
--- a/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/client.tsp
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/client.tsp
@@ -14,7 +14,7 @@ using Azure.Core;
 // Fix property name changes from lowercase to uppercase (etag -> eTag)
 @@clientName(LotSummary.eTag, "etag", "java");
 @@clientName(ModernChargeSummary.eTag, "etag", "java");
-@@clientName(ChargeSummary.eTag, "etag", "java");
+@@clientName(ChargeSummary.eTag, "etag", "java,python");
 @@clientName(LegacyChargeSummary.eTag, "etag", "java");
 @@clientName(EventSummary.eTag, "etag", "java");
 @@clientName(Budget.eTag, "etag", "java");


### PR DESCRIPTION
Adds `python` to the existing `@@clientName` override for `ChargeSummary.eTag` in the Consumption resource-manager TypeSpec, so the Python SDK also uses the lowercase `etag` property name (matching the existing Java override).