### PR TITLE
fix(ai-foundry/routines): align Foundry Routines TypeSpec contracts (rebased on latest feature/foundry-release)

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12254,46 +12254,16 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.after"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.before"
           },
           {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.order"
           },
           {
             "name": "api-version",
@@ -12312,33 +12282,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Routine"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineListResponse"
                 }
               }
             }
@@ -12576,46 +12520,16 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
           },
           {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
           },
           {
             "name": "api-version",
@@ -12634,33 +12548,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoutineRun"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
                 }
               }
             }
@@ -15042,11 +14930,52 @@
           "maxLength": 128
         }
       },
+      "ListRoutineRunsParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
         "required": false,
         "description": "An optional MLflow search-runs filter expression applied within the routine's experiment.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of runs to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -15061,6 +14990,47 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "ListRoutinesParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of routines to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -19575,6 +19545,49 @@
         ],
         "description": "Custom credential definition"
       },
+      "CustomRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type",
+          "provider",
+          "parameters"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom"
+            ],
+            "description": "The trigger type."
+          },
+          "provider": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The external provider that emits the custom event."
+          },
+          "event_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The provider-specific event name that fires the routine."
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Provider-specific trigger parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "A custom event routine trigger.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "DailyRecurrenceSchedule": {
         "type": "object",
         "required": [
@@ -23045,19 +23058,40 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueOpenedRoutineTrigger": {
+      "GitHubIssueEvent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "opened",
+              "closed"
+            ]
+          }
+        ],
+        "description": "Known GitHub issue events that can fire a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "GitHubIssueRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "assignee",
-          "repository"
+          "owner",
+          "repository",
+          "issue_event"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue_opened"
+              "github_issue"
             ],
             "description": "The trigger type."
           },
@@ -23066,15 +23100,23 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "assignee": {
+          "owner": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
+            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
+          },
+          "issue_event": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHubIssueEvent"
+              }
+            ],
+            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -23082,7 +23124,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue-opened routine trigger.",
+        "description": "A GitHub issue routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -23730,7 +23772,8 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -23741,9 +23784,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
-            "description": "The raw input sent to the downstream invocations target."
+            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -23761,8 +23802,7 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type",
-          "agent_endpoint_id"
+          "type"
         ],
         "properties": {
           "type": {
@@ -23772,10 +23812,18 @@
             ],
             "description": "The action type."
           },
+          "agent_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The project-scoped agent name for routine dispatch."
+          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+          },
+          "input": {
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "session_id": {
             "type": "string",
@@ -23788,7 +23836,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API.",
+        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -23798,7 +23846,8 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -23809,9 +23858,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
-            "description": "The user input sent to the downstream responses target."
+            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -23842,14 +23889,17 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for responses API dispatch."
+            "description": "The project-scoped agent name for routine dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for responses API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
-          "conversation_id": {
+          "input": {
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
+          },
+          "conversation": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -46642,10 +46692,7 @@
       "Routine": {
         "type": "object",
         "required": [
-          "name",
-          "enabled",
-          "triggers",
-          "action"
+          "enabled"
         ],
         "properties": {
           "name": {
@@ -46775,10 +46822,6 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
-        "required": [
-          "triggers",
-          "action"
-        ],
         "properties": {
           "description": {
             "type": "string",
@@ -46861,18 +46904,50 @@
           ]
         }
       },
+      "RoutineListResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first routine in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routines are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineRun": {
         "type": "object",
         "required": [
-          "id",
-          "status",
-          "trigger_type",
-          "started_at"
+          "id"
         ],
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt."
+            "description": "The MLflow run identifier for the routine attempt.",
+            "readOnly": true
           },
           "status": {
             "type": "string",
@@ -46894,6 +46969,10 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
+          "trigger_name": {
+            "type": "string",
+            "description": "The configured trigger name that produced the routine attempt."
+          },
           "attempt_source": {
             "allOf": [
               {
@@ -46910,6 +46989,22 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
+          "agent_id": {
+            "type": "string",
+            "description": "The project-scoped agent identifier recorded for the routine attempt."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "The conversation identifier used by a responses API dispatch."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "The hosted-agent session identifier used by an invocations API dispatch."
+          },
           "triggered_at": {
             "allOf": [
               {
@@ -46917,6 +47012,18 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
+          },
+          "scheduled_fire_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The scheduled fire time recorded for timer and schedule deliveries."
+          },
+          "trigger_time_zone": {
+            "type": "string",
+            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -46950,6 +47057,11 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
+          "error_status_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The downstream error status code captured for a failed attempt, when available."
+          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -46957,55 +47069,9 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
-          },
-          "diagnostics": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunDiagnostics"
-              }
-            ],
-            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunDiagnostics": {
-        "type": "object",
-        "required": [
-          "parameters",
-          "tags",
-          "metrics"
-        ],
-        "properties": {
-          "parameters": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow parameters recorded on the run, keyed by parameter name."
-          },
-          "tags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow tags recorded on the run, keyed by tag name."
-          },
-          "metrics": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "number",
-              "format": "double"
-            },
-            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
-          }
-        },
-        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -47034,6 +47100,40 @@
           ]
         }
       },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRun"
+            },
+            "description": "The requested list of routine runs."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first run in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routine runs are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routine runs.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -47054,7 +47154,8 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
+            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
+            "custom": "#/components/schemas/CustomRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -47072,7 +47173,8 @@
           {
             "type": "string",
             "enum": [
-              "github_issue_opened",
+              "custom",
+              "github_issue",
               "schedule",
               "timer"
             ]
@@ -48491,8 +48593,7 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type",
-          "at"
+          "type"
         ],
         "properties": {
           "type": {
@@ -48502,9 +48603,9 @@
             ],
             "description": "The trigger type."
           },
