### PR TITLE
Model type updates

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -21862,6 +21862,7 @@
           },
           "evalRun": {
             "type": "object",
+            "additionalProperties": {},
             "description": "The evaluation run payload."
           }
         },
@@ -45617,7 +45618,7 @@
           },
           "tokens": {
             "type": "integer",
-            "format": "int32",
+            "format": "int64",
             "description": "Total tokens consumed during the agent run for this task."
           },
           "duration_seconds": {
@@ -48611,6 +48612,7 @@
           },
           "initialization_parameters": {
             "type": "object",
+            "additionalProperties": {},
             "description": "The initialization parameters for the evaluation. Must support structured outputs."
           },
           "data_mapping": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -14871,6 +14871,7 @@ components:
           description: Identifier of the evaluation group.
         evalRun:
           type: object
+          additionalProperties: {}
           description: The evaluation run payload.
       allOf:
         - $ref: '#/components/schemas/ScheduleTask'
@@ -32301,7 +32302,7 @@ components:
           description: Composite score combining all evaluator scores.
         tokens:
           type: integer
-          format: int32
+          format: int64
           description: Total tokens consumed during the agent run for this task.
         duration_seconds:
           type: number
@@ -34320,6 +34321,7 @@ components:
           description: The version of the evaluator. Latest version if not specified.
         initialization_parameters:
           type: object
+          additionalProperties: {}
           description: The initialization parameters for the evaluation. Must support structured outputs.
         data_mapping:
           type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -25243,6 +25243,7 @@
           },
           "evalRun": {
             "type": "object",
+            "additionalProperties": {},
             "description": "The evaluation run payload."
           }
         },
@@ -49918,7 +49919,7 @@
           },
           "tokens": {
             "type": "integer",
-            "format": "int32",
+            "format": "int64",
             "description": "Total tokens consumed during the agent run for this task."
           },
           "duration_seconds": {
@@ -53031,6 +53032,7 @@
           },
           "initialization_parameters": {
             "type": "object",
+            "additionalProperties": {},
             "description": "The initialization parameters for the evaluation. Must support structured outputs."
           },
           "data_mapping": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -17167,6 +17167,7 @@ components:
           description: Identifier of the evaluation group.
         evalRun:
           type: object
+          additionalProperties: {}
           description: The evaluation run payload.
       allOf:
         - $ref: '#/components/schemas/ScheduleTask'
@@ -35232,7 +35233,7 @@ components:
           description: Composite score combining all evaluator scores.
         tokens:
           type: integer
-          format: int32
+          format: int64
           description: Total tokens consumed during the agent run for this task.
         duration_seconds:
           type: number
@@ -37333,6 +37334,7 @@ components:
           description: The version of the evaluator. Latest version if not specified.
         initialization_parameters:
           type: object
+          additionalProperties: {}
           description: The initialization parameters for the evaluation. Must support structured outputs.
         data_mapping:
           type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -193,7 +193,7 @@ model OptimizationTaskResult {
   composite_score: float64;
 
   @doc("Total tokens consumed during the agent run for this task.")
-  tokens: int32;
+  tokens: int64;
 
   @doc("Wall-clock seconds for this task's agent execution.")
   @encode(DurationKnownEncoding.seconds, float64)

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-evaluations/models.tsp
@@ -61,7 +61,7 @@ model GraderAzureAIEvaluator {
   evaluator_version?: string;
 
   /** The initialization parameters for the evaluation. Must support structured outputs. */
-  initialization_parameters?: {};
+  initialization_parameters?: Record<unknown>;
 
   /** The model to use for the evaluation. Must support structured outputs. */
   data_mapping?: Record<string>;

--- a/specification/ai-foundry/data-plane/Foundry/src/schedules/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/schedules/models.tsp
@@ -206,7 +206,7 @@ model EvaluationScheduleTask extends ScheduleTask {
   evalId: string;
 
   @doc("The evaluation run payload.")
-  evalRun: {};
+  evalRun: Record<unknown>;
 }
 
 @doc("Insight task for the schedule.")


### PR DESCRIPTION
This pull request updates several model definitions to improve type safety and support for structured data. The main changes involve replacing generic object types with more explicit record types and updating a numeric field to handle larger values.

**Model type improvements:**

* Changed the type of `initialization_parameters` in `GraderAzureAIEvaluator` from a generic object (`{}`) to `Record<unknown>` for better type safety and clarity.
* Changed the type of `evalRun` in `EvaluationScheduleTask` from a generic object (`{}`) to `Record<unknown>` to support more structured data.

**Numeric field update:**

* Updated the `tokens` field in `OptimizationTaskResult` from `int32` to `int64` to support larger token counts.