### PR TITLE
CostManagement: add python to clientName overrides for PivotType and KpiType

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -7,10 +7,10 @@ using Azure.Core;
 using Microsoft.CostManagement;
 
 // Rename PivotTypeType back to PivotType for Java
-@@clientName(PivotTypeType, "PivotType", "java,javascript");
+@@clientName(PivotTypeType, "PivotType", "java,javascript,python");
 
 // Rename KpiTypeType back to KpiType for Java
-@@clientName(KpiTypeType, "KpiType", "java,javascript");
+@@clientName(KpiTypeType, "KpiType", "java,javascript,python");
 
 // Rename DownloadURL back to DownloadUrl for Java
 @@clientName(DownloadURL, "DownloadUrl", "java");


### PR DESCRIPTION
Extend the existing `@@clientName` overrides for `PivotTypeType` → `PivotType` and `KpiTypeType` → `KpiType` to also apply to the `python` emitter, matching the existing `java` and `javascript` behavior.

### Change
```diff
-@@clientName(PivotTypeType, "PivotType", "java,javascript");
+@@clientName(PivotTypeType, "PivotType", "java,javascript,python");

-@@clientName(KpiTypeType, "KpiType", "java,javascript");
+@@clientName(KpiTypeType, "KpiType", "java,javascript,python");
```

Only affects the `client.tsp` customization for the Python SDK; no public REST API surface changes.