### PR TITLE
Align Foundry Routines TypeSpec contracts

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -23599,7 +23599,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The raw input sent to the downstream invocations target."
+            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -23638,7 +23638,7 @@
             "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
           "input": {
-            "description": "Static action input sent to the downstream target when the routine fires."
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "session_id": {
             "type": "string",
@@ -23673,7 +23673,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The user input sent to the downstream responses target."
+            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -23712,7 +23712,7 @@
             "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
           "input": {
-            "description": "Static action input sent to the downstream target when the routine fires."
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "conversation": {
             "type": "string",
@@ -46725,7 +46725,8 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt."
+            "description": "The MLflow run identifier for the routine attempt.",
+            "readOnly": true
           },
           "status": {
             "type": "string",
@@ -46747,7 +46748,7 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
-          "triggerName": {
+          "trigger_name": {
             "type": "string",
             "description": "The configured trigger name that produced the routine attempt."
           },
@@ -46767,19 +46768,19 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
-          "agentId": {
+          "agent_id": {
             "type": "string",
             "description": "The project-scoped agent identifier recorded for the routine attempt."
           },
-          "agentEndpointId": {
+          "agent_endpoint_id": {
             "type": "string",
             "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
           },
-          "conversationId": {
+          "conversation_id": {
             "type": "string",
             "description": "The conversation identifier used by a responses API dispatch."
           },
-          "sessionId": {
+          "session_id": {
             "type": "string",
             "description": "The hosted-agent session identifier used by an invocations API dispatch."
           },
@@ -46791,7 +46792,7 @@
             ],
             "description": "The logical trigger time recorded for the routine attempt."
           },
-          "scheduledFireAt": {
+          "scheduled_fire_at": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -46799,7 +46800,7 @@
             ],
             "description": "The scheduled fire time recorded for timer and schedule deliveries."
           },
-          "triggerTimeZone": {
+          "trigger_time_zone": {
             "type": "string",
             "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
@@ -48403,11 +48404,11 @@
           },
           "in": {
             "type": "string",
-            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time."
           },
           "at": {
             "type": "string",
-            "description": "Legacy timer expression alias accepted for backward compatibility. New callers should use `in`."
+            "description": "An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12254,7 +12254,16 @@
             }
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters"
+            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.after"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.before"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.order"
           },
           {
             "name": "api-version",
@@ -12273,7 +12282,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutinesListResponse"
+                  "$ref": "#/components/schemas/RoutineListResponse"
                 }
               }
             }
@@ -12511,13 +12520,16 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.orderBy"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.maxResults"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.pageToken"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
           },
           {
             "name": "api-version",
@@ -14782,6 +14794,26 @@
           "maxLength": 128
         }
       },
+      "ListRoutineRunsParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
@@ -14792,8 +14824,8 @@
         },
         "explode": false
       },
-      "ListRoutineRunsParameters.maxResults": {
-        "name": "maxResults",
+      "ListRoutineRunsParameters.limit": {
+        "name": "limit",
         "in": "query",
         "required": false,
         "description": "The maximum number of runs to return.",
@@ -14803,24 +14835,11 @@
         },
         "explode": false
       },
-      "ListRoutineRunsParameters.orderBy": {
-        "name": "orderBy",
+      "ListRoutineRunsParameters.order": {
+        "name": "order",
         "in": "query",
         "required": false,
-        "description": "Ordering expressions applied by the run-history backend.",
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.pageToken": {
-        "name": "pageToken",
-        "in": "query",
-        "required": false,
-        "description": "A page token returned by the previous list-runs response.",
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -14836,11 +14855,42 @@
           "maxLength": 128
         }
       },
-      "ListRoutinesParameters": {
-        "name": "continuationToken",
+      "ListRoutinesParameters.after": {
+        "name": "after",
         "in": "query",
         "required": false,
-        "description": "A continuation token returned by the previous list response.",
+        "description": "An opaque cursor returned as last_id by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of routines to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -46507,7 +46557,6 @@
       "Routine": {
         "type": "object",
         "required": [
-          "name",
           "enabled"
         ],
         "properties": {
@@ -46720,6 +46769,40 @@
           ]
         }
       },
+      "RoutineListResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first routine in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routines are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineRun": {
         "type": "object",
         "properties": {
@@ -46882,19 +46965,28 @@
       "RoutineRunsResponse": {
         "type": "object",
         "required": [
-          "value"
+          "data",
+          "has_more"
         ],
         "properties": {
-          "value": {
+          "data": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RoutineRun"
             },
             "description": "The requested list of routine runs."
           },
-          "nextPageToken": {
+          "first_id": {
             "type": "string",
-            "description": "A page token to pass as pageToken on the next list-runs request, when more runs are available."
+            "description": "The identifier of the first run in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routine runs are available after this page."
           }
         },
         "description": "The paginated response returned when listing routine runs.",
@@ -46951,35 +47043,6 @@
           }
         ],
         "description": "The discriminator values supported for routine triggers.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutinesListResponse": {
-        "type": "object",
-        "required": [
-          "value"
-        ],
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Routine"
-            },
-            "description": "The requested list of routines."
-          },
-          "continuationToken": {
-            "type": "string",
-            "description": "A continuation token to pass on the next list request, when more routines are available."
-          },
-          "nextLink": {
-            "type": "string",
-            "description": "A service-generated link to the next page, when available."
-          }
-        },
-        "description": "The paginated response returned when listing routines.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -48404,11 +48467,7 @@
           },
           "in": {
             "type": "string",
-            "description": "A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time."
-          },
-          "at": {
-            "type": "string",
-            "description": "An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -46805,6 +46805,9 @@
       },
       "RoutineRun": {
         "type": "object",
+        "required": [
+          "id"
+        ],
         "properties": {
           "id": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12254,46 +12254,7 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters"
           },
           {
             "name": "api-version",
@@ -12312,33 +12273,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Routine"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutinesListResponse"
                 }
               }
             }
@@ -12576,46 +12511,13 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.orderBy"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.maxResults"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.pageToken"
           },
           {
             "name": "api-version",
@@ -12634,33 +12536,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoutineRun"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
                 }
               }
             }
@@ -14916,6 +14792,40 @@
         },
         "explode": false
       },
+      "ListRoutineRunsParameters.maxResults": {
+        "name": "maxResults",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of runs to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.orderBy": {
+        "name": "orderBy",
+        "in": "query",
+        "required": false,
+        "description": "Ordering expressions applied by the run-history backend.",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.pageToken": {
+        "name": "pageToken",
+        "in": "query",
+        "required": false,
+        "description": "A page token returned by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.routine_name": {
         "name": "routine_name",
         "in": "path",
@@ -14925,6 +14835,16 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "ListRoutinesParameters": {
+        "name": "continuationToken",
+        "in": "query",
+        "required": false,
+        "description": "A continuation token returned by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -19440,6 +19360,49 @@
         ],
         "description": "Custom credential definition"
       },
+      "CustomRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type",
+          "provider",
+          "parameters"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom"
+            ],
+            "description": "The trigger type."
+          },
+          "provider": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The external provider that emits the custom event."
+          },
+          "event_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The provider-specific event name that fires the routine."
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Provider-specific trigger parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "A custom event routine trigger.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "DailyRecurrenceSchedule": {
         "type": "object",
         "required": [
@@ -22910,19 +22873,40 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueOpenedRoutineTrigger": {
+      "GitHubIssueEvent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "opened",
+              "closed"
+            ]
+          }
+        ],
+        "description": "Known GitHub issue events that can fire a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "GitHubIssueRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "assignee",
-          "repository"
+          "owner",
+          "repository",
+          "issue_event"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue_opened"
+              "github_issue"
             ],
             "description": "The trigger type."
           },
@@ -22931,15 +22915,23 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "assignee": {
+          "owner": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
+            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
+          },
+          "issue_event": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHubIssueEvent"
+              }
+            ],
+            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -22947,7 +22939,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue-opened routine trigger.",
+        "description": "A GitHub issue routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -23595,7 +23587,8 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -23606,8 +23599,6 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
             "description": "The raw input sent to the downstream invocations target."
           }
         },
@@ -23626,8 +23617,7 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type",
-          "agent_endpoint_id"
+          "type"
         ],
         "properties": {
           "type": {
@@ -23637,10 +23627,18 @@
             ],
             "description": "The action type."
           },
+          "agent_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The project-scoped agent name for routine dispatch."
+          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+          },
+          "input": {
+            "description": "Static action input sent to the downstream target when the routine fires."
           },
           "session_id": {
             "type": "string",
@@ -23653,7 +23651,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API.",
+        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -23663,7 +23661,8 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -23674,8 +23673,6 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
             "description": "The user input sent to the downstream responses target."
           }
         },
