### PR TITLE
Add Search C# provisioning emitter config

### DIFF
--- a/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/client.tsp
@@ -1186,6 +1186,18 @@ model AccessRulePropertiesSubscriptionsItem {
   uuid,
   "csharp"
 );
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning"
+@@clientOption(
+  SearchService,
+  "resource-rbac-roles",
+  #{
+    SearchIndexDataContributor: "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+    SearchIndexDataReader: "1407120a-92aa-4202-b7e9-c0e197c71c8f",
+    SearchServiceContributor: "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+  },
+  "csharp"
+);
 @@alternateType(QuotaUsageResult.id, armResourceIdentifier, "csharp");
 @@clientName(
   Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties,

--- a/specification/search/resource-manager/Microsoft.Search/Search/main.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/main.tsp
@@ -39,11 +39,6 @@ namespace Microsoft.Search;
  */
 enum Versions {
   /**
-   * The 2023-11-01 API version.
-   */
-  v2023_11_01: "2023-11-01",
-
-  /**
    * The 2025-05-01 API version.
    */
   v2025_05_01: "2025-05-01",

--- a/specification/search/resource-manager/Microsoft.Search/Search/main.tsp
+++ b/specification/search/resource-manager/Microsoft.Search/Search/main.tsp
@@ -39,6 +39,11 @@ namespace Microsoft.Search;
  */
 enum Versions {
   /**
+   * The 2023-11-01 API version.
+   */
+  v2023_11_01: "2023-11-01",
+
+  /**
    * The 2025-05-01 API version.
    */
   v2025_05_01: "2025-05-01",

--- a/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
+++ b/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
@@ -14,6 +14,10 @@ options:
     namespace: "Azure.ResourceManager.Search"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.Search"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version: "2025-05-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-search"
     namespace: "azure.mgmt.search"

--- a/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
+++ b/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
@@ -17,7 +17,7 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Search"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2023-11-01"
+    api-version: "2025-05-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-search"
     namespace: "azure.mgmt.search"

--- a/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
+++ b/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
@@ -17,7 +17,7 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.Search"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
-    api-version: "2025-05-01"
+    api-version: "2023-11-01"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-search"
     namespace: "azure.mgmt.search"


### PR DESCRIPTION
Adds the C# provisioning emitter configuration for `Azure.Provisioning.Search` targeting `Microsoft.Search` `2025-05-01`.Also adds the RBAC role metadata required for the provisioning generator to emit `SearchBuiltInRole` and role assignment helpers.Companion SDK PR: Azure/azure-sdk-for-net#59571 (https://github.com/Azure/azure-sdk-for-net/pull/59571)

Companion SDK PR: Azure/azure-sdk-for-net#59571 (https://github.com/Azure/azure-sdk-for-net/pull/59571)