-          "at": {
+          "in": {
             "type": "string",
-            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -8130,46 +8130,10 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
+        - $ref: '#/components/parameters/ListRoutinesParameters.after'
+        - $ref: '#/components/parameters/ListRoutinesParameters.before'
+        - $ref: '#/components/parameters/ListRoutinesParameters.order'
         - name: api-version
           in: query
           required: true
@@ -8183,26 +8147,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Routine'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -8346,46 +8291,10 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
         - name: api-version
           in: query
           required: true
@@ -8399,26 +8308,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/RoutineRun'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineRunsResponse'
         default:
           description: An unexpected error response.
           content:
@@ -10003,11 +9893,44 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutineRunsParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
       required: false
       description: An optional MLflow search-runs filter expression applied within the routine's experiment.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of runs to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutineRunsParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -10019,6 +9942,39 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutinesParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list response.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of routines to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutinesParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -13074,6 +13030,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
+    CustomRoutineTrigger:
+      type: object
+      required:
+        - type
+        - provider
+        - parameters
+      properties:
+        type:
+          type: string
+          enum:
+            - custom
+          description: The trigger type.
+        provider:
+          type: string
+          maxLength: 128
+          description: The external provider that emits the custom event.
+        event_name:
+          type: string
+          maxLength: 256
+          description: The provider-specific event name that fires the routine.
+        parameters:
+          type: object
+          additionalProperties: {}
+          description: Provider-specific trigger parameters.
+      allOf:
+        - $ref: '#/components/schemas/RoutineTrigger'
+      description: A custom event routine trigger.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -15649,34 +15635,50 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueOpenedRoutineTrigger:
+    GitHubIssueEvent:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - opened
+            - closed
+      description: Known GitHub issue events that can fire a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    GitHubIssueRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - assignee
+        - owner
         - repository
+        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue_opened
+            - github_issue
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        assignee:
+        owner:
           type: string
           maxLength: 128
-          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
+          description: The GitHub owner or organization that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
+        issue_event:
+          allOf:
+            - $ref: '#/components/schemas/GitHubIssueEvent'
+          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue-opened routine trigger.
+      description: A GitHub issue routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -16105,6 +16107,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -16112,9 +16115,7 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
-          description: The raw input sent to the downstream invocations target.
+          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -16125,24 +16126,29 @@ components:
       type: object
       required:
         - type
-        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
+        agent_name:
+          type: string
+          maxLength: 256
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for invocations API dispatch.
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API.
+      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -16150,6 +16156,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -16157,9 +16164,7 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
-          description: The user input sent to the downstream responses target.
+          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -16179,12 +16184,14 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for responses API dispatch.
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for responses API dispatch.
-        conversation_id:
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
+        conversation:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -33017,10 +33024,7 @@ components:
     Routine:
       type: object
       required:
-        - name
         - enabled
-        - triggers
-        - action
       properties:
         name:
           type: string
@@ -33099,9 +33103,6 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
-      required:
-        - triggers
-        - action
       properties:
         description:
           type: string
@@ -33152,17 +33153,39 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
+    RoutineListResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        first_id:
+          type: string
+          description: The identifier of the first routine in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routines are available after this page.
+      description: The paginated response returned when listing routines.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     RoutineRun:
       type: object
       required:
         - id
-        - status
-        - trigger_type
-        - started_at
       properties:
         id:
           type: string
           description: The MLflow run identifier for the routine attempt.
+          readOnly: true
         status:
           type: string
           description: The underlying MLflow run status.
@@ -33174,6 +33197,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
+        trigger_name:
+          type: string
+          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -33182,10 +33208,29 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
+        agent_id:
+          type: string
+          description: The project-scoped agent identifier recorded for the routine attempt.
+        agent_endpoint_id:
+          type: string
+          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
+        conversation_id:
+          type: string
+          description: The conversation identifier used by a responses API dispatch.
+        session_id:
+          type: string
+          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
+        scheduled_fire_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The scheduled fire time recorded for timer and schedule deliveries.
+        trigger_time_zone:
+          type: string
+          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -33206,44 +33251,17 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
+        error_status_code:
+          type: integer
+          format: int32
+          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
-        diagnostics:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunDiagnostics'
-          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunDiagnostics:
-      type: object
-      required:
-        - parameters
-        - tags
-        - metrics
-      properties:
-        parameters:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow parameters recorded on the run, keyed by parameter name.
-        tags:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow tags recorded on the run, keyed by tag name.
-        metrics:
-          type: object
-          additionalProperties:
-            type: number
-            format: double
-          description: Latest MLflow metric values recorded on the run, keyed by metric name.
-      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -33257,6 +33275,30 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunsResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoutineRun'
+          description: The requested list of routine runs.
+        first_id:
+          type: string
+          description: The identifier of the first run in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routine runs are available after this page.
+      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -33274,7 +33316,8 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
+          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
+          custom: '#/components/schemas/CustomRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -33284,7 +33327,8 @@ components:
         - type: string
         - type: string
           enum:
-            - github_issue_opened
+            - custom
+            - github_issue
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
@@ -34251,16 +34295,15 @@ components:
       type: object
       required:
         - type
-        - at
       properties:
         type:
           type: string
           enum:
             - timer
           description: The trigger type.
-        at:
+        in:
           type: string
-          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -14831,46 +14831,16 @@
             }
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.after"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.before"
           },
           {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutinesParameters.order"
           },
           {
             "name": "api-version",
@@ -14889,33 +14859,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Routine"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineListResponse"
                 }
               }
             }