@@ -23707,14 +23704,17 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for responses API dispatch."
+            "description": "The project-scoped agent name for routine dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for responses API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
-          "conversation_id": {
+          "input": {
+            "description": "Static action input sent to the downstream target when the routine fires."
+          },
+          "conversation": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -46508,9 +46508,7 @@
         "type": "object",
         "required": [
           "name",
-          "enabled",
-          "triggers",
-          "action"
+          "enabled"
         ],
         "properties": {
           "name": {
@@ -46640,10 +46638,6 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
-        "required": [
-          "triggers",
-          "action"
-        ],
         "properties": {
           "description": {
             "type": "string",
@@ -46728,12 +46722,6 @@
       },
       "RoutineRun": {
         "type": "object",
-        "required": [
-          "id",
-          "status",
-          "trigger_type",
-          "started_at"
-        ],
         "properties": {
           "id": {
             "type": "string",
@@ -46759,6 +46747,10 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
+          "triggerName": {
+            "type": "string",
+            "description": "The configured trigger name that produced the routine attempt."
+          },
           "attempt_source": {
             "allOf": [
               {
@@ -46775,6 +46767,22 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
+          "agentId": {
+            "type": "string",
+            "description": "The project-scoped agent identifier recorded for the routine attempt."
+          },
+          "agentEndpointId": {
+            "type": "string",
+            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
+          },
+          "conversationId": {
+            "type": "string",
+            "description": "The conversation identifier used by a responses API dispatch."
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "The hosted-agent session identifier used by an invocations API dispatch."
+          },
           "triggered_at": {
             "allOf": [
               {
@@ -46782,6 +46790,18 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
+          },
+          "scheduledFireAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The scheduled fire time recorded for timer and schedule deliveries."
+          },
+          "triggerTimeZone": {
+            "type": "string",
+            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -46815,6 +46835,11 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
+          "error_status_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The downstream error status code captured for a failed attempt, when available."
+          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -46822,55 +46847,9 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
-          },
-          "diagnostics": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunDiagnostics"
-              }
-            ],
-            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunDiagnostics": {
-        "type": "object",
-        "required": [
-          "parameters",
-          "tags",
-          "metrics"
-        ],
-        "properties": {
-          "parameters": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow parameters recorded on the run, keyed by parameter name."
-          },
-          "tags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow tags recorded on the run, keyed by tag name."
-          },
-          "metrics": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "number",
-              "format": "double"
-            },
-            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
-          }
-        },
-        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -46899,6 +46878,31 @@
           ]
         }
       },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRun"
+            },
+            "description": "The requested list of routine runs."
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "A page token to pass as pageToken on the next list-runs request, when more runs are available."
+          }
+        },
+        "description": "The paginated response returned when listing routine runs.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -46919,7 +46923,8 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
+            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
+            "custom": "#/components/schemas/CustomRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -46937,13 +46942,43 @@
           {
             "type": "string",
             "enum": [
-              "github_issue_opened",
+              "custom",
+              "github_issue",
               "schedule",
               "timer"
             ]
           }
         ],
         "description": "The discriminator values supported for routine triggers.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "RoutinesListResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "A continuation token to pass on the next list request, when more routines are available."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "A service-generated link to the next page, when available."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -48356,8 +48391,7 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type",
-          "at"
+          "type"
         ],
         "properties": {
           "type": {
@@ -48367,9 +48401,13 @@
             ],
             "description": "The trigger type."
           },
-          "at": {
+          "in": {
             "type": "string",
             "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+          },
+          "at": {
+            "type": "string",
+            "description": "Legacy timer expression alias accepted for backward compatibility. New callers should use `in`."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12282,7 +12282,33 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutineListResponse"
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Routine"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
                 }
               }
             }
@@ -12548,7 +12574,33 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutineRunsResponse"
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RoutineRun"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
                 }
               }
             }
@@ -46769,40 +46821,6 @@
           ]
         }
       },
-      "RoutineListResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "has_more"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Routine"
-            },
-            "description": "The requested list of routines."
-          },
-          "first_id": {
-            "type": "string",
-            "description": "The identifier of the first routine in this page, or null when the page is empty."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "True when more routines are available after this page."
-          }
-        },
-        "description": "The paginated response returned when listing routines.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
       "RoutineRun": {
         "type": "object",
         "required": [
@@ -46811,12 +46829,12 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt.",
+            "description": "The unique run identifier for the routine attempt.",
             "readOnly": true
           },
           "status": {
             "type": "string",
-            "description": "The underlying MLflow run status."
+            "description": "The run status."
           },
           "phase": {
             "allOf": [
@@ -46885,10 +46903,6 @@
               }
             ],
             "description": "The scheduled fire time recorded for timer and schedule deliveries."
-          },
-          "trigger_time_zone": {
-            "type": "string",
-            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -46959,40 +46973,6 @@
           }
         ],
         "description": "Known lifecycle phases recorded for a routine run.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunsResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "has_more"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RoutineRun"
-            },
-            "description": "The requested list of routine runs."
-          },
-          "first_id": {
-            "type": "string",
-            "description": "The identifier of the first run in this page, or null when the page is empty."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "True when more routine runs are available after this page."
-          }
-        },
-        "description": "The paginated response returned when listing routine runs.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -48468,13 +48448,10 @@
             ],
             "description": "The trigger type."
           },
