### PR TITLE
Fix Kubernetes C# gateway wrapper name

### DIFF
--- a/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/client.tsp
@@ -60,8 +60,7 @@ namespace Microsoft.Kubernetes;
 );
 @@clientName(ConnectedClusterKind.AWS, "Aws", "csharp");
 @@clientName(ConnectedClusterKind.GCP, "Gcp", "csharp");
-@@clientName(ConnectedClusterProperties.gateway, "IsGateway", "csharp");
-@@clientName(ConnectedClusterPatchProperties.gateway, "IsGateway", "csharp");
+@@clientName(Gateway.enabled, "IsGatewayEnabled", "csharp");
 @@clientName(CredentialResult, "ClusterUserCredentialResult", "csharp");
 @@clientName(CredentialResults, "ClusterUserCredentialsResult", "csharp");
 @@clientName(


### PR DESCRIPTION
Fixes the C# customization for the Kubernetes gateway wrapper name.

The previous customization renamed the internal complex `gateway` wrapper to `IsGateway`, while only the boolean `enabled` projection should use the `IsGatewayEnabled` name. This updates the C# customization to target `Gateway.enabled` so the internal wrapper remains `Gateway` and the public boolean accessor remains `IsGatewayEnabled`.

Companion SDK PR: Azure/azure-sdk-for-net#59432