### PR TITLE
Add two enums Support Channel and ChatConversationStatus to enable Persistent chat

### DIFF
--- a/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
@@ -97,7 +97,8 @@ interface ProblemClassifications {
 }
 
 @@doc(ClassifyProblems.classifyProblems::parameters.body, "Input to check.");
-@@doc(ClassifyProblemsNoSubscription.classifyProblems::parameters.body,
+@@doc(
+  ClassifyProblemsNoSubscription.classifyProblems::parameters.body,
   "Input to check."
 );
 @@doc(ProblemClassification.name, "Name of problem classification.");

--- a/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
@@ -15,7 +15,7 @@ namespace Microsoft.Support;
 
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 @tag("ProblemClassifications")
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 interface ClassifyProblems {
   /**
    * Classify the right problem classifications (categories) available for a specific Azure service.
@@ -42,7 +42,7 @@ interface ClassifyProblems {
 
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 @tag("ProblemClassifications")
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 interface ClassifyProblemsNoSubscription {
   /**
    * Classify the right problem classifications (categories) available for a specific Azure service.
@@ -97,8 +97,7 @@ interface ProblemClassifications {
 }
 
 @@doc(ClassifyProblems.classifyProblems::parameters.body, "Input to check.");
-@@doc(
-  ClassifyProblemsNoSubscription.classifyProblems::parameters.body,
+@@doc(ClassifyProblemsNoSubscription.classifyProblems::parameters.body,
   "Input to check."
 );
 @@doc(ProblemClassification.name, "Name of problem classification.");

--- a/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ProblemClassification.tsp
@@ -21,7 +21,7 @@ interface ClassifyProblems {
    * Classify the right problem classifications (categories) available for a specific Azure service.
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "non-standard operations"
-  @operationId("ProblemClassifications_classifyProblems")
+  @operationId("ProblemClassifications_ClassifyProblems")
   @autoRoute
   classifyProblems is ArmProviderActionSync<
     Request = ProblemClassificationsClassificationInput,
@@ -48,7 +48,7 @@ interface ClassifyProblemsNoSubscription {
    * Classify the right problem classifications (categories) available for a specific Azure service.
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "non-standard operations"
-  @operationId("ProblemClassificationsNoSubscription_classifyProblems")
+  @operationId("ProblemClassificationsNoSubscription_ClassifyProblems")
   @autoRoute
   classifyProblems is ArmProviderActionSync<
     Request = ProblemClassificationsClassificationInput,

--- a/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
@@ -46,6 +46,7 @@ interface ClassifyServicesNoSubscription {
 }
 
 @@doc(ClassifyServices.classifyServices::parameters.body, "Input to check.");
-@@doc(ClassifyServicesNoSubscription.classifyServices::parameters.body,
+@@doc(
+  ClassifyServicesNoSubscription.classifyServices::parameters.body,
   "Input to check."
 );

--- a/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
@@ -14,7 +14,7 @@ namespace Microsoft.Support;
 
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 @tag("ServiceClassifications")
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 interface ClassifyServices {
   /**
    * Classify the list of right Azure services.
@@ -31,7 +31,7 @@ interface ClassifyServices {
 
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "For backward compatibility"
 @tag("ServiceClassifications")
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 interface ClassifyServicesNoSubscription {
   /**
    * Classify the list of right Azure services.
@@ -46,7 +46,6 @@ interface ClassifyServicesNoSubscription {
 }
 
 @@doc(ClassifyServices.classifyServices::parameters.body, "Input to check.");
-@@doc(
-  ClassifyServicesNoSubscription.classifyServices::parameters.body,
+@@doc(ClassifyServicesNoSubscription.classifyServices::parameters.body,
   "Input to check."
 );

--- a/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/ServiceClassification.tsp
@@ -20,7 +20,7 @@ interface ClassifyServices {
    * Classify the list of right Azure services.
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "non-standard operations"
-  @operationId("ServiceClassifications_classifyServices")
+  @operationId("ServiceClassifications_ClassifyServices")
   @autoRoute
   classifyServices is ArmProviderActionSync<
     Request = ServiceClassificationRequest,
@@ -37,7 +37,7 @@ interface ClassifyServicesNoSubscription {
    * Classify the list of right Azure services.
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "non-standard operations"
-  @operationId("ServiceClassificationsNoSubscription_classifyServices")
+  @operationId("ServiceClassificationsNoSubscription_ClassifyServices")
   @autoRoute
   classifyServices is ArmProviderActionSync<
     Request = ServiceClassificationRequest,

--- a/specification/support/resource-manager/Microsoft.Support/Support/SupportTicketDetails.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/SupportTicketDetails.tsp
@@ -76,8 +76,10 @@ interface SupportTickets {
   @Azure.Core.useFinalStateVia("azure-async-operation")
   create is SupportTicketOps.CreateOrUpdateAsync<
     SupportTicketDetails,
-    Response = ArmResourceUpdatedResponse<SupportTicketDetails> | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
-      Azure.Core.Foundations.RetryAfterHeader>
+    Response =
+      | ArmResourceUpdatedResponse<SupportTicketDetails>
+      | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
+          Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**
@@ -163,8 +165,10 @@ interface SupportTicketsNoSubscription {
   @Azure.Core.useFinalStateVia("azure-async-operation")
   create is SupportTicketsNoSubscriptionOps.CreateOrUpdateAsync<
     SupportTicketDetails,
-    Response = ArmResourceUpdatedResponse<SupportTicketDetails> | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
-      Azure.Core.Foundations.RetryAfterHeader>
+    Response =
+      | ArmResourceUpdatedResponse<SupportTicketDetails>
+      | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
+          Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**
@@ -210,22 +214,28 @@ interface SupportTicketsNoSubscription {
 
 @@doc(SupportTicketDetails.name, "Support ticket name.");
 @@doc(SupportTicketDetails.properties, "Properties of the resource.");
-@@doc(SupportTickets.create::parameters.resource,
+@@doc(
+  SupportTickets.create::parameters.resource,
   "Support ticket request payload."
 );
-@@doc(SupportTickets.update::parameters.properties,
+@@doc(
+  SupportTickets.update::parameters.properties,
   "UpdateSupportTicket object."
 );
 @@doc(SupportTickets.checkNameAvailability::parameters.body, "Input to check.");
-@@doc(SupportTickets.lookUpResourceId::parameters.body,
+@@doc(
+  SupportTickets.lookUpResourceId::parameters.body,
   "Look up resource id request body"
 );
-@@doc(SupportTicketsNoSubscription.create::parameters.resource,
+@@doc(
+  SupportTicketsNoSubscription.create::parameters.resource,
   "Support ticket request payload."
 );
-@@doc(SupportTicketsNoSubscription.update::parameters.properties,
+@@doc(
+  SupportTicketsNoSubscription.update::parameters.properties,
   "UpdateSupportTicket object."
 );
-@@doc(SupportTicketsNoSubscription.checkNameAvailability::parameters.body,
+@@doc(
+  SupportTicketsNoSubscription.checkNameAvailability::parameters.body,
   "Input to check."
 );

--- a/specification/support/resource-manager/Microsoft.Support/Support/SupportTicketDetails.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/SupportTicketDetails.tsp
@@ -76,10 +76,8 @@ interface SupportTickets {
   @Azure.Core.useFinalStateVia("azure-async-operation")
   create is SupportTicketOps.CreateOrUpdateAsync<
     SupportTicketDetails,
-    Response =
-      | ArmResourceUpdatedResponse<SupportTicketDetails>
-      | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
-          Azure.Core.Foundations.RetryAfterHeader>
+    Response = ArmResourceUpdatedResponse<SupportTicketDetails> | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
+      Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**
@@ -127,7 +125,7 @@ interface SupportTickets {
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "non-standard operations"
   @operationId("LookUpResourceId_Post")
-  @added(Versions.v2025_06_01_preview)
+  @added(Versions.v2026_06_01)
   lookUpResourceId is ArmProviderActionSync<
     Request = LookUpResourceIdRequest,
     Response = LookUpResourceIdResponse
@@ -165,10 +163,8 @@ interface SupportTicketsNoSubscription {
   @Azure.Core.useFinalStateVia("azure-async-operation")
   create is SupportTicketsNoSubscriptionOps.CreateOrUpdateAsync<
     SupportTicketDetails,
-    Response =
-      | ArmResourceUpdatedResponse<SupportTicketDetails>
-      | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
-          Azure.Core.Foundations.RetryAfterHeader>
+    Response = ArmResourceUpdatedResponse<SupportTicketDetails> | ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = SupportTicketDetails> &
+      Azure.Core.Foundations.RetryAfterHeader>
   >;
 
   /**
@@ -214,28 +210,22 @@ interface SupportTicketsNoSubscription {
 
 @@doc(SupportTicketDetails.name, "Support ticket name.");
 @@doc(SupportTicketDetails.properties, "Properties of the resource.");
-@@doc(
-  SupportTickets.create::parameters.resource,
+@@doc(SupportTickets.create::parameters.resource,
   "Support ticket request payload."
 );
-@@doc(
-  SupportTickets.update::parameters.properties,
+@@doc(SupportTickets.update::parameters.properties,
   "UpdateSupportTicket object."
 );
 @@doc(SupportTickets.checkNameAvailability::parameters.body, "Input to check.");
-@@doc(
-  SupportTickets.lookUpResourceId::parameters.body,
+@@doc(SupportTickets.lookUpResourceId::parameters.body,
   "Look up resource id request body"
 );
-@@doc(
-  SupportTicketsNoSubscription.create::parameters.resource,
+@@doc(SupportTicketsNoSubscription.create::parameters.resource,
   "Support ticket request payload."
 );
-@@doc(
-  SupportTicketsNoSubscription.update::parameters.properties,
+@@doc(SupportTicketsNoSubscription.update::parameters.properties,
   "UpdateSupportTicket object."
 );
-@@doc(
-  SupportTicketsNoSubscription.checkNameAvailability::parameters.body,
+@@doc(SupportTicketsNoSubscription.checkNameAvailability::parameters.body,
   "Input to check."
 );

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailability.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/supportTickets"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_CheckNameAvailability",
+  "title": "Checks whether name is available for SupportTicket resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityForNoSubscriptionSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityForNoSubscriptionSupportTicketCommunication.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/communications"
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_CheckNameAvailability",
+  "title": "Checks whether name is available for Communication resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityForSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityForSupportTicketCommunication.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/communications"
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "Communications_CheckNameAvailability",
+  "title": "Checks whether name is available for Communication resource for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityWithSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CheckNameAvailabilityWithSubscription.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/supportTickets"
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "SupportTickets_CheckNameAvailability",
+  "title": "Checks whether name is available for a subscription support ticket resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassifications.json
@@ -29,6 +29,6 @@
       }
     }
   },
-  "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+  "operationId": "ProblemClassificationsNoSubscription_ClassifyProblems",
   "title": "Classify list of problemClassifications for a specified Azure service"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassifications.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "problemServiceName": "serviceId1",
+    "api-version": "2026-06-01",
+    "problemClassificationsClassificationInput": {
+      "issueSummary": "Can not connect to Windows VM"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "problemClassificationResults": [
+          {
+            "problemId": "problemId1",
+            "title": "Problem classification title",
+            "description": "Problem classification description",
+            "serviceId": "serviceId1",
+            "problemClassificationId": "problemClassificationId1",
+            "relatedService": {
+              "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+              "displayName": "SQL Server in VM - Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+  "title": "Classify list of problemClassifications for a specified Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassificationsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassificationsForSubscription.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "problemServiceName": "serviceId1",
+    "api-version": "2026-06-01",
+    "problemClassificationsClassificationInput": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "problemClassificationResults": [
+          {
+            "problemId": "problemId1",
+            "title": "Problem classification title",
+            "description": "Problem classification description",
+            "serviceId": "serviceId1",
+            "problemClassificationId": "problemClassificationId1",
+            "relatedService": {
+              "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+              "displayName": "SQL Server in VM - Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_classifyProblems",
+  "title": "Classify list of problemClassifications for a specified Azure service for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassificationsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyProblemClassificationsForSubscription.json
@@ -31,6 +31,6 @@
       }
     }
   },
-  "operationId": "ProblemClassifications_classifyProblems",
+  "operationId": "ProblemClassifications_ClassifyProblems",
   "title": "Classify list of problemClassifications for a specified Azure service for a subscription"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServices.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "serviceClassificationRequest": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceClassificationResults": [
+          {
+            "serviceId": "/providers/Microsoft.Support/services/5c41904f-1bcf-76e4-7a54-5fc07468f3cc",
+            "displayName": "Azure Update Manager",
+            "resourceTypes": [
+              "Microsoft.HybridCompute/machines",
+              "Microsoft.Maintenance/maintenanceConfigurations",
+              "Microsoft.Maintenance/configurationAssignments",
+              "MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          },
+          {
+            "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+            "displayName": "SQL Server in VM - Linux",
+            "resourceTypes": [
+              "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+  "title": "Classify list of Azure services"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServices.json
@@ -34,6 +34,6 @@
       }
     }
   },
-  "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+  "operationId": "ServiceClassificationsNoSubscription_ClassifyServices",
   "title": "Classify list of Azure services"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServicesForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServicesForSubscription.json
@@ -34,6 +34,6 @@
       }
     }
   },
-  "operationId": "ServiceClassifications_classifyServices",
+  "operationId": "ServiceClassifications_ClassifyServices",
   "title": "Classify list of Azure services for a subscription"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServicesForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ClassifyServicesForSubscription.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "serviceClassificationRequest": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/76cb77fa-8b17-4eab-9493-b65dace99813/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceClassificationResults": [
+          {
+            "serviceId": "/providers/Microsoft.Support/services/5c41904f-1bcf-76e4-7a54-5fc07468f3cc",
+            "displayName": "Azure Update Manager",
+            "resourceTypes": [
+              "Microsoft.HybridCompute/machines",
+              "Microsoft.Maintenance/maintenanceConfigurations",
+              "Microsoft.Maintenance/configurationAssignments",
+              "MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          },
+          {
+            "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+            "displayName": "SQL Server in VM - Linux",
+            "resourceTypes": [
+              "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ServiceClassifications_classifyServices",
+  "title": "Classify list of Azure services for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForActiveJobs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForActiveJobs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Jobs\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Jobs\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Active Jobs and Job Schedules for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForDedicatedCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForDedicatedCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for specific VM family cores for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForLowPriorityCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForLowPriorityCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Low-priority cores for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForPools.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSpecificBatchAccountForPools.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Pools\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Pools\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Pools for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBatchQuotaTicketForSubscription.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Subscription",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200,\"Type\":\"Account\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Subscription",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200,\"Type\":\"Account\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Batch accounts for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBillingSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBillingSupportTicket.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Refund request",
+          "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Billing",
+          "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Billing related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBillingSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateBillingSupportTicketForSubscription.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Refund request",
+          "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Billing",
+          "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Billing related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateCoresQuotaTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateCoresQuotaTicketForSubscription.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cores_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"SKU\":\"DSv3 Series\",\"NewLimit\":104}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cores_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"VmFamily\":\"DSv3 Series\",\"NewLimit\":104}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Compute VM Cores"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFile.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFile.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createFileParameters": {
+      "properties": {
+        "chunkSize": 41423,
+        "fileSize": 41423,
+        "numberOfChunks": 1
+      }
+    },
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_Create",
+  "title": "Create a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileForSubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createFileParameters": {
+      "properties": {
+        "chunkSize": 41423,
+        "fileSize": 41423,
+        "numberOfChunks": 1
+      }
+    },
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "Files_Create",
+  "title": "Create a file under a subscription workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileWorkspace.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspacesNoSubscription_Create",
+  "title": "Create a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileWorkspaceForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateFileWorkspaceForSubscription.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspaces_Create",
+  "title": "Create a file workspace for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateGenericQuotaTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateGenericQuotaTicket.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "Increase the maximum throughput per container limit to 10000 for account foo bar",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cosmosdb_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "Increase the maximum throughput per container limit to 10000 for account foo bar",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Cosmos DB",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cosmosdb_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for services that do not require additional details in the quotaTicketDetails object"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateMachineLearningQuotaTicketForDedicatedCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateMachineLearningQuotaTicketForDedicatedCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "BatchAml",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Machine Learning service",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for specific VM family cores for Machine Learning service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateMachineLearningQuotaTicketForLowPriorityCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateMachineLearningQuotaTicketForLowPriorityCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "BatchAml",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Machine Learning service",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Low-priority cores for Machine Learning service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateNoSubscriptionSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateNoSubscriptionSupportTicketCommunication.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testcommunication",
+    "createCommunicationParameters": {
+      "properties": {
+        "body": "This is a test message from a customer!",
+        "sender": "user@contoso.com",
+        "subject": "This is a test message from a customer!"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcommunication",
+        "type": "Microsoft.Support/communications",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testcommunication",
+        "properties": {
+          "body": "This is a test message from a customer!",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "This is a test message from a customer!"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_Create",
+  "title": "AddCommunicationToNoSubscriptionTicket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatabaseQuotaTicketForDTUs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatabaseQuotaTicketForDTUs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "DTUs",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL database",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "DTUs",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for DTUs for SQL Database"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatabaseQuotaTicketForServers.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatabaseQuotaTicketForServers.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Servers",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL database",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Servers",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Servers for SQL Database"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatawarehouseQuotaTicketForDTUs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatawarehouseQuotaTicketForDTUs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "DTUs",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Data Warehouse",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "DTUs",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for DTUs for Azure Synapse Analytics"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatawarehouseQuotaTicketForServers.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlDatawarehouseQuotaTicketForServers.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Servers",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Data Warehouse",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Servers",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Servers for Azure Synapse Analytics"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlManagedInstanceQuotaTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSqlManagedInstanceQuotaTicket.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_managedinstance_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "SQLMI",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"vCore\"}",
+              "region": "EastUS"
+            },
+            {
+              "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"Subnet\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Database Managed Instance",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "SQLMI",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"vCore\"}",
+                "region": "EastUS"
+              },
+              {
+                "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"Subnet\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Azure SQL managed instance"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSubMgmtSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSubMgmtSupportTicket.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Transfer ownership of my subscription",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Subscription Management related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSubMgmtSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSubMgmtSupportTicketForSubscription.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Transfer ownership of my subscription",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Subscription Management related issues for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateSupportTicketCommunication.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testcommunication",
+    "createCommunicationParameters": {
+      "properties": {
+        "body": "This is a test message from a customer!",
+        "sender": "user@contoso.com",
+        "subject": "This is a test message from a customer!"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcommunication",
+        "type": "Microsoft.Support/communications",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testcommunication",
+        "properties": {
+          "body": "This is a test message from a customer!",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "This is a test message from a customer!"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "Communications_Create",
+  "title": "AddCommunicationToSubscriptionTicket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateTechnicalSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateTechnicalSupportTicket.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+        "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+        "secondaryConsent": [
+          {
+            "type": "virtualmachinerunninglinuxservice",
+            "userConsent": "Yes"
+          }
+        ],
+        "serviceId": "/providers/Microsoft.Support/services/cddd3eb5-1830-b494-44fd-782f691479dc",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+          "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+          "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+          "require24X7Response": false,
+          "secondaryConsent": [
+            {
+              "type": "virtualmachinerunninglinuxservice",
+              "userConsent": "Yes"
+            }
+          ],
+          "serviceDisplayName": "Virtual Machine running Linux",
+          "serviceId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Technical issue related to a specific resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateTechnicalSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/CreateTechnicalSupportTicketForSubscription.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+        "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+        "secondaryConsent": [
+          {
+            "type": "virtualmachinerunninglinuxservice",
+            "userConsent": "Yes"
+          }
+        ],
+        "serviceId": "/providers/Microsoft.Support/services/cddd3eb5-1830-b494-44fd-782f691479dc",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "technicalTicketDetails": {
+          "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+        },
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+          "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+          "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+          "require24X7Response": false,
+          "secondaryConsent": [
+            {
+              "type": "virtualmachinerunninglinuxservice",
+              "userConsent": "Yes"
+            }
+          ],
+          "serviceDisplayName": "Virtual Machine running Linux",
+          "serviceId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "technicalTicketDetails": {
+            "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+          },
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Technical issue related to a specific resource for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetCommunicationDetailsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetCommunicationDetailsForSubscriptionSupportTicket.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testmessage",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/communications",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage",
+        "properties": {
+          "body": "this is a test message",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "this is a test message"
+        }
+      }
+    }
+  },
+  "operationId": "Communications_Get",
+  "title": "Get communication details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetCommunicationDetailsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetCommunicationDetailsForSupportTicket.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testmessage",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/communications",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage",
+        "properties": {
+          "body": "this is a test message",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2016-08-24T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "this is a test message"
+        }
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_Get",
+  "title": "Get communication details for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileDetails.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_Get",
+  "title": "Get details of a subscription file"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileDetailsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileDetailsForSubscription.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "Files_Get",
+  "title": "Get details of a subscription file"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileWorkspaceDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileWorkspaceDetails.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspacesNoSubscription_Get",
+  "title": "Get details of a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileWorkspaceDetailsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetFileWorkspaceDetailsForSubscription.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspaces_Get",
+  "title": "Get details of a subscription file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetProblemClassification.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetProblemClassification.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "problemClassificationName": "problemClassification_guid",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "problemClassification_guid",
+        "type": "Microsoft.Support/problemClassifications",
+        "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid",
+        "properties": {
+          "displayName": "Reservation Management / Exchanges and Refunds"
+        }
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_Get",
+  "title": "Gets details of problemClassification for Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetService.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetService.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "service_guid",
+        "type": "Microsoft.Support/services",
+        "id": "/providers/Microsoft.Support/services/service_guid",
+        "properties": {
+          "displayName": "Virtual Machine running Windows",
+          "resourceTypes": [
+            "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+            "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Services_Get",
+  "title": "Gets details of the Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetSubscriptionSupportTicketDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetSubscriptionSupportTicketDetails.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationUnavailable"
+          },
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "minimal",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore",
+          "supportChannel": "Email",
+          "chatConversationStatus": "None"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Get",
+  "title": "Get details of a subscription ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetSupportTicketDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetSupportTicketDetails.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationUnavailable"
+          },
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "minimal",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore",
+          "supportChannel": "Chat",
+          "chatConversationStatus": "Active"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Get",
+  "title": "Get details of a ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetchatTranscriptDetailsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetchatTranscriptDetailsForSubscriptionSupportTicket.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "chatTranscriptName": "69586795-45e9-45b5-bd9e-c9bb237d3e44",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/chatTranscripts",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/chatTranscripts/69586795-45e9-45b5-bd9e-c9bb237d3e44",
+        "properties": {
+          "messages": [
+            {
+              "body": "Hi again",
+              "communicationDirection": "outbound",
+              "contentType": "text",
+              "createdDate": "2020-03-23T20:18:19Z",
+              "sender": "support engineer 2"
+            },
+            {
+              "body": "hello",
+              "communicationDirection": "inbound",
+              "contentType": "text",
+              "createdDate": "2020-03-23T20:19:16Z",
+              "sender": "user"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ChatTranscripts_Get",
+  "title": "Get chat transcript details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetchatTranscriptDetailsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/GetchatTranscriptDetailsForSupportTicket.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "chatTranscriptName": "b371192a-b094-4a71-b093-7246029b0a54",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/chatTranscripts",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/chatTranscripts/b371192a-b094-4a71-b093-7246029b0a54",
+        "properties": {
+          "messages": [
+            {
+              "body": "Hi again",
+              "communicationDirection": "outbound",
+              "contentType": "text",
+              "createdDate": "2020-03-25T20:18:19Z",
+              "sender": "support engineer 2"
+            },
+            {
+              "body": "hello",
+              "communicationDirection": "inbound",
+              "contentType": "text",
+              "createdDate": "2020-03-25T20:19:16Z",
+              "sender": "user"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ChatTranscriptsNoSubscription_Get",
+  "title": "Get chat transcript details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListChatTranscriptsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListChatTranscriptsForSubscriptionSupportTicket.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:18:19Z",
+                  "sender": "support engineer"
+                },
+                {
+                  "body": "hi",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          },
+          {
+            "name": "f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi again",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:18:19Z",
+                  "sender": "support engineer 2"
+                },
+                {
+                  "body": "hello",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ChatTranscripts_List",
+  "title": "List chat transcripts for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListChatTranscriptsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListChatTranscriptsForSupportTicket.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:18:19Z",
+                  "sender": "support engineer"
+                },
+                {
+                  "body": "hi",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          },
+          {
+            "name": "f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi again",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:18:19Z",
+                  "sender": "support engineer 2"
+                },
+                {
+                  "body": "hello",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ChatTranscriptsNoSubscription_List",
+  "title": "List chat transcripts for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListCommunicationsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListCommunicationsForSubscriptionSupportTicket.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-24T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-29T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List communications for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListCommunicationsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListCommunicationsForSupportTicket.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-24T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-29T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List communications for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListFilesForSubscriptionUnderFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListFilesForSubscriptionUnderFileWorkspace.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          },
+          {
+            "name": "test2.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test2.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Files_List",
+  "title": "List files under a workspace for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListFilesUnderFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListFilesUnderFileWorkspace.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          },
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_List",
+  "title": "List files under a workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListOperations.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListOperations.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Support/services/read",
+            "display": {
+              "description": "Gets all the Azure services available for support",
+              "operation": "Reads Services",
+              "provider": "Microsoft Support",
+              "resource": "Service"
+            }
+          },
+          {
+            "name": "Microsoft.Support/problemClassifications/read",
+            "display": {
+              "description": "Gets all the problem classifications available for a specific Azure service",
+              "operation": "Reads Problem Classifications",
+              "provider": "Microsoft Support",
+              "resource": "Problem Classification"
+            }
+          },
+          {
+            "name": "Microsoft.Support/supportTickets/read",
+            "display": {
+              "description": "Gets all the support tickets",
+              "operation": "Reads Support Tickets",
+              "provider": "Microsoft Support",
+              "resource": "Support Ticket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/supportTickets/write",
+            "display": {
+              "description": "Updates support ticket",
+              "operation": "Updates support ticket",
+              "provider": "Microsoft Support",
+              "resource": "Support Ticket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/communications/read",
+            "display": {
+              "description": "Gets all the communications",
+              "operation": "Reads Communications",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          },
+          {
+            "name": "Microsoft.Support/communications/write",
+            "display": {
+              "description": "Creates a communication",
+              "operation": "Creates a communication",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          },
+          {
+            "name": "Microsoft.Support/register/action",
+            "display": {
+              "description": "Registers Support Resource Provider",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Registers Support Resource Provider",
+              "resource": "Support Registration"
+            }
+          },
+          {
+            "name": "Microsoft.Support/createSupportTicket/action",
+            "display": {
+              "description": "Creates support ticket",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Microsoft Support",
+              "resource": "SupportTicket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/addCommunication/action",
+            "display": {
+              "description": "Add communication to support ticket",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "Get all operations"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListProblemClassifications.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "problemClassification_guid_1",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_1",
+            "properties": {
+              "displayName": "Reservation Management / Exchanges and Refunds",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_2",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_2",
+            "properties": {
+              "displayName": "Reservation Management / Request Invoices",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_3",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_3",
+            "properties": {
+              "displayName": "Reservation Management / Other Iissues or Requests",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_4",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_4",
+            "properties": {
+              "displayName": "Other General Billing Questions",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_List",
+  "title": "Gets list of problemClassifications for a service for which a support ticket can be created"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListServices.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "service_guid_1",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_1",
+            "properties": {
+              "displayName": "Billing",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_2",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_2",
+            "properties": {
+              "displayName": "Service and subscription limits (quotas)",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_3",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_3",
+            "properties": {
+              "displayName": "Subscription management",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_4",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_4",
+            "properties": {
+              "displayName": "Data Explorer",
+              "resourceTypes": [
+                "MICROSOFT.KUSTO/CLUSTERS",
+                "MICROSOFT.KUSTO/DATABASES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_5",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_5",
+            "properties": {
+              "displayName": "Virtual Machine running Windows",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_6",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_6",
+            "properties": {
+              "displayName": "Virtual Machine running Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_7",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_7",
+            "properties": {
+              "displayName": "Virtual Network",
+              "resourceTypes": [
+                "MICROSOFT.NETWORK/VIRTUALNETWORKS",
+                "MICROSOFT.CLASSICNETWORK/VIRTUALNETWORKS"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Services_List",
+  "title": "Gets list of services for which a support ticket can be created"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTickets.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTickets.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInOpenState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInOpenState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Open'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets created on or after a certain date and in open state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInOpenStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInOpenStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Open'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets created on or after a certain date and in open state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInUpdatingState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInUpdatingState.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Updating'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets created on or after a certain date and in updating state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInUpdatingStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsCreatedOnOrAfterAndInUpdatingStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Updating'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets created on or after a certain date and in updating state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInOpenState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInOpenState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Open'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets in open state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInOpenStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInOpenStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Open'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets in open state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInUpdatingState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInUpdatingState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Updating'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets in updating state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInUpdatingStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsInUpdatingStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Updating'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets in updating state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsProblemClassificationIdEquals.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsProblemClassificationIdEquals.json
@@ -1,0 +1,89 @@
+{
+  "parameters": {
+    "$filter": "ProblemClassificationId eq 'compute_vm_problemClassification_guid'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testTicket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testTicket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "testTicket1",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205060010000072",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testTicket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testTicket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "testTicket2",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000077",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets with a certain problem classification id"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsProblemClassificationIdEqualsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsProblemClassificationIdEqualsForSubscription.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "$filter": "ProblemClassificationId eq 'compute_vm_problemClassification_guid'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testTicket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testTicket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "testTicket1",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205060010000072",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testTicket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testTicket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "testTicket2",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000077",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets with a certain problem classification id for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsServiceIdEquals.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsServiceIdEquals.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "$filter": "ServiceId eq 'vm_windows_service_guid'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000082",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000080",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets with a certain service id"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsServiceIdEqualsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListSupportTicketsServiceIdEqualsForSubscription.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "$filter": "ServiceId eq 'vm_windows_service_guid'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000082",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000080",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets with a certain service id for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSubscriptionSupportTicket.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-10T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List web communications for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSubscriptionSupportTicketCreatedOnOrAfter.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSubscriptionSupportTicketCreatedOnOrAfter.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web' and createdDate ge 2020-03-10T22:08:51Z",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-12T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List web communication created on or after a specific date for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSupportTicket.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web'",
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-10T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List web communications for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSupportTicketCreatedOnOrAfter.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/ListWebCommunicationsForSupportTicketCreatedOnOrAfter.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web' and createdDate ge 2020-03-10T22:08:51Z",
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-12T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List web communication created on or after a specific date for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/LookUpResourceId.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/LookUpResourceId.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "lookUpResourceIdRequest": {
+      "type": "Microsoft.Support/supportTickets",
+      "identifier": "1234668596"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "resourceId": "/subscriptions/subId/providers/Microsoft.Support/supportTickets/SupportTicketName"
+      }
+    }
+  },
+  "operationId": "LookUpResourceId_Post",
+  "title": "Look up resource id of support resource type"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateAdvancedDiagnosticConsentOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateAdvancedDiagnosticConsentOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "advancedDiagnosticConsent": "Yes"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update advanced diagnostic consent of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateAdvancedDiagnosticConsentOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateAdvancedDiagnosticConsentOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "advancedDiagnosticConsent": "Yes"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update advanced diagnostic consent of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateContactDetailsOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateContactDetailsOfSupportTicket.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "additionalEmailAddresses": [
+          "tname@contoso.com",
+          "teamtest@contoso.com"
+        ],
+        "country": "USA",
+        "firstName": "first name",
+        "lastName": "last name",
+        "phoneNumber": "123-456-7890",
+        "preferredContactMethod": "email",
+        "preferredSupportLanguage": "en-US",
+        "preferredTimeZone": "Pacific Standard Time",
+        "primaryEmailAddress": "test.name@contoso.com"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "first name",
+            "lastName": "last name",
+            "phoneNumber": "123-456-7890",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update contact details of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateContactDetailsOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateContactDetailsOfSupportTicketForSubscription.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "additionalEmailAddresses": [
+          "tname@contoso.com",
+          "teamtest@contoso.com"
+        ],
+        "country": "USA",
+        "firstName": "first name",
+        "lastName": "last name",
+        "phoneNumber": "123-456-7890",
+        "preferredContactMethod": "email",
+        "preferredSupportLanguage": "en-US",
+        "preferredTimeZone": "Pacific Standard Time",
+        "primaryEmailAddress": "test.name@contoso.com"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "first name",
+            "lastName": "last name",
+            "phoneNumber": "123-456-7890",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update contact details of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateEscalationStatusOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateEscalationStatusOfSupportTicket.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "supportTicketName": "testticket",
+    "api-version": "2026-06-01",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "phoneNumber": "123-456-7890"
+      },
+      "directConnectEscalation": {
+        "azureEEStatus": "EscalationInitiated",
+        "reasonForEscalation": "Server is down and business is impacted"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "properties": {
+          "supportTicketId": "118032014183770",
+          "description": "This is a test - please ignore",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "severity": "critical",
+          "require24X7Response": false,
+          "advancedDiagnosticConsent": "No",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "contactDetails": {
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "primaryEmailAddress": "test.name@contoso.com",
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "phoneNumber": "123-456-7890",
+            "preferredTimeZone": "Pacific Standard Time",
+            "country": "USA",
+            "preferredSupportLanguage": "en-US"
+          },
+          "serviceLevelAgreement": {
+            "startTime": "2020-03-20T21:36:18Z",
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240
+          },
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanType": "Premier",
+          "supportPlanDisplayName": "Premier",
+          "title": "Test - please ignore",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceDisplayName": "Subscription management",
+          "status": "Open",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationInitiated",
+            "allowedSeverities": [
+              "critical",
+              "highestcriticalimpact"
+            ],
+            "reasonForEscalation": "Server is down and business is impacted"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update escalation status of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateEscalationStatusOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateEscalationStatusOfSupportTicketForSubscription.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "api-version": "2026-06-01",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "phoneNumber": "123-456-7890"
+      },
+      "directConnectEscalation": {
+        "azureEEStatus": "EscalationInitiated",
+        "reasonForEscalation": "Server is down and business is impacted"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "properties": {
+          "supportTicketId": "118032014183770",
+          "description": "This is a test - please ignore",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "severity": "critical",
+          "require24X7Response": false,
+          "advancedDiagnosticConsent": "No",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "contactDetails": {
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "primaryEmailAddress": "test.name@contoso.com",
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "phoneNumber": "123-456-7890",
+            "preferredTimeZone": "Pacific Standard Time",
+            "country": "USA",
+            "preferredSupportLanguage": "en-US"
+          },
+          "serviceLevelAgreement": {
+            "startTime": "2020-03-20T21:36:18Z",
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240
+          },
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanType": "Premier",
+          "supportPlanDisplayName": "Premier",
+          "title": "Test - please ignore",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceDisplayName": "Subscription management",
+          "status": "Open",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationInitiated",
+            "allowedSeverities": [
+              "critical",
+              "highestcriticalimpact"
+            ],
+            "reasonForEscalation": "Server is down and business is impacted"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update escalation status of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateSeverityOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateSeverityOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "severity": "critical"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update severity of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateSeverityOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateSeverityOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "severity": "critical"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update severity of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateStatusOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateStatusOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "status": "closed"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Closed",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update status of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateStatusOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UpdateStatusOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "status": "closed"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Closed",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update status of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UploadFile.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UploadFile.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspaceName",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "uploadFile": {
+      "chunkIndex": 0,
+      "content": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABd"
+    }
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "FilesNoSubscription_Upload",
+  "title": "UploadFile"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UploadFileForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/examples/2026-06-01/UploadFileForSubscription.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspaceName",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "uploadFile": {
+      "chunkIndex": 0,
+      "content": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABd"
+    }
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Files_Upload",
+  "title": "UploadFileForSubscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/main.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/main.tsp
@@ -35,7 +35,6 @@ using TypeSpec.Versioning;
 @armProviderNamespace
 @service(#{ title: "Microsoft.Support" })
 @versioned(Versions)
-@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
 namespace Microsoft.Support;
 
 /**
@@ -45,12 +44,14 @@ enum Versions {
   /**
    * The 2024-04-01 API version.
    */
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   v2024_04_01: "2024-04-01",
 
   /**
-   * The 2025-06-01-preview API version.
+   * The 2026-06-01 API version.
    */
-  v2025_06_01_preview: "2025-06-01-preview",
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2026_06_01: "2026-06-01",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/support/resource-manager/Microsoft.Support/Support/models.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/models.tsp
@@ -186,11 +186,6 @@ union ChatConversationStatus {
    * Chat conversation has been closed.
    */
   Closed: "Closed",
-
-  /**
-   * No chat conversation associated.
-   */
-  None: "None",
 }
 
 /**

--- a/specification/support/resource-manager/Microsoft.Support/Support/models.tsp
+++ b/specification/support/resource-manager/Microsoft.Support/Support/models.tsp
@@ -122,7 +122,7 @@ union CreatedByType {
 /**
  * Status of Direct Connect Escalation.
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 union EscalationStatus {
   string,
 
@@ -150,6 +150,47 @@ union EscalationStatus {
    * Escalation is unavailable and cannot be initiated due to customer not being enrolled to direct escalation
    */
   EscalationUnavailable: "EscalationUnavailable",
+}
+
+/**
+ * Support channel type for the support ticket.
+ */
+@added(Versions.v2026_06_01)
+union SupportChannel {
+  string,
+
+  /**
+   * Chat support channel.
+   */
+  Chat: "Chat",
+
+  /**
+   * Web support channel.
+   */
+  Web: "Web",
+}
+
+/**
+ * Status of the chat conversation associated with the support ticket.
+ */
+@added(Versions.v2026_06_01)
+union ChatConversationStatus {
+  string,
+
+  /**
+   * Chat conversation is currently active.
+   */
+  Active: "Active",
+
+  /**
+   * Chat conversation has been closed.
+   */
+  Closed: "Closed",
+
+  /**
+   * No chat conversation associated.
+   */
+  None: "None",
 }
 
 /**
@@ -242,7 +283,7 @@ model ServiceProperties {
 /**
  * Input to problem classification Classification API.
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model ServiceClassificationRequest {
   /**
    * Natural language description of the customer’s issue.
@@ -263,7 +304,7 @@ model ServiceClassificationRequest {
 /**
  * Output of the service classification API.
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model ServiceClassificationOutput {
   /**
    * Set of problem classification objects classified.
@@ -276,7 +317,7 @@ model ServiceClassificationOutput {
  * Service Classification result object.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model ServiceClassificationAnswer extends ClassificationService {
   /**
    * Child service.
@@ -287,7 +328,7 @@ model ServiceClassificationAnswer extends ClassificationService {
 /**
  * Service Classification result object.
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model ClassificationService {
   /**
    * Azure resource Id of the service.
@@ -372,7 +413,7 @@ model ProblemClassificationsClassificationResult {
    */
   #suppress "@azure-tools/typespec-azure-core/no-openapi" "For backward compatibility"
   @OpenAPI.extension("x-ms-client-flatten", true)
-  @added(Versions.v2025_06_01_preview)
+  @added(Versions.v2026_06_01)
   relatedService?: ClassificationService;
 }
 