-          "in": {
+          "at": {
             "type": "string",
-            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
-          },
-          "time_zone": {
-            "type": "string",
-            "description": "An optional IANA or Windows time zone identifier when the timer uses a local timestamp."
+            "format": "date-time",
+            "description": "The UTC date and time at which the timer fires."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -33092,6 +33092,8 @@ components:
           - Routines=V1Preview
     RoutineRun:
       type: object
+      required:
+        - id
       properties:
         id:
           type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -8130,46 +8130,7 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutinesParameters'
         - name: api-version
           in: query
           required: true
@@ -8183,26 +8144,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Routine'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutinesListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -8346,46 +8288,9 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.orderBy'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.maxResults'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.pageToken'
         - name: api-version
           in: query
           required: true
@@ -8399,26 +8304,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/RoutineRun'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineRunsResponse'
         default:
           description: An unexpected error response.
           content:
@@ -9923,6 +9809,33 @@ components:
       schema:
         type: string
       explode: false
+    ListRoutineRunsParameters.maxResults:
+      name: maxResults
+      in: query
+      required: false
+      description: The maximum number of runs to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutineRunsParameters.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: Ordering expressions applied by the run-history backend.
+      schema:
+        type: array
+        items:
+          type: string
+      explode: false
+    ListRoutineRunsParameters.pageToken:
+      name: pageToken
+      in: query
+      required: false
+      description: A page token returned by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.routine_name:
       name: routine_name
       in: path
@@ -9931,6 +9844,14 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutinesParameters:
+      name: continuationToken
+      in: query
+      required: false
+      description: A continuation token returned by the previous list response.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -12987,6 +12908,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
+    CustomRoutineTrigger:
+      type: object
+      required:
+        - type
+        - provider
+        - parameters
+      properties:
+        type:
+          type: string
+          enum:
+            - custom
+          description: The trigger type.
+        provider:
+          type: string
+          maxLength: 128
+          description: The external provider that emits the custom event.
+        event_name:
+          type: string
+          maxLength: 256
+          description: The provider-specific event name that fires the routine.
+        parameters:
+          type: object
+          additionalProperties: {}
+          description: Provider-specific trigger parameters.
+      allOf:
+        - $ref: '#/components/schemas/RoutineTrigger'
+      description: A custom event routine trigger.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -15562,34 +15513,50 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueOpenedRoutineTrigger:
+    GitHubIssueEvent:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - opened
+            - closed
+      description: Known GitHub issue events that can fire a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    GitHubIssueRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - assignee
+        - owner
         - repository
+        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue_opened
+            - github_issue
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        assignee:
+        owner:
           type: string
           maxLength: 128
-          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
+          description: The GitHub owner or organization that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
+        issue_event:
+          allOf:
+            - $ref: '#/components/schemas/GitHubIssueEvent'
+          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue-opened routine trigger.
+      description: A GitHub issue routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -16018,6 +15985,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -16025,8 +15993,6 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
           description: The raw input sent to the downstream invocations target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
@@ -16038,24 +16004,29 @@ components:
       type: object
       required:
         - type
-        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
+        agent_name:
+          type: string
+          maxLength: 256
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for invocations API dispatch.
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static action input sent to the downstream target when the routine fires.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API.
+      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -16063,6 +16034,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -16070,8 +16042,6 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
           description: The user input sent to the downstream responses target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
@@ -16092,12 +16062,14 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for responses API dispatch.
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for responses API dispatch.
-        conversation_id:
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static action input sent to the downstream target when the routine fires.
+        conversation:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -32932,8 +32904,6 @@ components:
       required:
         - name
         - enabled
-        - triggers
-        - action
       properties:
         name:
           type: string
@@ -33012,9 +32982,6 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
-      required:
-        - triggers
-        - action
       properties:
         description:
           type: string
@@ -33067,11 +33034,6 @@ components:
           - Routines=V1Preview
     RoutineRun:
       type: object
-      required:
-        - id
-        - status
-        - trigger_type
-        - started_at
       properties:
         id:
           type: string
@@ -33087,6 +33049,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
+        triggerName:
+          type: string
+          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -33095,10 +33060,29 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
+        agentId:
+          type: string
+          description: The project-scoped agent identifier recorded for the routine attempt.
+        agentEndpointId:
+          type: string
+          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
+        conversationId:
+          type: string
+          description: The conversation identifier used by a responses API dispatch.
+        sessionId:
+          type: string
+          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
+        scheduledFireAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The scheduled fire time recorded for timer and schedule deliveries.
+        triggerTimeZone:
+          type: string
+          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -33119,44 +33103,17 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
+        error_status_code:
+          type: integer
+          format: int32
+          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
-        diagnostics:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunDiagnostics'
-          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunDiagnostics:
-      type: object
-      required:
-        - parameters
-        - tags
-        - metrics
-      properties:
-        parameters:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow parameters recorded on the run, keyed by parameter name.
-        tags:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow tags recorded on the run, keyed by tag name.
-        metrics:
-          type: object
-          additionalProperties:
-            type: number
-            format: double
-          description: Latest MLflow metric values recorded on the run, keyed by metric name.
-      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -33170,6 +33127,23 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunsResponse:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoutineRun'
+          description: The requested list of routine runs.
+        nextPageToken:
+          type: string
+          description: A page token to pass as pageToken on the next list-runs request, when more runs are available.
+      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -33187,7 +33161,8 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
+          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
+          custom: '#/components/schemas/CustomRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -33197,10 +33172,31 @@ components:
         - type: string
         - type: string
           enum:
-            - github_issue_opened
+            - custom
+            - github_issue
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutinesListResponse:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        continuationToken:
+          type: string
+          description: A continuation token to pass on the next list request, when more routines are available.
+        nextLink:
+          type: string
+          description: A service-generated link to the next page, when available.
+      description: The paginated response returned when listing routines.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -34164,16 +34160,18 @@ components:
       type: object
       required:
         - type
-        - at
       properties:
         type:
           type: string
           enum:
             - timer
           description: The trigger type.
-        at:
+        in:
           type: string
           description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+        at:
+          type: string
+          description: Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -8130,7 +8130,10 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - $ref: '#/components/parameters/ListRoutinesParameters'
+        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
+        - $ref: '#/components/parameters/ListRoutinesParameters.after'
+        - $ref: '#/components/parameters/ListRoutinesParameters.before'
+        - $ref: '#/components/parameters/ListRoutinesParameters.order'
         - name: api-version
           in: query
           required: true
@@ -8144,7 +8147,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutinesListResponse'
+                $ref: '#/components/schemas/RoutineListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -8288,9 +8291,10 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.orderBy'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.maxResults'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.pageToken'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
         - name: api-version
           in: query
           required: true
@@ -9801,6 +9805,22 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutineRunsParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
@@ -9809,8 +9829,8 @@ components:
       schema:
         type: string
       explode: false
-    ListRoutineRunsParameters.maxResults:
-      name: maxResults
+    ListRoutineRunsParameters.limit:
+      name: limit
       in: query
       required: false
       description: The maximum number of runs to return.
@@ -9818,21 +9838,11 @@ components:
         type: integer
         format: int32
       explode: false
-    ListRoutineRunsParameters.orderBy:
-      name: orderBy
+    ListRoutineRunsParameters.order:
+      name: order
       in: query
       required: false
-      description: Ordering expressions applied by the run-history backend.
-      schema:
-        type: array
-        items:
-          type: string
-      explode: false
-    ListRoutineRunsParameters.pageToken:
-      name: pageToken
-      in: query
-      required: false
-      description: A page token returned by the previous list-runs response.
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -9844,11 +9854,36 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutinesParameters:
-      name: continuationToken
+    ListRoutinesParameters.after:
+      name: after
       in: query
       required: false
-      description: A continuation token returned by the previous list response.
+      description: An opaque cursor returned as last_id by the previous list response.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of routines to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutinesParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -32902,7 +32937,6 @@ components:
     Routine:
       type: object
       required:
-        - name
         - enabled
       properties:
         name:
@@ -33032,6 +33066,30 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
+    RoutineListResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        first_id:
+          type: string
+          description: The identifier of the first routine in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routines are available after this page.
+      description: The paginated response returned when listing routines.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     RoutineRun:
       type: object
       properties:
@@ -33134,16 +33192,23 @@ components:
     RoutineRunsResponse:
       type: object
       required:
-        - value
+        - data
+        - has_more
       properties:
-        value:
+        data:
           type: array
           items:
             $ref: '#/components/schemas/RoutineRun'
           description: The requested list of routine runs.
-        nextPageToken:
+        first_id:
           type: string
-          description: A page token to pass as pageToken on the next list-runs request, when more runs are available.
+          description: The identifier of the first run in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routine runs are available after this page.
       description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
@@ -33178,26 +33243,6 @@ components:
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutinesListResponse:
-      type: object
-      required:
-        - value
-      properties:
-        value:
-          type: array
-          items:
-            $ref: '#/components/schemas/Routine'
-          description: The requested list of routines.
-        continuationToken:
-          type: string
-          description: A continuation token to pass on the next list request, when more routines are available.
-        nextLink:
-          type: string
-          description: A service-generated link to the next page, when available.
-      description: The paginated response returned when listing routines.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -34169,10 +34214,7 @@ components:
           description: The trigger type.
         in:
           type: string
-          description: A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.
-        at:
-          type: string
-          description: An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.
+          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -8147,7 +8147,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutineListResponse'
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Routine'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
         default:
           description: An unexpected error response.
           content:
@@ -8308,7 +8327,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutineRunsResponse'
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RoutineRun'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
         default:
           description: An unexpected error response.
           content:
@@ -33066,30 +33104,6 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
-    RoutineListResponse:
-      type: object
-      required:
-        - data
-        - has_more
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/Routine'
-          description: The requested list of routines.
-        first_id:
-          type: string
-          description: The identifier of the first routine in this page, or null when the page is empty.
-        last_id:
-          type: string
-          description: An opaque cursor to pass as the next after query parameter when has_more is true.
-        has_more:
-          type: boolean
-          description: True when more routines are available after this page.
-      description: The paginated response returned when listing routines.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
     RoutineRun:
       type: object
       required:
@@ -33097,11 +33111,11 @@ components:
       properties:
         id:
           type: string
-          description: The MLflow run identifier for the routine attempt.
+          description: The unique run identifier for the routine attempt.
           readOnly: true
         status:
           type: string
-          description: The underlying MLflow run status.
+          description: The run status.
         phase:
           allOf:
             - $ref: '#/components/schemas/RoutineRunPhase'
@@ -33141,9 +33155,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The scheduled fire time recorded for timer and schedule deliveries.
-        trigger_time_zone:
-          type: string
-          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -33188,30 +33199,6 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunsResponse:
-      type: object
-      required:
-        - data
-        - has_more
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/RoutineRun'
-          description: The requested list of routine runs.
-        first_id:
-          type: string
-          description: The identifier of the first run in this page, or null when the page is empty.
-        last_id:
-          type: string
-          description: An opaque cursor to pass as the next after query parameter when has_more is true.
-        has_more:
-          type: boolean
-          description: True when more routine runs are available after this page.
-      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -34214,12 +34201,10 @@ components:
           enum:
             - timer
           description: The trigger type.
-        in:
+        at:
           type: string
-          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
-        time_zone:
-          type: string
-          description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.
+          format: date-time
+          description: The UTC date and time at which the timer fires.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
       description: A one-shot timer routine trigger.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -15993,7 +15993,7 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          description: The raw input sent to the downstream invocations target.
+          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -16019,7 +16019,7 @@ components:
           maxLength: 256
           description: Legacy endpoint-scoped agent identifier for routine dispatch.
         input:
-          description: Static action input sent to the downstream target when the routine fires.
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         session_id:
           type: string
           maxLength: 256
@@ -16042,7 +16042,7 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          description: The user input sent to the downstream responses target.
+          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -16068,7 +16068,7 @@ components:
           maxLength: 256
           description: Legacy endpoint-scoped agent identifier for routine dispatch.
         input:
-          description: Static action input sent to the downstream target when the routine fires.
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         conversation:
           type: string
           maxLength: 256
@@ -33038,6 +33038,7 @@ components:
         id:
           type: string
           description: The MLflow run identifier for the routine attempt.
+          readOnly: true
         status:
           type: string
           description: The underlying MLflow run status.
@@ -33049,7 +33050,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
-        triggerName:
+        trigger_name:
           type: string
           description: The configured trigger name that produced the routine attempt.
         attempt_source:
@@ -33060,27 +33061,27 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
-        agentId:
+        agent_id:
           type: string
           description: The project-scoped agent identifier recorded for the routine attempt.
-        agentEndpointId:
+        agent_endpoint_id:
           type: string
           description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
-        conversationId:
+        conversation_id:
           type: string
           description: The conversation identifier used by a responses API dispatch.
-        sessionId:
+        session_id:
           type: string
           description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
-        scheduledFireAt:
+        scheduled_fire_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The scheduled fire time recorded for timer and schedule deliveries.
-        triggerTimeZone:
+        trigger_time_zone:
           type: string
           description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
@@ -34168,10 +34169,10 @@ components:
           description: The trigger type.
         in:
           type: string
-          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+          description: A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.
         at:
           type: string
-          description: Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.
+          description: An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14859,7 +14859,33 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutineListResponse"
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Routine"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
                 }
               }
             }
@@ -15125,7 +15151,33 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutineRunsResponse"
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RoutineRun"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
                 }
               }
             }
@@ -51163,40 +51215,6 @@
           ]
         }
       },
-      "RoutineListResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "has_more"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Routine"
-            },
-            "description": "The requested list of routines."
-          },
-          "first_id": {
-            "type": "string",
-            "description": "The identifier of the first routine in this page, or null when the page is empty."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "True when more routines are available after this page."
-          }
-        },
-        "description": "The paginated response returned when listing routines.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
       "RoutineRun": {
         "type": "object",
         "required": [
@@ -51205,12 +51223,12 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt.",
+            "description": "The unique run identifier for the routine attempt.",
             "readOnly": true
           },
           "status": {
             "type": "string",
-            "description": "The underlying MLflow run status."
+            "description": "The run status."
           },
           "phase": {
             "allOf": [
@@ -51279,10 +51297,6 @@
               }
             ],
             "description": "The scheduled fire time recorded for timer and schedule deliveries."
-          },
-          "trigger_time_zone": {
-            "type": "string",
-            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -51353,40 +51367,6 @@
           }
         ],
         "description": "Known lifecycle phases recorded for a routine run.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunsResponse": {
-        "type": "object",
-        "required": [
-          "data",
-          "has_more"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RoutineRun"
-            },
-            "description": "The requested list of routine runs."
-          },
-          "first_id": {
-            "type": "string",
-            "description": "The identifier of the first run in this page, or null when the page is empty."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "True when more routine runs are available after this page."
-          }
-        },
-        "description": "The paginated response returned when listing routine runs.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -52888,13 +52868,10 @@
             ],
             "description": "The trigger type."
           },
