### PR TITLE
Updated sdkReleaseType to be settable independently

### DIFF
--- a/eng/pipelines/spec-gen-sdk.yml
+++ b/eng/pipelines/spec-gen-sdk.yml
@@ -21,10 +21,11 @@ parameters:
   - name: SdkReleaseType
     type: string
     values:
+      - 'none'
       - 'beta'
       - 'stable'
-    default: 'beta'
-    displayName: 'SDK release type (ignored when API version is "none")'
+    default: 'none'
+    displayName: 'SDK release type'
   - name: CreatePullRequest
     type: boolean
     default: false

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -243,8 +243,12 @@ stages:
           fi
 
           if [ "${{ parameters.ApiVersion }}" != "" ] && [ "${{ parameters.ApiVersion }}" != "none" ]; then
-            optional_params="$optional_params --api-version ${{ parameters.ApiVersion }} --sdk-release-type ${{ parameters.SdkReleaseType }}"
-            sdk_gen_info="$sdk_gen_info API Version: ${{ parameters.ApiVersion }}, SDK Release Type: ${{ parameters.SdkReleaseType }},"
+            optional_params="$optional_params --api-version ${{ parameters.ApiVersion }}"
+            sdk_gen_info="$sdk_gen_info API Version: ${{ parameters.ApiVersion }},"
+          fi
+          if [ "${{ parameters.SdkReleaseType }}" != "" ] && [ "${{ parameters.SdkReleaseType }}" != "none" ]; then
+            optional_params="$optional_params --sdk-release-type ${{ parameters.SdkReleaseType }}"
+            sdk_gen_info="$sdk_gen_info SDK Release Type: ${{ parameters.SdkReleaseType }},"
           fi
           sdk_gen_info="$sdk_gen_info and CommitSHA: '$updatedSpecRepoCommit' in SpecRepo: '${{ parameters.SpecRepoUrl }}'"
 


### PR DESCRIPTION
Resolved https://github.com/Azure/azure-sdk-tools/issues/15764

**Key changes**:

* Changed the default value of `SdkReleaseType` from `'beta'` to `'none'` and updated the display name to remove the reference to the API version, making the default behavior more explicit and decoupling it from `ApiVersion`.

* Modified the stage template so that `--sdk-release-type` is only passed to the command when `SdkReleaseType` is set and not `'none'`, ensuring unnecessary parameters are not included.