@@ -618,14 +659,28 @@ model SupportTicketDetailsProperties {
   /**
    * Direct Connect Escalation details for a support ticket.
    */
-  @added(Versions.v2025_06_01_preview)
+  @added(Versions.v2026_06_01)
   directConnectEscalation?: DirectConnectEscalation;
 
   /**
    * Contains a link to the post on the community forum.
    */
-  @added(Versions.v2025_06_01_preview)
+  @added(Versions.v2026_06_01)
   communityForumPost?: string;
+
+  /**
+   * Support channel type for the support ticket.
+   */
+  @added(Versions.v2026_06_01)
+  @visibility(Lifecycle.Read)
+  supportChannel?: SupportChannel;
+
+  /**
+   * Status of the chat conversation associated with the support ticket.
+   */
+  @added(Versions.v2026_06_01)
+  @visibility(Lifecycle.Read)
+  chatConversationStatus?: ChatConversationStatus;
 }
 
 /**
@@ -808,7 +863,7 @@ model UpdateSupportTicket {
   /**
    * Direct Connect Escalation details for a support ticket.
    */
-  @added(Versions.v2025_06_01_preview)
+  @added(Versions.v2026_06_01)
   directConnectEscalation?: DirectConnectEscalation;
 }
 
@@ -1021,7 +1076,7 @@ model UploadFile {
 /**
  * Direct Connect Escalation details for a support ticket.
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model DirectConnectEscalation {
   /**
    * Status of Direct Connect Escalation.
@@ -1043,7 +1098,7 @@ model DirectConnectEscalation {
 /**
  * The look up resource Id request body
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model LookUpResourceIdRequest {
   /**
    * The System generated Id that is unique. Use supportTicketId property for Microsoft.Support/supportTickets resource type.
@@ -1064,7 +1119,7 @@ model LookUpResourceIdRequest {
 /**
  * The look up resource id response
  */
-@added(Versions.v2025_06_01_preview)
+@added(Versions.v2026_06_01)
 model LookUpResourceIdResponse {
   /**
    * The resource Id of support resource type.

--- a/specification/support/resource-manager/Microsoft.Support/Support/readme.md
+++ b/specification/support/resource-manager/Microsoft.Support/Support/readme.md
@@ -26,16 +26,16 @@ These are the global settings for the Support API.
 
 ``` yaml
 openapi-type: arm
-tag: package-2025-06-01-preview
+tag: package-2026-06-01
 ```
 
-### Tag: package-2025-06-01-preview
+### Tag: package-2026-06-01
 
-These settings apply only when `--tag=package-2025-06-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2026-06-01` is specified on the command line.
 
-```yaml $(tag) == 'package-2025-06-01-preview'
+```yaml $(tag) == 'package-2026-06-01'
 input-file:
-  - preview/2025-06-01-preview/support.json
+  - stable/2026-06-01/support.json
 
 suppressions:
   - code: ConsistentPatchProperties
@@ -43,7 +43,7 @@ suppressions:
     where:
       - $.paths["/providers/Microsoft.Support/supportTickets/{supportTicketName}"].patch.parameters[2]["schema"]
       - $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}"].patch.parameters[3]["schema"]
-    reason: "Rule: The property 'directConnectEscalation' in the request body either not apppear in the resource model or has the wrong level. Justification: This rule is being suppressed because all other properties associated with the same request are also suppressed. We are unable to update the public API to a different definition, as doing so would deviate from the expected behavior."
+    reason: "Pre-existing: The PATCH request body uses a separate UpdateSupportTicket model with properties like severity, status, contactDetails, advancedDiagnosticConsent, secondaryConsent, and directConnectEscalation that are at a different level than in the resource model. This is by design for backward compatibility and cannot be changed without breaking existing clients."
 ```
 
 ### Tag: package-2024-04

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailability.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailability.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/supportTickets"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_CheckNameAvailability",
+  "title": "Checks whether name is available for SupportTicket resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityForNoSubscriptionSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityForNoSubscriptionSupportTicketCommunication.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/communications"
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_CheckNameAvailability",
+  "title": "Checks whether name is available for Communication resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityForSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityForSupportTicketCommunication.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/communications"
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "Communications_CheckNameAvailability",
+  "title": "Checks whether name is available for Communication resource for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityWithSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CheckNameAvailabilityWithSubscription.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "checkNameAvailabilityInput": {
+      "name": "sampleName",
+      "type": "Microsoft.Support/supportTickets"
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "Name not available",
+        "nameAvailable": false,
+        "reason": "Name is already in use"
+      }
+    }
+  },
+  "operationId": "SupportTickets_CheckNameAvailability",
+  "title": "Checks whether name is available for a subscription support ticket resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassifications.json
@@ -29,6 +29,6 @@
       }
     }
   },
-  "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+  "operationId": "ProblemClassificationsNoSubscription_ClassifyProblems",
   "title": "Classify list of problemClassifications for a specified Azure service"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassifications.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "problemServiceName": "serviceId1",
+    "api-version": "2026-06-01",
+    "problemClassificationsClassificationInput": {
+      "issueSummary": "Can not connect to Windows VM"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "problemClassificationResults": [
+          {
+            "problemId": "problemId1",
+            "title": "Problem classification title",
+            "description": "Problem classification description",
+            "serviceId": "serviceId1",
+            "problemClassificationId": "problemClassificationId1",
+            "relatedService": {
+              "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+              "displayName": "SQL Server in VM - Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+  "title": "Classify list of problemClassifications for a specified Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassificationsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassificationsForSubscription.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "problemServiceName": "serviceId1",
+    "api-version": "2026-06-01",
+    "problemClassificationsClassificationInput": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "problemClassificationResults": [
+          {
+            "problemId": "problemId1",
+            "title": "Problem classification title",
+            "description": "Problem classification description",
+            "serviceId": "serviceId1",
+            "problemClassificationId": "problemClassificationId1",
+            "relatedService": {
+              "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+              "displayName": "SQL Server in VM - Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_classifyProblems",
+  "title": "Classify list of problemClassifications for a specified Azure service for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassificationsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyProblemClassificationsForSubscription.json
@@ -31,6 +31,6 @@
       }
     }
   },
-  "operationId": "ProblemClassifications_classifyProblems",
+  "operationId": "ProblemClassifications_ClassifyProblems",
   "title": "Classify list of problemClassifications for a specified Azure service for a subscription"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServices.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "serviceClassificationRequest": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceClassificationResults": [
+          {
+            "serviceId": "/providers/Microsoft.Support/services/5c41904f-1bcf-76e4-7a54-5fc07468f3cc",
+            "displayName": "Azure Update Manager",
+            "resourceTypes": [
+              "Microsoft.HybridCompute/machines",
+              "Microsoft.Maintenance/maintenanceConfigurations",
+              "Microsoft.Maintenance/configurationAssignments",
+              "MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          },
+          {
+            "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+            "displayName": "SQL Server in VM - Linux",
+            "resourceTypes": [
+              "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+  "title": "Classify list of Azure services"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServices.json
@@ -34,6 +34,6 @@
       }
     }
   },
-  "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+  "operationId": "ServiceClassificationsNoSubscription_ClassifyServices",
   "title": "Classify list of Azure services"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServicesForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServicesForSubscription.json
@@ -34,6 +34,6 @@
       }
     }
   },
-  "operationId": "ServiceClassifications_classifyServices",
+  "operationId": "ServiceClassifications_ClassifyServices",
   "title": "Classify list of Azure services for a subscription"
 }

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServicesForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ClassifyServicesForSubscription.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "api-version": "2026-06-01",
+    "serviceClassificationRequest": {
+      "issueSummary": "Can not connect to Windows VM",
+      "resourceId": "/subscriptions/76cb77fa-8b17-4eab-9493-b65dace99813/resourceGroups/rgname/providers/Microsoft.Compute/virtualMachines/vmname"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "serviceClassificationResults": [
+          {
+            "serviceId": "/providers/Microsoft.Support/services/5c41904f-1bcf-76e4-7a54-5fc07468f3cc",
+            "displayName": "Azure Update Manager",
+            "resourceTypes": [
+              "Microsoft.HybridCompute/machines",
+              "Microsoft.Maintenance/maintenanceConfigurations",
+              "Microsoft.Maintenance/configurationAssignments",
+              "MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          },
+          {
+            "serviceId": "/providers/Microsoft.Support/services/40ef020e-8ae7-8d57-b538-9153c47cee69",
+            "displayName": "SQL Server in VM - Linux",
+            "resourceTypes": [
+              "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+              "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ServiceClassifications_classifyServices",
+  "title": "Classify list of Azure services for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForActiveJobs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForActiveJobs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Jobs\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Jobs\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Active Jobs and Job Schedules for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForDedicatedCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForDedicatedCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for specific VM family cores for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForLowPriorityCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForLowPriorityCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Low-priority cores for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForPools.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSpecificBatchAccountForPools.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Account",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Pools\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"AccountName\":\"test\",\"NewLimit\":200,\"Type\":\"Pools\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Pools for a Batch account"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBatchQuotaTicketForSubscription.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Subscription",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200,\"Type\":\"Account\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Batch",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/batch_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Subscription",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200,\"Type\":\"Account\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Batch accounts for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBillingSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBillingSupportTicket.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Refund request",
+          "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Billing",
+          "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Billing related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBillingSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateBillingSupportTicketForSubscription.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Refund request",
+          "problemClassificationId": "/providers/Microsoft.Support/services/billing_service_guid/problemClassifications/billing_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Billing",
+          "serviceId": "/providers/Microsoft.Support/services/billing_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Billing related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateCoresQuotaTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateCoresQuotaTicketForSubscription.json
@@ -1,0 +1,98 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cores_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"SKU\":\"DSv3 Series\",\"NewLimit\":104}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cores_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"VmFamily\":\"DSv3 Series\",\"NewLimit\":104}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Compute VM Cores"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFile.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFile.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createFileParameters": {
+      "properties": {
+        "chunkSize": 41423,
+        "fileSize": 41423,
+        "numberOfChunks": 1
+      }
+    },
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_Create",
+  "title": "Create a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileForSubscription.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createFileParameters": {
+      "properties": {
+        "chunkSize": 41423,
+        "fileSize": 41423,
+        "numberOfChunks": 1
+      }
+    },
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "Files_Create",
+  "title": "Create a file under a subscription workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileWorkspace.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspacesNoSubscription_Create",
+  "title": "Create a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileWorkspaceForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateFileWorkspaceForSubscription.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "201": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspaces_Create",
+  "title": "Create a file workspace for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateGenericQuotaTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateGenericQuotaTicket.json
@@ -1,0 +1,77 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "Increase the maximum throughput per container limit to 10000 for account foo bar",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cosmosdb_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "Increase the maximum throughput per container limit to 10000 for account foo bar",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Cosmos DB",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/cosmosdb_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for services that do not require additional details in the quotaTicketDetails object"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateMachineLearningQuotaTicketForDedicatedCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateMachineLearningQuotaTicketForDedicatedCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "BatchAml",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Machine Learning service",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"VMFamily\":\"standardA0_A7Family\",\"NewLimit\":200,\"Type\":\"Dedicated\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for specific VM family cores for Machine Learning service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateMachineLearningQuotaTicketForLowPriorityCores.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateMachineLearningQuotaTicketForLowPriorityCores.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "BatchAml",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Machine Learning service",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/machine_learning_service_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Account",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200,\"Type\":\"LowPriority\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Low-priority cores for Machine Learning service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateNoSubscriptionSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateNoSubscriptionSupportTicketCommunication.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testcommunication",
+    "createCommunicationParameters": {
+      "properties": {
+        "body": "This is a test message from a customer!",
+        "sender": "user@contoso.com",
+        "subject": "This is a test message from a customer!"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcommunication",
+        "type": "Microsoft.Support/communications",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testcommunication",
+        "properties": {
+          "body": "This is a test message from a customer!",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "This is a test message from a customer!"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_Create",
+  "title": "AddCommunicationToNoSubscriptionTicket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatabaseQuotaTicketForDTUs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatabaseQuotaTicketForDTUs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "DTUs",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL database",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "DTUs",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for DTUs for SQL Database"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatabaseQuotaTicketForServers.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatabaseQuotaTicketForServers.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Servers",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL database",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_database_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Servers",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Servers for SQL Database"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatawarehouseQuotaTicketForDTUs.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatawarehouseQuotaTicketForDTUs.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "DTUs",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Data Warehouse",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "DTUs",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"ServerName\":\"testserver\",\"NewLimit\":54000}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for DTUs for Azure Synapse Analytics"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatawarehouseQuotaTicketForServers.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlDatawarehouseQuotaTicketForServers.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "Servers",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Data Warehouse",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "Servers",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Servers for Azure Synapse Analytics"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlManagedInstanceQuotaTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSqlManagedInstanceQuotaTicket.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_managedinstance_problemClassification_guid",
+        "quotaTicketDetails": {
+          "quotaChangeRequestSubType": "SQLMI",
+          "quotaChangeRequestVersion": "1.0",
+          "quotaChangeRequests": [
+            {
+              "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"vCore\"}",
+              "region": "EastUS"
+            },
+            {
+              "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"Subnet\"}",
+              "region": "EastUS"
+            }
+          ]
+        },
+        "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "testticket",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "SQL Database Managed Instance",
+          "problemClassificationId": "/providers/Microsoft.Support/services/quota_service_guid/problemClassifications/sql_datawarehouse_problemClassification_guid",
+          "quotaTicketDetails": {
+            "quotaChangeRequestSubType": "SQLMI",
+            "quotaChangeRequestVersion": "1.0",
+            "quotaChangeRequests": [
+              {
+                "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"vCore\"}",
+                "region": "EastUS"
+              },
+              {
+                "payload": "{\"NewLimit\":200, \"Metadata\":null, \"Type\":\"Subnet\"}",
+                "region": "EastUS"
+              }
+            ]
+          },
+          "require24X7Response": false,
+          "serviceDisplayName": "Service and subscription limits (quotas)",
+          "serviceId": "/providers/Microsoft.Support/services/quota_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket to request Quota increase for Azure SQL managed instance"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSubMgmtSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSubMgmtSupportTicket.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Transfer ownership of my subscription",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Subscription Management related issues"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSubMgmtSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSubMgmtSupportTicketForSubscription.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "No",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+        "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Transfer ownership of my subscription",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/subscription_management_problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Subscription Management related issues for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSupportTicketCommunication.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateSupportTicketCommunication.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testcommunication",
+    "createCommunicationParameters": {
+      "properties": {
+        "body": "This is a test message from a customer!",
+        "sender": "user@contoso.com",
+        "subject": "This is a test message from a customer!"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcommunication",
+        "type": "Microsoft.Support/communications",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testcommunication",
+        "properties": {
+          "body": "This is a test message from a customer!",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "This is a test message from a customer!"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "Communications_Create",
+  "title": "AddCommunicationToSubscriptionTicket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateTechnicalSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateTechnicalSupportTicket.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+        "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+        "secondaryConsent": [
+          {
+            "type": "virtualmachinerunninglinuxservice",
+            "userConsent": "Yes"
+          }
+        ],
+        "serviceId": "/providers/Microsoft.Support/services/cddd3eb5-1830-b494-44fd-782f691479dc",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "title": "my title"
+      }
+    },
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+          "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+          "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+          "require24X7Response": false,
+          "secondaryConsent": [
+            {
+              "type": "virtualmachinerunninglinuxservice",
+              "userConsent": "Yes"
+            }
+          ],
+          "serviceDisplayName": "Virtual Machine running Linux",
+          "serviceId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Create",
+  "title": "Create a ticket for Technical issue related to a specific resource"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateTechnicalSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/CreateTechnicalSupportTicketForSubscription.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "createSupportTicketParameters": {
+      "properties": {
+        "description": "my description",
+        "advancedDiagnosticConsent": "Yes",
+        "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+        "contactDetails": {
+          "country": "usa",
+          "firstName": "abc",
+          "lastName": "xyz",
+          "preferredContactMethod": "email",
+          "preferredSupportLanguage": "en-US",
+          "preferredTimeZone": "Pacific Standard Time",
+          "primaryEmailAddress": "abc@contoso.com"
+        },
+        "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+        "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+        "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+        "secondaryConsent": [
+          {
+            "type": "virtualmachinerunninglinuxservice",
+            "userConsent": "Yes"
+          }
+        ],
+        "serviceId": "/providers/Microsoft.Support/services/cddd3eb5-1830-b494-44fd-782f691479dc",
+        "severity": "moderate",
+        "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+        "technicalTicketDetails": {
+          "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+        },
+        "title": "my title"
+      }
+    },
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "my description",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "usa",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+          "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid/problemClassifications/problemClassification_guid",
+          "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+          "require24X7Response": false,
+          "secondaryConsent": [
+            {
+              "type": "virtualmachinerunninglinuxservice",
+              "userConsent": "Yes"
+            }
+          ],
+          "serviceDisplayName": "Virtual Machine running Linux",
+          "serviceId": "/providers/Microsoft.Support/services/virtual_machine_running_linux_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "moderate",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "119120321001170",
+          "technicalTicketDetails": {
+            "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+          },
+          "title": "my title"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationsStatus/operationid?api-version=2026-06-01",
+        "location": "https://management.azure.com/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/operationResults/operationid?api-version=2026-06-01"
+      }
+    }
+  },
+  "operationId": "SupportTickets_Create",
+  "title": "Create a ticket for Technical issue related to a specific resource for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetCommunicationDetailsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetCommunicationDetailsForSubscriptionSupportTicket.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testmessage",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/communications",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage",
+        "properties": {
+          "body": "this is a test message",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2020-03-10T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "this is a test message"
+        }
+      }
+    }
+  },
+  "operationId": "Communications_Get",
+  "title": "Get communication details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetCommunicationDetailsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetCommunicationDetailsForSupportTicket.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "communicationName": "testmessage",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/communications",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage",
+        "properties": {
+          "body": "this is a test message",
+          "communicationDirection": "outbound",
+          "communicationType": "web",
+          "createdDate": "2016-08-24T20:18:19Z",
+          "sender": "user@contoso.com",
+          "subject": "this is a test message"
+        }
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_Get",
+  "title": "Get communication details for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileDetails.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_Get",
+  "title": "Get details of a subscription file"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileDetailsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileDetailsForSubscription.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "test.txt",
+        "type": "Microsoft.Support/files",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test.txt",
+        "properties": {
+          "chunkSize": 41423,
+          "createdOn": "2022-08-24T20:18:19Z",
+          "fileSize": 41423,
+          "numberOfChunks": 1
+        }
+      }
+    }
+  },
+  "operationId": "Files_Get",
+  "title": "Get details of a subscription file"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileWorkspaceDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileWorkspaceDetails.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspacesNoSubscription_Get",
+  "title": "Get details of a file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileWorkspaceDetailsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetFileWorkspaceDetailsForSubscription.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testworkspace",
+        "type": "Microsoft.Support/fileWorkspaces",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace",
+        "properties": {
+          "createdOn": "2022-08-24T20:18:19Z",
+          "expirationTime": "2022-08-25T20:18:19Z"
+        }
+      }
+    }
+  },
+  "operationId": "FileWorkspaces_Get",
+  "title": "Get details of a subscription file workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetProblemClassification.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetProblemClassification.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "problemClassificationName": "problemClassification_guid",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "problemClassification_guid",
+        "type": "Microsoft.Support/problemClassifications",
+        "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid",
+        "properties": {
+          "displayName": "Reservation Management / Exchanges and Refunds"
+        }
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_Get",
+  "title": "Gets details of problemClassification for Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetService.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetService.json
@@ -1,0 +1,24 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "service_guid",
+        "type": "Microsoft.Support/services",
+        "id": "/providers/Microsoft.Support/services/service_guid",
+        "properties": {
+          "displayName": "Virtual Machine running Windows",
+          "resourceTypes": [
+            "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+            "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "Services_Get",
+  "title": "Gets details of the Azure service"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetSubscriptionSupportTicketDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetSubscriptionSupportTicketDetails.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationUnavailable"
+          },
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "minimal",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore",
+          "supportChannel": "Email",
+          "chatConversationStatus": "None"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Get",
+  "title": "Get details of a subscription ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetSupportTicketDetails.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetSupportTicketDetails.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+          "contactDetails": {
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "abc@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationUnavailable"
+          },
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "minimal",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore",
+          "supportChannel": "Chat",
+          "chatConversationStatus": "Active"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Get",
+  "title": "Get details of a ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetchatTranscriptDetailsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetchatTranscriptDetailsForSubscriptionSupportTicket.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "chatTranscriptName": "69586795-45e9-45b5-bd9e-c9bb237d3e44",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/chatTranscripts",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/chatTranscripts/69586795-45e9-45b5-bd9e-c9bb237d3e44",
+        "properties": {
+          "messages": [
+            {
+              "body": "Hi again",
+              "communicationDirection": "outbound",
+              "contentType": "text",
+              "createdDate": "2020-03-23T20:18:19Z",
+              "sender": "support engineer 2"
+            },
+            {
+              "body": "hello",
+              "communicationDirection": "inbound",
+              "contentType": "text",
+              "createdDate": "2020-03-23T20:19:16Z",
+              "sender": "user"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ChatTranscripts_Get",
+  "title": "Get chat transcript details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetchatTranscriptDetailsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/GetchatTranscriptDetailsForSupportTicket.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "chatTranscriptName": "b371192a-b094-4a71-b093-7246029b0a54",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testmessage",
+        "type": "Microsoft.Support/chatTranscripts",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket/chatTranscripts/b371192a-b094-4a71-b093-7246029b0a54",
+        "properties": {
+          "messages": [
+            {
+              "body": "Hi again",
+              "communicationDirection": "outbound",
+              "contentType": "text",
+              "createdDate": "2020-03-25T20:18:19Z",
+              "sender": "support engineer 2"
+            },
+            {
+              "body": "hello",
+              "communicationDirection": "inbound",
+              "contentType": "text",
+              "createdDate": "2020-03-25T20:19:16Z",
+              "sender": "user"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "ChatTranscriptsNoSubscription_Get",
+  "title": "Get chat transcript details for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListChatTranscriptsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListChatTranscriptsForSubscriptionSupportTicket.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:18:19Z",
+                  "sender": "support engineer"
+                },
+                {
+                  "body": "hi",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          },
+          {
+            "name": "f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi again",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:18:19Z",
+                  "sender": "support engineer 2"
+                },
+                {
+                  "body": "hello",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ChatTranscripts_List",
+  "title": "List chat transcripts for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListChatTranscriptsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListChatTranscriptsForSupportTicket.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/55989c71-1727-4cd9-abad-ddb8770f71cd",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:18:19Z",
+                  "sender": "support engineer"
+                },
+                {
+                  "body": "hi",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-24T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          },
+          {
+            "name": "f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "type": "Microsoft.Support/chatTranscripts",
+            "id": "/providers/Microsoft.Support/supportTickets/2207120020000085/chatTranscripts/f15051e3-a2f2-489f-9e64-8cfa203f44f8",
+            "properties": {
+              "messages": [
+                {
+                  "body": "Hi again",
+                  "communicationDirection": "outbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:18:19Z",
+                  "sender": "support engineer 2"
+                },
+                {
+                  "body": "hello",
+                  "communicationDirection": "inbound",
+                  "contentType": "text",
+                  "createdDate": "2020-03-25T20:19:16Z",
+                  "sender": "user"
+                }
+              ],
+              "startTime": "2023-08-22T22:46:35Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ChatTranscriptsNoSubscription_List",
+  "title": "List chat transcripts for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListCommunicationsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListCommunicationsForSubscriptionSupportTicket.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-24T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-29T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List communications for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListCommunicationsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListCommunicationsForSupportTicket.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-24T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-29T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List communications for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListFilesForSubscriptionUnderFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListFilesForSubscriptionUnderFileWorkspace.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          },
+          {
+            "name": "test2.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test2.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Files_List",
+  "title": "List files under a workspace for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListFilesUnderFileWorkspace.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListFilesUnderFileWorkspace.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileWorkspaceName": "testworkspace"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          },
+          {
+            "name": "test1.txt",
+            "type": "Microsoft.Support/files",
+            "id": "/providers/Microsoft.Support/fileWorkspaces/testworkspace/files/test1.txt",
+            "properties": {
+              "chunkSize": 41423,
+              "createdOn": "2022-08-24T20:18:19Z",
+              "fileSize": 41423,
+              "numberOfChunks": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "FilesNoSubscription_List",
+  "title": "List files under a workspace"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListOperations.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListOperations.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.Support/services/read",
+            "display": {
+              "description": "Gets all the Azure services available for support",
+              "operation": "Reads Services",
+              "provider": "Microsoft Support",
+              "resource": "Service"
+            }
+          },
+          {
+            "name": "Microsoft.Support/problemClassifications/read",
+            "display": {
+              "description": "Gets all the problem classifications available for a specific Azure service",
+              "operation": "Reads Problem Classifications",
+              "provider": "Microsoft Support",
+              "resource": "Problem Classification"
+            }
+          },
+          {
+            "name": "Microsoft.Support/supportTickets/read",
+            "display": {
+              "description": "Gets all the support tickets",
+              "operation": "Reads Support Tickets",
+              "provider": "Microsoft Support",
+              "resource": "Support Ticket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/supportTickets/write",
+            "display": {
+              "description": "Updates support ticket",
+              "operation": "Updates support ticket",
+              "provider": "Microsoft Support",
+              "resource": "Support Ticket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/communications/read",
+            "display": {
+              "description": "Gets all the communications",
+              "operation": "Reads Communications",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          },
+          {
+            "name": "Microsoft.Support/communications/write",
+            "display": {
+              "description": "Creates a communication",
+              "operation": "Creates a communication",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          },
+          {
+            "name": "Microsoft.Support/register/action",
+            "display": {
+              "description": "Registers Support Resource Provider",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Registers Support Resource Provider",
+              "resource": "Support Registration"
+            }
+          },
+          {
+            "name": "Microsoft.Support/createSupportTicket/action",
+            "display": {
+              "description": "Creates support ticket",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Microsoft Support",
+              "resource": "SupportTicket"
+            }
+          },
+          {
+            "name": "Microsoft.Support/addCommunication/action",
+            "display": {
+              "description": "Add communication to support ticket",
+              "operation": "Registers Support Resource Provider",
+              "provider": "Microsoft Support",
+              "resource": "Communication"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "Get all operations"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListProblemClassifications.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListProblemClassifications.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "serviceName": "service_guid"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "problemClassification_guid_1",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_1",
+            "properties": {
+              "displayName": "Reservation Management / Exchanges and Refunds",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_2",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_2",
+            "properties": {
+              "displayName": "Reservation Management / Request Invoices",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_3",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_3",
+            "properties": {
+              "displayName": "Reservation Management / Other Iissues or Requests",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          },
+          {
+            "name": "problemClassification_guid_4",
+            "type": "Microsoft.Support/problemClassifications",
+            "id": "/providers/Microsoft.Support/services/service_guid/problemClassifications/problemClassification_guid_4",
+            "properties": {
+              "displayName": "Other General Billing Questions",
+              "secondaryConsentEnabled": [
+                {
+                  "type": "DatabricksConsent",
+                  "description": "For faster resolution, allow Microsoft and Databricks to temporarily have read and write access to your Databricks workspace. We will only access to read and write to your cluster for the purpose of resolving your support issue and in conformance with Microsoft's Privacy Policy."
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ProblemClassifications_List",
+  "title": "Gets list of problemClassifications for a service for which a support ticket can be created"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListServices.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListServices.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "service_guid_1",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_1",
+            "properties": {
+              "displayName": "Billing",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_2",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_2",
+            "properties": {
+              "displayName": "Service and subscription limits (quotas)",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_3",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_3",
+            "properties": {
+              "displayName": "Subscription management",
+              "resourceTypes": []
+            }
+          },
+          {
+            "name": "service_guid_4",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_4",
+            "properties": {
+              "displayName": "Data Explorer",
+              "resourceTypes": [
+                "MICROSOFT.KUSTO/CLUSTERS",
+                "MICROSOFT.KUSTO/DATABASES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_5",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_5",
+            "properties": {
+              "displayName": "Virtual Machine running Windows",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_6",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_6",
+            "properties": {
+              "displayName": "Virtual Machine running Linux",
+              "resourceTypes": [
+                "MICROSOFT.CLASSICCOMPUTE/VIRTUALMACHINES",
+                "MICROSOFT.COMPUTE/VIRTUALMACHINES"
+              ]
+            }
+          },
+          {
+            "name": "service_guid_7",
+            "type": "Microsoft.Support/services",
+            "id": "/providers/Microsoft.Support/services/service_guid_7",
+            "properties": {
+              "displayName": "Virtual Network",
+              "resourceTypes": [
+                "MICROSOFT.NETWORK/VIRTUALNETWORKS",
+                "MICROSOFT.CLASSICNETWORK/VIRTUALNETWORKS"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Services_List",
+  "title": "Gets list of services for which a support ticket can be created"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTickets.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTickets.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "communityForumPost": "https://learn.microsoft.com/en-us/answers/questions/2283704/unverified-app-listed-under-applications-from-pers",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInOpenState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInOpenState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Open'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets created on or after a certain date and in open state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInOpenStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInOpenStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Open'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets created on or after a certain date and in open state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingState.json
@@ -1,0 +1,112 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Updating'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets created on or after a certain date and in updating state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "createdDate ge 2020-03-10T22:08:51Z and status eq 'Updating'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-11T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-12T21:36:18Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-12T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-11T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets created on or after a certain date and in updating state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInOpenState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInOpenState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Open'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets in open state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInOpenStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInOpenStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Open'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets in open state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInUpdatingState.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInUpdatingState.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Updating'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets in updating state"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInUpdatingStateBySubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsInUpdatingStateBySubscription.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "$filter": "status eq 'Updating'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Connectivity / Cannot connect to virtual machine by using RDP or SSH",
+              "problemClassificationId": "/providers/Microsoft.Support/services/virtual_machine_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Linux",
+              "serviceId": "/providers/Microsoft.Support/services/virtual_machine_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "moderate",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "119120321001170",
+              "technicalTicketDetails": {
+                "resourceId": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/testserver"
+              },
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "No",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2020-03-20T21:36:18Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2020-03-20T21:36:23Z",
+              "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+              "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "Subscription management",
+              "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+              "serviceLevelAgreement": {
+                "expirationTime": "2020-03-21T17:36:18Z",
+                "slaMinutes": 240,
+                "startTime": "2020-03-20T21:36:18Z"
+              },
+              "severity": "minimal",
+              "status": "Updating",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "118032014183771",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets in updating state for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsProblemClassificationIdEquals.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsProblemClassificationIdEquals.json
@@ -1,0 +1,89 @@
+{
+  "parameters": {
+    "$filter": "ProblemClassificationId eq 'compute_vm_problemClassification_guid'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testTicket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testTicket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "testTicket1",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205060010000072",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testTicket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testTicket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "testTicket2",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000077",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets with a certain problem classification id"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsProblemClassificationIdEqualsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsProblemClassificationIdEqualsForSubscription.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "$filter": "ProblemClassificationId eq 'compute_vm_problemClassification_guid'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testTicket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testTicket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "testTicket1",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205060010000072",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testTicket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testTicket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "testTicket2",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "Compute-VM (cores-vCPUs) subscription limit increases",
+              "problemClassificationId": "/providers/Microsoft.Support/services/service_guid/problemClassifications/compute_vm_problemClassification_guid",
+              "require24X7Response": false,
+              "serviceDisplayName": "service_displayName",
+              "serviceId": "/providers/Microsoft.Support/services/service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000077",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets with a certain problem classification id for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsServiceIdEquals.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsServiceIdEquals.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "$filter": "ServiceId eq 'vm_windows_service_guid'",
+    "api-version": "2026-06-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000082",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000080",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_List",
+  "title": "List support tickets with a certain service id"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsServiceIdEqualsForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListSupportTicketsServiceIdEqualsForSubscription.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "$filter": "ServiceId eq 'vm_windows_service_guid'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testticket1",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket1",
+            "properties": {
+              "description": "my description",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "usa",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:52:10Z",
+              "enrollmentId": "",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-12T23:05:19Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000082",
+              "title": "my title"
+            }
+          },
+          {
+            "name": "testticket2",
+            "type": "Microsoft.Support/supportTickets",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket2",
+            "properties": {
+              "description": "This is a test - please ignore",
+              "advancedDiagnosticConsent": "Yes",
+              "contactDetails": {
+                "country": "USA",
+                "firstName": "abc",
+                "lastName": "xyz",
+                "preferredContactMethod": "email",
+                "preferredSupportLanguage": "en-US",
+                "preferredTimeZone": "Pacific Standard Time",
+                "primaryEmailAddress": "abc@contoso.com"
+              },
+              "createdDate": "2022-05-04T21:38:42Z",
+              "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+              "modifiedDate": "2022-05-04T21:39:14Z",
+              "problemClassificationDisplayName": "problemClassification_displayName",
+              "problemClassificationId": "/providers/Microsoft.Support/services/vm_windows_service_guid/problemClassifications/problemClassification_guid",
+              "problemScopingQuestions": "{\"articleId\":\"076846c1-4c0b-4b21-91c6-1a30246b3867\",\"scopingDetails\":[{\"question\":\"When did the problem begin?\",\"controlId\":\"problem_start_time\",\"orderId\":1,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"2023-08-31T18:55:00.739Z\",\"value\":\"2023-08-31T18:55:00.739Z\",\"type\":\"datetime\"}},{\"question\":\"API Type of the Cosmos DB account\",\"controlId\":\"api_type\",\"orderId\":2,\"inputType\":\"static\",\"answer\":{\"displayValue\":\"Table\",\"value\":\"tables\",\"type\":\"string\"}},{\"question\":\"Table name\",\"controlId\":\"collection_name_table\",\"orderId\":11,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"Select Table Name\",\"value\":\"dont_know_answer\",\"type\":\"string\"}},{\"question\":\"Provide additional details about the issue you're facing\",\"controlId\":\"problem_description\",\"orderId\":12,\"inputType\":\"nonstatic\",\"answer\":{\"displayValue\":\"test ticket, please ignore and close\",\"value\":\"test ticket, please ignore and close\",\"type\":\"string\"}}]}",
+              "require24X7Response": false,
+              "secondaryConsent": [
+                {
+                  "type": "VirtualMachine",
+                  "userConsent": "Yes"
+                }
+              ],
+              "serviceDisplayName": "Virtual Machine running Windows",
+              "serviceId": "/providers/Microsoft.Support/services/vm_windows_service_guid",
+              "severity": "minimal",
+              "status": "Open",
+              "supportEngineer": {
+                "emailAddress": "xyz@contoso.com"
+              },
+              "supportPlanDisplayName": "Premier",
+              "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+              "supportPlanType": "Premier",
+              "supportTicketId": "2205040010000080",
+              "title": "Test - please ignore"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "SupportTickets_List",
+  "title": "List support tickets with a certain service id for a subscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSubscriptionSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSubscriptionSupportTicket.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web'",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-10T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List web communications for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSubscriptionSupportTicketCreatedOnOrAfter.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSubscriptionSupportTicketCreatedOnOrAfter.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web' and createdDate ge 2020-03-10T22:08:51Z",
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-12T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Communications_List",
+  "title": "List web communication created on or after a specific date for a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSupportTicket.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web'",
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-10T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List web communications for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSupportTicketCreatedOnOrAfter.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/ListWebCommunicationsForSupportTicketCreatedOnOrAfter.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "$filter": "communicationType eq 'web' and createdDate ge 2020-03-10T22:08:51Z",
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testmessage1",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage1",
+            "properties": {
+              "body": "this is a test message",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-11T20:18:19Z",
+              "sender": "user@contoso.com",
+              "subject": "this is a test message"
+            }
+          },
+          {
+            "name": "testmessage2",
+            "type": "Microsoft.Support/communications",
+            "id": "/providers/Microsoft.Support/supportTickets/testticket/communications/testmessage2",
+            "properties": {
+              "body": "test",
+              "communicationDirection": "outbound",
+              "communicationType": "web",
+              "createdDate": "2020-03-12T10:53:19Z",
+              "sender": "user@contoso.com",
+              "subject": "test"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CommunicationsNoSubscription_List",
+  "title": "List web communication created on or after a specific date for a no-subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/LookUpResourceId.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/LookUpResourceId.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "lookUpResourceIdRequest": {
+      "type": "Microsoft.Support/supportTickets",
+      "identifier": "1234668596"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "resourceId": "/subscriptions/subId/providers/Microsoft.Support/supportTickets/SupportTicketName"
+      }
+    }
+  },
+  "operationId": "LookUpResourceId_Post",
+  "title": "Look up resource id of support resource type"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateAdvancedDiagnosticConsentOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateAdvancedDiagnosticConsentOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "advancedDiagnosticConsent": "Yes"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update advanced diagnostic consent of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateAdvancedDiagnosticConsentOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateAdvancedDiagnosticConsentOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "advancedDiagnosticConsent": "Yes"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update advanced diagnostic consent of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateContactDetailsOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateContactDetailsOfSupportTicket.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "additionalEmailAddresses": [
+          "tname@contoso.com",
+          "teamtest@contoso.com"
+        ],
+        "country": "USA",
+        "firstName": "first name",
+        "lastName": "last name",
+        "phoneNumber": "123-456-7890",
+        "preferredContactMethod": "email",
+        "preferredSupportLanguage": "en-US",
+        "preferredTimeZone": "Pacific Standard Time",
+        "primaryEmailAddress": "test.name@contoso.com"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "first name",
+            "lastName": "last name",
+            "phoneNumber": "123-456-7890",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update contact details of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateContactDetailsOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateContactDetailsOfSupportTicketForSubscription.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "additionalEmailAddresses": [
+          "tname@contoso.com",
+          "teamtest@contoso.com"
+        ],
+        "country": "USA",
+        "firstName": "first name",
+        "lastName": "last name",
+        "phoneNumber": "123-456-7890",
+        "preferredContactMethod": "email",
+        "preferredSupportLanguage": "en-US",
+        "preferredTimeZone": "Pacific Standard Time",
+        "primaryEmailAddress": "test.name@contoso.com"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "first name",
+            "lastName": "last name",
+            "phoneNumber": "123-456-7890",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update contact details of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateEscalationStatusOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateEscalationStatusOfSupportTicket.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "supportTicketName": "testticket",
+    "api-version": "2026-06-01",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "phoneNumber": "123-456-7890"
+      },
+      "directConnectEscalation": {
+        "azureEEStatus": "EscalationInitiated",
+        "reasonForEscalation": "Server is down and business is impacted"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "properties": {
+          "supportTicketId": "118032014183770",
+          "description": "This is a test - please ignore",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "severity": "critical",
+          "require24X7Response": false,
+          "advancedDiagnosticConsent": "No",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "contactDetails": {
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "primaryEmailAddress": "test.name@contoso.com",
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "phoneNumber": "123-456-7890",
+            "preferredTimeZone": "Pacific Standard Time",
+            "country": "USA",
+            "preferredSupportLanguage": "en-US"
+          },
+          "serviceLevelAgreement": {
+            "startTime": "2020-03-20T21:36:18Z",
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240
+          },
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanType": "Premier",
+          "supportPlanDisplayName": "Premier",
+          "title": "Test - please ignore",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceDisplayName": "Subscription management",
+          "status": "Open",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationInitiated",
+            "allowedSeverities": [
+              "critical",
+              "highestcriticalimpact"
+            ],
+            "reasonForEscalation": "Server is down and business is impacted"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update escalation status of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateEscalationStatusOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateEscalationStatusOfSupportTicketForSubscription.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "api-version": "2026-06-01",
+    "updateSupportTicket": {
+      "contactDetails": {
+        "phoneNumber": "123-456-7890"
+      },
+      "directConnectEscalation": {
+        "azureEEStatus": "EscalationInitiated",
+        "reasonForEscalation": "Server is down and business is impacted"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "properties": {
+          "supportTicketId": "118032014183770",
+          "description": "This is a test - please ignore",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "severity": "critical",
+          "require24X7Response": false,
+          "advancedDiagnosticConsent": "No",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "contactDetails": {
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "primaryEmailAddress": "test.name@contoso.com",
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "phoneNumber": "123-456-7890",
+            "preferredTimeZone": "Pacific Standard Time",
+            "country": "USA",
+            "preferredSupportLanguage": "en-US"
+          },
+          "serviceLevelAgreement": {
+            "startTime": "2020-03-20T21:36:18Z",
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240
+          },
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanType": "Premier",
+          "supportPlanDisplayName": "Premier",
+          "title": "Test - please ignore",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceDisplayName": "Subscription management",
+          "status": "Open",
+          "directConnectEscalation": {
+            "azureEEStatus": "EscalationInitiated",
+            "allowedSeverities": [
+              "critical",
+              "highestcriticalimpact"
+            ],
+            "reasonForEscalation": "Server is down and business is impacted"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "modifiedDate": "2020-03-20T21:36:23Z"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update escalation status of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateSeverityOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateSeverityOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "severity": "critical"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update severity of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateSeverityOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateSeverityOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "severity": "critical"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Open",
+          "supportEngineer": {
+            "emailAddress": "xyz@contoso.com"
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update severity of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateStatusOfSupportTicket.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateStatusOfSupportTicket.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "status": "closed"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "Yes",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Closed",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTicketsNoSubscription_Update",
+  "title": "Update status of a support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateStatusOfSupportTicketForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UpdateStatusOfSupportTicketForSubscription.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "supportTicketName": "testticket",
+    "updateSupportTicket": {
+      "status": "closed"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testticket",
+        "type": "Microsoft.Support/supportTickets",
+        "id": "/subscriptions/132d901f-189d-4381-9214-fe68e27e05a1/providers/Microsoft.Support/supportTickets/testticket",
+        "properties": {
+          "description": "This is a test - please ignore",
+          "advancedDiagnosticConsent": "No",
+          "contactDetails": {
+            "additionalEmailAddresses": [
+              "tname@contoso.com",
+              "teamtest@contoso.com"
+            ],
+            "country": "USA",
+            "firstName": "abc",
+            "lastName": "xyz",
+            "preferredContactMethod": "email",
+            "preferredSupportLanguage": "en-US",
+            "preferredTimeZone": "Pacific Standard Time",
+            "primaryEmailAddress": "test.name@contoso.com"
+          },
+          "createdDate": "2020-03-20T21:36:18Z",
+          "fileWorkspaceName": "6f16735c-1530836f-e9970f1a-2e49-47b7-96cd-9746b83aa066",
+          "modifiedDate": "2020-03-20T21:36:23Z",
+          "problemClassificationDisplayName": "Add or Edit VAT, TAX ID, or PO Number",
+          "problemClassificationId": "/providers/Microsoft.Support/services/subscription_management_service_guid/problemClassifications/problemClassification_guid",
+          "require24X7Response": false,
+          "serviceDisplayName": "Subscription management",
+          "serviceId": "/providers/Microsoft.Support/services/subscription_management_service_guid",
+          "serviceLevelAgreement": {
+            "expirationTime": "2020-03-21T17:36:18Z",
+            "slaMinutes": 240,
+            "startTime": "2020-03-20T21:36:18Z"
+          },
+          "severity": "critical",
+          "status": "Closed",
+          "supportEngineer": {
+            "emailAddress": null
+          },
+          "supportPlanDisplayName": "Premier",
+          "supportPlanId": "U291cmNlOlNDTSxDbGFyaWZ5SW5zdGFsbGF0aW9uU2l0ZUlkOjcsTGluZUl0ZW1JZDo5ODY1NzIyOSxDb250cmFjdElkOjk4NjU5MTk0LFN1YnNjcmlwdGlvbklkOjc2Y2I3N2ZhLThiMTctNGVhYi05NDkzLWI2NWRhY2U5OTgxMyw=",
+          "supportPlanType": "Premier",
+          "supportTicketId": "118032014183770",
+          "title": "Test - please ignore"
+        }
+      }
+    }
+  },
+  "operationId": "SupportTickets_Update",
+  "title": "Update status of a subscription support ticket"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UploadFile.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UploadFile.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspaceName",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "uploadFile": {
+      "chunkIndex": 0,
+      "content": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABd"
+    }
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "FilesNoSubscription_Upload",
+  "title": "UploadFile"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UploadFileForSubscription.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/examples/UploadFileForSubscription.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-06-01",
+    "fileName": "test.txt",
+    "fileWorkspaceName": "testworkspaceName",
+    "subscriptionId": "132d901f-189d-4381-9214-fe68e27e05a1",
+    "uploadFile": {
+      "chunkIndex": 0,
+      "content": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABd"
+    }
+  },
+  "responses": {
+    "204": {}
+  },
+  "operationId": "Files_Upload",
+  "title": "UploadFileForSubscription"
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/support.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/support.json
@@ -1,0 +1,3713 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.Support",
+    "version": "2026-06-01",
+    "description": "Microsoft Azure Support Resource Provider.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Services"
+    },
+    {
+      "name": "ServiceClassifications"
+    },
+    {
+      "name": "ProblemClassifications"
+    },
+    {
+      "name": "Communications"
+    },
+    {
+      "name": "SupportTickets"
+    },
+    {
+      "name": "CommunicationsNoSubscription"
+    },
+    {
+      "name": "SupportTicketsNoSubscription"
+    },
+    {
+      "name": "ChatTranscripts"
+    },
+    {
+      "name": "ChatTranscriptsNoSubscription"
+    },
+    {
+      "name": "FileWorkspaces"
+    },
+    {
+      "name": "FileWorkspacesNoSubscription"
+    },
+    {
+      "name": "Files"
+    },
+    {
+      "name": "FilesNoSubscription"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Support/checkNameAvailability": {
+      "post": {
+        "operationId": "SupportTicketsNoSubscription_CheckNameAvailability",
+        "description": "Check the availability of a resource name. This API should be used to check the uniqueness of the name for support ticket creation for the selected subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "checkNameAvailabilityInput",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Checks whether name is available for SupportTicket resource": {
+            "$ref": "./examples/CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/classifyServices": {
+      "post": {
+        "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+        "tags": [
+          "ServiceClassifications"
+        ],
+        "description": "Classify the list of right Azure services.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "serviceClassificationRequest",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceClassificationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ServiceClassificationOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Classify list of Azure services": {
+            "$ref": "./examples/ClassifyServices.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}": {
+      "get": {
+        "operationId": "FileWorkspacesNoSubscription_Get",
+        "tags": [
+          "FileWorkspacesNoSubscription"
+        ],
+        "description": "Gets details for a specific file workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileWorkspaceDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a file workspace": {
+            "$ref": "./examples/GetFileWorkspaceDetails.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FileWorkspacesNoSubscription_Create",
+        "tags": [
+          "FileWorkspacesNoSubscription"
+        ],
+        "description": "Creates a new file workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'FileWorkspaceDetails' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileWorkspaceDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a file workspace": {
+            "$ref": "./examples/CreateFileWorkspace.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files": {
+      "get": {
+        "operationId": "FilesNoSubscription_List",
+        "tags": [
+          "FilesNoSubscription"
+        ],
+        "description": "Lists all the Files information under a workspace for an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/FilesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List files under a workspace": {
+            "$ref": "./examples/ListFilesUnderFileWorkspace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files/{fileName}": {
+      "get": {
+        "operationId": "FilesNoSubscription_Get",
+        "tags": [
+          "FilesNoSubscription"
+        ],
+        "description": "Returns details of a specific file in a work space.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a subscription file": {
+            "$ref": "./examples/GetFileDetails.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FilesNoSubscription_Create",
+        "tags": [
+          "FilesNoSubscription"
+        ],
+        "description": "Creates a new file under a workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createFileParameters",
+            "in": "body",
+            "description": "Create file object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'FileDetails' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a file workspace": {
+            "$ref": "./examples/CreateFile.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files/{fileName}/upload": {
+      "post": {
+        "operationId": "FilesNoSubscription_Upload",
+        "tags": [
+          "FilesNoSubscription"
+        ],
+        "description": "This API allows you to upload content to a file",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "uploadFile",
+            "in": "body",
+            "description": "UploadFile object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UploadFile"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UploadFile": {
+            "$ref": "./examples/UploadFile.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/lookUpResourceId": {
+      "post": {
+        "operationId": "LookUpResourceId_Post",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "This operation fetches ARM resource id of support resource type.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "lookUpResourceIdRequest",
+            "in": "body",
+            "description": "Look up resource id request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LookUpResourceIdRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LookUpResourceIdResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Look up resource id of support resource type": {
+            "$ref": "./examples/LookUpResourceId.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get all operations": {
+            "$ref": "./examples/ListOperations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/services": {
+      "get": {
+        "operationId": "Services_List",
+        "tags": [
+          "Services"
+        ],
+        "description": "Lists all the Azure services available for support ticket creation. For **Technical** issues, select the Service Id that maps to the Azure service/product as displayed in the **Services** drop-down list on the Azure portal's [New support request](https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/overview) page. Always use the service and its corresponding problem classification(s) obtained programmatically for support ticket creation. This practice ensures that you always have the most recent set of service and problem classification Ids.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServicesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets list of services for which a support ticket can be created": {
+            "$ref": "./examples/ListServices.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/services/{serviceName}": {
+      "get": {
+        "operationId": "Services_Get",
+        "tags": [
+          "Services"
+        ],
+        "description": "Gets a specific Azure service for support ticket creation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "Name of the Azure service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Service"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets details of the Azure service": {
+            "$ref": "./examples/GetService.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/services/{problemServiceName}/classifyProblems": {
+      "post": {
+        "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+        "tags": [
+          "ProblemClassifications"
+        ],
+        "description": "Classify the right problem classifications (categories) available for a specific Azure service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "problemServiceName",
+            "in": "path",
+            "description": "Name of the Azure service for which the problem classifications need to be retrieved.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "problemClassificationsClassificationInput",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProblemClassificationsClassificationInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProblemClassificationsClassificationOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Classify list of problemClassifications for a specified Azure service": {
+            "$ref": "./examples/ClassifyProblemClassifications.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/services/{serviceName}/problemClassifications": {
+      "get": {
+        "operationId": "ProblemClassifications_List",
+        "tags": [
+          "ProblemClassifications"
+        ],
+        "description": "Lists all the problem classifications (categories) available for a specific Azure service. Always use the service and problem classifications obtained programmatically. This practice ensures that you always have the most recent set of service and problem classification Ids.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "Name of the Azure service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProblemClassificationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets list of problemClassifications for a service for which a support ticket can be created": {
+            "$ref": "./examples/ListProblemClassifications.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/services/{serviceName}/problemClassifications/{problemClassificationName}": {
+      "get": {
+        "operationId": "ProblemClassifications_Get",
+        "tags": [
+          "ProblemClassifications"
+        ],
+        "description": "Get problem classification details for a specific Azure service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "Name of the Azure service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "problemClassificationName",
+            "in": "path",
+            "description": "Name of problem classification.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProblemClassification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets details of problemClassification for Azure service": {
+            "$ref": "./examples/GetProblemClassification.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets": {
+      "get": {
+        "operationId": "SupportTicketsNoSubscription_List",
+        "tags": [
+          "SupportTicketsNoSubscription"
+        ],
+        "description": "Lists all the support tickets. <br/><br/>You can also filter the support tickets by <i>Status</i>, <i>CreatedDate</i>, , <i>ServiceId</i>, and <i>ProblemClassificationId</i> using the $filter parameter. Output will be a paged result with <i>nextLink</i>, using which you can retrieve the next set of support tickets. <br/><br/>Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of values to return in the collection. Default is 25 and max is 100.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. We support 'odata v4.0' filter semantics. <a target='_blank' href='https://docs.microsoft.com/odata/concepts/queryoptions-overview'>Learn more</a> <br/><i>Status</i> , <i>ServiceId</i>, and <i>ProblemClassificationId</i> filters can only be used with 'eq' operator. For <i>CreatedDate</i> filter, the supported operators are 'gt' and 'ge'. When using both filters, combine them using the logical 'AND'.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List support tickets": {
+            "$ref": "./examples/ListSupportTickets.json"
+          },
+          "List support tickets created on or after a certain date and in open state": {
+            "$ref": "./examples/ListSupportTicketsCreatedOnOrAfterAndInOpenState.json"
+          },
+          "List support tickets created on or after a certain date and in updating state": {
+            "$ref": "./examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingState.json"
+          },
+          "List support tickets in open state": {
+            "$ref": "./examples/ListSupportTicketsInOpenState.json"
+          },
+          "List support tickets in updating state": {
+            "$ref": "./examples/ListSupportTicketsInUpdatingState.json"
+          },
+          "List support tickets with a certain problem classification id": {
+            "$ref": "./examples/ListSupportTicketsProblemClassificationIdEquals.json"
+          },
+          "List support tickets with a certain service id": {
+            "$ref": "./examples/ListSupportTicketsServiceIdEquals.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}": {
+      "get": {
+        "operationId": "SupportTicketsNoSubscription_Get",
+        "tags": [
+          "SupportTicketsNoSubscription"
+        ],
+        "description": "Gets details for a specific support ticket. Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a ticket": {
+            "$ref": "./examples/GetSupportTicketDetails.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SupportTicketsNoSubscription_Create",
+        "tags": [
+          "SupportTicketsNoSubscription"
+        ],
+        "description": "Creates a new support ticket for Billing, and Subscription Management issues. Learn the [prerequisites](https://aka.ms/supportAPI) required to create a support ticket.<br/><br/>Always call the Services and ProblemClassifications API to get the most recent set of services and problem categories required for support ticket creation.<br/><br/>Adding attachments is not currently supported via the API. To add a file to an existing support ticket, visit the [Manage support ticket](https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/managesupportrequest) page in the Azure portal, select the support ticket, and use the file upload control to add a new file.<br/><br/>Providing consent to share diagnostic information with Azure support is currently not supported via the API. The Azure support engineer working on your ticket will reach out to you for consent if your issue requires gathering diagnostic information from your Azure resources.<br/><br/>",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createSupportTicketParameters",
+            "in": "body",
+            "description": "Support ticket request payload.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SupportTicketDetails' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a ticket for Billing related issues": {
+            "$ref": "./examples/CreateBillingSupportTicket.json"
+          },
+          "Create a ticket for Subscription Management related issues": {
+            "$ref": "./examples/CreateSubMgmtSupportTicket.json"
+          },
+          "Create a ticket for Technical issue related to a specific resource": {
+            "$ref": "./examples/CreateTechnicalSupportTicket.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SupportTicketDetails"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "SupportTicketsNoSubscription_Update",
+        "tags": [
+          "SupportTicketsNoSubscription"
+        ],
+        "description": "This API allows you to update the severity level, ticket status, and your contact information in the support ticket.<br/><br/>Note: The severity levels cannot be changed if a support ticket is actively being worked upon by an Azure support engineer. In such a case, contact your support engineer to request severity update by adding a new communication using the Communications API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "updateSupportTicket",
+            "in": "body",
+            "description": "UpdateSupportTicket object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateSupportTicket"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update advanced diagnostic consent of a support ticket": {
+            "$ref": "./examples/UpdateAdvancedDiagnosticConsentOfSupportTicket.json"
+          },
+          "Update contact details of a support ticket": {
+            "$ref": "./examples/UpdateContactDetailsOfSupportTicket.json"
+          },
+          "Update escalation status of a support ticket": {
+            "$ref": "./examples/UpdateEscalationStatusOfSupportTicket.json"
+          },
+          "Update severity of a support ticket": {
+            "$ref": "./examples/UpdateSeverityOfSupportTicket.json"
+          },
+          "Update status of a support ticket": {
+            "$ref": "./examples/UpdateStatusOfSupportTicket.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}/chatTranscripts": {
+      "get": {
+        "operationId": "ChatTranscriptsNoSubscription_List",
+        "tags": [
+          "ChatTranscriptsNoSubscription"
+        ],
+        "description": "Lists all chat transcripts for a support ticket",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ChatTranscriptsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List chat transcripts for a no-subscription support ticket": {
+            "$ref": "./examples/ListChatTranscriptsForSupportTicket.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}/chatTranscripts/{chatTranscriptName}": {
+      "get": {
+        "operationId": "ChatTranscriptsNoSubscription_Get",
+        "tags": [
+          "ChatTranscriptsNoSubscription"
+        ],
+        "description": "Returns chatTranscript details for a no subscription support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "chatTranscriptName",
+            "in": "path",
+            "description": "The name of the ChatTranscriptDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ChatTranscriptDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get chat transcript details for a subscription support ticket": {
+            "$ref": "./examples/GetchatTranscriptDetailsForSupportTicket.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}/checkNameAvailability": {
+      "post": {
+        "operationId": "CommunicationsNoSubscription_CheckNameAvailability",
+        "tags": [
+          "SupportTicketsNoSubscription"
+        ],
+        "description": "Check the availability of a resource name. This API should be used to check the uniqueness of the name for adding a new communication to the support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "checkNameAvailabilityInput",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Checks whether name is available for Communication resource": {
+            "$ref": "./examples/CheckNameAvailabilityForNoSubscriptionSupportTicketCommunication.json"
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications": {
+      "get": {
+        "operationId": "CommunicationsNoSubscription_List",
+        "tags": [
+          "CommunicationsNoSubscription"
+        ],
+        "description": "Lists all communications (attachments not included) for a support ticket. <br/></br> You can also filter support ticket communications by _CreatedDate_ or _CommunicationType_ using the $filter parameter. The only type of communication supported today is _Web_. Output will be a paged result with _nextLink_, using which you can retrieve the next set of Communication results. <br/><br/>Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of values to return in the collection. Default is 10 and max is 10.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. You can filter by communicationType and createdDate properties. CommunicationType supports Equals ('eq') operator and createdDate supports Greater Than ('gt') and Greater Than or Equals ('ge') operators. You may combine the CommunicationType and CreatedDate filters by Logical And ('and') operator.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommunicationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List communications for a no-subscription support ticket": {
+            "$ref": "./examples/ListCommunicationsForSupportTicket.json"
+          },
+          "List web communication created on or after a specific date for a no-subscription support ticket": {
+            "$ref": "./examples/ListWebCommunicationsForSupportTicketCreatedOnOrAfter.json"
+          },
+          "List web communications for a no-subscription support ticket": {
+            "$ref": "./examples/ListWebCommunicationsForSupportTicket.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications/{communicationName}": {
+      "get": {
+        "operationId": "CommunicationsNoSubscription_Get",
+        "tags": [
+          "CommunicationsNoSubscription"
+        ],
+        "description": "Returns communication details for a support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "communicationName",
+            "in": "path",
+            "description": "The name of the CommunicationDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get communication details for a no-subscription support ticket": {
+            "$ref": "./examples/GetCommunicationDetailsForSupportTicket.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommunicationsNoSubscription_Create",
+        "tags": [
+          "CommunicationsNoSubscription"
+        ],
+        "description": "Adds a new customer communication to an Azure support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "communicationName",
+            "in": "path",
+            "description": "The name of the CommunicationDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createCommunicationParameters",
+            "in": "body",
+            "description": "Communication object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommunicationDetails' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AddCommunicationToNoSubscriptionTicket": {
+            "$ref": "./examples/CreateNoSubscriptionSupportTicketCommunication.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommunicationDetails"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/checkNameAvailability": {
+      "post": {
+        "operationId": "SupportTickets_CheckNameAvailability",
+        "description": "Check the availability of a resource name. This API should be used to check the uniqueness of the name for support ticket creation for the selected subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "checkNameAvailabilityInput",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Checks whether name is available for a subscription support ticket resource": {
+            "$ref": "./examples/CheckNameAvailabilityWithSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/classifyServices": {
+      "post": {
+        "operationId": "ServiceClassifications_classifyServices",
+        "tags": [
+          "ServiceClassifications"
+        ],
+        "description": "Classify the list of right Azure services.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "serviceClassificationRequest",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceClassificationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ServiceClassificationOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Classify list of Azure services for a subscription": {
+            "$ref": "./examples/ClassifyServicesForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}": {
+      "get": {
+        "operationId": "FileWorkspaces_Get",
+        "tags": [
+          "FileWorkspaces"
+        ],
+        "description": "Gets details for a specific file workspace in an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileWorkspaceDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a subscription file workspace": {
+            "$ref": "./examples/GetFileWorkspaceDetailsForSubscription.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "FileWorkspaces_Create",
+        "tags": [
+          "FileWorkspaces"
+        ],
+        "description": "Creates a new file workspace for the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'FileWorkspaceDetails' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileWorkspaceDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a file workspace for a subscription": {
+            "$ref": "./examples/CreateFileWorkspaceForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files": {
+      "get": {
+        "operationId": "Files_List",
+        "tags": [
+          "Files"
+        ],
+        "description": "Lists all the Files information under a workspace for an Azure subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/FilesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List files under a workspace for a subscription": {
+            "$ref": "./examples/ListFilesForSubscriptionUnderFileWorkspace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files/{fileName}": {
+      "get": {
+        "operationId": "Files_Get",
+        "tags": [
+          "Files"
+        ],
+        "description": "Returns details of a specific file in a work space.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a subscription file": {
+            "$ref": "./examples/GetFileDetailsForSubscription.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Files_Create",
+        "tags": [
+          "Files"
+        ],
+        "description": "Creates a new file under a workspace for the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createFileParameters",
+            "in": "body",
+            "description": "Create file object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'FileDetails' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FileDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a file under a subscription workspace": {
+            "$ref": "./examples/CreateFileForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/fileWorkspaces/{fileWorkspaceName}/files/{fileName}/upload": {
+      "post": {
+        "operationId": "Files_Upload",
+        "tags": [
+          "Files"
+        ],
+        "description": "This API allows you to upload content to a file",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "fileWorkspaceName",
+            "in": "path",
+            "description": "The name of the FileWorkspaceDetails",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$"
+          },
+          {
+            "name": "fileName",
+            "in": "path",
+            "description": "The name of the FileDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "uploadFile",
+            "in": "body",
+            "description": "UploadFile object",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UploadFile"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UploadFileForSubscription": {
+            "$ref": "./examples/UploadFileForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/services/{problemServiceName}/classifyProblems": {
+      "post": {
+        "operationId": "ProblemClassifications_classifyProblems",
+        "tags": [
+          "ProblemClassifications"
+        ],
+        "description": "Classify the right problem classifications (categories) available for a specific Azure service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "problemServiceName",
+            "in": "path",
+            "description": "Name of the Azure service for which the problem classifications need to be retrieved.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z_\\-. ]+$",
+            "x-ms-parameter-location": "method"
+          },
+          {
+            "name": "problemClassificationsClassificationInput",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProblemClassificationsClassificationInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProblemClassificationsClassificationOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Classify list of problemClassifications for a specified Azure service for a subscription": {
+            "$ref": "./examples/ClassifyProblemClassificationsForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets": {
+      "get": {
+        "operationId": "SupportTickets_List",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "Lists all the support tickets for an Azure subscription. You can also filter the support tickets by _Status_, _CreatedDate_, _ServiceId_, and _ProblemClassificationId_ using the $filter parameter. Output will be a paged result with _nextLink_, using which you can retrieve the next set of support tickets. <br/><br/>Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of values to return in the collection. Default is 25 and max is 100.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. We support 'odata v4.0' filter semantics. [Learn more](https://docs.microsoft.com/odata/concepts/queryoptions-overview). _Status_, _ServiceId_, and _ProblemClassificationId_ filters can only be used with Equals ('eq') operator. For _CreatedDate_ filter, the supported operators are Greater Than ('gt') and Greater Than or Equals ('ge'). When using both filters, combine them using the logical 'AND'.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List support tickets created on or after a certain date and in open state for a subscription": {
+            "$ref": "./examples/ListSupportTicketsCreatedOnOrAfterAndInOpenStateBySubscription.json"
+          },
+          "List support tickets created on or after a certain date and in updating state for a subscription": {
+            "$ref": "./examples/ListSupportTicketsCreatedOnOrAfterAndInUpdatingStateBySubscription.json"
+          },
+          "List support tickets for a subscription": {
+            "$ref": "./examples/ListSupportTicketsBySubscription.json"
+          },
+          "List support tickets in open state for a subscription": {
+            "$ref": "./examples/ListSupportTicketsInOpenStateBySubscription.json"
+          },
+          "List support tickets in updating state for a subscription": {
+            "$ref": "./examples/ListSupportTicketsInUpdatingStateBySubscription.json"
+          },
+          "List support tickets with a certain problem classification id for a subscription": {
+            "$ref": "./examples/ListSupportTicketsProblemClassificationIdEqualsForSubscription.json"
+          },
+          "List support tickets with a certain service id for a subscription": {
+            "$ref": "./examples/ListSupportTicketsServiceIdEqualsForSubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}": {
+      "get": {
+        "operationId": "SupportTickets_Get",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "Get ticket details for an Azure subscription. Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get details of a subscription ticket": {
+            "$ref": "./examples/GetSubscriptionSupportTicketDetails.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SupportTickets_Create",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "Creates a new support ticket for Subscription and Service limits (Quota), Technical, Billing, and Subscription Management issues for the specified subscription. Learn the [prerequisites](https://aka.ms/supportAPI) required to create a support ticket.<br/><br/>Always call the Services and ProblemClassifications API to get the most recent set of services and problem categories required for support ticket creation.<br/><br/>Adding attachments is not currently supported via the API. To add a file to an existing support ticket, visit the [Manage support ticket](https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/managesupportrequest) page in the Azure portal, select the support ticket, and use the file upload control to add a new file.<br/><br/>Providing consent to share diagnostic information with Azure support is currently not supported via the API. The Azure support engineer working on your ticket will reach out to you for consent if your issue requires gathering diagnostic information from your Azure resources.<br/><br/>**Creating a support ticket for on-behalf-of**: Include _x-ms-authorization-auxiliary_ header to provide an auxiliary token as per [documentation](https://docs.microsoft.com/azure/azure-resource-manager/management/authenticate-multi-tenant). The primary token will be from the tenant for whom a support ticket is being raised against the subscription, i.e. Cloud solution provider (CSP) customer tenant. The auxiliary token will be from the Cloud solution provider (CSP) partner tenant.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createSupportTicketParameters",
+            "in": "body",
+            "description": "Support ticket request payload.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SupportTicketDetails' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a ticket for Billing related issues": {
+            "$ref": "./examples/CreateBillingSupportTicketForSubscription.json"
+          },
+          "Create a ticket for Subscription Management related issues for a subscription": {
+            "$ref": "./examples/CreateSubMgmtSupportTicketForSubscription.json"
+          },
+          "Create a ticket for Technical issue related to a specific resource for a subscription": {
+            "$ref": "./examples/CreateTechnicalSupportTicketForSubscription.json"
+          },
+          "Create a ticket to request Quota increase for Active Jobs and Job Schedules for a Batch account": {
+            "$ref": "./examples/CreateBatchQuotaTicketForSpecificBatchAccountForActiveJobs.json"
+          },
+          "Create a ticket to request Quota increase for Azure SQL managed instance": {
+            "$ref": "./examples/CreateSqlManagedInstanceQuotaTicket.json"
+          },
+          "Create a ticket to request Quota increase for Batch accounts for a subscription": {
+            "$ref": "./examples/CreateBatchQuotaTicketForSubscription.json"
+          },
+          "Create a ticket to request Quota increase for Compute VM Cores": {
+            "$ref": "./examples/CreateCoresQuotaTicketForSubscription.json"
+          },
+          "Create a ticket to request Quota increase for DTUs for Azure Synapse Analytics": {
+            "$ref": "./examples/CreateSqlDatawarehouseQuotaTicketForDTUs.json"
+          },
+          "Create a ticket to request Quota increase for DTUs for SQL Database": {
+            "$ref": "./examples/CreateSqlDatabaseQuotaTicketForDTUs.json"
+          },
+          "Create a ticket to request Quota increase for Low-priority cores for Machine Learning service": {
+            "$ref": "./examples/CreateMachineLearningQuotaTicketForLowPriorityCores.json"
+          },
+          "Create a ticket to request Quota increase for Low-priority cores for a Batch account": {
+            "$ref": "./examples/CreateBatchQuotaTicketForSpecificBatchAccountForLowPriorityCores.json"
+          },
+          "Create a ticket to request Quota increase for Pools for a Batch account": {
+            "$ref": "./examples/CreateBatchQuotaTicketForSpecificBatchAccountForPools.json"
+          },
+          "Create a ticket to request Quota increase for Servers for Azure Synapse Analytics": {
+            "$ref": "./examples/CreateSqlDatawarehouseQuotaTicketForServers.json"
+          },
+          "Create a ticket to request Quota increase for Servers for SQL Database": {
+            "$ref": "./examples/CreateSqlDatabaseQuotaTicketForServers.json"
+          },
+          "Create a ticket to request Quota increase for services that do not require additional details in the quotaTicketDetails object": {
+            "$ref": "./examples/CreateGenericQuotaTicket.json"
+          },
+          "Create a ticket to request Quota increase for specific VM family cores for Machine Learning service": {
+            "$ref": "./examples/CreateMachineLearningQuotaTicketForDedicatedCores.json"
+          },
+          "Create a ticket to request Quota increase for specific VM family cores for a Batch account": {
+            "$ref": "./examples/CreateBatchQuotaTicketForSpecificBatchAccountForDedicatedCores.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SupportTicketDetails"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "SupportTickets_Update",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "This API allows you to update the severity level, ticket status, advanced diagnostic consent and your contact information in the support ticket.<br/><br/>Note: The severity levels cannot be changed if a support ticket is actively being worked upon by an Azure support engineer. In such a case, contact your support engineer to request severity update by adding a new communication using the Communications API.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "updateSupportTicket",
+            "in": "body",
+            "description": "UpdateSupportTicket object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateSupportTicket"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SupportTicketDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update advanced diagnostic consent of a subscription support ticket": {
+            "$ref": "./examples/UpdateAdvancedDiagnosticConsentOfSupportTicketForSubscription.json"
+          },
+          "Update contact details of a subscription support ticket": {
+            "$ref": "./examples/UpdateContactDetailsOfSupportTicketForSubscription.json"
+          },
+          "Update escalation status of a subscription support ticket": {
+            "$ref": "./examples/UpdateEscalationStatusOfSupportTicketForSubscription.json"
+          },
+          "Update severity of a subscription support ticket": {
+            "$ref": "./examples/UpdateSeverityOfSupportTicketForSubscription.json"
+          },
+          "Update status of a subscription support ticket": {
+            "$ref": "./examples/UpdateStatusOfSupportTicketForSubscription.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/chatTranscripts": {
+      "get": {
+        "operationId": "ChatTranscripts_List",
+        "tags": [
+          "ChatTranscripts"
+        ],
+        "description": "Lists all chat transcripts for a support ticket under subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ChatTranscriptsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List chat transcripts for a subscription support ticket": {
+            "$ref": "./examples/ListChatTranscriptsForSubscriptionSupportTicket.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/chatTranscripts/{chatTranscriptName}": {
+      "get": {
+        "operationId": "ChatTranscripts_Get",
+        "tags": [
+          "ChatTranscripts"
+        ],
+        "description": "Returns chatTranscript details for a support ticket under a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "chatTranscriptName",
+            "in": "path",
+            "description": "The name of the ChatTranscriptDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ChatTranscriptDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get chat transcript details for a subscription support ticket": {
+            "$ref": "./examples/GetchatTranscriptDetailsForSubscriptionSupportTicket.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/checkNameAvailability": {
+      "post": {
+        "operationId": "Communications_CheckNameAvailability",
+        "tags": [
+          "SupportTickets"
+        ],
+        "description": "Check the availability of a resource name. This API should be used to check the uniqueness of the name for adding a new communication to the support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "checkNameAvailabilityInput",
+            "in": "body",
+            "description": "Input to check.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityInput"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CheckNameAvailabilityOutput"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Checks whether name is available for Communication resource for a subscription support ticket": {
+            "$ref": "./examples/CheckNameAvailabilityForSupportTicketCommunication.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications": {
+      "get": {
+        "operationId": "Communications_List",
+        "tags": [
+          "Communications"
+        ],
+        "description": "Lists all communications (attachments not included) for a support ticket. <br/></br> You can also filter support ticket communications by _CreatedDate_ or _CommunicationType_ using the $filter parameter. The only type of communication supported today is _Web_. Output will be a paged result with _nextLink_, using which you can retrieve the next set of Communication results. <br/><br/>Support ticket data is available for 18 months after ticket creation. If a ticket was created more than 18 months ago, a request for data might cause an error.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of values to return in the collection. Default is 10 and max is 10.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. You can filter by communicationType and createdDate properties. CommunicationType supports Equals ('eq') operator and createdDate supports Greater Than ('gt') and Greater Than or Equals ('ge') operators. You may combine the CommunicationType and CreatedDate filters by Logical And ('and') operator.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommunicationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List communications for a subscription support ticket": {
+            "$ref": "./examples/ListCommunicationsForSubscriptionSupportTicket.json"
+          },
+          "List web communication created on or after a specific date for a subscription support ticket": {
+            "$ref": "./examples/ListWebCommunicationsForSubscriptionSupportTicketCreatedOnOrAfter.json"
+          },
+          "List web communications for a subscription support ticket": {
+            "$ref": "./examples/ListWebCommunicationsForSubscriptionSupportTicket.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Support/supportTickets/{supportTicketName}/communications/{communicationName}": {
+      "get": {
+        "operationId": "Communications_Get",
+        "tags": [
+          "Communications"
+        ],
+        "description": "Returns communication details for a support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "communicationName",
+            "in": "path",
+            "description": "The name of the CommunicationDetails",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get communication details for a subscription support ticket": {
+            "$ref": "./examples/GetCommunicationDetailsForSubscriptionSupportTicket.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Communications_Create",
+        "tags": [
+          "Communications"
+        ],
+        "description": "Adds a new customer communication to an Azure support ticket.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "supportTicketName",
+            "in": "path",
+            "description": "The name of the SupportTicketDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "communicationName",
+            "in": "path",
+            "description": "The name of the CommunicationDetails",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createCommunicationParameters",
+            "in": "body",
+            "description": "Communication object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommunicationDetails' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommunicationDetails"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AddCommunicationToSubscriptionTicket": {
+            "$ref": "./examples/CreateSupportTicketCommunication.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommunicationDetails"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "ChatConversationStatus": {
+      "type": "string",
+      "description": "Status of the chat conversation associated with the support ticket.",
+      "enum": [
+        "Active",
+        "Closed",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ChatConversationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "Chat conversation is currently active."
+          },
+          {
+            "name": "Closed",
+            "value": "Closed",
+            "description": "Chat conversation has been closed."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No chat conversation associated."
+          }
+        ]
+      }
+    },
+    "ChatTranscriptDetails": {
+      "type": "object",
+      "description": "Object that represents a Chat Transcript resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ChatTranscriptDetailsProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ChatTranscriptDetailsProperties": {
+      "type": "object",
+      "description": "Describes the properties of a Chat Transcript Details resource.",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "description": "List of chat transcript communication resources.",
+          "items": {
+            "$ref": "#/definitions/MessageProperties"
+          },
+          "x-ms-identifiers": []
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the chat began.",
+          "readOnly": true
+        }
+      }
+    },
+    "ChatTranscriptsListResult": {
+      "type": "object",
+      "description": "[Placeholder] Description for page model",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property"
+        },
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/ChatTranscriptDetails"
+          }
+        }
+      }
+    },
+    "CheckNameAvailabilityInput": {
+      "type": "object",
+      "description": "Input of CheckNameAvailability API.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The resource name to validate."
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The type of resource."
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "CheckNameAvailabilityOutput": {
+      "type": "object",
+      "description": "Output of check name availability API.",
+      "properties": {
+        "nameAvailable": {
+          "type": "boolean",
+          "description": "Indicates whether the name is available.",
+          "readOnly": true
+        },
+        "reason": {
+          "type": "string",
+          "description": "The reason why the name is not available.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The detailed error message describing why the name is not available.",
+          "readOnly": true
+        }
+      }
+    },
+    "ClassificationService": {
+      "type": "object",
+      "description": "Service Classification result object.",
+      "properties": {
+        "serviceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource Id of the service.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Localized name of the azure service.",
+          "readOnly": true
+        },
+        "resourceTypes": {
+          "type": "array",
+          "description": "List of applicable ARM resource types for this service.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CommunicationDetails": {
+      "type": "object",
+      "description": "Object that represents a Communication resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommunicationDetailsProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CommunicationDetailsProperties": {
+      "type": "object",
+      "description": "Describes the properties of a communication resource.",
+      "properties": {
+        "communicationType": {
+          "$ref": "#/definitions/CommunicationType",
+          "description": "Communication type.",
+          "readOnly": true
+        },
+        "communicationDirection": {
+          "$ref": "#/definitions/CommunicationDirection",
+          "description": "Direction of communication.",
+          "readOnly": true
+        },
+        "sender": {
+          "type": "string",
+          "description": "Email address of the sender. This property is required if called by a service principal."
+        },
+        "subject": {
+          "type": "string",
+          "description": "Subject of the communication."
+        },
+        "body": {
+          "type": "string",
+          "description": "Body of the communication."
+        },
+        "createdDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the communication was created.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "subject",
+        "body"
+      ]
+    },
+    "CommunicationDirection": {
+      "type": "string",
+      "description": "Direction of communication.",
+      "enum": [
+        "inbound",
+        "outbound"
+      ],
+      "x-ms-enum": {
+        "name": "CommunicationDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "inbound",
+            "value": "inbound"
+          },
+          {
+            "name": "outbound",
+            "value": "outbound"
+          }
+        ]
+      }
+    },
+    "CommunicationType": {
+      "type": "string",
+      "description": "Communication type.",
+      "enum": [
+        "web",
+        "phone"
+      ],
+      "x-ms-enum": {
+        "name": "CommunicationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "web",
+            "value": "web"
+          },
+          {
+            "name": "phone",
+            "value": "phone"
+          }
+        ]
+      }
+    },
+    "CommunicationsListResult": {
+      "type": "object",
+      "description": "[Placeholder] Description for page model",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property"
+        },
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/CommunicationDetails"
+          }
+        }
+      }
+    },
+    "Consent": {
+      "type": "string",
+      "description": "Advanced diagnostic consent to be updated on the support ticket.",
+      "enum": [
+        "Yes",
+        "No"
+      ],
+      "x-ms-enum": {
+        "name": "Consent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Yes",
+            "value": "Yes"
+          },
+          {
+            "name": "No",
+            "value": "No"
+          }
+        ]
+      }
+    },
+    "ContactProfile": {
+      "type": "object",
+      "description": "Contact information associated with the support ticket.",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "First name."
+        },
+        "lastName": {
+          "type": "string",
+          "description": "Last name."
+        },
+        "preferredContactMethod": {
+          "$ref": "#/definitions/PreferredContactMethod",
+          "description": "Preferred contact method."
+        },
+        "primaryEmailAddress": {
+          "type": "string",
+          "description": "Primary email address."
+        },
+        "additionalEmailAddresses": {
+          "type": "array",
+          "description": "Additional email addresses listed will be copied on any correspondence about the support ticket.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phoneNumber": {
+          "type": "string",
+          "description": "Phone number. This is required if preferred contact method is phone. It is also required when submitting 'critical' or 'highestcriticalimpact' severity cases."
+        },
+        "preferredTimeZone": {
+          "type": "string",
+          "description": "Time zone of the user. This is the name of the time zone from [Microsoft Time Zone Index Values](https://support.microsoft.com/help/973627/microsoft-time-zone-index-values)."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country of the user. This is the ISO 3166-1 alpha-3 code."
+        },
+        "preferredSupportLanguage": {
+          "type": "string",
+          "description": "Preferred language of support from Azure. Support languages vary based on the severity you choose for your support ticket. Learn more at [Azure Severity and responsiveness](https://azure.microsoft.com/support/plans/response). Use the standard language-country code. Valid values are 'en-us' for English, 'zh-hans' for Chinese, 'es-es' for Spanish, 'fr-fr' for French, 'ja-jp' for Japanese, 'ko-kr' for Korean, 'ru-ru' for Russian, 'pt-br' for Portuguese, 'it-it' for Italian, 'zh-tw' for Chinese and 'de-de' for German."
+        }
+      },
+      "required": [
+        "firstName",
+        "lastName",
+        "preferredContactMethod",
+        "primaryEmailAddress",
+        "preferredTimeZone",
+        "country",
+        "preferredSupportLanguage"
+      ]
+    },
+    "DirectConnectEscalation": {
+      "type": "object",
+      "description": "Direct Connect Escalation details for a support ticket.",
+      "properties": {
+        "azureEEStatus": {
+          "$ref": "#/definitions/EscalationStatus",
+          "description": "Status of Direct Connect Escalation."
+        },
+        "allowedSeverities": {
+          "type": "array",
+          "description": "An array containing the allowed severities for direct connect escalation.",
+          "items": {
+            "$ref": "#/definitions/SeverityLevel"
+          }
+        },
+        "reasonForEscalation": {
+          "type": "string",
+          "description": "Reason for escalation / business impact."
+        }
+      }
+    },
+    "EscalationStatus": {
+      "type": "string",
+      "description": "Status of Direct Connect Escalation.",
+      "enum": [
+        "EscalationAvailable",
+        "EscalationInitiated",
+        "EscalationProcessed",
+        "EscalationUnsupported",
+        "EscalationUnavailable"
+      ],
+      "x-ms-enum": {
+        "name": "EscalationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EscalationAvailable",
+            "value": "EscalationAvailable",
+            "description": "Escalation is available and uninitiated"
+          },
+          {
+            "name": "EscalationInitiated",
+            "value": "EscalationInitiated",
+            "description": "Escalation is unavailable and has been initiated"
+          },
+          {
+            "name": "EscalationProcessed",
+            "value": "EscalationProcessed",
+            "description": "Escalation is unavailable and has finished processing after being initiated"
+          },
+          {
+            "name": "EscalationUnsupported",
+            "value": "EscalationUnsupported",
+            "description": "Escalation is unavailable and cannot be initiated due to direct escalation being unsupported on this product or topic"
+          },
+          {
+            "name": "EscalationUnavailable",
+            "value": "EscalationUnavailable",
+            "description": "Escalation is unavailable and cannot be initiated due to customer not being enrolled to direct escalation"
+          }
+        ]
+      }
+    },
+    "FileDetails": {
+      "type": "object",
+      "description": "Object that represents File Details resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileDetailsProperties",
+          "description": "Properties of the resource",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FileDetailsProperties": {
+      "type": "object",
+      "description": "Describes the properties of a file.",
+      "properties": {
+        "createdOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when file workspace was created.",
+          "readOnly": true
+        },
+        "chunkSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Size of each chunk. The size of each chunk should be provided in bytes and must not exceed 2.5 megabytes (MB)."
+        },
+        "fileSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Size of the file to be uploaded. The file size must not exceed 5 MB and should be provided in bytes."
+        },
+        "numberOfChunks": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of chunks to be uploaded. The maximum number of allowed chunks is 2."
+        }
+      }
+    },
+    "FileWorkspaceDetails": {
+      "type": "object",
+      "description": "Object that represents FileWorkspaceDetails resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FileWorkspaceDetailsProperties",
+          "description": "Properties of the resource",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "FileWorkspaceDetailsProperties": {
+      "type": "object",
+      "description": "Describes the properties of a file workspace.",
+      "properties": {
+        "createdOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when file workspace was created.",
+          "readOnly": true
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when file workspace is going to expire.",
+          "readOnly": true
+        }
+      }
+    },
+    "FilesListResult": {
+      "type": "object",
+      "description": "[Placeholder] Description for page model",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property"
+        },
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/FileDetails"
+          }
+        }
+      }
+    },
+    "IsTemporaryTicket": {
+      "type": "string",
+      "description": "This property indicates if support ticket is a temporary ticket.",
+      "enum": [
+        "Yes",
+        "No"
+      ],
+      "x-ms-enum": {
+        "name": "IsTemporaryTicket",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Yes",
+            "value": "Yes"
+          },
+          {
+            "name": "No",
+            "value": "No"
+          }
+        ]
+      }
+    },
+    "LookUpResourceIdRequest": {
+      "type": "object",
+      "description": "The look up resource Id request body",
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "The System generated Id that is unique. Use supportTicketId property for Microsoft.Support/supportTickets resource type."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of resource.",
+          "enum": [
+            "Microsoft.Support/supportTickets"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceType",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "LookUpResourceIdResponse": {
+      "type": "object",
+      "description": "The look up resource id response",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The resource Id of support resource type."
+        }
+      }
+    },
+    "MessageProperties": {
+      "type": "object",
+      "description": "Describes the properties of a Message Details resource.",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "description": "Content type.",
+          "readOnly": true
+        },
+        "communicationDirection": {
+          "$ref": "#/definitions/CommunicationDirection",
+          "description": "Direction of communication.",
+          "readOnly": true
+        },
+        "sender": {
+          "type": "string",
+          "description": "Name of the sender."
+        },
+        "body": {
+          "type": "string",
+          "description": "Body of the communication."
+        },
+        "createdDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the communication was created.",
+          "readOnly": true
+        }
+      }
+    },
+    "PreferredContactMethod": {
+      "type": "string",
+      "description": "Preferred contact method.",
+      "enum": [
+        "email",
+        "phone"
+      ],
+      "x-ms-enum": {
+        "name": "PreferredContactMethod",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "email",
+            "value": "email"
+          },
+          {
+            "name": "phone",
+            "value": "phone"
+          }
+        ]
+      }
+    },
+    "ProblemClassification": {
+      "type": "object",
+      "description": "ProblemClassification resource object.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProblemClassificationProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProblemClassificationProperties": {
+      "type": "object",
+      "description": "Details about a problem classification available for an Azure service.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Localized name of problem classification."
+        },
+        "secondaryConsentEnabled": {
+          "type": "array",
+          "description": "This property indicates whether secondary consent is present for problem classification",
+          "items": {
+            "$ref": "#/definitions/SecondaryConsentEnabled"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ProblemClassificationsClassificationInput": {
+      "type": "object",
+      "description": "Input to problem classification Classification API.",
+      "properties": {
+        "issueSummary": {
+          "type": "string",
+          "description": "Natural language description of the customer’s issue."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM resource Id of the resource that is having the issue."
+        }
+      },
+      "required": [
+        "issueSummary"
+      ]
+    },
+    "ProblemClassificationsClassificationOutput": {
+      "type": "object",
+      "description": "Output of the problem classification Classification API.",
+      "properties": {
+        "problemClassificationResults": {
+          "type": "array",
+          "description": "Set of problem classification objects classified.",
+          "items": {
+            "$ref": "#/definitions/ProblemClassificationsClassificationResult"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ProblemClassificationsClassificationResult": {
+      "type": "object",
+      "description": "ProblemClassification Classification result object.",
+      "properties": {
+        "problemId": {
+          "type": "string",
+          "description": "Identifier that may be used for solution discovery or some other purposes.",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the problem classification result.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the problem classification result.",
+          "readOnly": true
+        },
+        "serviceId": {
+          "type": "string",
+          "description": "Identifier of the service associated with this problem classification result.",
+          "readOnly": true
+        },
+        "problemClassificationId": {
+          "type": "string",
+          "description": "Identifier that may be used for support ticket creation.",
+          "readOnly": true
+        },
+        "relatedService": {
+          "$ref": "#/definitions/ClassificationService",
+          "description": "Related service.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ProblemClassificationsListResult": {
+      "type": "object",
+      "description": "Collection of ProblemClassification resources.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items"
+        },
+        "value": {
+          "type": "array",
+          "description": "List of ProblemClassification resources.",
+          "items": {
+            "$ref": "#/definitions/ProblemClassification"
+          }
+        }
+      }
+    },
+    "QuotaChangeRequest": {
+      "type": "object",
+      "description": "This property is required for providing the region and new quota limits.",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Region for which the quota increase request is being made."
+        },
+        "payload": {
+          "type": "string",
+          "description": "Payload of the quota increase request."
+        }
+      }
+    },
+    "QuotaTicketDetails": {
+      "type": "object",
+      "description": "Additional set of information required for quota increase support ticket for certain quota types, e.g.: Virtual machine cores. Get complete details about Quota payload support request along with examples at [Support quota request](https://aka.ms/supportrpquotarequestpayload).",
+      "properties": {
+        "quotaChangeRequestSubType": {
+          "type": "string",
+          "description": "Required for certain quota types when there is a sub type, such as Batch, for which you are requesting a quota increase."
+        },
+        "quotaChangeRequestVersion": {
+          "type": "string",
+          "description": "Quota change request version."
+        },
+        "quotaChangeRequests": {
+          "type": "array",
+          "description": "This property is required for providing the region and new quota limits.",
+          "items": {
+            "$ref": "#/definitions/QuotaChangeRequest"
+          },
+          "x-ms-identifiers": [
+            "region"
+          ]
+        }
+      }
+    },
+    "SecondaryConsent": {
+      "type": "object",
+      "description": "This property indicates secondary consent for the support ticket.",
+      "properties": {
+        "userConsent": {
+          "$ref": "#/definitions/UserConsent",
+          "description": "User consent value provided"
+        },
+        "type": {
+          "type": "string",
+          "description": "The service name for which the secondary consent is being provided. The value needs to be retrieved from the Problem Classification API response."
+        }
+      }
+    },
+    "SecondaryConsentEnabled": {
+      "type": "object",
+      "description": "This property indicates whether secondary consent is present for problem classification.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "User consent description."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Azure service for which secondary consent is needed for case creation."
+        }
+      }
+    },
+    "Service": {
+      "type": "object",
+      "description": "Object that represents a Service resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ServiceClassificationAnswer": {
+      "type": "object",
+      "description": "Service Classification result object.",
+      "properties": {
+        "childService": {
+          "$ref": "#/definitions/ClassificationService",
+          "description": "Child service."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ClassificationService"
+        }
+      ]
+    },
+    "ServiceClassificationOutput": {
+      "type": "object",
+      "description": "Output of the service classification API.",
+      "properties": {
+        "serviceClassificationResults": {
+          "type": "array",
+          "description": "Set of problem classification objects classified.",
+          "items": {
+            "$ref": "#/definitions/ServiceClassificationAnswer"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ServiceClassificationRequest": {
+      "type": "object",
+      "description": "Input to problem classification Classification API.",
+      "properties": {
+        "issueSummary": {
+          "type": "string",
+          "description": "Natural language description of the customer’s issue."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM resource Id of the resource that is having the issue."
+        },
+        "additionalContext": {
+          "type": "string",
+          "description": "Additional information in the form of a string."
+        }
+      }
+    },
+    "ServiceLevelAgreement": {
+      "type": "object",
+      "description": "Service Level Agreement details for a support ticket.",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the service level agreement starts.",
+          "readOnly": true
+        },
+        "expirationTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the service level agreement expires.",
+          "readOnly": true
+        },
+        "slaMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Service Level Agreement in minutes.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceProperties": {
+      "type": "object",
+      "description": "Details about an Azure service available for support ticket creation.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Localized name of the Azure service."
+        },
+        "resourceTypes": {
+          "type": "array",
+          "description": "ARM Resource types.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServicesListResult": {
+      "type": "object",
+      "description": "Collection of Service resources.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items"
+        },
+        "value": {
+          "type": "array",
+          "description": "List of Service resources.",
+          "items": {
+            "$ref": "#/definitions/Service"
+          }
+        }
+      }
+    },
+    "SeverityLevel": {
+      "type": "string",
+      "description": "A value that indicates the urgency of the case, which in turn determines the response time according to the service level agreement of the technical support plan you have with Azure. Note: 'Highest critical impact', also known as the 'Emergency - Severe impact' level in the Azure portal is reserved only for our Premium customers.",
+      "enum": [
+        "minimal",
+        "moderate",
+        "critical",
+        "highestcriticalimpact"
+      ],
+      "x-ms-enum": {
+        "name": "SeverityLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "minimal",
+            "value": "minimal"
+          },
+          {
+            "name": "moderate",
+            "value": "moderate"
+          },
+          {
+            "name": "critical",
+            "value": "critical"
+          },
+          {
+            "name": "highestcriticalimpact",
+            "value": "highestcriticalimpact"
+          }
+        ]
+      }
+    },
+    "Status": {
+      "type": "string",
+      "description": "Status to be updated on the ticket.",
+      "enum": [
+        "open",
+        "closed"
+      ],
+      "x-ms-enum": {
+        "name": "Status",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "open",
+            "value": "open"
+          },
+          {
+            "name": "closed",
+            "value": "closed"
+          }
+        ]
+      }
+    },
+    "SupportChannel": {
+      "type": "string",
+      "description": "Support channel type for the support ticket.",
+      "enum": [
+        "Chat",
+        "Web"
+      ],
+      "x-ms-enum": {
+        "name": "SupportChannel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Chat",
+            "value": "Chat",
+            "description": "Chat support channel."
+          },
+          {
+            "name": "Web",
+            "value": "Web",
+            "description": "Web support channel."
+          }
+        ]
+      }
+    },
+    "SupportEngineer": {
+      "type": "object",
+      "description": "Support engineer information.",
+      "properties": {
+        "emailAddress": {
+          "type": "string",
+          "description": "Email address of the Azure Support engineer assigned to the support ticket.",
+          "readOnly": true
+        }
+      }
+    },
+    "SupportTicketDetails": {
+      "type": "object",
+      "description": "Object that represents SupportTicketDetails resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SupportTicketDetailsProperties",
+          "description": "Properties of the resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SupportTicketDetailsProperties": {
+      "type": "object",
+      "description": "Describes the properties of a support ticket.",
+      "properties": {
+        "supportTicketId": {
+          "type": "string",
+          "description": "System generated support ticket Id that is unique."
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the question or issue."
+        },
+        "problemClassificationId": {
+          "type": "string",
+          "description": "Each Azure service has its own set of issue categories, also known as problem classification. This parameter is the unique Id for the type of problem you are experiencing."
+        },
+        "problemClassificationDisplayName": {
+          "type": "string",
+          "description": "Localized name of problem classification.",
+          "readOnly": true
+        },
+        "severity": {
+          "$ref": "#/definitions/SeverityLevel",
+          "description": "A value that indicates the urgency of the case, which in turn determines the response time according to the service level agreement of the technical support plan you have with Azure. Note: 'Highest critical impact', also known as the 'Emergency - Severe impact' level in the Azure portal is reserved only for our Premium customers."
+        },
+        "enrollmentId": {
+          "type": "string",
+          "description": "Enrollment Id associated with the support ticket."
+        },
+        "require24X7Response": {
+          "type": "boolean",
+          "description": "Indicates if this requires a 24x7 response from Azure."
+        },
+        "advancedDiagnosticConsent": {
+          "$ref": "#/definitions/Consent",
+          "description": "Advanced diagnostic consent to be updated on the support ticket."
+        },
+        "problemScopingQuestions": {
+          "type": "string",
+          "description": "Problem scoping questions associated with the support ticket."
+        },
+        "supportPlanId": {
+          "type": "string",
+          "description": "Support plan id associated with the support ticket."
+        },
+        "contactDetails": {
+          "$ref": "#/definitions/ContactProfile",
+          "description": "Contact information of the user requesting to create a support ticket."
+        },
+        "serviceLevelAgreement": {
+          "$ref": "#/definitions/ServiceLevelAgreement",
+          "description": "Service Level Agreement information for this support ticket."
+        },
+        "supportEngineer": {
+          "$ref": "#/definitions/SupportEngineer",
+          "description": "Information about the support engineer working on this support ticket."
+        },
+        "supportPlanType": {
+          "type": "string",
+          "description": "Support plan type associated with the support ticket.",
+          "readOnly": true
+        },
+        "supportPlanDisplayName": {
+          "type": "string",
+          "description": "Support plan type associated with the support ticket.",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the support ticket."
+        },
+        "problemStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the problem started."
+        },
+        "serviceId": {
+          "type": "string",
+          "description": "This is the resource Id of the Azure service resource associated with the support ticket."
+        },
+        "serviceDisplayName": {
+          "type": "string",
+          "description": "Localized name of the Azure service.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the support ticket.",
+          "readOnly": true
+        },
+        "createdDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the support ticket was created.",
+          "readOnly": true
+        },
+        "modifiedDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time in UTC (ISO 8601 format) when the support ticket was last modified.",
+          "readOnly": true
+        },
+        "fileWorkspaceName": {
+          "type": "string",
+          "description": "File workspace name."
+        },
+        "isTemporaryTicket": {
+          "$ref": "#/definitions/IsTemporaryTicket",
+          "description": "This property indicates if support ticket is a temporary ticket.",
+          "readOnly": true
+        },
+        "technicalTicketDetails": {
+          "$ref": "#/definitions/TechnicalTicketDetails",
+          "description": "Additional ticket details associated with a technical support ticket request."
+        },
+        "quotaTicketDetails": {
+          "$ref": "#/definitions/QuotaTicketDetails",
+          "description": "Additional ticket details associated with a quota support ticket request."
+        },
+        "secondaryConsent": {
+          "type": "array",
+          "description": "This property indicates secondary consents for the support ticket",
+          "items": {
+            "$ref": "#/definitions/SecondaryConsent"
+          },
+          "x-ms-identifiers": []
+        },
+        "directConnectEscalation": {
+          "$ref": "#/definitions/DirectConnectEscalation",
+          "description": "Direct Connect Escalation details for a support ticket."
+        },
+        "communityForumPost": {
+          "type": "string",
+          "description": "Contains a link to the post on the community forum."
+        },
+        "supportChannel": {
+          "$ref": "#/definitions/SupportChannel",
+          "description": "Support channel type for the support ticket.",
+          "readOnly": true
+        },
+        "chatConversationStatus": {
+          "$ref": "#/definitions/ChatConversationStatus",
+          "description": "Status of the chat conversation associated with the support ticket.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "description",
+        "problemClassificationId",
+        "severity",
+        "advancedDiagnosticConsent",
+        "contactDetails",
+        "title",
+        "serviceId"
+      ]
+    },
+    "SupportTicketsListResult": {
+      "type": "object",
+      "description": "[Placeholder] Description for page model",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "[Placeholder] Description for nextLink property"
+        },
+        "value": {
+          "type": "array",
+          "description": "[Placeholder] Description for value property",
+          "items": {
+            "$ref": "#/definitions/SupportTicketDetails"
+          }
+        }
+      }
+    },
+    "TechnicalTicketDetails": {
+      "type": "object",
+      "description": "Additional information for technical support ticket.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "This is the resource Id of the Azure service resource (For example: A virtual machine resource or an HDInsight resource) for which the support ticket is created."
+        }
+      }
+    },
+    "Type": {
+      "type": "string",
+      "description": "The type of resource.",
+      "enum": [
+        "Microsoft.Support/supportTickets",
+        "Microsoft.Support/communications"
+      ],
+      "x-ms-enum": {
+        "name": "Type",
+        "modelAsString": false
+      }
+    },
+    "UpdateContactProfile": {
+      "type": "object",
+      "description": "Contact information associated with the support ticket.",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "First name."
+        },
+        "lastName": {
+          "type": "string",
+          "description": "Last name."
+        },
+        "preferredContactMethod": {
+          "$ref": "#/definitions/PreferredContactMethod",
+          "description": "Preferred contact method."
+        },
+        "primaryEmailAddress": {
+          "type": "string",
+          "description": "Primary email address."
+        },
+        "additionalEmailAddresses": {
+          "type": "array",
+          "description": "Email addresses listed will be copied on any correspondence about the support ticket.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phoneNumber": {
+          "type": "string",
+          "description": "Phone number. This is required if preferred contact method is phone. It is also required when submitting 'critical' or 'highestcriticalimpact' severity cases."
+        },
+        "preferredTimeZone": {
+          "type": "string",
+          "description": "Time zone of the user. This is the name of the time zone from [Microsoft Time Zone Index Values](https://support.microsoft.com/help/973627/microsoft-time-zone-index-values)."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country of the user. This is the ISO 3166-1 alpha-3 code."
+        },
+        "preferredSupportLanguage": {
+          "type": "string",
+          "description": "Preferred language of support from Azure. Support languages vary based on the severity you choose for your support ticket. Learn more at [Azure Severity and responsiveness](https://azure.microsoft.com/support/plans/response/). Use the standard language-country code. Valid values are 'en-us' for English, 'zh-hans' for Chinese, 'es-es' for Spanish, 'fr-fr' for French, 'ja-jp' for Japanese, 'ko-kr' for Korean, 'ru-ru' for Russian, 'pt-br' for Portuguese, 'it-it' for Italian, 'zh-tw' for Chinese and 'de-de' for German."
+        }
+      }
+    },
+    "UpdateSupportTicket": {
+      "type": "object",
+      "description": "Updates severity, ticket status, contact details, advanced diagnostic consent and secondary consent in the support ticket.",
+      "properties": {
+        "severity": {
+          "$ref": "#/definitions/SeverityLevel",
+          "description": "Severity level."
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "Status to be updated on the ticket."
+        },
+        "contactDetails": {
+          "$ref": "#/definitions/UpdateContactProfile",
+          "description": "Contact details to be updated on the support ticket."
+        },
+        "advancedDiagnosticConsent": {
+          "$ref": "#/definitions/Consent",
+          "description": "Advanced diagnostic consent to be updated on the support ticket."
+        },
+        "secondaryConsent": {
+          "type": "array",
+          "description": "This property indicates secondary consents for the support ticket",
+          "items": {
+            "$ref": "#/definitions/SecondaryConsent"
+          },
+          "x-ms-identifiers": []
+        },
+        "directConnectEscalation": {
+          "$ref": "#/definitions/DirectConnectEscalation",
+          "description": "Direct Connect Escalation details for a support ticket."
+        }
+      }
+    },
+    "UploadFile": {
+      "type": "object",
+      "description": "File content associated with the file under a workspace.",
+      "properties": {
+        "content": {
+          "type": "string",
+          "description": "File Content in base64 encoded format"
+        },
+        "chunkIndex": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Index of the uploaded chunk (Index starts at 0)"
+        }
+      }
+    },
+    "UserConsent": {
+      "type": "string",
+      "description": "User consent value provided",
+      "enum": [
+        "Yes",
+        "No"
+      ],
+      "x-ms-enum": {
+        "name": "UserConsent",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Yes",
+            "value": "Yes"
+          },
+          {
+            "name": "No",
+            "value": "No"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/support.json
+++ b/specification/support/resource-manager/Microsoft.Support/Support/stable/2026-06-01/support.json
@@ -124,7 +124,7 @@
     },
     "/providers/Microsoft.Support/classifyServices": {
       "post": {
-        "operationId": "ServiceClassificationsNoSubscription_classifyServices",
+        "operationId": "ServiceClassificationsNoSubscription_ClassifyServices",
         "tags": [
           "ServiceClassifications"
         ],
@@ -601,7 +601,7 @@
     },
     "/providers/Microsoft.Support/services/{problemServiceName}/classifyProblems": {
       "post": {
-        "operationId": "ProblemClassificationsNoSubscription_classifyProblems",
+        "operationId": "ProblemClassificationsNoSubscription_ClassifyProblems",
         "tags": [
           "ProblemClassifications"
         ],
@@ -1347,7 +1347,7 @@
     },
     "/subscriptions/{subscriptionId}/providers/Microsoft.Support/classifyServices": {
       "post": {
-        "operationId": "ServiceClassifications_classifyServices",
+        "operationId": "ServiceClassifications_ClassifyServices",
         "tags": [
           "ServiceClassifications"
         ],
@@ -1691,7 +1691,7 @@
     },
     "/subscriptions/{subscriptionId}/providers/Microsoft.Support/services/{problemServiceName}/classifyProblems": {
       "post": {
-        "operationId": "ProblemClassifications_classifyProblems",
+        "operationId": "ProblemClassifications_ClassifyProblems",
         "tags": [
           "ProblemClassifications"
         ],
@@ -2385,8 +2385,7 @@
       "description": "Status of the chat conversation associated with the support ticket.",
       "enum": [
         "Active",
-        "Closed",
-        "None"
+        "Closed"
       ],
       "x-ms-enum": {
         "name": "ChatConversationStatus",
@@ -2401,11 +2400,6 @@
             "name": "Closed",
             "value": "Closed",
             "description": "Chat conversation has been closed."
-          },
-          {
-            "name": "None",
-            "value": "None",
-            "description": "No chat conversation associated."
           }
         ]
       }

--- a/specification/support/resource-manager/Microsoft.Support/Support/suppressions.yaml
+++ b/specification/support/resource-manager/Microsoft.Support/Support/suppressions.yaml
@@ -13,3 +13,10 @@
 - tool: TypeSpecRequirement
   path: ./stable/2020-04-01/*.json
   reason: Brownfield service not ready to migrate
+- tool: TypeSpecValidation
+  rules:
+    - Compile
+  sub-rules:
+    - ExtraSwagger
+  path: ./preview/2025-06-01-preview/support.json
+  reason: Preview version 2025-06-01-preview has been promoted to stable 2026-06-01 and is no longer emitted by TypeSpec


### PR DESCRIPTION
Add two enums Support Channel and ChatConversationStatus to enable Persistent chat

PR on the private/main repo - https://github.com/Azure/azure-rest-api-specs-pr/pull/28423/

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
