### PR TITLE
Customize Kubernetes C# management SDK API

### DIFF
--- a/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
@@ -41,18 +41,34 @@ namespace Microsoft.Kubernetes;
   "ConnectedClusterArcAgentryConfiguration",
   "csharp"
 );
-@@clientName(AuthenticationMethod, "ClusterUserCredentialAuthenticationMethod", "csharp");
+@@clientName(
+  AuthenticationMethod,
+  "ClusterUserCredentialAuthenticationMethod",
+  "csharp"
+);
 @@clientName(AuthenticationMethod.AAD, "Aad", "csharp");
 @@clientName(AutoUpgradeOptions, "ConnectedClusterAutoUpgradeMode", "csharp");
-@@clientName(AzureHybridBenefit, "ConnectedClusterAzureHybridBenefit", "csharp");
-@@clientName(ConnectivityStatus, "ConnectedClusterConnectivityStatus", "csharp");
+@@clientName(
+  AzureHybridBenefit,
+  "ConnectedClusterAzureHybridBenefit",
+  "csharp"
+);
+@@clientName(
+  ConnectivityStatus,
+  "ConnectedClusterConnectivityStatus",
+  "csharp"
+);
 @@clientName(ConnectedClusterKind.AWS, "Aws", "csharp");
 @@clientName(ConnectedClusterKind.GCP, "Gcp", "csharp");
 @@clientName(ConnectedClusterProperties.gateway, "IsGateway", "csharp");
 @@clientName(ConnectedClusterPatchProperties.gateway, "IsGateway", "csharp");
 @@clientName(CredentialResult, "ClusterUserCredentialResult", "csharp");
 @@clientName(CredentialResults, "ClusterUserCredentialsResult", "csharp");
-@@clientName(HybridConnectionConfig, "ClusterUserCredentialHybridConnectionConfig", "csharp");
+@@clientName(
+  HybridConnectionConfig,
+  "ClusterUserCredentialHybridConnectionConfig",
+  "csharp"
+);
 @@clientName(OidcIssuerProfile, "ConnectedClusterOidcIssuerProfile", "csharp");
 @@clientName(PrivateLinkState, "ConnectedClusterPrivateLinkState", "csharp");
 @@clientName(ProvisioningState, "ConnectedClusterProvisioningState", "csharp");

--- a/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
@@ -29,16 +29,41 @@ namespace Microsoft.Kubernetes;
   armResourceIdentifier,
   "csharp"
 );
+@@clientName(AadProfile, "ConnectedClusterAadProfile", "csharp");
 @@clientName(AadProfile.enableAzureRBAC, "EnableAzureRbac", "csharp");
 @@clientName(AadProfile.adminGroupObjectIDs, "AdminGroupObjectIds", "csharp");
 @@clientName(AadProfile.tenantID, "TenantId", "csharp");
+@@clientName(AgentError, "ConnectedClusterAgentError", "csharp");
 @@clientName(AgentError.time, "OccurredOn", "csharp");
+@@clientName(ArcAgentProfile, "ConnectedClusterArcAgentProfile", "csharp");
+@@clientName(
+  ArcAgentryConfigurations,
+  "ConnectedClusterArcAgentryConfiguration",
+  "csharp"
+);
+@@clientName(AuthenticationMethod, "ClusterUserCredentialAuthenticationMethod", "csharp");
 @@clientName(AuthenticationMethod.AAD, "Aad", "csharp");
+@@clientName(AutoUpgradeOptions, "ConnectedClusterAutoUpgradeMode", "csharp");
+@@clientName(AzureHybridBenefit, "ConnectedClusterAzureHybridBenefit", "csharp");
+@@clientName(ConnectivityStatus, "ConnectedClusterConnectivityStatus", "csharp");
 @@clientName(ConnectedClusterKind.AWS, "Aws", "csharp");
 @@clientName(ConnectedClusterKind.GCP, "Gcp", "csharp");
 @@clientName(ConnectedClusterProperties.gateway, "IsGateway", "csharp");
 @@clientName(ConnectedClusterPatchProperties.gateway, "IsGateway", "csharp");
