### PR TITLE
Remove Kubernetes provisioning API version override

### DIFF
--- a/specification/hybridkubernetes/HybridKubernetes.Management/tspconfig.yaml
+++ b/specification/hybridkubernetes/HybridKubernetes.Management/tspconfig.yaml
@@ -18,7 +18,6 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Kubernetes"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2025-12-01-preview"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-hybridkubernetes"
     namespace: "azure.mgmt.hybridkubernetes"


### PR DESCRIPTION
Removes the explicit C# provisioning emitter `api-version` override for HybridKubernetes.

The management SDK C# `api-version` override is left unchanged.