@@ -15153,46 +15097,16 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
           },
           {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
           },
           {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
           },
           {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
           },
           {
             "name": "api-version",
@@ -15211,33 +15125,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "data",
-                    "has_more"
-                  ],
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/RoutineRun"
-                      },
-                      "description": "The requested list of items."
-                    },
-                    "first_id": {
-                      "type": "string",
-                      "description": "The first ID represented in this list."
-                    },
-                    "last_id": {
-                      "type": "string",
-                      "description": "The last ID represented in this list."
-                    },
-                    "has_more": {
-                      "type": "boolean",
-                      "description": "A value indicating whether there are additional values available not captured in this list."
-                    }
-                  },
-                  "description": "The response data for a requested list of items."
+                  "$ref": "#/components/schemas/RoutineRunsResponse"
                 }
               }
             }
@@ -17619,11 +17507,52 @@
           "maxLength": 128
         }
       },
+      "ListRoutineRunsParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
         "required": false,
         "description": "An optional MLflow search-runs filter expression applied within the routine's experiment.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of runs to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutineRunsParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -17638,6 +17567,47 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "ListRoutinesParameters.after": {
+        "name": "after",
+        "in": "query",
+        "required": false,
+        "description": "An opaque cursor returned as last_id by the previous list response.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.before": {
+        "name": "before",
+        "in": "query",
+        "required": false,
+        "description": "Unsupported. Reserved for future backward pagination support.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "The maximum number of routines to return.",
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "explode": false
+      },
+      "ListRoutinesParameters.order": {
+        "name": "order",
+        "in": "query",
+        "required": false,
+        "description": "The ordering direction. Supported values are asc and desc.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -22790,6 +22760,49 @@
         ],
         "description": "Custom credential definition"
       },
+      "CustomRoutineTrigger": {
+        "type": "object",
+        "required": [
+          "type",
+          "provider",
+          "parameters"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom"
+            ],
+            "description": "The trigger type."
+          },
+          "provider": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "The external provider that emits the custom event."
+          },
+          "event_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The provider-specific event name that fires the routine."
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Provider-specific trigger parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RoutineTrigger"
+          }
+        ],
+        "description": "A custom event routine trigger.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "DailyRecurrenceSchedule": {
         "type": "object",
         "required": [
@@ -27141,19 +27154,40 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueOpenedRoutineTrigger": {
+      "GitHubIssueEvent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "opened",
+              "closed"
+            ]
+          }
+        ],
+        "description": "Known GitHub issue events that can fire a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "GitHubIssueRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "assignee",
-          "repository"
+          "owner",
+          "repository",
+          "issue_event"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue_opened"
+              "github_issue"
             ],
             "description": "The trigger type."
           },
@@ -27162,15 +27196,23 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "assignee": {
+          "owner": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
+            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
+          },
+          "issue_event": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GitHubIssueEvent"
+              }
+            ],
+            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -27178,7 +27220,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue-opened routine trigger.",
+        "description": "A GitHub issue routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -27899,7 +27941,8 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -27910,9 +27953,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
-            "description": "The raw input sent to the downstream invocations target."
+            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -27930,8 +27971,7 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type",
-          "agent_endpoint_id"
+          "type"
         ],
         "properties": {
           "type": {
@@ -27941,10 +27981,18 @@
             ],
             "description": "The action type."
           },
+          "agent_name": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "The project-scoped agent name for routine dispatch."
+          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+          },
+          "input": {
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
           },
           "session_id": {
             "type": "string",
@@ -27957,7 +28005,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API.",
+        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -27967,7 +28015,8 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "input"
         ],
         "properties": {
           "type": {
@@ -27978,9 +28027,7 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "type": "string",
-            "maxLength": 32768,
-            "description": "The user input sent to the downstream responses target."
+            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
           }
         },
         "allOf": [
@@ -28011,14 +28058,17 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for responses API dispatch."
+            "description": "The project-scoped agent name for routine dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "The endpoint-scoped agent identifier for responses API dispatch."
+            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
           },
