### PR TITLE
[containerservice][fleet] Add explicit SDK package metadata to tspconfig

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
@@ -19,23 +19,27 @@ options:
   "@azure-tools/typespec-python":
     service-dir: "sdk/containerservice"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-containerservicefleet"
+    package-dir: "azure-mgmt-containerservicefleet"
     namespace: "azure.mgmt.containerservicefleet"
     generate-test: true
     generate-sample: true
     flavor: azure
   "@azure-typespec/http-client-csharp-mgmt":
-    namespace: "Azure.ResourceManager.ContainerServiceFleet"
+    package-name: "Azure.ResourceManager.ContainerServiceFleet"
+    namespace: "{package-name}"
     emitter-output-dir: "{output-dir}/sdk/fleet/{namespace}"
     api-version: 2026-02-01-preview
     skip-api-version-override: true # this is temporary
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-containerservicefleet"
+    package-dir: "azure-resourcemanager-containerservicefleet"
     namespace: "com.azure.resourcemanager.containerservicefleet"
     service-name: "Container Service Fleet"
     flavor: azure
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerservicefleet"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontainerservicefleet"
+    package-dir: "armcontainerservicefleet"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservicefleet/v3"
     fix-const-stuttering: true
     flavor: "azure"
@@ -48,5 +52,6 @@ options:
     flavor: azure
     experimental-extensible-enums: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-containerservicefleet"
+    package-dir: "arm-containerservicefleet"
     package-details:
       name: "@azure/arm-containerservicefleet"


### PR DESCRIPTION
## Purpose
Add explicit SDK package metadata fields in the Fleet TypeSpec config so Azure SDK release-plan tooling can resolve package names for .NET, JavaScript, Python, Java, and Go.

## Changes
- add `package-dir` for Python, Java, Go, and JavaScript emitters
- add `package-name` for the C# management emitter and bind `namespace` to it

## Context
This is a targeted metadata-only change to test/fix `Update SDK details in release plan ...` for Fleet release planning and SDK generation.