+@@clientName(CredentialResult, "ClusterUserCredentialResult", "csharp");
+@@clientName(CredentialResults, "ClusterUserCredentialsResult", "csharp");
+@@clientName(HybridConnectionConfig, "ClusterUserCredentialHybridConnectionConfig", "csharp");
+@@clientName(OidcIssuerProfile, "ConnectedClusterOidcIssuerProfile", "csharp");
+@@clientName(PrivateLinkState, "ConnectedClusterPrivateLinkState", "csharp");
+@@clientName(ProvisioningState, "ConnectedClusterProvisioningState", "csharp");
+@@clientName(SecurityProfile, "ConnectedClusterSecurityProfile", "csharp");
 @@clientName(SecurityProfile.workloadIdentity, "IsWorkloadIdentity", "csharp");
+@@clientName(
+  SecurityProfileWorkloadIdentity,
+  "ConnectedClusterWorkloadIdentityProfile",
+  "csharp"
+);
+@@clientName(SystemComponent, "ConnectedClusterSystemComponent", "csharp");
 @@clientName(
   ListClusterUserCredentialProperties.clientProxy,
   "UseClientProxy",

--- a/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
@@ -24,5 +24,30 @@ namespace Microsoft.Kubernetes;
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
+@@alternateType(
+  ConnectedClusterProperties.privateLinkScopeResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+@@clientName(AadProfile.enableAzureRBAC, "EnableAzureRbac", "csharp");
+@@clientName(AadProfile.adminGroupObjectIDs, "AdminGroupObjectIds", "csharp");
+@@clientName(AadProfile.tenantID, "TenantId", "csharp");
+@@clientName(AgentError.time, "OccurredOn", "csharp");
+@@clientName(AuthenticationMethod.AAD, "Aad", "csharp");
+@@clientName(ConnectedClusterKind.AWS, "Aws", "csharp");
+@@clientName(ConnectedClusterKind.GCP, "Gcp", "csharp");
+@@clientName(ConnectedClusterProperties.gateway, "IsGateway", "csharp");
+@@clientName(ConnectedClusterPatchProperties.gateway, "IsGateway", "csharp");
+@@clientName(SecurityProfile.workloadIdentity, "IsWorkloadIdentity", "csharp");
+@@clientName(
+  ListClusterUserCredentialProperties.clientProxy,
+  "UseClientProxy",
+  "csharp"
+);
+@@clientName(
+  HybridConnectionConfig.expirationTime,
+  "ExpirationTimeInSeconds",
+  "csharp"
+);
 @@clientName(Microsoft.Kubernetes, "ConnectedKubernetesClient", "javascript");
 @@clientName(Microsoft.Kubernetes, "ConnectedKubernetesClient", "python");

--- a/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
@@ -65,6 +65,16 @@ namespace Microsoft.Kubernetes;
 );
 @@clientName(SystemComponent, "ConnectedClusterSystemComponent", "csharp");
 @@clientName(
+  ListClusterUserCredentialProperties,
+  "GetClusterUserCredentialContent",
+  "csharp"
+);
+@@clientName(
+  ConnectedClusters.listClusterUserCredential::parameters.body,
+  "content",
+  "csharp"
+);
+@@clientName(
   ListClusterUserCredentialProperties.clientProxy,
   "UseClientProxy",
   "csharp"

--- a/specification/hybridkubernetes/HybridKubernetes.Management/tspconfig.yaml
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/tspconfig.yaml
@@ -14,6 +14,7 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     package-name: "Azure.ResourceManager.Kubernetes"
     namespace: "{package-name}"
+    api-version: "2025-12-01-preview"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-hybridkubernetes"
     namespace: "azure.mgmt.hybridkubernetes"


### PR DESCRIPTION
Applies C# management SDK API review customizations for `Azure.ResourceManager.Kubernetes` only.

Changes:
- Pins the C# management emitter to `2025-12-01-preview`, matching the current management SDK API version.
- Adds C# `@@clientName` customizations for contextual `ConnectedCluster*` and `ClusterUserCredential*` model/enum names.
- Renames the cluster credential action payload to `GetClusterUserCredentialContent` and its operation parameter to `content`.
- Adds C# `@@clientName` customizations for acronym casing and boolean/timestamp property names.
- Adds a C# `@@alternateType` customization so `privateLinkScopeResourceId` emits as `ResourceIdentifier`.

Companion SDK PR: Azure/azure-sdk-for-net#59432