### PR TITLE
Use better names other than 'body', since it gets emitted in SDKs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/routes.tsp
@@ -38,7 +38,7 @@ interface AgentOptimizationJobs {
       ...WithOperationId;
 
       @doc("The optimization job inputs.")
-      @body body: OptimizationJobInputs;
+      @body inputs: OptimizationJobInputs;
     },
     JobCreatedResponse<OptimizationJob>
   >;
@@ -211,7 +211,7 @@ interface AgentOptimizationJobs {
       @path candidateId: string;
 
       @doc("Promotion details.")
-      @body body: PromoteCandidateRequest;
+      @body candidate_request: PromoteCandidateRequest;
     },
     PromoteCandidateResponse
   >;


### PR DESCRIPTION
There is no change in OpenAPI3 files, since this is just a TypeSpec label. But it does get used as the input argument name in emitted SDK methods. We want more descriptive names than `body`
