### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-containerinstance

### DIFF
--- a/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
+++ b/specification/containerinstance/resource-manager/Microsoft.ContainerInstance/ContainerInstance/client.tsp
@@ -242,6 +242,7 @@ using Microsoft.ContainerInstance;
   "csharp"
 );
 @@access(ContainerGroupProvisioningState, Access.public, "csharp");
+@@access(ContainerGroupProvisioningState, Access.public, "python");
 
 // Fix identity types to use ARM common ManagedServiceIdentity for backward compat
 @@alternateType(


### PR DESCRIPTION
Mitigate Python SDK breaking changes introduced by the Container Instance TypeSpec migration.

- Expose `ContainerGroupProvisioningState` enum to Python (`@@access(..., Access.public, "python")`) to preserve the public enum present in `azure-mgmt-containerinstance` <= 10.x.
