### PR TITLE
Agent pool rollback 2026-04-01 GA

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -171,15 +171,16 @@ model ManagedClusterAgentPoolProfileProperties {
   /**
    * The version of node image
    */
-  @renamedFrom(Versions.v2026_04_02_preview, "nodeImageVersion")
-  @removed(Versions.v2026_04_02_preview)
+  @renamedFrom(Versions.v2026_04_01, "nodeImageVersion")
+  @removed(Versions.v2026_04_01)
   @visibility(Lifecycle.Read)
   readOnlyNodeImageVersion?: string;
 
   /**
-   * The version of node image
+   * The version of the node image. Setting this value triggers an agentPool rollback.
+   * Only values from `recentlyUsedVersions` are allowed.
    */
-  @added(Versions.v2026_04_02_preview)
+  @added(Versions.v2026_04_01)
   nodeImageVersion?: string;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolUpgradeProfile.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolUpgradeProfile.tsp
@@ -83,7 +83,7 @@ model AgentPoolUpgradeProfileProperties {
   /**
    * List of historical good versions for rollback operations.
    */
-  @added(Versions.v2026_04_02_preview)
+  @added(Versions.v2026_04_01)
   @visibility(Lifecycle.Read)
   @identifiers(#[])
   recentlyUsedVersions?: AgentPoolRecentlyUsedVersion[];
@@ -116,7 +116,7 @@ model AgentPoolUpgradeProfilePropertiesUpgradesItem {
 /**
  * A historical version that can be used for rollback operations.
  */
-@added(Versions.v2026_04_02_preview)
+@added(Versions.v2026_04_01)
 model AgentPoolRecentlyUsedVersion {
   /**
    * The Kubernetes version (major.minor.patch) available for rollback.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
@@ -10867,7 +10867,7 @@
         },
         "nodeImageVersion": {
           "type": "string",
-          "description": "The version of node image"
+          "description": "The version of the node image. Setting this value triggers an agentPool rollback.\nOnly values from `recentlyUsedVersions` are allowed."
         },
         "upgradeStrategy": {
           "$ref": "#/definitions/UpgradeStrategy",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-04-01/managedClusters.json
@@ -4930,6 +4930,25 @@
         }
       }
     },
+    "AgentPoolRecentlyUsedVersion": {
+      "type": "object",
+      "description": "A historical version that can be used for rollback operations.",
+      "properties": {
+        "orchestratorVersion": {
+          "type": "string",
+          "description": "The Kubernetes version (major.minor.patch) available for rollback."
+        },
+        "nodeImageVersion": {
+          "type": "string",
+          "description": "The node image version available for rollback."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp when this version was last used."
+        }
+      }
+    },
     "AgentPoolSSHAccess": {
       "type": "string",
       "description": "SSH access method of an agent pool.",
@@ -5071,6 +5090,15 @@
           "items": {
             "$ref": "#/definitions/AgentPoolUpgradeProfilePropertiesUpgradesItem"
           },
+          "x-ms-identifiers": []
+        },
+        "recentlyUsedVersions": {
+          "type": "array",
+          "description": "List of historical good versions for rollback operations.",
+          "items": {
+            "$ref": "#/definitions/AgentPoolRecentlyUsedVersion"
+          },
+          "readOnly": true,
           "x-ms-identifiers": []
         },
         "latestNodeImageVersion": {
@@ -7227,8 +7255,7 @@
         },
         "nodeImageVersion": {
           "type": "string",
-          "description": "The version of node image",
-          "readOnly": true
+          "description": "The version of the node image. Setting this value triggers an agentPool rollback.\nOnly values from `recentlyUsedVersions` are allowed."
         },
         "upgradeSettings": {
           "$ref": "#/definitions/AgentPoolUpgradeSettings",


### PR DESCRIPTION
Approved AKS handbook API review: https://github.com/azure-management-and-platforms/aks-handbook/pull/111

Promotes agent pool rollback from the 2026-04 preview surface into the 2026-04-01 stable API based on approved AKS API review doc:
https://github.com/azure-management-and-platforms/aks-handbook/pull/111

Changes:
- Promotes `recentlyUsedVersions` and `AgentPoolRecentlyUsedVersion` from `v2026_04_02_preview` to `v2026_04_01`.
- Makes `ManagedClusterAgentPoolProfileProperties.nodeImageVersion` writable in `2026-04-01` for rollback.
- Regenerates the 2026-04 stable and preview swagger output.

Validation:
- `npx tsp compile specification/containerservice/resource-manager/Microsoft.ContainerService/aks --emit @azure-tools/typespec-autorest`
- `git diff --check`
- `npx prettier --plugin @typespec/prettier-plugin-typespec --check specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolUpgradeProfile.tsp`