### PR TITLE
[SecurityInsights] Mitigate Python SDK enum-rename breaking changes

### DIFF
--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
@@ -76,3 +76,15 @@ using Azure.ClientGenerator.Core;
 );
 @@clientLocation(listGeodataByIp, "SecurityInsightsClient", "go");
 @@clientLocation(listWhoisByDomain, "SecurityInsightsClient", "go");
+
+@@clientName(EntityKindEnum, "EntityKind", "python");
+@@clientName(
+  ThreatIntelligenceResourceInnerKind,
+  "ThreatIntelligenceResourceKindEnum",
+  "python"
+);
+@@clientName(
+  ThreatIntelligenceSortingOrder,
+  "ThreatIntelligenceSortingCriteriaEnum",
+  "python"
+);


### PR DESCRIPTION
Mitigate Python SDK breaking changes for `azure-mgmt-securityinsight` introduced by TypeSpec migration.

Adds `@@clientName` aliases in `client.tsp` so the Python SDK keeps the original enum names:

| TypeSpec name | Python client name |
|---|---|
| `EntityKindEnum` | `EntityKind` |
| `ThreatIntelligenceResourceInnerKind` | `ThreatIntelligenceResourceKindEnum` |
| `ThreatIntelligenceSortingOrder` | `ThreatIntelligenceSortingCriteriaEnum` |

This restores backward compatibility for the renamed enums reported in the changelog of [Azure/azure-sdk-for-python#47157](https://github.com/Azure/azure-sdk-for-python/pull/47157) (lines 407-409).

Only `client.tsp` is changed; no wire/schema changes.
