### PR TITLE
Fix PR stale triage: include draft PRs, run daily

### DIFF
--- a/.github/policies/pr.stale.yml
+++ b/.github/policies/pr.stale.yml
@@ -1,0 +1,52 @@
+id: pr.stale
+name: GitOps.PullRequestIssueManagement
+description: Mark and close stale pull requests
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: Mark PRs with no activity for 14 days as stale
+        frequencies:
+          - weekday:
+              day: Monday
+              time: 13:0
+        filters:
+          - isPullRequest
+          - isOpen
+          - isNotLabeledWith:
+              label: no-recent-activity
+          - noActivitySince:
+              days: 14
+        actions:
+          - addLabel:
+              label: no-recent-activity
+          - addReply:
+              reply: >-
+                Hi @${issueAuthor}.
+                Your PR has had no activity for 14 days and is marked as stale. If no further updates are made within 14 days, this PR will automatically be closed.
+                To keep this PR active, please remove the `no-recent-activity` label or push new changes.
+
+      - description: Close PRs that have been stale for 14 more days (28 days total)
+        frequencies:
+          - weekday:
+              day: Monday
+              time: 13:0
+        filters:
+          - isPullRequest
+          - isOpen
+          - hasLabel:
+              label: no-recent-activity
+          - noActivitySince:
+              days: 14
+        actions:
+          - closeIssue
+          - addReply:
+              reply: >-
+                Hi @${issueAuthor}.
+                This PR has been closed since it had no activity for 28 days. If you still need this change, please reopen the PR and @mention the assignee for review.
+
+onFailure:
+onSuccess:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -43,40 +43,19 @@ configuration:
           reply: Hi, we're sending this friendly reminder because we haven't heard back from you in a while. We need more information about this issue to help address it. Please be sure to give us your input within the next **7 days**. If we don't hear back from you within **14 days** of this comment the issue will be automatically closed. Thank you!
     - description: 
       frequencies:
-      - weekday:
-          day: Monday
-          time: 0:0
-      filters:
-      - noActivitySince:
-          days: 14
-      - isOpen
-      - isNotLabeledWith:
-          label: no-recent-activity
-      - isNotLabeledWith:
-          label: customer-reported
-      - isPullRequest
-      - isNotDraftPullRequest
-      actions:
-      - addReply:
-          reply: 'Hi, @${issueAuthor}. Your PR has no update for 14 days and it is marked as stale PR. If no further update for over 14 days, the bot will close the PR.  If you want to refresh the PR, please remove `no-recent-activity` label. '
-      - addLabel:
-          label: no-recent-activity
-    - description: 
-      frequencies:
       - daily:
           time: 13:0
       filters:
+      - isIssue
       - isOpen
       - hasLabel:
           label: no-recent-activity
       - noActivitySince:
           days: 14
-      - isNotLabeledWith:
-          label: customer-reported
       actions:
       - closeIssue
       - addReply:
-          reply: Hi, @${issueAuthor}. The PR will be closed since the PR has no update for 28 days.  If you still need the PR review to proceed, please reopen it and @ mention PR assignee.
+          reply: Hi, @${issueAuthor}. This issue has been closed since it had no activity for 14 days after being marked as stale. If you still need help, please reopen it.
     eventResponderTasks:
     - if:
       - payloadType: Issue_Comment


### PR DESCRIPTION
Try to cleanup the  massive amount of PRs left in this repo.

Moved PR stale policy into a dedicated file (`.github/policies/pr.stale.yml`).

Changes to the policy:
- Include draft PRs (previously excluded)
- Remove `customer-reported` exclusion

