### PR TITLE
Allow toolbox versions with skills only

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14007,7 +14007,17 @@
                     "items": {
                       "$ref": "#/components/schemas/OpenAI.Tool"
                     },
-                    "description": "The list of tools to include in this version."
+                    "minItems": 1,
+                    "description": "The list of tools to include in this version. Provide at least one tool or one skill."
+                  },
+                  "skills": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ToolboxSkill"
+                    },
+                    "minItems": 1,
+                    "maxItems": 16,
+                    "description": "The list of skills to include in this version. Provide at least one tool or one skill."
                   },
                   "policies": {
                     "allOf": [
@@ -14017,10 +14027,7 @@
                     ],
                     "description": "Policy configuration for this toolbox version."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -47872,6 +47879,59 @@
         ],
         "description": "A tool for searching over the agent's toolbox.\nWhen present, deferred tools are hidden from `tools/list` and only\ndiscoverable via `search_tools` queries at runtime."
       },
+      "ToolboxSkill": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "A unique identifier for the skill."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The name of the skill."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "A description of the skill."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkillTag"
+            },
+            "maxItems": 5,
+            "description": "The keywords describing classes of capabilities for the skill."
+          },
+          "examples": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkillExample"
+            },
+            "maxItems": 5,
+            "description": "A list of example scenarios that the skill can perform."
+          }
+        },
+        "description": "A skill contained in a toolbox version."
+      },
+      "ToolboxSkillExample": {
+        "type": "string",
+        "maxLength": 1024,
+        "description": "An example scenario that a toolbox skill can perform."
+      },
+      "ToolboxSkillTag": {
+        "type": "string",
+        "maxLength": 32,
+        "description": "A keyword describing a class of capabilities for a toolbox skill."
+      },
       "ToolboxVersionObject": {
         "type": "object",
         "required": [
@@ -47879,8 +47939,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {
@@ -47920,7 +47979,17 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             },
-            "description": "The list of tools contained in this toolbox version."
+            "minItems": 1,
+            "description": "The list of tools contained in this toolbox version. At least one of tools or skills is present."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkill"
+            },
+            "minItems": 1,
+            "maxItems": 16,
+            "description": "The list of skills contained in this toolbox version. At least one of tools or skills is present."
           },
           "policies": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9316,13 +9316,19 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/OpenAI.Tool'
-                  description: The list of tools to include in this version.
+                  minItems: 1
+                  description: The list of tools to include in this version. Provide at least one tool or one skill.
+                skills:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ToolboxSkill'
+                  minItems: 1
+                  maxItems: 16
+                  description: The list of skills to include in this version. Provide at least one tool or one skill.
                 policies:
                   allOf:
                     - $ref: '#/components/schemas/ToolboxPolicies'
                   description: Policy configuration for this toolbox version.
-              required:
-                - tools
     get:
       operationId: listToolboxVersions
       description: List all versions of a toolbox.
@@ -33866,6 +33872,47 @@ components:
         A tool for searching over the agent's toolbox.
         When present, deferred tools are hidden from `tools/list` and only
         discoverable via `search_tools` queries at runtime.
+    ToolboxSkill:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: A unique identifier for the skill.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The name of the skill.
+        description:
+          type: string
+          maxLength: 2048
+          description: A description of the skill.
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkillTag'
+          maxItems: 5
+          description: The keywords describing classes of capabilities for the skill.
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkillExample'
+          maxItems: 5
+          description: A list of example scenarios that the skill can perform.
+      description: A skill contained in a toolbox version.
+    ToolboxSkillExample:
+      type: string
+      maxLength: 1024
+      description: An example scenario that a toolbox skill can perform.
+    ToolboxSkillTag:
+      type: string
+      maxLength: 32
+      description: A keyword describing a class of capabilities for a toolbox skill.
     ToolboxVersionObject:
       type: object
       required:
