### PR TITLE
Fix(computelimit): Rename C# clientName for FeatureEnableRequest to ComputeLimitFeatureEnableContent

### DIFF
--- a/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/client.tsp
+++ b/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/client.tsp
@@ -24,7 +24,7 @@ using Microsoft.ComputeLimit;
 @@clientName(FeatureState, "ComputeLimitFeatureState", "csharp");
 @@clientName(
   FeatureEnableRequest,
-  "ComputeLimitFeatureEnableRequest",
+  "ComputeLimitFeatureEnableContent",
   "csharp"
 );
 @@clientName(VmFamily, "ComputeLimitVmFamily", "csharp");


### PR DESCRIPTION
Resolves .NET SDK linter failure for model names ending in `Request`. Uses @@clientName in client.tsp to rename only for C# SDK, avoiding impact to other language SDKs.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