-          "in": {
+          "at": {
             "type": "string",
-            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
-          },
-          "time_zone": {
-            "type": "string",
-            "description": "An optional IANA or Windows time zone identifier when the timer uses a local timestamp."
+            "format": "date-time",
+            "description": "The UTC date and time at which the timer fires."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14831,7 +14831,16 @@
             }
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters"
+            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.after"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.before"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutinesParameters.order"
           },
           {
             "name": "api-version",
@@ -14850,7 +14859,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RoutinesListResponse"
+                  "$ref": "#/components/schemas/RoutineListResponse"
                 }
               }
             }
@@ -15088,13 +15097,16 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.orderBy"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.maxResults"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.pageToken"
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
+          },
+          {
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
           },
           {
             "name": "api-version",
@@ -17359,6 +17371,26 @@
           "maxLength": 128
         }
       },
+      "ListRoutineRunsParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
@@ -17369,8 +17401,8 @@
         },
         "explode": false
       },
-      "ListRoutineRunsParameters.maxResults": {
-        "name": "maxResults",
+      "ListRoutineRunsParameters.limit": {
+        "name": "limit",
         "in": "query",
         "required": false,
         "description": "The maximum number of runs to return.",
@@ -17380,24 +17412,11 @@
         },
         "explode": false
       },
-      "ListRoutineRunsParameters.orderBy": {
-        "name": "orderBy",
+      "ListRoutineRunsParameters.order": {
+        "name": "order",
         "in": "query",
         "required": false,
-        "description": "Ordering expressions applied by the run-history backend.",
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.pageToken": {
-        "name": "pageToken",
-        "in": "query",
-        "required": false,
-        "description": "A page token returned by the previous list-runs response.",
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -17413,11 +17432,42 @@
           "maxLength": 128
         }
       },
-      "ListRoutinesParameters": {
-        "name": "continuationToken",
+      "ListRoutinesParameters.after": {
+        "name": "after",
         "in": "query",
         "required": false,
-        "description": "A continuation token returned by the previous list response.",
+        "description": "An opaque cursor returned as last_id by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of routines to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -50901,7 +50951,6 @@
       "Routine": {
         "type": "object",
         "required": [
-          "name",
           "enabled"
         ],
         "properties": {
@@ -51114,6 +51163,40 @@
           ]
         }
       },
+      "RoutineListResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first routine in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routines are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineRun": {
         "type": "object",
         "properties": {
@@ -51276,19 +51359,28 @@
       "RoutineRunsResponse": {
         "type": "object",
         "required": [
-          "value"
+          "data",
+          "has_more"
         ],
         "properties": {
-          "value": {
+          "data": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RoutineRun"
             },
             "description": "The requested list of routine runs."
           },
-          "nextPageToken": {
+          "first_id": {
             "type": "string",
-            "description": "A page token to pass as pageToken on the next list-runs request, when more runs are available."
+            "description": "The identifier of the first run in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routine runs are available after this page."
           }
         },
         "description": "The paginated response returned when listing routine runs.",
@@ -51345,35 +51437,6 @@
           }
         ],
         "description": "The discriminator values supported for routine triggers.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutinesListResponse": {
-        "type": "object",
-        "required": [
-          "value"
-        ],
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Routine"
-            },
-            "description": "The requested list of routines."
-          },
-          "continuationToken": {
-            "type": "string",
-            "description": "A continuation token to pass on the next list request, when more routines are available."
-          },
-          "nextLink": {
-            "type": "string",
-            "description": "A service-generated link to the next page, when available."
-          }
-        },
-        "description": "The paginated response returned when listing routines.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -52824,11 +52887,7 @@
           },
           "in": {
             "type": "string",
-            "description": "A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time."
-          },
-          "at": {
-            "type": "string",
-            "description": "An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14831,46 +14831,7 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters"
           },
           {
             "name": "api-version",
@@ -14889,33 +14850,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Routine"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutinesListResponse"
                 }
               }
             }
@@ -15153,46 +15088,13 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.orderBy"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.maxResults"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.pageToken"
           },
           {
             "name": "api-version",
@@ -15211,33 +15113,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoutineRun"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
                 }
               }
             }
@@ -17493,6 +17369,40 @@
         },
         "explode": false
       },
+      "ListRoutineRunsParameters.maxResults": {
+        "name": "maxResults",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of runs to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.orderBy": {
+        "name": "orderBy",
+        "in": "query",
+        "required": false,
+        "description": "Ordering expressions applied by the run-history backend.",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.pageToken": {
+        "name": "pageToken",
+        "in": "query",
+        "required": false,
+        "description": "A page token returned by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.routine_name": {
         "name": "routine_name",
         "in": "path",
@@ -17502,6 +17412,16 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "ListRoutinesParameters": {
+        "name": "continuationToken",
+        "in": "query",
+        "required": false,
+        "description": "A continuation token returned by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -22655,6 +22575,49 @@
         ],
         "description": "Custom credential definition"
       },
+      "CustomRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type",
+          "provider",
+          "parameters"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom"
+            ],
+            "description": "The trigger type."
+          },
+          "provider": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The external provider that emits the custom event."
+          },
+          "event_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The provider-specific event name that fires the routine."
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Provider-specific trigger parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "A custom event routine trigger.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "DailyRecurrenceSchedule": {
         "type": "object",
         "required": [
@@ -27006,19 +26969,40 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueOpenedRoutineTrigger": {
+      "GitHubIssueEvent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "opened",
+              "closed"
+            ]
+          }
+        ],
+        "description": "Known GitHub issue events that can fire a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "GitHubIssueRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "assignee",
-          "repository"
+          "owner",
+          "repository",
+          "issue_event"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue_opened"
+              "github_issue"
             ],
             "description": "The trigger type."
           },
@@ -27027,15 +27011,23 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "assignee": {
+          "owner": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
+            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
+          },
+          "issue_event": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHubIssueEvent"
+              }
+            ],
+            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -27043,7 +27035,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue-opened routine trigger.",
+        "description": "A GitHub issue routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -27764,7 +27756,8 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -27775,8 +27768,6 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
             "description": "The raw input sent to the downstream invocations target."
           }
         },
@@ -27795,8 +27786,7 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type",
-          "agent_endpoint_id"
+          "type"
         ],
         "properties": {
           "type": {
@@ -27806,10 +27796,18 @@
             ],
             "description": "The action type."
           },
+          "agent_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The project-scoped agent name for routine dispatch."
+          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+          },
+          "input": {
+            "description": "Static action input sent to the downstream target when the routine fires."
           },
           "session_id": {
             "type": "string",
@@ -27822,7 +27820,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API.",
+        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -27832,7 +27830,8 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -27843,8 +27842,6 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
             "description": "The user input sent to the downstream responses target."
           }
         },
@@ -27876,14 +27873,17 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for responses API dispatch."
+            "description": "The project-scoped agent name for routine dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for responses API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
-          "conversation_id": {
+          "input": {
+            "description": "Static action input sent to the downstream target when the routine fires."
+          },
+          "conversation": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -50902,9 +50902,7 @@
         "type": "object",
         "required": [
           "name",
-          "enabled",
-          "triggers",
-          "action"
+          "enabled"
         ],
         "properties": {
           "name": {
@@ -51034,10 +51032,6 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
-        "required": [
-          "triggers",
-          "action"
-        ],
         "properties": {
           "description": {
             "type": "string",
@@ -51122,12 +51116,6 @@
       },
       "RoutineRun": {
         "type": "object",
-        "required": [
-          "id",
-          "status",
-          "trigger_type",
-          "started_at"
-        ],
         "properties": {
           "id": {
             "type": "string",
@@ -51153,6 +51141,10 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
+          "triggerName": {
+            "type": "string",
+            "description": "The configured trigger name that produced the routine attempt."
+          },
           "attempt_source": {
             "allOf": [
               {
@@ -51169,6 +51161,22 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
+          "agentId": {
+            "type": "string",
+            "description": "The project-scoped agent identifier recorded for the routine attempt."
+          },
+          "agentEndpointId": {
+            "type": "string",
+            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
+          },
+          "conversationId": {
+            "type": "string",
+            "description": "The conversation identifier used by a responses API dispatch."
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "The hosted-agent session identifier used by an invocations API dispatch."
+          },
           "triggered_at": {
             "allOf": [
               {
@@ -51176,6 +51184,18 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
+          },
+          "scheduledFireAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The scheduled fire time recorded for timer and schedule deliveries."
+          },
+          "triggerTimeZone": {
+            "type": "string",
+            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -51209,6 +51229,11 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
+          "error_status_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The downstream error status code captured for a failed attempt, when available."
+          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -51216,55 +51241,9 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
-          },
-          "diagnostics": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunDiagnostics"
-              }
-            ],
-            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunDiagnostics": {
-        "type": "object",
-        "required": [
-          "parameters",
-          "tags",
-          "metrics"
-        ],
-        "properties": {
-          "parameters": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow parameters recorded on the run, keyed by parameter name."
-          },
-          "tags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow tags recorded on the run, keyed by tag name."
-          },
-          "metrics": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "number",
-              "format": "double"
-            },
-            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
-          }
-        },
-        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -51293,6 +51272,31 @@
           ]
         }
       },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRun"
+            },
+            "description": "The requested list of routine runs."
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "A page token to pass as pageToken on the next list-runs request, when more runs are available."
+          }
+        },
+        "description": "The paginated response returned when listing routine runs.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -51313,7 +51317,8 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
+            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
+            "custom": "#/components/schemas/CustomRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -51331,13 +51336,43 @@
           {
             "type": "string",
             "enum": [
-              "github_issue_opened",
+              "custom",
+              "github_issue",
               "schedule",
               "timer"
             ]
           }
         ],
         "description": "The discriminator values supported for routine triggers.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "RoutinesListResponse": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "continuationToken": {
