### PR TITLE
AKS: client.tsp .NET SDK naming polish for design guideline compliance

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -1548,6 +1548,31 @@ namespace Azure.ResourceManager.Models {
   "enableCsiProxy",
   "java"
 );
+
+// .NET design guideline naming polish (azure-sdk-for-net PR #59192 review feedback)
+@@clientName(
+  ControlPlaneScalingSize,
+  "ManagedClusterControlPlaneScalingSize",
+  "csharp"
+);
+@@clientName(HardEvictionThreshold, "KubeletHardEvictionThreshold", "csharp");
+@@clientName(KubeReserved, "KubeletReservedResources", "csharp");
+@@clientName(
+  ManagedClusterHostedSystemProfile.systemNodeSubnetID,
+  "SystemNodeSubnetId",
+  "csharp"
+);
+@@clientName(
+  ManagedClusterHostedSystemProfile.nodeSubnetID,
+  "NodeSubnetId",
+  "csharp"
+);
+@@clientName(
+  ManagedClusterAzureMonitorProfileMetrics.controlPlane,
+  "IsControlPlane",
+  "csharp"
+);
+
 // TODO: drop the type replacement upon next major breaking change
 @@alternateType(
   ManagedClusterIdentity.type,


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.

---

## Context

This PR adds `@@clientName(..., "csharp")` overrides in `client.tsp` only — no changes to `main.tsp`, `models.tsp`, routes, or the generated `openapi.json`. Renames target the upcoming `Azure.ResourceManager.ContainerService` 1.5.0-beta.2 release (api-version `2026-03-02-preview`) to address [Azure SDK for .NET design guideline review feedback](https://github.com/Azure/azure-sdk-for-net/pull/59192#pullrequestreview-4369808831).

| TypeSpec | C# generated name |
|---|---|
| `ControlPlaneScalingSize` | `ManagedClusterControlPlaneScalingSize` |
| `HardEvictionThreshold` | `KubeletHardEvictionThreshold` |
| `KubeReserved` | `KubeletReservedResources` |
| `ManagedClusterHostedSystemProfile.systemNodeSubnetID` | `SystemNodeSubnetId` |
| `ManagedClusterHostedSystemProfile.nodeSubnetID` | `NodeSubnetId` |
| `ManagedClusterAzureMonitorProfileMetrics.controlPlane` | `IsControlPlane` (auto-flattens to public `IsControlPlaneEnabled`) |

Regenerated `sdk/containerservice/Azure.ResourceManager.ContainerService` locally against this branch — build succeeds with 0 warnings / 0 errors; JSON wire names are preserved via `[WirePath("...")]` attributes on the generated properties.

**Release plan:** [release plan 2233](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releasePlan=2233) (originally submitted with spec PR [#42502](https://github.com/Azure/azure-rest-api-specs/pull/42502)).
