### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-msi

### DIFF
--- a/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/client.tsp
+++ b/specification/msi/resource-manager/Microsoft.ManagedIdentity/ManagedIdentity/client.tsp
@@ -6,7 +6,7 @@ using Microsoft.ManagedIdentity;
 @@clientName(
   Microsoft.ManagedIdentity,
   "ManagedServiceIdentityClient",
-  "javascript, java"
+  "javascript, java, python"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: added in TypeSpec migration, follow aka.ms/tsp/conversion-fix for details"


### PR DESCRIPTION
Mitigate Python SDK breaking changes for `azure-mgmt-msi` introduced by the TypeSpec migration.

- Added `python` to the `@@clientName` scope for `Microsoft.ManagedIdentity` so the Python SDK keeps the `ManagedServiceIdentityClient` class name.
