### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-resource-policy

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Authorization/policy/client.tsp
+++ b/specification/resources/resource-manager/Microsoft.Authorization/policy/client.tsp
@@ -23,7 +23,7 @@ namespace Microsoft.Authorization {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "For client"
   @summary("Retrieves the policy assignment with the given ID.")
-  @scope("java,csharp,go")
+  @scope("java,csharp,go,python")
   @clientLocation(PolicyAssignments)
   @get
   @route("/{+policyAssignmentId}")
@@ -37,7 +37,7 @@ namespace Microsoft.Authorization {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "For client"
   @summary("Creates or updates a policy assignment.")
-  @scope("java,csharp,go")
+  @scope("java,csharp,go,python")
   @clientLocation(PolicyAssignments)
   @put
   @route("/{+policyAssignmentId}")
@@ -58,7 +58,7 @@ namespace Microsoft.Authorization {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "For client"
   #suppress "@typespec/http/patch-implicit-optional" "For client"
   @summary("Updates a policy assignment.")
-  @scope("java,csharp,go")
+  @scope("java,csharp,go,python")
   @clientLocation(PolicyAssignments)
   @patch
   @route("/{+policyAssignmentId}")
@@ -78,7 +78,7 @@ namespace Microsoft.Authorization {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "For client"
   @summary("Deletes a policy assignment.")
-  @scope("java,csharp,go")
+  @scope("java,csharp,go,python")
   @clientLocation(PolicyAssignments)
   @delete
   @route("/{+policyAssignmentId}")


### PR DESCRIPTION
Mitigate Python SDK breaking changes introduced by the Swagger-to-TypeSpec migration for `azure-mgmt-resource-policy`.

- Added `python` to `@scope` on the four `PolicyAssignments` `*ById` operations (`getById`, `createById`, `updateById`, `deleteById`) in `client.tsp`, restoring the public surface (`get_by_id` / `create_by_id` / `update_by_id` / `delete_by_id`) that the Swagger-generated SDK exposed via autorest's `azure-arm` behavior.
