### PR TITLE
[servicebus] fix for Namespaces.update to be sync operation

### DIFF
--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/SBNamespace.tsp
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/SBNamespace.tsp
@@ -71,15 +71,14 @@ interface SBNamespaces {
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "Required to preserve wire compatibility with the legacy Service Bus ARM REST contract during OpenAPI-to-TypeSpec conversion; changing this shape would be a breaking change."
   #suppress "@azure-tools/typespec-azure-resource-manager/lro-location-header" "Required to preserve wire compatibility with the legacy Service Bus ARM REST contract during OpenAPI-to-TypeSpec conversion; changing this shape would be a breaking change."
-  @Azure.Core.useFinalStateVia("azure-async-operation")
   @patch(#{ implicitOptionality: false })
   update is ArmCustomPatchSync<
     SBNamespace,
     PatchModel = SBNamespaceUpdateParameters,
     Response =
       | ArmResponse<SBNamespace>
-      | ArmAcceptedLroResponse<LroHeaders = ArmCombinedLroHeaders<FinalResult = SBNamespace> &
-          Azure.Core.Foundations.RetryAfterHeader>,
+      | (CreatedResponse & SBNamespace)
+      | AcceptedResponse,
     Error = ErrorResponse
   >;
 

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2025-05-01-preview/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2025-05-01-preview/NameSpaces/SBNameSpaceUpdate.json
@@ -43,6 +43,36 @@
         }
       }
     },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-01-01/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/examples/2026-01-01/NameSpaces/SBNameSpaceUpdate.json
@@ -43,6 +43,36 @@
         }
       }
     },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/examples/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/examples/NameSpaces/SBNameSpaceUpdate.json
@@ -43,6 +43,36 @@
         }
       }
     },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/preview/2025-05-01-preview/servicebus.json
@@ -418,24 +418,14 @@
               "$ref": "#/definitions/SBNamespace"
             }
           },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
             }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
           },
           "default": {
             "description": "An unexpected error response.",
@@ -448,12 +438,7 @@
           "NameSpaceUpdate": {
             "$ref": "./examples/NameSpaces/SBNameSpaceUpdate.json"
           }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/SBNamespace"
-        },
-        "x-ms-long-running-operation": true
+        }
       },
       "delete": {
         "operationId": "Namespaces_Delete",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/examples/NameSpaces/SBNameSpaceUpdate.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/examples/NameSpaces/SBNameSpaceUpdate.json
@@ -43,6 +43,36 @@
         }
       }
     },
+    "201": {
+      "body": {
+        "name": "sdk-Namespace-3285",
+        "type": "Microsoft.ServiceBus/Namespaces",
+        "id": "/subscriptions/5f750a97-50d9-4e36-8081-c9ee4c0210d4/resourceGroups/ArunMonocle/providers/Microsoft.ServiceBus/namespaces/sdk-Namespace-3285",
+        "location": "South Central US",
+        "properties": {
+          "createdAt": "2017-05-25T23:07:58.17Z",
+          "disableLocalAuth": false,
+          "metricId": "5f750a97-50d9-4e36-8081-c9ee4c0210d4:sdk-namespace-3285",
+          "minimumTlsVersion": "1.1",
+          "platformCapabilities": {
+            "confidentialCompute": {
+              "mode": "Disabled"
+            }
+          },
+          "provisioningState": "Updating",
+          "serviceBusEndpoint": "https://sdk-Namespace-3285.servicebus.windows-int.net:443/",
+          "updatedAt": "2017-05-25T23:08:45.497Z"
+        },
+        "sku": {
+          "name": "Standard",
+          "tier": "Standard"
+        },
+        "tags": {
+          "tag3": "value3",
+          "tag4": "value4"
+        }
+      }
+    },
     "202": {
       "headers": {
         "azure-asyncoperation": "http://azure.async.operation/status",

--- a/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/servicebus.json
+++ b/specification/servicebus/resource-manager/Microsoft.ServiceBus/ServiceBus/stable/2026-01-01/servicebus.json
@@ -418,24 +418,14 @@
               "$ref": "#/definitions/SBNamespace"
             }
           },
-          "202": {
-            "description": "Resource operation accepted.",
-            "headers": {
-              "Azure-AsyncOperation": {
-                "type": "string",
-                "format": "uri",
-                "description": "A link to the status monitor"
-              },
-              "Location": {
-                "type": "string",
-                "description": "The Location header contains the URL where the status of the long running operation can be checked."
-              },
-              "Retry-After": {
-                "type": "integer",
-                "format": "int32",
-                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
-              }
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/SBNamespace"
             }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed."
           },
           "default": {
             "description": "An unexpected error response.",
@@ -448,12 +438,7 @@
           "NameSpaceUpdate": {
             "$ref": "./examples/NameSpaces/SBNameSpaceUpdate.json"
           }
-        },
-        "x-ms-long-running-operation-options": {
-          "final-state-via": "azure-async-operation",
-          "final-state-schema": "#/definitions/SBNamespace"
-        },
-        "x-ms-long-running-operation": true
+        }
       },
       "delete": {
         "operationId": "Namespaces_Delete",


### PR DESCRIPTION
Mirrors the fix from #43376 (Event Hubs) for Service Bus: the `Namespaces.update` operation is changed to a sync operation, returning `200`, `201`, or `202` instead of an LRO.

Changes:
- `SBNamespace.tsp`: updated `update` operation signature to use `ArmCustomPatchSync` with `ArmResponse<SBNamespace> | (CreatedResponse & SBNamespace) | AcceptedResponse` (already applied by author).
- Added `201` response body to `SBNameSpaceUpdate.json` examples for both api versions:
  - `examples/2026-01-01/NameSpaces/SBNameSpaceUpdate.json`
  - `examples/2025-05-01-preview/NameSpaces/SBNameSpaceUpdate.json`
- Regenerated swagger and swagger-side example files via `tsp compile`.