### PR TITLE
Fix Traffic Manager user metrics resource name

### DIFF
--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/UserMetricsModel.tsp
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/UserMetricsModel.tsp
@@ -36,7 +36,8 @@ alias UserMetricsModelOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @key("trafficManagerUserMetricsKey")
     trafficManagerUserMetricsKey: "default";
   },
-  ErrorType = CloudError
+  ErrorType = CloudError,
+  ResourceName = "TrafficManagerUserMetrics"
 >;
 
 @armResourceOperations

--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
@@ -14,6 +14,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.TrafficManager"
+    api-version: "2022-04-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-trafficmanager"
     namespace: "azure.mgmt.trafficmanager"


### PR DESCRIPTION
## Description

Adds the ResourceName argument to the Traffic Manager user metrics LegacyOperations template so SDK generation can preserve the intended TrafficManagerUserMetricsResource name without SDK-side CodeGenType customization.

Related to Azure/azure-sdk-for-net#59410