-          "conversation_id": {
+          "input": {
+            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
+          },
+          "conversation": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -51036,10 +51086,7 @@
       "Routine": {
         "type": "object",
         "required": [
-          "name",
-          "enabled",
-          "triggers",
-          "action"
+          "enabled"
         ],
         "properties": {
           "name": {
@@ -51169,10 +51216,6 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
-        "required": [
-          "triggers",
-          "action"
-        ],
         "properties": {
           "description": {
             "type": "string",
@@ -51255,18 +51298,50 @@
           ]
         }
       },
+      "RoutineListResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Routine"
+            },
+            "description": "The requested list of routines."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first routine in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routines are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routines.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineRun": {
         "type": "object",
         "required": [
-          "id",
-          "status",
-          "trigger_type",
-          "started_at"
+          "id"
         ],
         "properties": {
           "id": {
             "type": "string",
-            "description": "The MLflow run identifier for the routine attempt."
+            "description": "The MLflow run identifier for the routine attempt.",
+            "readOnly": true
           },
           "status": {
             "type": "string",
@@ -51288,6 +51363,10 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
+          "trigger_name": {
+            "type": "string",
+            "description": "The configured trigger name that produced the routine attempt."
+          },
           "attempt_source": {
             "allOf": [
               {
@@ -51304,6 +51383,22 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
+          "agent_id": {
+            "type": "string",
+            "description": "The project-scoped agent identifier recorded for the routine attempt."
+          },
+          "agent_endpoint_id": {
+            "type": "string",
+            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
+          },
+          "conversation_id": {
+            "type": "string",
+            "description": "The conversation identifier used by a responses API dispatch."
+          },
+          "session_id": {
+            "type": "string",
+            "description": "The hosted-agent session identifier used by an invocations API dispatch."
+          },
           "triggered_at": {
             "allOf": [
               {
@@ -51311,6 +51406,18 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
+          },
+          "scheduled_fire_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "The scheduled fire time recorded for timer and schedule deliveries."
+          },
+          "trigger_time_zone": {
+            "type": "string",
+            "description": "The trigger time zone recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -51344,6 +51451,11 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
+          "error_status_code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The downstream error status code captured for a failed attempt, when available."
+          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -51351,55 +51463,9 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
-          },
-          "diagnostics": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunDiagnostics"
-              }
-            ],
-            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "RoutineRunDiagnostics": {
-        "type": "object",
-        "required": [
-          "parameters",
-          "tags",
-          "metrics"
-        ],
-        "properties": {
-          "parameters": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow parameters recorded on the run, keyed by parameter name."
-          },
-          "tags": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "MLflow tags recorded on the run, keyed by tag name."
-          },
-          "metrics": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "number",
-              "format": "double"
-            },
-            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
-          }
-        },
-        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -51428,6 +51494,40 @@
           ]
         }
       },
+      "RoutineRunsResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoutineRun"
+            },
+            "description": "The requested list of routine runs."
+          },
+          "first_id": {
+            "type": "string",
+            "description": "The identifier of the first run in this page, or null when the page is empty."
+          },
+          "last_id": {
+            "type": "string",
+            "description": "An opaque cursor to pass as the next after query parameter when has_more is true."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True when more routine runs are available after this page."
+          }
+        },
+        "description": "The paginated response returned when listing routine runs.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -51448,7 +51548,8 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
+            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
+            "custom": "#/components/schemas/CustomRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -51466,7 +51567,8 @@
           {
             "type": "string",
             "enum": [
-              "github_issue_opened",
+              "custom",
+              "github_issue",
               "schedule",
               "timer"
             ]
@@ -52911,8 +53013,7 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type",
-          "at"
+          "type"
         ],
         "properties": {
           "type": {
@@ -52922,9 +53023,9 @@
             ],
             "description": "The trigger type."
           },