@@ -33874,7 +33921,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           type: object
@@ -33911,7 +33957,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-          description: The list of tools contained in this toolbox version.
+          minItems: 1
+          description: The list of tools contained in this toolbox version. At least one of tools or skills is present.
+        skills:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkill'
+          minItems: 1
+          maxItems: 16
+          description: The list of skills contained in this toolbox version. At least one of tools or skills is present.
         policies:
           allOf:
             - $ref: '#/components/schemas/ToolboxPolicies'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -16584,7 +16584,17 @@
                     "items": {
                       "$ref": "#/components/schemas/OpenAI.Tool"
                     },
-                    "description": "The list of tools to include in this version."
+                    "minItems": 1,
+                    "description": "The list of tools to include in this version. Provide at least one tool or one skill."
+                  },
+                  "skills": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ToolboxSkill"
+                    },
+                    "minItems": 1,
+                    "maxItems": 16,
+                    "description": "The list of skills to include in this version. Provide at least one tool or one skill."
                   },
                   "policies": {
                     "allOf": [
@@ -16594,10 +16604,7 @@
                     ],
                     "description": "Policy configuration for this toolbox version."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -52293,6 +52300,59 @@
         ],
         "description": "A tool for searching over the agent's toolbox.\nWhen present, deferred tools are hidden from `tools/list` and only\ndiscoverable via `search_tools` queries at runtime."
       },
+      "ToolboxSkill": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "A unique identifier for the skill."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "description": "The name of the skill."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "A description of the skill."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkillTag"
+            },
+            "maxItems": 5,
+            "description": "The keywords describing classes of capabilities for the skill."
+          },
+          "examples": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkillExample"
+            },
+            "maxItems": 5,
+            "description": "A list of example scenarios that the skill can perform."
+          }
+        },
+        "description": "A skill contained in a toolbox version."
+      },
+      "ToolboxSkillExample": {
+        "type": "string",
+        "maxLength": 1024,
+        "description": "An example scenario that a toolbox skill can perform."
+      },
+      "ToolboxSkillTag": {
+        "type": "string",
+        "maxLength": 32,
+        "description": "A keyword describing a class of capabilities for a toolbox skill."
+      },
       "ToolboxVersionObject": {
         "type": "object",
         "required": [
@@ -52300,8 +52360,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {
@@ -52341,7 +52400,17 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.Tool"
             },
-            "description": "The list of tools contained in this toolbox version."
+            "minItems": 1,
+            "description": "The list of tools contained in this toolbox version. At least one of tools or skills is present."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolboxSkill"
+            },
+            "minItems": 1,
+            "maxItems": 16,
+            "description": "The list of skills contained in this toolbox version. At least one of tools or skills is present."
           },
           "policies": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11050,13 +11050,19 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/OpenAI.Tool'
-                  description: The list of tools to include in this version.
+                  minItems: 1
+                  description: The list of tools to include in this version. Provide at least one tool or one skill.
+                skills:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ToolboxSkill'
+                  minItems: 1
+                  maxItems: 16
+                  description: The list of skills to include in this version. Provide at least one tool or one skill.
                 policies:
                   allOf:
                     - $ref: '#/components/schemas/ToolboxPolicies'
                   description: Policy configuration for this toolbox version.
-              required:
-                - tools
     get:
       operationId: listToolboxVersions
       description: List all versions of a toolbox.
@@ -36880,6 +36886,47 @@ components:
         A tool for searching over the agent's toolbox.
         When present, deferred tools are hidden from `tools/list` and only
         discoverable via `search_tools` queries at runtime.
+    ToolboxSkill:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: A unique identifier for the skill.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: The name of the skill.
+        description:
+          type: string
+          maxLength: 2048
+          description: A description of the skill.
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkillTag'
+          maxItems: 5
+          description: The keywords describing classes of capabilities for the skill.
+        examples:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkillExample'
+          maxItems: 5
+          description: A list of example scenarios that the skill can perform.
+      description: A skill contained in a toolbox version.
+    ToolboxSkillExample:
+      type: string
+      maxLength: 1024
+      description: An example scenario that a toolbox skill can perform.
+    ToolboxSkillTag:
+      type: string
+      maxLength: 32
+      description: A keyword describing a class of capabilities for a toolbox skill.
     ToolboxVersionObject:
       type: object
       required:
