### PR TITLE
Skip sdk generation for rust in case of OpenAPI specs

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -398,23 +398,30 @@ export function getRequiredSettingValue(
  * Indicates which generation tool should be used for a given spec.
  * - "azsdk-cli": Use azsdk-cli for generation (Rust TypeSpec specs)
  * - "spec-gen-sdk": Use existing spec-gen-sdk tool
+ * - "skipped": Generation is not applicable (e.g., Rust with OpenAPI-only spec)
  * - "unsupported": The required tool is not available (e.g., Rust without azsdk-cli)
  */
-export type GenerationTool = "azsdk-cli" | "spec-gen-sdk" | "unsupported";
+export type GenerationTool = "azsdk-cli" | "spec-gen-sdk" | "skipped" | "unsupported";
 
 /**
  * Determines whether to use azsdk-cli or spec-gen-sdk for a given spec.
  * Currently only uses azsdk-cli for Rust TypeSpec specs when the CLI is
  * available. All other languages and OpenAPI specs use spec-gen-sdk.
+ * Returns "skipped" if Rust is requested with only an OpenAPI (readme.md) spec.
  * Returns "unsupported" if Rust is requested but azsdk-cli is not installed.
  */
 export function selectGenerationTool(
   tspConfigPath?: string,
-  _readmePath?: string,
+  readmePath?: string,
   sdkLanguage?: SdkName,
 ): GenerationTool {
-  if (tspConfigPath && sdkLanguage === "azure-sdk-for-rust") {
-    return isAzsdkCliAvailable() ? "azsdk-cli" : "unsupported";
+  if (sdkLanguage === "azure-sdk-for-rust") {
+    if (!tspConfigPath && readmePath) {
+      return "skipped";
+    }
+    if (tspConfigPath) {
+      return isAzsdkCliAvailable() ? "azsdk-cli" : "unsupported";
+    }
   }
   return "spec-gen-sdk";
 }

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -322,7 +322,21 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
 
     logMessage(`Generating SDK from ${changedSpecPathText}`, LogLevel.Group);
 
-    if (tool === "azsdk-cli" && changedSpec.typespecProject) {
+    // Rust only supports TypeSpec; skip generation for OpenAPI (readme.md) specs
+    if (
+      commandInput.sdkLanguage === "azure-sdk-for-rust" &&
+      !changedSpec.typespecProject &&
+      changedSpec.readmeMd
+    ) {
+      logMessage(
+        `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
+        LogLevel.Warn,
+      );
+      executionReport = {
+        packages: [],
+        executionResult: "succeeded",
+      };
+    } else if (tool === "azsdk-cli" && changedSpec.typespecProject) {
       // azsdk-cli path for TypeSpec specs
       try {
         await resetGitRepo(commandInput.localSdkRepoPath);

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -188,10 +188,18 @@ export async function generateSdkForSingleSpec(): Promise<CommandResult> {
   }
 
   await installLanguageToolchain(commandInput);
-
-  if (tool === "azsdk-cli" && commandInput.tspConfigPath) {
+  logMessage(`Generating SDK from ${specConfigPathText}`, LogLevel.Group);
+  if (tool === "skipped") {
+    logMessage(
+      `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
+      LogLevel.Warn,
+    );
+    executionReport = {
+      packages: [],
+      executionResult: "succeeded",
+    };
+  } else if (tool === "azsdk-cli" && commandInput.tspConfigPath) {
     // azsdk-cli path for TypeSpec specs
-    logMessage(`Generating SDK (azsdk-cli) from ${specConfigPathText}`, LogLevel.Group);
     const result = await runAzsdkGeneration(commandInput, commandInput.tspConfigPath);
     executionReport = result.executionReport;
     statusCode = result.statusCode;
@@ -199,7 +207,6 @@ export async function generateSdkForSingleSpec(): Promise<CommandResult> {
   } else {
     // Existing spec-gen-sdk path
     const specGenSdkCommand = prepareSpecGenSdkCommand(commandInput);
-    logMessage(`Generating SDK from ${specConfigPathText}`, LogLevel.Group);
     logMessage(`Runner command:${specGenSdkCommand.join(" ")}`);
     try {
       await runSpecGenSdkCommand(specGenSdkCommand);
@@ -322,12 +329,7 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
 
     logMessage(`Generating SDK from ${changedSpecPathText}`, LogLevel.Group);
 
-    // Rust only supports TypeSpec; skip generation for OpenAPI (readme.md) specs
-    if (
-      commandInput.sdkLanguage === "azure-sdk-for-rust" &&
-      !changedSpec.typespecProject &&
-      changedSpec.readmeMd
-    ) {
+    if (tool === "skipped") {
       logMessage(
         `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
         LogLevel.Warn,
@@ -513,7 +515,17 @@ export async function generateSdkForBatchSpecs(batchType: string): Promise<Comma
       continue;
     }
 
-    if (tool === "azsdk-cli" && specConfigs.tspconfigPath) {
+    if (tool === "skipped") {
+      specConfigPath = specConfigs.readmePath ?? "";
+      logMessage(
+        `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
+        LogLevel.Warn,
+      );
+      executionReport = {
+        packages: [],
+        executionResult: "succeeded",
+      };
+    } else if (tool === "azsdk-cli" && specConfigs.tspconfigPath) {
       // azsdk-cli path for TypeSpec specs
       specConfigPath = specConfigs.tspconfigPath;
       logMessage(`Using azsdk-cli for ${specConfigPath}`, LogLevel.Info);

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -192,7 +192,7 @@ export async function generateSdkForSingleSpec(): Promise<CommandResult> {
   if (tool === "skipped") {
     logMessage(
       `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
-      LogLevel.Warn,
+      LogLevel.Info,
     );
     executionReport = {
       packages: [],
@@ -332,7 +332,7 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
     if (tool === "skipped") {
       logMessage(
         `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
-        LogLevel.Warn,
+        LogLevel.Info,
       );
       executionReport = {
         packages: [],
@@ -519,7 +519,7 @@ export async function generateSdkForBatchSpecs(batchType: string): Promise<Comma
       specConfigPath = specConfigs.readmePath ?? "";
       logMessage(
         `SDK generation from OpenAPI (readme.md) is not supported for ${commandInput.sdkRepoName}. Skipping spec.`,
-        LogLevel.Warn,
+        LogLevel.Info,
       );
       executionReport = {
         packages: [],

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   logIssuesToPipeline,
   parseArguments,
   prepareSpecGenSdkCommand,
+  selectGenerationTool,
   setPipelineVariables,
 } from "../src/command-helpers.js";
 import * as log from "../src/log.js";
@@ -646,6 +647,40 @@ describe("commands.ts", () => {
 
       const result2 = getRequiredSettingValue(false, false, "azure-sdk-for-python");
       expect(result2).toBe(true);
+    });
+  });
+
+  describe("selectGenerationTool", () => {
+    test("should return 'skipped' for Rust with only readme path", () => {
+      const result = selectGenerationTool(
+        undefined,
+        "specification/compute/resource-manager/readme.md",
+        SdkName.Rust,
+      );
+      expect(result).toBe("skipped");
+    });
+
+    test("should return 'spec-gen-sdk' for non-Rust with only readme path", () => {
+      const result = selectGenerationTool(
+        undefined,
+        "specification/compute/resource-manager/readme.md",
+        SdkName.Js,
+      );
+      expect(result).toBe("spec-gen-sdk");
+    });
+
+    test("should return 'spec-gen-sdk' for non-Rust with tspconfig path", () => {
+      const result = selectGenerationTool(
+        "specification/compute/Compute.Management/tspconfig.yaml",
+        undefined,
+        SdkName.Js,
+      );
+      expect(result).toBe("spec-gen-sdk");
+    });
+
+    test("should return 'spec-gen-sdk' when no paths are provided", () => {
+      const result = selectGenerationTool(undefined, undefined, SdkName.Rust);
+      expect(result).toBe("spec-gen-sdk");
     });
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -176,6 +176,39 @@ describe("generateSdkForSingleSpec", () => {
       LogLevel.Error,
     );
   });
+
+  test("should skip SDK generation for Rust when only readme path is provided", async () => {
+    const mockCommandInput = {
+      readmePath: "specification/compute/resource-manager/readme.md",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "release",
+      localSdkRepoPath: "/sdk/path",
+      sdkRepoName: "azure-sdk-for-rust",
+      sdkLanguage: SdkName.Rust,
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "installLanguageToolchain").mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "setPipelineVariables").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await generateSdkForSingleSpec();
+
+    expect(result.statusCode).toBe(0);
+    expect(result.executionResult).toBe("succeeded");
+    expect(log.logMessage).toHaveBeenCalledWith(
+      `SDK generation from OpenAPI (readme.md) is not supported for ${mockCommandInput.sdkRepoName}. Skipping spec.`,
+      LogLevel.Info,
+    );
+    expect(utils.runSpecGenSdkCommand).not.toHaveBeenCalled();
+  });
 });
 
 describe("generateSdkForSpecPr", () => {
@@ -554,6 +587,57 @@ describe("generateSdkForSpecPr", () => {
       LogLevel.Error,
     );
   });
+
+  test("should skip SDK generation for Rust when changed spec has only readme", async () => {
+    const mockCommandInput = {
+      localSdkRepoPath: "path/to/local/repo",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "spec-pull-request",
+      sdkRepoName: "azure-sdk-for-rust",
+      sdkLanguage: SdkName.Rust,
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+    const mockChangedSpecs = [
+      {
+        specs: [
+          "specification/compute/resource-manager/Microsoft.Compute/preview/2021-10-01-preview/examples/VMs_Get.json",
+        ],
+        readmeMd: "specification/compute/resource-manager/readme.md",
+      },
+    ];
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
+    vi.spyOn(commandHelpers, "installLanguageToolchain").mockResolvedValue(undefined);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
+    vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const { statusCode } = await generateSdkForSpecPr();
+
+    expect(statusCode).toBe(0);
+    expect(log.logMessage).toHaveBeenCalledWith(
+      `SDK generation from OpenAPI (readme.md) is not supported for ${mockCommandInput.sdkRepoName}. Skipping spec.`,
+      LogLevel.Info,
+    );
+    expect(utils.runSpecGenSdkCommand).not.toHaveBeenCalled();
+    expect(utils.resetGitRepo).not.toHaveBeenCalled();
+    expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
+      mockCommandInput,
+      "succeeded",
+      false,
+      true,
+      false,
+      "",
+      [],
+      true,
+    );
+  });
 });
 
 describe("generateSdkForBatchSpecs", () => {
@@ -749,5 +833,49 @@ describe("generateSdkForBatchSpecs", () => {
     const calls = getNormalizedFsCalls(fs.writeFileSync as Mock);
     expect(calls).toMatchSnapshot();
     logSpy.mockRestore();
+  });
+
+  test("should skip SDK generation for Rust when spec has only readme path", async () => {
+    const mockBatchType = "all-specs";
+    const mockSpecPaths = [
+      {
+        readmePath: "specification/compute/resource-manager/readme.md",
+      },
+    ];
+    const mockInput = {
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "batch",
+      localSdkRepoPath: "/sdk/path",
+      sdkRepoName: "azure-sdk-for-rust",
+      sdkLanguage: SdkName.Rust,
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockInput);
+    vi.spyOn(commandHelpers, "installLanguageToolchain").mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "getSpecPaths").mockReturnValue(mockSpecPaths);
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    vi.spyOn(log, "vsoAddAttachment").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await generateSdkForBatchSpecs(mockBatchType);
+
+    expect(result.statusCode).toBe(0);
+    expect(result.executionResult).toBe("succeeded");
+    expect(log.logMessage).toHaveBeenCalledWith(
+      `SDK generation from OpenAPI (readme.md) is not supported for ${mockInput.sdkRepoName}. Skipping spec.`,
+      LogLevel.Info,
+    );
+    expect(utils.runSpecGenSdkCommand).not.toHaveBeenCalled();
+    expect(utils.resetGitRepo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This pull request updates the SDK generation workflow to correctly handle cases where Rust SDKs are requested for OpenAPI-only specs (i.e., those without a TypeSpec config). It introduces a new "skipped" state to indicate that generation should not proceed in these cases and ensures that the runner logs and reports these skips gracefully across single, PR, and batch generation commands.

Key changes:

* Added a new `GenerationTool` value `"skipped"` to represent cases where SDK generation is not applicable (e.g., Rust with only an OpenAPI spec and no TypeSpec config). The selection logic in `selectGenerationTool` now returns `"skipped"` in these cases.

* Updated `generateSdkForSingleSpec`, `generateSdkForSpecPr`, and `generateSdkForBatchSpecs` to check for the `"skipped"` tool. When detected, the runner logs a warning, marks the execution as succeeded with no packages, and skips generation instead of attempting to run a tool.