+            "type": "string",
+            "description": "A continuation token to pass on the next list request, when more routines are available."
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "A service-generated link to the next page, when available."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -52776,8 +52811,7 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type",
-          "at"
+          "type"
         ],
         "properties": {
           "type": {
@@ -52787,9 +52821,13 @@
             ],
             "description": "The trigger type."
           },
-          "at": {
+          "in": {
             "type": "string",
             "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+          },
+          "at": {
+            "type": "string",
+            "description": "Legacy timer expression alias accepted for backward compatibility. New callers should use `in`."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -27768,7 +27768,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The raw input sent to the downstream invocations target."
+            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -27807,7 +27807,7 @@
             "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
           "input": {
-            "description": "Static action input sent to the downstream target when the routine fires."
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "session_id": {
             "type": "string",
@@ -27842,7 +27842,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The user input sent to the downstream responses target."
+            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -27881,7 +27881,7 @@
             "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
           "input": {
-            "description": "Static action input sent to the downstream target when the routine fires."
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "conversation": {
             "type": "string",
@@ -51119,7 +51119,8 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt."
+            "description": "The MLflow run identifier for the routine attempt.",
+            "readOnly": true
           },
           "status": {
             "type": "string",
@@ -51141,7 +51142,7 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
-          "triggerName": {
+          "trigger_name": {
             "type": "string",
             "description": "The configured trigger name that produced the routine attempt."
           },
@@ -51161,19 +51162,19 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
-          "agentId": {
+          "agent_id": {
             "type": "string",
             "description": "The project-scoped agent identifier recorded for the routine attempt."
           },
-          "agentEndpointId": {
+          "agent_endpoint_id": {
             "type": "string",
             "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
           },
-          "conversationId": {
+          "conversation_id": {
             "type": "string",
             "description": "The conversation identifier used by a responses API dispatch."
           },
-          "sessionId": {
+          "session_id": {
             "type": "string",
             "description": "The hosted-agent session identifier used by an invocations API dispatch."
           },
@@ -51185,7 +51186,7 @@
             ],
             "description": "The logical trigger time recorded for the routine attempt."
           },
-          "scheduledFireAt": {
+          "scheduled_fire_at": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -51193,7 +51194,7 @@
             ],
             "description": "The scheduled fire time recorded for timer and schedule deliveries."
           },
-          "triggerTimeZone": {
+          "trigger_time_zone": {
             "type": "string",
             "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
@@ -52823,11 +52824,11 @@
           },
           "in": {
             "type": "string",
-            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time."
           },
           "at": {
             "type": "string",
-            "description": "Legacy timer expression alias accepted for backward compatibility. New callers should use `in`."
+            "description": "An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -51199,6 +51199,9 @@
       },
       "RoutineRun": {
         "type": "object",
+        "required": [
+          "id"
+        ],
         "properties": {
           "id": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -36088,6 +36088,8 @@ components:
           - Routines=V1Preview
     RoutineRun:
       type: object
+      required:
+        - id
       properties:
         id:
           type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9864,7 +9864,10 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - $ref: '#/components/parameters/ListRoutinesParameters'
+        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
+        - $ref: '#/components/parameters/ListRoutinesParameters.after'
+        - $ref: '#/components/parameters/ListRoutinesParameters.before'
+        - $ref: '#/components/parameters/ListRoutinesParameters.order'
         - name: api-version
           in: query
           required: true
@@ -9878,7 +9881,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutinesListResponse'
+                $ref: '#/components/schemas/RoutineListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -10022,9 +10025,10 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.orderBy'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.maxResults'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.pageToken'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
         - name: api-version
           in: query
           required: true
@@ -11535,6 +11539,22 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutineRunsParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
@@ -11543,8 +11563,8 @@ components:
       schema:
         type: string
       explode: false
-    ListRoutineRunsParameters.maxResults:
-      name: maxResults
+    ListRoutineRunsParameters.limit:
+      name: limit
       in: query
       required: false
       description: The maximum number of runs to return.
@@ -11552,21 +11572,11 @@ components:
         type: integer
         format: int32
       explode: false
-    ListRoutineRunsParameters.orderBy:
-      name: orderBy
+    ListRoutineRunsParameters.order:
+      name: order
       in: query
       required: false
-      description: Ordering expressions applied by the run-history backend.
-      schema:
-        type: array
-        items:
-          type: string
-      explode: false
-    ListRoutineRunsParameters.pageToken:
-      name: pageToken
-      in: query
-      required: false
-      description: A page token returned by the previous list-runs response.
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -11578,11 +11588,36 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutinesParameters:
-      name: continuationToken
+    ListRoutinesParameters.after:
+      name: after
       in: query
       required: false
-      description: A continuation token returned by the previous list response.
+      description: An opaque cursor returned as last_id by the previous list response.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of routines to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutinesParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -35898,7 +35933,6 @@ components:
     Routine:
       type: object
       required:
-        - name
         - enabled
       properties:
         name:
@@ -36028,6 +36062,30 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
+    RoutineListResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        first_id:
+          type: string
+          description: The identifier of the first routine in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routines are available after this page.
+      description: The paginated response returned when listing routines.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     RoutineRun:
       type: object
       properties:
@@ -36130,16 +36188,23 @@ components:
     RoutineRunsResponse:
       type: object
       required:
-        - value
+        - data
+        - has_more
       properties:
-        value:
+        data:
           type: array
           items:
             $ref: '#/components/schemas/RoutineRun'
           description: The requested list of routine runs.
-        nextPageToken:
+        first_id:
           type: string
-          description: A page token to pass as pageToken on the next list-runs request, when more runs are available.
+          description: The identifier of the first run in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routine runs are available after this page.
       description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
@@ -36174,26 +36239,6 @@ components:
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutinesListResponse:
-      type: object
-      required:
-        - value
-      properties:
-        value:
-          type: array
-          items:
-            $ref: '#/components/schemas/Routine'
-          description: The requested list of routines.
-        continuationToken:
-          type: string
-          description: A continuation token to pass on the next list request, when more routines are available.
-        nextLink:
-          type: string
-          description: A service-generated link to the next page, when available.
-      description: The paginated response returned when listing routines.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -37182,10 +37227,7 @@ components:
           description: The trigger type.
         in:
           type: string
-          description: A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.
-        at:
-          type: string
-          description: An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.
+          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9881,7 +9881,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutineListResponse'
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Routine'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
         default:
           description: An unexpected error response.
           content:
@@ -10042,7 +10061,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoutineRunsResponse'
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RoutineRun'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
         default:
           description: An unexpected error response.
           content:
@@ -36062,30 +36100,6 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
-    RoutineListResponse:
-      type: object
-      required:
-        - data
-        - has_more
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/Routine'
-          description: The requested list of routines.
-        first_id:
-          type: string
-          description: The identifier of the first routine in this page, or null when the page is empty.
-        last_id:
-          type: string
-          description: An opaque cursor to pass as the next after query parameter when has_more is true.
-        has_more:
-          type: boolean
-          description: True when more routines are available after this page.
-      description: The paginated response returned when listing routines.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
     RoutineRun:
       type: object
       required:
@@ -36093,11 +36107,11 @@ components:
       properties:
         id:
           type: string
-          description: The MLflow run identifier for the routine attempt.
+          description: The unique run identifier for the routine attempt.
           readOnly: true
         status:
           type: string
-          description: The underlying MLflow run status.
+          description: The run status.
         phase:
           allOf:
             - $ref: '#/components/schemas/RoutineRunPhase'
@@ -36137,9 +36151,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The scheduled fire time recorded for timer and schedule deliveries.
-        trigger_time_zone:
-          type: string
-          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -36184,30 +36195,6 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunsResponse:
-      type: object
-      required:
-        - data
-        - has_more
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/RoutineRun'
-          description: The requested list of routine runs.
-        first_id:
-          type: string
-          description: The identifier of the first run in this page, or null when the page is empty.
-        last_id:
-          type: string
-          description: An opaque cursor to pass as the next after query parameter when has_more is true.
-        has_more:
-          type: boolean
-          description: True when more routine runs are available after this page.
-      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -37227,12 +37214,10 @@ components:
           enum:
             - timer
           description: The trigger type.
-        in:
+        at:
           type: string
-          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
-        time_zone:
-          type: string
-          description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.
+          format: date-time
+          description: The UTC date and time at which the timer fires.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
       description: A one-shot timer routine trigger.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9864,46 +9864,7 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutinesParameters'
         - name: api-version
           in: query
           required: true
@@ -9917,26 +9878,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Routine'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutinesListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -10080,46 +10022,9 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.orderBy'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.maxResults'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.pageToken'
         - name: api-version
           in: query
           required: true
@@ -10133,26 +10038,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/RoutineRun'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineRunsResponse'
         default:
           description: An unexpected error response.
           content:
@@ -11657,6 +11543,33 @@ components:
       schema:
         type: string
       explode: false
+    ListRoutineRunsParameters.maxResults:
+      name: maxResults
+      in: query
+      required: false
+      description: The maximum number of runs to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutineRunsParameters.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: Ordering expressions applied by the run-history backend.
+      schema:
+        type: array
+        items:
+          type: string
+      explode: false
+    ListRoutineRunsParameters.pageToken:
+      name: pageToken
+      in: query
+      required: false
+      description: A page token returned by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.routine_name:
       name: routine_name
       in: path
@@ -11665,6 +11578,14 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutinesParameters:
+      name: continuationToken
+      in: query
+      required: false
+      description: A continuation token returned by the previous list response.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -15168,6 +15089,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
+    CustomRoutineTrigger:
+      type: object
+      required:
+        - type
+        - provider
+        - parameters
+      properties:
+        type:
+          type: string
+          enum:
+            - custom
+          description: The trigger type.
+        provider:
+          type: string
+          maxLength: 128
+          description: The external provider that emits the custom event.
+        event_name:
+          type: string
+          maxLength: 256
+          description: The provider-specific event name that fires the routine.
+        parameters:
+          type: object
+          additionalProperties: {}
+          description: Provider-specific trigger parameters.
+      allOf:
+        - $ref: '#/components/schemas/RoutineTrigger'
+      description: A custom event routine trigger.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -18349,34 +18300,50 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueOpenedRoutineTrigger:
+    GitHubIssueEvent:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - opened
+            - closed
+      description: Known GitHub issue events that can fire a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    GitHubIssueRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - assignee
+        - owner
         - repository
+        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue_opened
+            - github_issue
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        assignee:
+        owner:
           type: string
           maxLength: 128
-          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
+          description: The GitHub owner or organization that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
+        issue_event:
+          allOf:
+            - $ref: '#/components/schemas/GitHubIssueEvent'
+          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue-opened routine trigger.
+      description: A GitHub issue routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -18851,6 +18818,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -18858,8 +18826,6 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
           description: The raw input sent to the downstream invocations target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
@@ -18871,24 +18837,29 @@ components:
       type: object
       required:
         - type
-        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
+        agent_name:
+          type: string
+          maxLength: 256
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for invocations API dispatch.
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static action input sent to the downstream target when the routine fires.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API.
+      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -18896,6 +18867,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -18903,8 +18875,6 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
           description: The user input sent to the downstream responses target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
@@ -18925,12 +18895,14 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for responses API dispatch.
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for responses API dispatch.
-        conversation_id:
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static action input sent to the downstream target when the routine fires.
+        conversation:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -35928,8 +35900,6 @@ components:
       required:
         - name
         - enabled
-        - triggers
-        - action
       properties:
         name:
           type: string
@@ -36008,9 +35978,6 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
-      required:
-        - triggers
-        - action
       properties:
         description:
           type: string
@@ -36063,11 +36030,6 @@ components:
           - Routines=V1Preview
     RoutineRun:
       type: object
-      required:
-        - id
-        - status
-        - trigger_type
-        - started_at
       properties:
         id:
           type: string
@@ -36083,6 +36045,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
+        triggerName:
+          type: string
+          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -36091,10 +36056,29 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
+        agentId:
+          type: string
+          description: The project-scoped agent identifier recorded for the routine attempt.
+        agentEndpointId:
+          type: string
+          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
+        conversationId:
+          type: string
+          description: The conversation identifier used by a responses API dispatch.
+        sessionId:
+          type: string
+          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
+        scheduledFireAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The scheduled fire time recorded for timer and schedule deliveries.
+        triggerTimeZone:
+          type: string
+          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -36115,44 +36099,17 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
+        error_status_code:
+          type: integer
+          format: int32
+          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
-        diagnostics:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunDiagnostics'
-          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunDiagnostics:
-      type: object
-      required:
-        - parameters
-        - tags
-        - metrics
-      properties:
-        parameters:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow parameters recorded on the run, keyed by parameter name.
-        tags:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow tags recorded on the run, keyed by tag name.
-        metrics:
-          type: object
-          additionalProperties:
-            type: number
-            format: double
-          description: Latest MLflow metric values recorded on the run, keyed by metric name.
-      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36166,6 +36123,23 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunsResponse:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoutineRun'
+          description: The requested list of routine runs.
+        nextPageToken:
+          type: string
+          description: A page token to pass as pageToken on the next list-runs request, when more runs are available.
+      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36183,7 +36157,8 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
+          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
+          custom: '#/components/schemas/CustomRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -36193,10 +36168,31 @@ components:
         - type: string
         - type: string
           enum:
-            - github_issue_opened
+            - custom
+            - github_issue
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutinesListResponse:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        continuationToken:
+          type: string
+          description: A continuation token to pass on the next list request, when more routines are available.
+        nextLink:
+          type: string
+          description: A service-generated link to the next page, when available.
+      description: The paginated response returned when listing routines.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -37177,16 +37173,18 @@ components:
       type: object
       required:
         - type
-        - at
       properties:
         type:
           type: string
           enum:
             - timer
           description: The trigger type.
-        at:
+        in:
           type: string
           description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+        at:
+          type: string
+          description: Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -18826,7 +18826,7 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          description: The raw input sent to the downstream invocations target.
+          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -18852,7 +18852,7 @@ components:
           maxLength: 256
           description: Legacy endpoint-scoped agent identifier for routine dispatch.
         input:
-          description: Static action input sent to the downstream target when the routine fires.
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         session_id:
           type: string
           maxLength: 256
@@ -18875,7 +18875,7 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          description: The user input sent to the downstream responses target.
+          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -18901,7 +18901,7 @@ components:
           maxLength: 256
           description: Legacy endpoint-scoped agent identifier for routine dispatch.
         input:
-          description: Static action input sent to the downstream target when the routine fires.
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         conversation:
           type: string
           maxLength: 256
@@ -36034,6 +36034,7 @@ components:
         id:
           type: string
           description: The MLflow run identifier for the routine attempt.
+          readOnly: true
         status:
           type: string
           description: The underlying MLflow run status.
@@ -36045,7 +36046,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
-        triggerName:
+        trigger_name:
           type: string
           description: The configured trigger name that produced the routine attempt.
         attempt_source:
@@ -36056,27 +36057,27 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
-        agentId:
+        agent_id:
           type: string
           description: The project-scoped agent identifier recorded for the routine attempt.
-        agentEndpointId:
+        agent_endpoint_id:
           type: string
           description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
-        conversationId:
+        conversation_id:
           type: string
           description: The conversation identifier used by a responses API dispatch.
-        sessionId:
+        session_id:
           type: string
           description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
-        scheduledFireAt:
+        scheduled_fire_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The scheduled fire time recorded for timer and schedule deliveries.
-        triggerTimeZone:
+        trigger_time_zone:
           type: string
           description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
@@ -37181,10 +37182,10 @@ components:
           description: The trigger type.
         in:
           type: string
-          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+          description: A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.
         at:
           type: string
-          description: Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.
+          description: An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -15,8 +15,11 @@ const RoutineRequiredPreviews = #{
 union RoutineTriggerType {
   string,
 
-  @doc("A GitHub issue-opened trigger.")
-  github_issue_opened: "github_issue_opened",
+  @doc("A custom event trigger.")
+  custom: "custom",
+
+  @doc("A GitHub issue trigger.")
+  github_issue: "github_issue",
 
   @doc("A recurring cron-based trigger.")
   schedule: "schedule",
@@ -70,6 +73,18 @@ union RoutineAttemptSource {
   timer_delivery: "timer_delivery",
 }
 
+@doc("Known GitHub issue events that can fire a routine.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+union GitHubIssueEvent {
+  string,
+
+  @doc("The routine fires when a GitHub issue is opened.")
+  opened: "opened",
+
+  @doc("The routine fires when a GitHub issue is closed.")
+  closed: "closed",
+}
+
 @doc("Known lifecycle phases recorded for a routine run.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 union RoutineRunPhase {
@@ -118,29 +133,53 @@ model TimerRoutineTrigger extends RoutineTrigger {
   type: RoutineTriggerType.timer;
 
   @doc("A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.")
-  at: string;
+  in?: string;
+
+  @doc("Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.")
+  at?: string;
 
   @doc("An optional IANA or Windows time zone identifier when the timer uses a local timestamp.")
   time_zone?: string;
 }
 
-@doc("A GitHub issue-opened routine trigger.")
+@doc("A GitHub issue routine trigger.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model GitHubIssueOpenedRoutineTrigger extends RoutineTrigger {
+model GitHubIssueRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
-  type: RoutineTriggerType.github_issue_opened;
+  type: RoutineTriggerType.github_issue;
 
   @doc("The workspace connection identifier that resolves the GitHub configuration for the trigger.")
   @maxLength(256)
   connection_id: string;
 
-  @doc("The GitHub assignee or organization filter that scopes which issues can fire the trigger.")
+  @doc("The GitHub owner or organization that scopes which issues can fire the trigger.")
   @maxLength(128)
-  assignee: string;
+  owner: string;
 
   @doc("The GitHub repository filter that scopes which issues can fire the trigger.")
   @maxLength(128)
   repository: string;
+
+  @doc("The GitHub issue event that fires the routine.")
+  issue_event: GitHubIssueEvent;
+}
+
+@doc("A custom event routine trigger.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model CustomRoutineTrigger extends RoutineTrigger {
+  @doc("The trigger type.")
+  type: RoutineTriggerType.custom;
+
+  @doc("The external provider that emits the custom event.")
+  @maxLength(128)
+  provider: string;
+
+  @doc("The provider-specific event name that fires the routine.")
+  @maxLength(256)
+  event_name?: string;
+
+  @doc("Provider-specific trigger parameters.")
+  parameters: Record<unknown>;
 }
 
 @doc("Base model for a routine action.")
@@ -151,34 +190,39 @@ model RoutineAction {
   type: RoutineActionType;
 }
 
+alias InvokeAgentRoutineActionFields = {
+  @doc("The project-scoped agent name for routine dispatch.")
+  @maxLength(256)
+  agent_name?: string;
+
+  @doc("Legacy endpoint-scoped agent identifier for routine dispatch.")
+  @maxLength(256)
+  agent_endpoint_id?: string;
+
+  @doc("Static action input sent to the downstream target when the routine fires.")
+  input?: unknown;
+};
+
 @doc("Dispatches a routine through the responses API. Exactly one of agent_name or agent_endpoint_id must be provided.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model InvokeAgentResponsesApiRoutineAction extends RoutineAction {
   @doc("The action type.")
   type: RoutineActionType.invoke_agent_responses_api;
 
-  @doc("The project-scoped agent name for responses API dispatch.")
-  @maxLength(256)
-  agent_name?: string;
-
-  @doc("The endpoint-scoped agent identifier for responses API dispatch.")
-  @maxLength(256)
-  agent_endpoint_id?: string;
+  ...InvokeAgentRoutineActionFields;
 
   @doc("An optional existing conversation identifier to continue during the downstream dispatch.")
   @maxLength(256)
-  conversation_id?: string;
+  conversation?: string;
 }
 
-@doc("Dispatches a routine through the raw invocations API.")
+@doc("Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model InvokeAgentInvocationsApiRoutineAction extends RoutineAction {
   @doc("The action type.")
   type: RoutineActionType.invoke_agent_invocations_api;
 
-  @doc("The endpoint-scoped agent identifier for invocations API dispatch.")
-  @maxLength(256)
-  agent_endpoint_id: string;
+  ...InvokeAgentRoutineActionFields;
 
   @doc("An optional existing hosted-agent session identifier to continue during the downstream dispatch.")
   @maxLength(256)
@@ -200,10 +244,10 @@ model Routine {
   enabled: boolean;
 
   @doc("The triggers configured for the routine.")
-  triggers: RoutineTriggers;
+  triggers?: RoutineTriggers;
 
   @doc("The action executed when the routine fires.")
-  action: RoutineAction;
+  action?: RoutineAction;
 
   @doc("The time when the routine was created.")
   created_at?: FoundryTimestamp;
@@ -223,10 +267,25 @@ model RoutineCreateOrUpdateRequest {
   enabled?: boolean;
 
   @doc("The triggers configured for the routine. In v1, exactly one trigger entry is supported.")
-  triggers: RoutineTriggers;
+  triggers?: RoutineTriggers;
 
   @doc("The action executed when the routine fires.")
-  action: RoutineAction;
+  action?: RoutineAction;
+}
+
+@doc("The paginated response returned when listing routines.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model RoutinesListResponse {
+  @doc("The requested list of routines.")
+  @pageItems
+  value: Routine[];
+
+  @doc("A continuation token to pass on the next list request, when more routines are available.")
+  @continuationToken
+  continuationToken?: string;
+
+  @doc("A service-generated link to the next page, when available.")
+  nextLink?: string;
 }
 
 @doc("Base model for a manual dispatch payload.")
@@ -244,8 +303,7 @@ model InvokeAgentResponsesApiDispatchPayload extends RoutineDispatchPayload {
   type: RoutineDispatchPayloadType.invoke_agent_responses_api;
 
   @doc("The user input sent to the downstream responses target.")
-  @maxLength(32768)
-  input?: string;
+  input: unknown;
 }
 
 @doc("A manual payload used to test an invocations API routine dispatch.")
@@ -255,8 +313,7 @@ model InvokeAgentInvocationsApiDispatchPayload extends RoutineDispatchPayload {
   type: RoutineDispatchPayloadType.invoke_agent_invocations_api;
 
   @doc("The raw input sent to the downstream invocations target.")
-  @maxLength(32768)
-  input?: string;
+  input: unknown;
 }
 
 @doc("Request body for the public dispatch_async route.")
@@ -279,33 +336,23 @@ model DispatchRoutineResponse {
   task_id?: string;
 }
 
-@doc("Generic diagnostics captured on a routine run.")
-@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model RoutineRunDiagnostics {
-  @doc("MLflow parameters recorded on the run, keyed by parameter name.")
-  parameters: Record<string>;
-
-  @doc("MLflow tags recorded on the run, keyed by tag name.")
-  tags: Record<string>;
-
-  @doc("Latest MLflow metric values recorded on the run, keyed by metric name.")
-  metrics: Record<float64>;
-}
-
 @doc("A single routine run returned from the run history API.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineRun {
   @doc("The MLflow run identifier for the routine attempt.")
-  id: string;
+  id?: string;
 
   @doc("The underlying MLflow run status.")
-  status: string;
+  status?: string;
 
   @doc("The AgentExtensions lifecycle phase for the routine attempt.")
   phase?: RoutineRunPhase;
 
   @doc("The trigger type that produced the routine attempt.")
-  trigger_type: RoutineTriggerType;
+  trigger_type?: RoutineTriggerType;
+
+  @doc("The configured trigger name that produced the routine attempt.")
+  triggerName?: string;
 
   @doc("The source path that created the routine attempt.")
   attempt_source?: RoutineAttemptSource;
@@ -313,11 +360,29 @@ model RoutineRun {
   @doc("The action type dispatched for the routine attempt.")
   action_type?: RoutineActionType;
 
+  @doc("The project-scoped agent identifier recorded for the routine attempt.")
+  agentId?: string;
+
+  @doc("The legacy endpoint-scoped agent identifier recorded for the routine attempt.")
+  agentEndpointId?: string;
+
+  @doc("The conversation identifier used by a responses API dispatch.")
+  conversationId?: string;
+
+  @doc("The hosted-agent session identifier used by an invocations API dispatch.")
+  sessionId?: string;
+
   @doc("The logical trigger time recorded for the routine attempt.")
   triggered_at?: FoundryTimestamp;
 
+  @doc("The scheduled fire time recorded for timer and schedule deliveries.")
+  scheduledFireAt?: FoundryTimestamp;
+
+  @doc("The trigger time zone recorded for timer and schedule deliveries.")
+  triggerTimeZone?: string;
+
   @doc("The time when the underlying run started.")
-  started_at: FoundryTimestamp;
+  started_at?: FoundryTimestamp;
 
   @doc("The time when the underlying run reached a terminal state.")
   ended_at?: FoundryTimestamp;
@@ -334,14 +399,26 @@ model RoutineRun {
   @doc("The workspace task identifier linked to the routine attempt, when available.")
   task_id?: string;
 
+  @doc("The downstream error status code captured for a failed attempt, when available.")
+  error_status_code?: int32;
+
   @doc("The fully qualified error type captured for a failed attempt, when available.")
   error_type?: string;
 
   @doc("The truncated failure message captured for a failed attempt, when available.")
   error_message?: string;
+}
 
-  @doc("Diagnostic data captured for the routine attempt.")
-  diagnostics?: RoutineRunDiagnostics;
+@doc("The paginated response returned when listing routine runs.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model RoutineRunsResponse {
+  @doc("The requested list of routine runs.")
+  @pageItems
+  value: RoutineRun[];
+
+  @doc("A page token to pass as pageToken on the next list-runs request, when more runs are available.")
+  @continuationToken
+  nextPageToken?: string;
 }
 
 @doc("Parameters for creating or updating a routine.")
@@ -380,7 +457,10 @@ model DisableRoutineParameters {
 
 @doc("Parameters for listing routines.")
 model ListRoutinesParameters {
-  ...CommonPageQueryParameters;
+  @doc("A continuation token returned by the previous list response.")
+  @query
+  @continuationToken
+  continuationToken?: string;
 }
 
 @doc("Parameters for deleting a routine.")
@@ -402,7 +482,18 @@ model ListRoutineRunsParameters {
   @query
   filter?: string;
 
-  ...CommonPageQueryParameters;
+  @doc("Ordering expressions applied by the run-history backend.")
+  @query
+  orderBy?: string[];
+
+  @doc("The maximum number of runs to return.")
+  @query
+  maxResults?: int32;
+
+  @doc("A page token returned by the previous list-runs response.")
+  @query
+  @continuationToken
+  pageToken?: string;
 }
 
 @doc("Parameters for dispatching a routine asynchronously.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -132,11 +132,8 @@ model TimerRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
   type: RoutineTriggerType.timer;
 
-  @doc("A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.")
-  in?: string;
-
-  @doc("An optional IANA or Windows time zone identifier when the timer uses a local timestamp.")
-  time_zone?: string;
+  @doc("The UTC date and time at which the timer fires.")
+  at?: utcDateTime;
 }
 
 @doc("A GitHub issue routine trigger.")
@@ -270,24 +267,6 @@ model RoutineCreateOrUpdateRequest {
   action?: RoutineAction;
 }
 
-@doc("The paginated response returned when listing routines.")
-@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model RoutineListResponse {
-  @doc("The requested list of routines.")
-  @pageItems
-  data: Routine[];
-
-  @doc("The identifier of the first routine in this page, or null when the page is empty.")
-  first_id?: string;
-
-  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
-  @continuationToken
-  last_id?: string;
-
-  @doc("True when more routines are available after this page.")
-  has_more: boolean;
-}
-
 @doc("Base model for a manual dispatch payload.")
 @discriminator("type")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
@@ -339,11 +318,11 @@ model DispatchRoutineResponse {
 @doc("A single routine run returned from the run history API.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineRun {
-  @doc("The MLflow run identifier for the routine attempt.")
+  @doc("The unique run identifier for the routine attempt.")
   @visibility(Lifecycle.Read)
   id: string;
 
-  @doc("The underlying MLflow run status.")
+  @doc("The run status.")
   status?: string;
 
   @doc("The AgentExtensions lifecycle phase for the routine attempt.")
@@ -379,9 +358,6 @@ model RoutineRun {
   @doc("The scheduled fire time recorded for timer and schedule deliveries.")
   scheduled_fire_at?: FoundryTimestamp;
 
-  @doc("The trigger time zone recorded for timer and schedule deliveries.")
-  trigger_time_zone?: string;
-
   @doc("The time when the underlying run started.")
   started_at?: FoundryTimestamp;
 
@@ -408,24 +384,6 @@ model RoutineRun {
 
   @doc("The truncated failure message captured for a failed attempt, when available.")
   error_message?: string;
-}
-
-@doc("The paginated response returned when listing routine runs.")
-@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model RoutineRunsResponse {
-  @doc("The requested list of routine runs.")
-  @pageItems
-  data: RoutineRun[];
-
-  @doc("The identifier of the first run in this page, or null when the page is empty.")
-  first_id?: string;
-
-  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
-  @continuationToken
-  last_id?: string;
-
-  @doc("True when more routine runs are available after this page.")
-  has_more: boolean;
 }
 
 @doc("Parameters for creating or updating a routine.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -132,11 +132,8 @@ model TimerRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
   type: RoutineTriggerType.timer;
 
-  @doc("A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.")
+  @doc("A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.")
   in?: string;
-
-  @doc("An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.")
-  at?: string;
 
   @doc("An optional IANA or Windows time zone identifier when the timer uses a local timestamp.")
   time_zone?: string;
@@ -234,7 +231,7 @@ model InvokeAgentInvocationsApiRoutineAction extends RoutineAction {
 model Routine {
   @doc("The routine name.")
   @maxLength(128)
-  name: string;
+  name?: string;
 
   @doc("A human-readable description of the routine.")
   @maxLength(1024)
@@ -275,17 +272,20 @@ model RoutineCreateOrUpdateRequest {
 
 @doc("The paginated response returned when listing routines.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model RoutinesListResponse {
+model RoutineListResponse {
   @doc("The requested list of routines.")
   @pageItems
-  value: Routine[];
+  data: Routine[];
 
-  @doc("A continuation token to pass on the next list request, when more routines are available.")
+  @doc("The identifier of the first routine in this page, or null when the page is empty.")
+  first_id?: string;
+
+  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
   @continuationToken
-  continuationToken?: string;
+  last_id?: string;
 
-  @doc("A service-generated link to the next page, when available.")
-  nextLink?: string;
+  @doc("True when more routines are available after this page.")
+  has_more: boolean;
 }
 
 @doc("Base model for a manual dispatch payload.")
@@ -415,11 +415,17 @@ model RoutineRun {
 model RoutineRunsResponse {
   @doc("The requested list of routine runs.")
   @pageItems
-  value: RoutineRun[];
+  data: RoutineRun[];
 
-  @doc("A page token to pass as pageToken on the next list-runs request, when more runs are available.")
+  @doc("The identifier of the first run in this page, or null when the page is empty.")
+  first_id?: string;
+
+  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
   @continuationToken
-  nextPageToken?: string;
+  last_id?: string;
+
+  @doc("True when more routine runs are available after this page.")
+  has_more: boolean;
 }
 
 @doc("Parameters for creating or updating a routine.")
@@ -458,10 +464,22 @@ model DisableRoutineParameters {
 
 @doc("Parameters for listing routines.")
 model ListRoutinesParameters {
-  @doc("A continuation token returned by the previous list response.")
+  @doc("The maximum number of routines to return.")
+  @query
+  limit?: int32;
+
+  @doc("An opaque cursor returned as last_id by the previous list response.")
   @query
   @continuationToken
-  continuationToken?: string;
+  after?: string;
+
+  @doc("Unsupported. Reserved for future backward pagination support.")
+  @query
+  before?: string;
+
+  @doc("The ordering direction. Supported values are asc and desc.")
+  @query
+  order?: string;
 }
 
 @doc("Parameters for deleting a routine.")
@@ -483,18 +501,22 @@ model ListRoutineRunsParameters {
   @query
   filter?: string;
 
-  @doc("Ordering expressions applied by the run-history backend.")
-  @query
-  orderBy?: string[];
-
   @doc("The maximum number of runs to return.")
   @query
-  maxResults?: int32;
+  limit?: int32;
 
-  @doc("A page token returned by the previous list-runs response.")
+  @doc("An opaque cursor returned as last_id by the previous list-runs response.")
   @query
   @continuationToken
-  pageToken?: string;
+  after?: string;
+
+  @doc("Unsupported. Reserved for future backward pagination support.")
+  @query
+  before?: string;
+
+  @doc("The ordering direction. Supported values are asc and desc.")
+  @query
+  order?: string;
 }
 
 @doc("Parameters for dispatching a routine asynchronously.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -341,7 +341,7 @@ model DispatchRoutineResponse {
 model RoutineRun {
   @doc("The MLflow run identifier for the routine attempt.")
   @visibility(Lifecycle.Read)
-  id?: string;
+  id: string;
 
   @doc("The underlying MLflow run status.")
   status?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -132,10 +132,10 @@ model TimerRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
   type: RoutineTriggerType.timer;
 
-  @doc("A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.")
+  @doc("A relative timer expression from now, such as `2h` or `15m`. Callers can specify either `in` for relative timing or `at` for absolute timing; stored routines are normalized to an absolute fire time.")
   in?: string;
 
-  @doc("Legacy timer expression alias accepted for backward compatibility. New callers should use `in`.")
+  @doc("An absolute timer expression. Supported values include an ISO-8601 timestamp with an explicit offset or a local timestamp paired with `time_zone`. Callers can specify either `at` for absolute timing or `in` for relative timing; stored routines are normalized to an absolute fire time.")
   at?: string;
 
   @doc("An optional IANA or Windows time zone identifier when the timer uses a local timestamp.")
@@ -199,7 +199,7 @@ alias InvokeAgentRoutineActionFields = {
   @maxLength(256)
   agent_endpoint_id?: string;
 
-  @doc("Static action input sent to the downstream target when the routine fires.")
+  @doc("Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.")
   input?: unknown;
 };
 
@@ -302,7 +302,7 @@ model InvokeAgentResponsesApiDispatchPayload extends RoutineDispatchPayload {
   @doc("The manual dispatch payload type.")
   type: RoutineDispatchPayloadType.invoke_agent_responses_api;
 
-  @doc("The user input sent to the downstream responses target.")
+  @doc("The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.")
   input: unknown;
 }
 
@@ -312,7 +312,7 @@ model InvokeAgentInvocationsApiDispatchPayload extends RoutineDispatchPayload {
   @doc("The manual dispatch payload type.")
   type: RoutineDispatchPayloadType.invoke_agent_invocations_api;
 
-  @doc("The raw input sent to the downstream invocations target.")
+  @doc("The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.")
   input: unknown;
 }
 
@@ -340,6 +340,7 @@ model DispatchRoutineResponse {
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineRun {
   @doc("The MLflow run identifier for the routine attempt.")
+  @visibility(Lifecycle.Read)
   id?: string;
 
   @doc("The underlying MLflow run status.")
@@ -352,7 +353,7 @@ model RoutineRun {
   trigger_type?: RoutineTriggerType;
 
   @doc("The configured trigger name that produced the routine attempt.")
-  triggerName?: string;
+  trigger_name?: string;
 
   @doc("The source path that created the routine attempt.")
   attempt_source?: RoutineAttemptSource;
@@ -361,25 +362,25 @@ model RoutineRun {
   action_type?: RoutineActionType;
 
   @doc("The project-scoped agent identifier recorded for the routine attempt.")
-  agentId?: string;
+  agent_id?: string;
 
   @doc("The legacy endpoint-scoped agent identifier recorded for the routine attempt.")
-  agentEndpointId?: string;
+  agent_endpoint_id?: string;
 
   @doc("The conversation identifier used by a responses API dispatch.")
-  conversationId?: string;
+  conversation_id?: string;
 
   @doc("The hosted-agent session identifier used by an invocations API dispatch.")
-  sessionId?: string;
+  session_id?: string;
 
   @doc("The logical trigger time recorded for the routine attempt.")
   triggered_at?: FoundryTimestamp;
 
   @doc("The scheduled fire time recorded for timer and schedule deliveries.")
-  scheduledFireAt?: FoundryTimestamp;
+  scheduled_fire_at?: FoundryTimestamp;
 
   @doc("The trigger time zone recorded for timer and schedule deliveries.")
-  triggerTimeZone?: string;
+  trigger_time_zone?: string;
 
   @doc("The time when the underlying run started.")
   started_at?: FoundryTimestamp;

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
@@ -67,7 +67,7 @@ interface Routines {
   listRoutines is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutinesParameters,
-    RoutineListResponse
+    AgentsPagedResult<Routine>
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
@@ -92,7 +92,7 @@ interface Routines {
   listRoutineRuns is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutineRunsParameters,
-    RoutineRunsResponse
+    AgentsPagedResult<RoutineRun>
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
@@ -67,7 +67,7 @@ interface Routines {
   listRoutines is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutinesParameters,
-    AgentsPagedResult<Routine>
+    RoutinesListResponse
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
@@ -92,7 +92,7 @@ interface Routines {
   listRoutineRuns is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutineRunsParameters,
-    AgentsPagedResult<RoutineRun>
+    RoutineRunsResponse
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
@@ -67,7 +67,7 @@ interface Routines {
   listRoutines is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutinesParameters,
-    RoutinesListResponse
+    RoutineListResponse
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"


### PR DESCRIPTION
## Summary
- Aligns Foundry Routines TypeSpec with the latest unmerged AgentExtensions contracts from Vienna branch `users/akannava/agentextensions-routine-contract-cleanup` at commit `67e864164aa406b1a6f634dbae8278c63aa329d0`.
- Updates trigger/action discriminators and wire fields, including `github_issue`, `custom`, timer `in`, action `input`, `conversation`, and `session_id`.
- Updates routine and run-history list operations to use service response shapes (`value`/`continuationToken`, `value`/`nextPageToken`) and regenerates Foundry OpenAPI artifacts.

## Lineage check
This targets the same `Azure/azure-rest-api-specs` Foundry TypeSpec path on `feature/foundry-release` used by Linda Li PR #42779 and Farhad PR #43186.

## Validation
- `npx prettier --plugin=@typespec/prettier-plugin-typespec --parser typespec --check specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp`
- `npx tsp compile specification/ai-foundry/data-plane/Foundry --warn-as-error`
- `git diff --check`