### PR TITLE
Make toolbox tools optional

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -14575,10 +14575,7 @@
                     ],
                     "description": "Policy configuration for this toolbox version."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -48611,8 +48608,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9680,8 +9680,6 @@ paths:
                   allOf:
                     - $ref: '#/components/schemas/ToolboxPolicies'
                   description: Policy configuration for this toolbox version.
-              required:
-                - tools
     get:
       operationId: listToolboxVersions
       description: List all versions of a toolbox.
@@ -34344,7 +34342,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -17152,10 +17152,7 @@
                     ],
                     "description": "Policy configuration for this toolbox version."
                   }
-                },
-                "required": [
-                  "tools"
-                ]
+                }
               }
             }
           }
@@ -53031,8 +53028,7 @@
           "id",
           "name",
           "version",
-          "created_at",
-          "tools"
+          "created_at"
         ],
         "properties": {
           "metadata": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11414,8 +11414,6 @@ paths:
                   allOf:
                     - $ref: '#/components/schemas/ToolboxPolicies'
                   description: Policy configuration for this toolbox version.
-              required:
-                - tools
     get:
       operationId: listToolboxVersions
       description: List all versions of a toolbox.
@@ -37357,7 +37355,6 @@ components:
         - name
         - version
         - created_at
-        - tools
       properties:
         metadata:
           type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -69,7 +69,7 @@ model ToolboxVersionObject {
   created_at: utcDateTime;
 
   @doc("The list of tools contained in this toolbox version.")
-  tools: OpenAI.Tool[];
+  tools?: OpenAI.Tool[];
 
   @doc("The list of skill sources included in this toolbox version.")
   skills?: ToolboxSkill[];
@@ -92,7 +92,7 @@ alias CreateToolboxVersionRequest = {
   metadata?: Record<string>;
 
   @doc("The list of tools to include in this version.")
-  tools: OpenAI.Tool[];
+  tools?: OpenAI.Tool[];
 
   @doc("The list of skill sources to include in this version. A skill reference specifies a skill name and optionally a version. If version is omitted, the skill's default version is used.")
   skills?: ToolboxSkill[];


### PR DESCRIPTION
## Summary
- Make toolbox version `tools` optional on create and response models.
- Leave existing toolbox `skills` support unchanged.
- Regenerate Foundry OpenAPI outputs.

## Validation
- `npx tsp format src/toolboxes/models.tsp`
- `npx tsp compile .`
- `git diff --check`