@@ -36888,7 +36935,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           type: object
@@ -36925,7 +36971,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.Tool'
-          description: The list of tools contained in this toolbox version.
+          minItems: 1
+          description: The list of tools contained in this toolbox version. At least one of tools or skills is present.
+        skills:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolboxSkill'
+          minItems: 1
+          maxItems: 16
+          description: The list of skills contained in this toolbox version. At least one of tools or skills is present.
         policies:
           allOf:
             - $ref: '#/components/schemas/ToolboxPolicies'

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -13,6 +13,39 @@ model ToolboxPolicies {
   rai_config?: RaiConfig;
 }
 
+@doc("An example scenario that a toolbox skill can perform.")
+@maxLength(1024)
+scalar ToolboxSkillExample extends string;
+
+@doc("A keyword describing a class of capabilities for a toolbox skill.")
+@maxLength(32)
+scalar ToolboxSkillTag extends string;
+
+@doc("A skill contained in a toolbox version.")
+model ToolboxSkill {
+  @doc("A unique identifier for the skill.")
+  @maxLength(64)
+  @minLength(1)
+  id: string;
+
+  @doc("The name of the skill.")
+  @maxLength(128)
+  @minLength(1)
+  name: string;
+
+  @doc("A description of the skill.")
+  @maxLength(2048)
+  description?: string;
+
+  @doc("The keywords describing classes of capabilities for the skill.")
+  @maxItems(5)
+  tags?: ToolboxSkillTag[];
+
+  @doc("A list of example scenarios that the skill can perform.")
+  @maxItems(5)
+  examples?: ToolboxSkillExample[];
+}
+
 @doc("A toolbox that stores reusable tool definitions for agents.")
 model ToolboxObject {
   @doc("The unique identifier of the toolbox.")
@@ -48,8 +81,14 @@ model ToolboxVersionObject {
   @encode("unixTimestamp", int32)
   created_at: utcDateTime;
 
-  @doc("The list of tools contained in this toolbox version.")
-  tools: OpenAI.Tool[];
+  @doc("The list of tools contained in this toolbox version. At least one of tools or skills is present.")
+  @minItems(1)
+  tools?: OpenAI.Tool[];
+
+  @doc("The list of skills contained in this toolbox version. At least one of tools or skills is present.")
+  @maxItems(16)
+  @minItems(1)
+  skills?: ToolboxSkill[];
 
   @doc("Policy configuration for the toolbox version.")
   policies?: ToolboxPolicies;
@@ -68,8 +107,14 @@ alias CreateToolboxVersionRequest = {
   @doc("Arbitrary key-value metadata to associate with the toolbox.")
   metadata?: Record<string>;
 
-  @doc("The list of tools to include in this version.")
-  tools: OpenAI.Tool[];
+  @doc("The list of tools to include in this version. Provide at least one tool or one skill.")
+  @minItems(1)
+  tools?: OpenAI.Tool[];
+
+  @doc("The list of skills to include in this version. Provide at least one tool or one skill.")
+  @maxItems(16)
+  @minItems(1)
+  skills?: ToolboxSkill[];
 
   @doc("Policy configuration for this toolbox version.")
   policies?: ToolboxPolicies;


### PR DESCRIPTION
## Summary
- Make toolbox version `tools` optional on create and response models.
- Add toolbox-owned `ToolboxSkill` and optional `skills` on toolbox version create/response.
- Document that callers should provide at least one non-empty category: `tools` or `skills`.
- Keep existing `OpenAI.Tool[]` unchanged in this smaller PR; toolbox/OpenAI tool decoupling remains isolated in #43467.

## Split from decoupling change
This PR is intentionally limited to toolbox `tools` optionality and toolbox `skills`. It does **not** introduce `ToolboxTool` or remove any OpenAI tool variants from toolbox payloads; that larger schema split is tracked separately in #43467.

## Validation
- `npx tsp format src/toolboxes/models.tsp`
- `npx tsp compile .`
- `git diff --check`
