### PR TITLE
Address ARM review comments on MaintenanceWindowResource

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/MaintenanceWindow.tsp
@@ -37,7 +37,7 @@ model MaintenanceWindowResource
     Resource = MaintenanceWindowResource,
     KeyName = "maintenanceWindowName",
     SegmentName = "maintenanceWindows",
-    NamePattern = "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+    NamePattern = "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
   >;
 }
 
@@ -52,6 +52,10 @@ model MaintenanceWindowResource
   MaintenanceWindows.createOrUpdate::parameters.resource,
   "The maintenance window to create or update."
 );
+@@doc(
+  MaintenanceWindows.updateTags::parameters.properties,
+  "Parameters supplied to the Update maintenance window Tags operation."
+);
 
 @armResourceOperations
 @added(Versions.v2026_04_02_preview)
@@ -65,6 +69,15 @@ interface MaintenanceWindows {
    * Creates or updates a maintenance window.
    */
   createOrUpdate is ArmResourceCreateOrReplaceAsync<MaintenanceWindowResource>;
+
+  /**
+   * Updates tags on a maintenance window.
+   */
+  @patch(#{ implicitOptionality: false })
+  updateTags is ArmCustomPatchSync<
+    MaintenanceWindowResource,
+    PatchModel = TagsObject
+  >;
 
   /**
    * Deletes a maintenance window.
@@ -134,7 +147,7 @@ model MaintenanceWindowResourceProperties {
    * preferred wall-clock time year-round; the maintenance window will shift by one
    * hour relative to local time when DST starts or ends.
    */
-  @pattern("^(-|\\+)[0-9]{2}:[0-9]{2}$")
+  @pattern("^[+-](0\\d|1[0-4]):(00|15|30|45)$")
   utcOffset?: string;
 
   /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-04-02-preview/managedClusters.json
@@ -809,7 +809,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
           }
         ],
         "responses": {
@@ -856,7 +856,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
           },
           {
             "name": "resource",
@@ -910,6 +910,57 @@
         },
         "x-ms-long-running-operation": true
       },
+      "patch": {
+        "operationId": "MaintenanceWindows_UpdateTags",
+        "tags": [
+          "MaintenanceWindows"
+        ],
+        "description": "Updates tags on a maintenance window.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "maintenanceWindowName",
+            "in": "path",
+            "description": "The name of the maintenance window.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "Parameters supplied to the Update maintenance window Tags operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceWindowResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
       "delete": {
         "operationId": "MaintenanceWindows_Delete",
         "tags": [
@@ -934,7 +985,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
           }
         ],
         "responses": {
@@ -10510,7 +10561,7 @@
         "utcOffset": {
           "type": "string",
           "description": "The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00'\nfor PST. If not specified, the default is '+00:00'.\nNote: this is a static offset and does not adjust for Daylight Saving Time.\nCustomers in DST-observing regions should pick the offset that matches their\npreferred wall-clock time year-round; the maintenance window will shift by one\nhour relative to local time when DST starts or ends.",
-          "pattern": "^(-|\\+)[0-9]{2}:[0-9]{2}$"
+          "pattern": "^[+-](0\\d|1[0-4]):(00|15|30|45)$"
         },
         "notAllowedDates": {
           "type": "array",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/readme.md
@@ -1482,10 +1482,6 @@ directive:
   - suppress: TrackedResourcePatchOperation
     from: containerService.json
     reason: ACS service is deprecated so a PATCH endpoint won't be implemented
-  - suppress: TrackedResourcePatchOperation
-    from: managedClusters.json
-    where: $.definitions.MaintenanceWindowResource
-    reason: Maintenance windows do not expose a separate PATCH operation; tags are updated via the createOrUpdate PUT operation.
   - suppress: DefinitionsPropertiesNamesCamelCase
     from: managedClusters.json
     where: $.definitions.ManagedClusterSecurityProfile.properties.customCATrustCertificates      


### PR DESCRIPTION
## Summary

Addresses the three ARM API reviewer comments on `MaintenanceWindowResource` from PR #43043:

- **Blocking / RPC-Patch-V1-03** — Add sync tags-only PATCH (`MaintenanceWindows_UpdateTags`, `ArmCustomPatchSync<..., PatchModel = TagsObject>`) to satisfy the tracked-resource PATCH requirement, matching the AKS precedent used by `Snapshots`, `ManagedClusterSnapshots`, and `ManagedNamespaces`. Removes the corresponding `TrackedResourcePatchOperation` suppression from `readme.md`.
- **Warning / Pattern validation** — Tighten the `utcOffset` pattern to bound hours to `-14..+14` and limit minutes to the legal IANA values (`00`, `15`, `30`, `45`). Covers all real-world offsets including `+05:45` (Nepal) and `+05:30` (India).
- **Suggestion / Naming convention** — Remove underscore (`_`) from the `maintenanceWindowName` `NamePattern` to align with ARM resource-name conventions and other AKS peer resources (e.g. `agentPools`).