### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-databoxedge

### DIFF
--- a/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/client.tsp
+++ b/specification/databoxedge/resource-manager/Microsoft.DataBoxEdge/DataBoxEdge/client.tsp
@@ -2013,6 +2013,9 @@ op DataBoxEdgeDevicesGetExtendedInformationCustomized(
 @@clientName(ShareAccessProtocol.NFS, "Nfs", "csharp");
 @@clientName(RoleTypes.IOT, "IoT", "csharp");
 @@clientName(RoleTypes.ASA, "Asa", "csharp");
+
+@@clientName(MetricDimension_V1, "MetricDimensionV1", "python");
+@@clientName(MetricSpecification_V1, "MetricSpecificationV1", "python");
 @@clientName(RoleTypes.MEC, "Mec", "csharp");
 @@clientName(NetworkGroup.NonRDMA, "NonRdma", "csharp");
 @@clientName(NetworkGroup.RDMA, "Rdma", "csharp");


### PR DESCRIPTION
Mitigate Python SDK breaking changes introduced by TypeSpec migration for `azure-mgmt-databoxedge`.

- `@@clientName(MetricDimension_V1, "MetricDimensionV1", "python")` — restore prior model name.
- `@@clientName(MetricSpecification_V1, "MetricSpecificationV1", "python")` — restore prior model name.
