### PR TITLE
Rename input argument `body` to `model_version_update` in the Models update method

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/models/routes.tsp
@@ -77,7 +77,7 @@ interface Models
   @extension("x-ms-foundry-meta", ModelsRequiredPreviews)
   createOrUpdateVersion is Azure.Core.Foundations.ResourceOperation<
     ModelVersion,
-    InputParameters<UpdateModelVersionRequest> & ModelsPreviewHeader,
+    InputParameters<UpdateModelVersionRequest, "model_version_update"> & ModelsPreviewHeader,
     Azure.Core.Foundations.ResourceCreatedOrOkResponse<ModelVersion>
   >;
 


### PR DESCRIPTION
This change does not affect OpenAPI3 files, just emitted SDK. It overrides the default input argument name "body" with "model_version_update" (or modelVersionUpdate, depending on the language). I've done similar TypeSpec changes in the past to remove "body" as input argument name.

We already have a Models "create" method that takes input arguments "name", "version" and "model_version". With this change, the "update" method will look similar and will have input arguments "name", "version" and "model_version_update".
