### PR TITLE
[Storage] Remove fixed 2025-08-01 api-version overrides from SDK emitters

### DIFF
--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -18,7 +18,6 @@ options:
     generate-test: true
     generate-sample: true
     flavor: "azure"
-    api-version: "2025-08-01"
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-storage"
     namespace: "com.azure.resourcemanager.storage"
@@ -35,7 +34,6 @@ options:
     rename-model:
       FailoverRequestFailoverType: FailoverType
       ListKeysRequestExpand: ListKeyExpand
-    api-version: "2025-08-01"
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-storage"
     service-dir: sdk/storage
@@ -44,7 +42,6 @@ options:
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-storage"
-    api-version: "2025-08-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storage"
     emitter-output-dir: "{output-dir}/{service-dir}/armstorage"
@@ -55,12 +52,10 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
-    api-version: "2025-08-01"
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Storage"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
-    api-version: 2025-08-01
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.


## Summary
- remove api-version: "2025-08-01" overrides from all SDK emitter blocks in specification/storage/Storage.Management/tspconfig.yaml
- allow SDK emitters to follow the active API version configuration instead of a pinned 2025-08-01 override

## Why
This unblocks creating a release plan for Microsoft.Storage RP targeting API version 2026-04-01.

## Validation
- searched specification/storage/Storage.Management/tspconfig.yaml and confirmed no api-version entries remain
