### PR TITLE
feat(ai-foundry/eval-rules): add samplingRate to ContinuousEvaluationRuleAction

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18957,9 +18957,10 @@
             "type": "number",
             "format": "double",
             "maximum": 100,
-            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.",
+            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.",
             "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": true,
+            "default": 100
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18952,6 +18952,14 @@
             "type": "integer",
             "format": "int32",
             "description": "Maximum number of evaluation runs allowed per hour."
+          },
+          "samplingRate": {
+            "type": "number",
+            "format": "double",
+            "maximum": 100,
+            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.",
+            "minimum": 0,
+            "exclusiveMinimum": true
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12632,9 +12632,10 @@ components:
           type: number
           format: double
           maximum: 100
-          description: Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.
+          description: Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.
           minimum: 0
           exclusiveMinimum: true
+          default: 100
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12628,6 +12628,13 @@ components:
           type: integer
           format: int32
           description: Maximum number of evaluation runs allowed per hour.
+        samplingRate:
+          type: number
+          format: double
+          maximum: 100
+          description: Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.
+          minimum: 0
+          exclusiveMinimum: true
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -22137,9 +22137,10 @@
             "type": "number",
             "format": "double",
             "maximum": 100,
-            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.",
+            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.",
             "minimum": 0,
-            "exclusiveMinimum": true
+            "exclusiveMinimum": true,
+            "default": 100
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -22132,6 +22132,14 @@
             "type": "integer",
             "format": "int32",
             "description": "Maximum number of evaluation runs allowed per hour."
+          },
+          "samplingRate": {
+            "type": "number",
+            "format": "double",
+            "maximum": 100,
+            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.",
+            "minimum": 0,
+            "exclusiveMinimum": true
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14786,9 +14786,10 @@ components:
           type: number
           format: double
           maximum: 100
-          description: Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.
+          description: Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.
           minimum: 0
           exclusiveMinimum: true
+          default: 100
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14782,6 +14782,13 @@ components:
           type: integer
           format: int32
           description: Maximum number of evaluation runs allowed per hour.
+        samplingRate:
+          type: number
+          format: double
+          maximum: 100
+          description: Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.
+          minimum: 0
+          exclusiveMinimum: true
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
@@ -42,10 +42,10 @@ model ContinuousEvaluationRuleAction extends EvaluationRuleAction {
   @doc("Maximum number of evaluation runs allowed per hour.")
   maxHourlyRuns?: int32;
 
-  @doc("Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.")
+  @doc("Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.")
   @minValueExclusive(0)
   @maxValue(100)
-  samplingRate?: float64;
+  samplingRate?: float64 = 100;
 }
 
 @doc("Evaluation rule action for human evaluation.")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp
@@ -41,6 +41,11 @@ model ContinuousEvaluationRuleAction extends EvaluationRuleAction {
 
   @doc("Maximum number of evaluation runs allowed per hour.")
   maxHourlyRuns?: int32;
+
+  @doc("Percentage (0-100] chance that a matching event triggers an evaluation. Omit to evaluate every event.")
+  @minValueExclusive(0)
+  @maxValue(100)
+  samplingRate?: float64;
 }
 
 @doc("Evaluation rule action for human evaluation.")


### PR DESCRIPTION
# Summary

Adds an optional `samplingRate` field to `ContinuousEvaluationRuleAction` to mirror server-side support that already exists in the AI Foundry evaluation service.

When set, each matching event has a (`samplingRate` / 100) chance of triggering an evaluation. When omitted, every event is evaluated (equivalent to `samplingRate: 100`). To disable the rule entirely, callers should set `enabled: false` rather than `samplingRate: 0` (which is rejected by the service).

# Change

In `specification/ai-foundry/data-plane/Foundry/src/evaluation-rules/models.tsp`:

``typespec
@doc("Sampling rate as a percentage, greater than 0 and at most 100. ...")
@minValueExclusive(0)
@maxValue(100)
samplingRate?: float64;
``

# Server-side validation already in place

The Foundry RAI evaluation service already accepts and validates `samplingRate` with the same constraints expressed here:

- `rate <= 0 || rate > 100` -> `400 BadRequest`
- `null` (omitted) -> treated as `100` (full sampling)

This change makes the wire contract reflect that behavior so generated SDKs (Python, .NET, Java, JS) can expose the field to customers and so OpenAPI consumers can rely on it.

# Generated artifacts

Regenerated both openapi3 outputs via `npx tsp compile .` from `specification/ai-foundry/data-plane/Foundry`:

- `openapi3/v1/microsoft-foundry-openapi3.{json,yaml}`
- `openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}`

# Branch target

Targeting `feature/foundry-release` (the working branch for the v1 Foundry surface), matching prior PRs to this area.

# Related

This closes a known TypeSpec gap surfaced by the RAISvc API contract test refresh (Vienna PR #2128878). After this merges, that PR's last documented skip — `ContinuousEvaluationRuleAction_MatchesContinuousEvaluationRuleActionSchema` — can be removed and the contract tests will validate the field end-to-end.
