### PR TITLE
Add solutionType to EdgeMachineUpdate (2026-05-01-preview)

### DIFF
--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_CreateOrUpdate.json
@@ -9,6 +9,7 @@
     "default": "default",
     "resource": {
       "properties": {
+        "solutionType": "AzureLinux",
         "values": [
           {
             "vsrVersion": "1.2.0",
@@ -31,6 +32,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",
@@ -64,6 +66,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_Get.json
@@ -15,6 +15,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineUpdates_List.json
@@ -16,6 +16,7 @@
             "name": "default",
             "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
             "properties": {
+              "solutionType": "AzureLinux",
               "values": [
                 {
                   "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -8666,6 +8666,9 @@ model EdgeMachineUpdateInfo {
 /** Properties for EdgeMachineUpdate resource. */
 @added(Versions.v2026_05_01_preview)
 model EdgeMachineUpdateProperties {
+  /** The solution type for the available updates. */
+  solutionType?: ProvisioningOsType;
+
   /** The list of available updates. */
   @identifiers(#[])
   values: EdgeMachineUpdateInfo[];

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_CreateOrUpdate.json
@@ -9,6 +9,7 @@
     "default": "default",
     "resource": {
       "properties": {
+        "solutionType": "AzureLinux",
         "values": [
           {
             "vsrVersion": "1.2.0",
@@ -31,6 +32,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",
@@ -64,6 +66,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_Get.json
@@ -15,6 +15,7 @@
         "name": "default",
         "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
         "properties": {
+          "solutionType": "AzureLinux",
           "values": [
             {
               "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_List.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineUpdates_List.json
@@ -16,6 +16,7 @@
             "name": "default",
             "type": "Microsoft.AzureStackHCI/edgeMachines/updates",
             "properties": {
+              "solutionType": "AzureLinux",
               "values": [
                 {
                   "vsrVersion": "1.2.0",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
@@ -14102,6 +14102,10 @@
       "type": "object",
       "description": "Properties for EdgeMachineUpdate resource.",
       "properties": {
+        "solutionType": {
+          "$ref": "#/definitions/ProvisioningOsType",
+          "description": "The solution type for the available updates."
+        },
         "values": {
           "type": "array",
           "description": "The list of available updates.",


### PR DESCRIPTION
Adds an optional `solutionType` property to `EdgeMachineUpdateProperties` for the `2026-05-01-preview` API version, typed as the existing extensible `ProvisioningOsType` enum (AzureLinux / HCI).

This mirrors the change made in the private spec repo (azure-rest-api-specs-pr#28744). Examples (CreateOrUpdate / Get / List) updated to include `solutionType: AzureLinux`.

Reference: Azure/azure-rest-api-specs#43203