-          "at": {
+          "in": {
             "type": "string",
-            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+            "description": "A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time."
           },
           "time_zone": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -9864,46 +9864,10 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
+        - $ref: '#/components/parameters/ListRoutinesParameters.after'
+        - $ref: '#/components/parameters/ListRoutinesParameters.before'
+        - $ref: '#/components/parameters/ListRoutinesParameters.order'
         - name: api-version
           in: query
           required: true
@@ -9917,26 +9881,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Routine'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineListResponse'
         default:
           description: An unexpected error response.
           content:
@@ -10080,46 +10025,10 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
+        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
         - name: api-version
           in: query
           required: true
@@ -10133,26 +10042,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - data
-                  - has_more
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/RoutineRun'
-                    description: The requested list of items.
-                  first_id:
-                    type: string
-                    description: The first ID represented in this list.
-                  last_id:
-                    type: string
-                    description: The last ID represented in this list.
-                  has_more:
-                    type: boolean
-                    description: A value indicating whether there are additional values available not captured in this list.
-                description: The response data for a requested list of items.
+                $ref: '#/components/schemas/RoutineRunsResponse'
         default:
           description: An unexpected error response.
           content:
@@ -11737,11 +11627,44 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutineRunsParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list-runs response.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
       required: false
       description: An optional MLflow search-runs filter expression applied within the routine's experiment.
+      schema:
+        type: string
+      explode: false
+    ListRoutineRunsParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of runs to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutineRunsParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -11753,6 +11676,39 @@ components:
       schema:
         type: string
         maxLength: 128
+    ListRoutinesParameters.after:
+      name: after
+      in: query
+      required: false
+      description: An opaque cursor returned as last_id by the previous list response.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.before:
+      name: before
+      in: query
+      required: false
+      description: Unsupported. Reserved for future backward pagination support.
+      schema:
+        type: string
+      explode: false
+    ListRoutinesParameters.limit:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of routines to return.
+      schema:
+        type: integer
+        format: int32
+      explode: false
+    ListRoutinesParameters.order:
+      name: order
+      in: query
+      required: false
+      description: The ordering direction. Supported values are asc and desc.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -15255,6 +15211,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
+    CustomRoutineTrigger:
+      type: object
+      required:
+        - type
+        - provider
+        - parameters
+      properties:
+        type:
+          type: string
+          enum:
+            - custom
+          description: The trigger type.
+        provider:
+          type: string
+          maxLength: 128
+          description: The external provider that emits the custom event.
+        event_name:
+          type: string
+          maxLength: 256
+          description: The provider-specific event name that fires the routine.
+        parameters:
+          type: object
+          additionalProperties: {}
+          description: Provider-specific trigger parameters.
+      allOf:
+        - $ref: '#/components/schemas/RoutineTrigger'
+      description: A custom event routine trigger.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -18436,34 +18422,50 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueOpenedRoutineTrigger:
+    GitHubIssueEvent:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - opened
+            - closed
+      description: Known GitHub issue events that can fire a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    GitHubIssueRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - assignee
+        - owner
         - repository
+        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue_opened
+            - github_issue
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        assignee:
+        owner:
           type: string
           maxLength: 128
-          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
+          description: The GitHub owner or organization that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
+        issue_event:
+          allOf:
+            - $ref: '#/components/schemas/GitHubIssueEvent'
+          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue-opened routine trigger.
+      description: A GitHub issue routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -18938,6 +18940,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -18945,9 +18948,7 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
-          description: The raw input sent to the downstream invocations target.
+          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -18958,24 +18959,29 @@ components:
       type: object
       required:
         - type
-        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
+        agent_name:
+          type: string
+          maxLength: 256
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for invocations API dispatch.
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API.
+      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -18983,6 +18989,7 @@ components:
       type: object
       required:
         - type
+        - input
       properties:
         type:
           type: string
@@ -18990,9 +18997,7 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          type: string
-          maxLength: 32768
-          description: The user input sent to the downstream responses target.
+          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -19012,12 +19017,14 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for responses API dispatch.
+          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: The endpoint-scoped agent identifier for responses API dispatch.
-        conversation_id:
+          description: Legacy endpoint-scoped agent identifier for routine dispatch.
+        input:
+          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
+        conversation:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -36013,10 +36020,7 @@ components:
     Routine:
       type: object
       required:
-        - name
         - enabled
-        - triggers
-        - action
       properties:
         name:
           type: string
@@ -36095,9 +36099,6 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
-      required:
-        - triggers
-        - action
       properties:
         description:
           type: string
@@ -36148,17 +36149,39 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
+    RoutineListResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Routine'
+          description: The requested list of routines.
+        first_id:
+          type: string
+          description: The identifier of the first routine in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routines are available after this page.
+      description: The paginated response returned when listing routines.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
     RoutineRun:
       type: object
       required:
         - id
-        - status
-        - trigger_type
-        - started_at
       properties:
         id:
           type: string
           description: The MLflow run identifier for the routine attempt.
+          readOnly: true
         status:
           type: string
           description: The underlying MLflow run status.
@@ -36170,6 +36193,9 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
+        trigger_name:
+          type: string
+          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -36178,10 +36204,29 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
+        agent_id:
+          type: string
+          description: The project-scoped agent identifier recorded for the routine attempt.
+        agent_endpoint_id:
+          type: string
+          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
+        conversation_id:
+          type: string
+          description: The conversation identifier used by a responses API dispatch.
+        session_id:
+          type: string
+          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
+        scheduled_fire_at:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: The scheduled fire time recorded for timer and schedule deliveries.
+        trigger_time_zone:
+          type: string
+          description: The trigger time zone recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -36202,44 +36247,17 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
+        error_status_code:
+          type: integer
+          format: int32
+          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
-        diagnostics:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunDiagnostics'
-          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunDiagnostics:
-      type: object
-      required:
-        - parameters
-        - tags
-        - metrics
-      properties:
-        parameters:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow parameters recorded on the run, keyed by parameter name.
-        tags:
-          type: object
-          additionalProperties:
-            type: string
-          description: MLflow tags recorded on the run, keyed by tag name.
-        metrics:
-          type: object
-          additionalProperties:
-            type: number
-            format: double
-          description: Latest MLflow metric values recorded on the run, keyed by metric name.
-      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36253,6 +36271,30 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunsResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoutineRun'
+          description: The requested list of routine runs.
+        first_id:
+          type: string
+          description: The identifier of the first run in this page, or null when the page is empty.
+        last_id:
+          type: string
+          description: An opaque cursor to pass as the next after query parameter when has_more is true.
+        has_more:
+          type: boolean
+          description: True when more routine runs are available after this page.
+      description: The paginated response returned when listing routine runs.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36270,7 +36312,8 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
+          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
+          custom: '#/components/schemas/CustomRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -36280,7 +36323,8 @@ components:
         - type: string
         - type: string
           enum:
-            - github_issue_opened
+            - custom
+            - github_issue
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
@@ -37264,16 +37308,15 @@ components:
       type: object
       required:
         - type
-        - at
       properties:
         type:
           type: string
           enum:
             - timer
           description: The trigger type.
-        at:
+        in:
           type: string
-          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+          description: A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.
         time_zone:
           type: string
           description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -15,8 +15,11 @@ const RoutineRequiredPreviews = #{
 union RoutineTriggerType {
   string,
 
-  @doc("A GitHub issue-opened trigger.")
-  github_issue_opened: "github_issue_opened",
+  @doc("A custom event trigger.")
+  custom: "custom",
+
+  @doc("A GitHub issue trigger.")
+  github_issue: "github_issue",
 
   @doc("A recurring cron-based trigger.")
   schedule: "schedule",
@@ -70,6 +73,18 @@ union RoutineAttemptSource {
   timer_delivery: "timer_delivery",
 }
 
+@doc("Known GitHub issue events that can fire a routine.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+union GitHubIssueEvent {
+  string,
+
+  @doc("The routine fires when a GitHub issue is opened.")
+  opened: "opened",
+
+  @doc("The routine fires when a GitHub issue is closed.")
+  closed: "closed",
+}
+
 @doc("Known lifecycle phases recorded for a routine run.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 union RoutineRunPhase {
@@ -117,30 +132,51 @@ model TimerRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
   type: RoutineTriggerType.timer;
 
-  @doc("A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.")
-  at: string;
+  @doc("A relative timer expression from now, such as `2h` or `15m`. Stored routines are normalized to an absolute fire time.")
+  in?: string;
 
   @doc("An optional IANA or Windows time zone identifier when the timer uses a local timestamp.")
   time_zone?: string;
 }
 
-@doc("A GitHub issue-opened routine trigger.")
+@doc("A GitHub issue routine trigger.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model GitHubIssueOpenedRoutineTrigger extends RoutineTrigger {
+model GitHubIssueRoutineTrigger extends RoutineTrigger {
   @doc("The trigger type.")
-  type: RoutineTriggerType.github_issue_opened;
+  type: RoutineTriggerType.github_issue;
 
   @doc("The workspace connection identifier that resolves the GitHub configuration for the trigger.")
   @maxLength(256)
   connection_id: string;
 
-  @doc("The GitHub assignee or organization filter that scopes which issues can fire the trigger.")
+  @doc("The GitHub owner or organization that scopes which issues can fire the trigger.")
   @maxLength(128)
-  assignee: string;
+  owner: string;
 
   @doc("The GitHub repository filter that scopes which issues can fire the trigger.")
   @maxLength(128)
   repository: string;
+
+  @doc("The GitHub issue event that fires the routine.")
+  issue_event: GitHubIssueEvent;
+}
+
+@doc("A custom event routine trigger.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model CustomRoutineTrigger extends RoutineTrigger {
+  @doc("The trigger type.")
+  type: RoutineTriggerType.custom;
+
+  @doc("The external provider that emits the custom event.")
+  @maxLength(128)
+  provider: string;
+
+  @doc("The provider-specific event name that fires the routine.")
+  @maxLength(256)
+  event_name?: string;
+
+  @doc("Provider-specific trigger parameters.")
+  parameters: Record<unknown>;
 }
 
 @doc("Base model for a routine action.")
@@ -151,34 +187,39 @@ model RoutineAction {
   type: RoutineActionType;
 }
 
+alias InvokeAgentRoutineActionFields = {
+  @doc("The project-scoped agent name for routine dispatch.")
+  @maxLength(256)
+  agent_name?: string;
+
+  @doc("Legacy endpoint-scoped agent identifier for routine dispatch.")
+  @maxLength(256)
+  agent_endpoint_id?: string;
+
+  @doc("Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.")
+  input?: unknown;
+};
+
 @doc("Dispatches a routine through the responses API. Exactly one of agent_name or agent_endpoint_id must be provided.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model InvokeAgentResponsesApiRoutineAction extends RoutineAction {
   @doc("The action type.")
   type: RoutineActionType.invoke_agent_responses_api;
 
-  @doc("The project-scoped agent name for responses API dispatch.")
-  @maxLength(256)
-  agent_name?: string;
-
-  @doc("The endpoint-scoped agent identifier for responses API dispatch.")
-  @maxLength(256)
-  agent_endpoint_id?: string;
+  ...InvokeAgentRoutineActionFields;
 
   @doc("An optional existing conversation identifier to continue during the downstream dispatch.")
   @maxLength(256)
-  conversation_id?: string;
+  conversation?: string;
 }
 
-@doc("Dispatches a routine through the raw invocations API.")
+@doc("Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model InvokeAgentInvocationsApiRoutineAction extends RoutineAction {
   @doc("The action type.")
   type: RoutineActionType.invoke_agent_invocations_api;
 
-  @doc("The endpoint-scoped agent identifier for invocations API dispatch.")
-  @maxLength(256)
-  agent_endpoint_id: string;
+  ...InvokeAgentRoutineActionFields;
 
   @doc("An optional existing hosted-agent session identifier to continue during the downstream dispatch.")
   @maxLength(256)
@@ -190,7 +231,7 @@ model InvokeAgentInvocationsApiRoutineAction extends RoutineAction {
 model Routine {
   @doc("The routine name.")
   @maxLength(128)
-  name: string;
+  name?: string;
 
   @doc("A human-readable description of the routine.")
   @maxLength(1024)
@@ -200,10 +241,10 @@ model Routine {
   enabled: boolean;
 
   @doc("The triggers configured for the routine.")
-  triggers: RoutineTriggers;
+  triggers?: RoutineTriggers;
 
   @doc("The action executed when the routine fires.")
-  action: RoutineAction;
+  action?: RoutineAction;
 
   @doc("The time when the routine was created.")
   created_at?: FoundryTimestamp;
@@ -223,10 +264,28 @@ model RoutineCreateOrUpdateRequest {
   enabled?: boolean;
 
   @doc("The triggers configured for the routine. In v1, exactly one trigger entry is supported.")
-  triggers: RoutineTriggers;
+  triggers?: RoutineTriggers;
 
   @doc("The action executed when the routine fires.")
-  action: RoutineAction;
+  action?: RoutineAction;
+}
+
+@doc("The paginated response returned when listing routines.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model RoutineListResponse {
+  @doc("The requested list of routines.")
+  @pageItems
+  data: Routine[];
+
+  @doc("The identifier of the first routine in this page, or null when the page is empty.")
+  first_id?: string;
+
+  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
+  @continuationToken
+  last_id?: string;
+
+  @doc("True when more routines are available after this page.")
+  has_more: boolean;
 }
 
 @doc("Base model for a manual dispatch payload.")
@@ -243,9 +302,8 @@ model InvokeAgentResponsesApiDispatchPayload extends RoutineDispatchPayload {
   @doc("The manual dispatch payload type.")
   type: RoutineDispatchPayloadType.invoke_agent_responses_api;
 
-  @doc("The user input sent to the downstream responses target.")
-  @maxLength(32768)
-  input?: string;
+  @doc("The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.")
+  input: unknown;
 }
 
 @doc("A manual payload used to test an invocations API routine dispatch.")
@@ -254,9 +312,8 @@ model InvokeAgentInvocationsApiDispatchPayload extends RoutineDispatchPayload {
   @doc("The manual dispatch payload type.")
   type: RoutineDispatchPayloadType.invoke_agent_invocations_api;
 
-  @doc("The raw input sent to the downstream invocations target.")
-  @maxLength(32768)
-  input?: string;
+  @doc("The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.")
+  input: unknown;
 }
 
 @doc("Request body for the public dispatch_async route.")
@@ -279,33 +336,24 @@ model DispatchRoutineResponse {
   task_id?: string;
 }
 
-@doc("Generic diagnostics captured on a routine run.")
-@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
-model RoutineRunDiagnostics {
-  @doc("MLflow parameters recorded on the run, keyed by parameter name.")
-  parameters: Record<string>;
-
-  @doc("MLflow tags recorded on the run, keyed by tag name.")
-  tags: Record<string>;
-
-  @doc("Latest MLflow metric values recorded on the run, keyed by metric name.")
-  metrics: Record<float64>;
-}
-
 @doc("A single routine run returned from the run history API.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineRun {
   @doc("The MLflow run identifier for the routine attempt.")
+  @visibility(Lifecycle.Read)
   id: string;
 
   @doc("The underlying MLflow run status.")
-  status: string;
+  status?: string;
 
   @doc("The AgentExtensions lifecycle phase for the routine attempt.")
   phase?: RoutineRunPhase;
 
   @doc("The trigger type that produced the routine attempt.")
-  trigger_type: RoutineTriggerType;
+  trigger_type?: RoutineTriggerType;
+
+  @doc("The configured trigger name that produced the routine attempt.")
+  trigger_name?: string;
 
   @doc("The source path that created the routine attempt.")
   attempt_source?: RoutineAttemptSource;
@@ -313,11 +361,29 @@ model RoutineRun {
   @doc("The action type dispatched for the routine attempt.")
   action_type?: RoutineActionType;
 
+  @doc("The project-scoped agent identifier recorded for the routine attempt.")
+  agent_id?: string;
+
+  @doc("The legacy endpoint-scoped agent identifier recorded for the routine attempt.")
+  agent_endpoint_id?: string;
+
+  @doc("The conversation identifier used by a responses API dispatch.")
+  conversation_id?: string;
+
+  @doc("The hosted-agent session identifier used by an invocations API dispatch.")
+  session_id?: string;
+
   @doc("The logical trigger time recorded for the routine attempt.")
   triggered_at?: FoundryTimestamp;
 
+  @doc("The scheduled fire time recorded for timer and schedule deliveries.")
+  scheduled_fire_at?: FoundryTimestamp;
+
+  @doc("The trigger time zone recorded for timer and schedule deliveries.")
+  trigger_time_zone?: string;
+
   @doc("The time when the underlying run started.")
-  started_at: FoundryTimestamp;
+  started_at?: FoundryTimestamp;
 
   @doc("The time when the underlying run reached a terminal state.")
   ended_at?: FoundryTimestamp;
@@ -334,14 +400,32 @@ model RoutineRun {
   @doc("The workspace task identifier linked to the routine attempt, when available.")
   task_id?: string;
 
+  @doc("The downstream error status code captured for a failed attempt, when available.")
+  error_status_code?: int32;
+
   @doc("The fully qualified error type captured for a failed attempt, when available.")
   error_type?: string;
 
   @doc("The truncated failure message captured for a failed attempt, when available.")
   error_message?: string;
+}
 
-  @doc("Diagnostic data captured for the routine attempt.")
-  diagnostics?: RoutineRunDiagnostics;
+@doc("The paginated response returned when listing routine runs.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model RoutineRunsResponse {
+  @doc("The requested list of routine runs.")
+  @pageItems
+  data: RoutineRun[];
+
+  @doc("The identifier of the first run in this page, or null when the page is empty.")
+  first_id?: string;
+
+  @doc("An opaque cursor to pass as the next after query parameter when has_more is true.")
+  @continuationToken
+  last_id?: string;
+
+  @doc("True when more routine runs are available after this page.")
+  has_more: boolean;
 }
 
 @doc("Parameters for creating or updating a routine.")
@@ -380,7 +464,22 @@ model DisableRoutineParameters {
 
 @doc("Parameters for listing routines.")
 model ListRoutinesParameters {
-  ...CommonPageQueryParameters;
+  @doc("The maximum number of routines to return.")
+  @query
+  limit?: int32;
+
+  @doc("An opaque cursor returned as last_id by the previous list response.")
+  @query
+  @continuationToken
+  after?: string;
+
+  @doc("Unsupported. Reserved for future backward pagination support.")
+  @query
+  before?: string;
+
+  @doc("The ordering direction. Supported values are asc and desc.")
+  @query
+  order?: string;
 }
 
 @doc("Parameters for deleting a routine.")
@@ -402,7 +501,22 @@ model ListRoutineRunsParameters {
   @query
   filter?: string;
 
-  ...CommonPageQueryParameters;
+  @doc("The maximum number of runs to return.")
+  @query
+  limit?: int32;
+
+  @doc("An opaque cursor returned as last_id by the previous list-runs response.")
+  @query
+  @continuationToken
+  after?: string;
+
+  @doc("Unsupported. Reserved for future backward pagination support.")
+  @query
+  before?: string;
+
+  @doc("The ordering direction. Supported values are asc and desc.")
+  @query
+  order?: string;
 }
 
 @doc("Parameters for dispatching a routine asynchronously.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/routes.tsp
@@ -67,7 +67,7 @@ interface Routines {
   listRoutines is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutinesParameters,
-    AgentsPagedResult<Routine>
+    RoutineListResponse
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"
@@ -92,7 +92,7 @@ interface Routines {
   listRoutineRuns is FoundryDataPlanePreviewOperation<
     FoundryFeaturesOptInKeys.routines_v1_preview,
     ListRoutineRunsParameters,
-    AgentsPagedResult<RoutineRun>
+    RoutineRunsResponse
   >;
 
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "not yet an Azure operation"


### PR DESCRIPTION
## Summary

This is a rebased version of PR #43498 "Align Foundry Routines TypeSpec contracts" by @akshaya-a, applied on top of the latest `feature/foundry-release` to fix the Python/JS SDK Validation CI failures.

## Root cause of CI failures in #43498

PR #43498 was based on commit `d4bf96330a` (May 26), but commit `2d8ec07cef` ("Skills API: Versioned Skills aligned with OpenAI and agentskills.io #43283") landed later and renamed Skills operations in the interface:
- `createSkill` → `createSkillVersion`
- `createSkillFromPackage` → `createSkillVersionFromFiles`
- `downloadSkill` → `getSkillContent`

The SDK validation pipeline merges PRs with the current `feature/foundry-release` HEAD before compiling, so it finds `invalid-ref: Interface doesn't have member createSkill` in `client.tsp`. This PR is rebased on the current HEAD, so those references are already correct.

## Changes included (from #43498)

- `RoutineTriggerType`: replaced `github_issue_opened` with `custom` + `github_issue`
- Added `GitHubIssueEvent` union (opened/closed)
- `TimerRoutineTrigger`: renamed `at` → `in` (relative duration expression)
- `GitHubIssueOpenedRoutineTrigger` → `GitHubIssueRoutineTrigger` with `issue_event` field and `assignee` → `owner`
- Added `CustomRoutineTrigger` with `provider`, `event_name?`, `parameters: Record<unknown>`
- Added `InvokeAgentRoutineActionFields` alias for shared action fields
- `InvokeAgentResponsesApiRoutineAction`: uses shared alias; `conversation_id` → `conversation`
- `InvokeAgentInvocationsApiRoutineAction`: uses shared alias (`agent_endpoint_id` now optional)
- `Routine.name/triggers/action` made optional; `RoutineCreateOrUpdateRequest.triggers/action` made optional
- Added `RoutineListResponse` and `RoutineRunsResponse` pagination models
- `listRoutines`/`listRoutineRuns` return `RoutineListResponse`/`RoutineRunsResponse`
- Removed `RoutineRunDiagnostics` model and `diagnostics` field from `RoutineRun`
- `RoutineRun`: added `trigger_name`, `agent_id`, `agent_endpoint_id`, `conversation_id`, `session_id`, `scheduled_fire_at`, `trigger_time_zone`, `error_status_code`; `id` uses `@visibility(Lifecycle.Read)` and is **required** (per reviewer suggestion)
- `ListRoutinesParameters`/`ListRoutineRunsParameters`: explicit `limit`/`after`/`before`/`order` fields
- Dispatch payload `input` fields changed from `string?` to `unknown` (required)

## Reviewer suggestions addressed

- `RoutineRun.id`: made required (`id: string`) since `@visibility(Lifecycle.Read)` already handles write suppression (per @glecaros comment on #43498)