### PR TITLE
[Key Vault Certificates] PlatformManaged: structured metadata + CertificateUsage enum (2026-03-01-preview)

### DIFF
--- a/specification/keyvault/data-plane/Certificates/models.tsp
+++ b/specification/keyvault/data-plane/Certificates/models.tsp
@@ -392,21 +392,100 @@ model CertificatePolicy {
 }
 
 /**
+ * The intended usage of a platform-managed certificate. The service maps each usage to a specific
+ * issuer, EKUs, and key-usage defaults. This feature is currently intended for internal use only.
+ */
+@added(Versions.v2026_03_01_preview)
+union CertificateUsage {
+  string,
+
+  /** Public TLS server authentication (issued via OneCertV2-PublicCA, EKU: ServerAuth). */
+  PublicTLSServerAuth: "PublicTLSServerAuth",
+
+  /** Public client and server authentication (issued via OneCertV2-PublicCA, EKUs: ServerAuth + ClientAuth). */
+  PublicClientAndServerAuth: "PublicClientAndServerAuth",
+
+  /** Private TLS server authentication (issued via OneCertV2-PrivateCA, EKU: ServerAuth). */
+  PrivateTLSServerAuth: "PrivateTLSServerAuth",
+
+  /** Private client and server authentication (issued via OneCertV2-PrivateCA, EKUs: ServerAuth + ClientAuth). */
+  PrivateClientAndServerAuth: "PrivateClientAndServerAuth",
+
+  /** STS token acquisition (DSTS or ESTS). Requires appId and stsType in metadata. */
+  STSTokenAcquisition: "STSTokenAcquisition",
+}
+
+/**
+ * The STS type for platform-managed certificates with STSTokenAcquisition usage.
+ */
+@added(Versions.v2026_03_01_preview)
+union PlatformManagedStsType {
+  string,
+
+  /** Microsoft dSTS. */
+  DSTS: "DSTS",
+
+  /** Microsoft eSTS. */
+  ESTS: "ESTS",
+}
+
+/**
+ * Optional overrides for platform-managed certificate behavior.
+ */
+@added(Versions.v2026_03_01_preview)
+model PlatformManagedOverrides {
+  /**
+   * Explicit opt-in to fast rotation for subscriptions that have globally opted out of fast rotation
+   * (via the ReducedCertValidityOptOut AFEC flag). Must be set to true for those subscriptions;
+   * ignored for subscriptions that already have fast rotation enabled. Not persisted - used only
+   * at request validation time.
+   */
+  fastRotation?: boolean;
+}
+
+/**
+ * Structured metadata for a platform-managed certificate.
+ */
+@added(Versions.v2026_03_01_preview)
+model PlatformManagedMetadata {
+  /**
+   * Subject Alternative Names. DNS names are required for standard (non-STSTokenAcquisition) usages;
+   * the Subject is derived from the first DNS name.
+   */
+  subjectAlternateNames?: SubjectAlternativeNames;
+
+  /**
+   * Application ID. Required when certificateUsage is STSTokenAcquisition.
+   */
+  appId?: string;
+
+  /**
+   * STS type. Required when certificateUsage is STSTokenAcquisition.
+   */
+  stsType?: PlatformManagedStsType;
+
+  /**
+   * Optional overrides for platform-managed behavior.
+   */
+  overrides?: PlatformManagedOverrides;
+}
+
+/**
  * Properties of the platform managed certificate. This feature is currently intended for internal use only.
  */
 @added(Versions.v2026_03_01_preview)
 model PlatformManaged {
   /**
-   * The intended usage of the certificate.
+   * The intended usage of the certificate. The service uses this to determine the issuer,
+   * validity period, lifetime actions, EKUs, and key usage for the certificate.
    */
-  certificateUsage: string;
+  certificateUsage: CertificateUsage;
 
   /**
-   * JSON-formatted platform managed metadata. The schema is intentionally undefined as this feature is currently intended for internal use only.
+   * Structured metadata describing the platform-managed certificate. The required fields depend
+   * on the value of certificateUsage.
    */
-  #suppress "@azure-tools/typespec-azure-core/no-unknown"
-  #suppress "@azure-tools/typespec-azure-core/bad-record-type"
-  metadata?: Record<unknown>;
+  metadata?: PlatformManagedMetadata;
 }
 
 /**

--- a/specification/keyvault/data-plane/Certificates/preview/2026-03-01-preview/certificates.json
+++ b/specification/keyvault/data-plane/Certificates/preview/2026-03-01-preview/certificates.json
@@ -1787,6 +1787,48 @@
         }
       }
     },
+    "CertificateUsage": {
+      "type": "string",
+      "description": "The intended usage of a platform-managed certificate. The service maps each usage to a specific\nissuer, EKUs, and key-usage defaults. This feature is currently intended for internal use only.",
+      "enum": [
+        "PublicTLSServerAuth",
+        "PublicClientAndServerAuth",
+        "PrivateTLSServerAuth",
+        "PrivateClientAndServerAuth",
+        "STSTokenAcquisition"
+      ],
+      "x-ms-enum": {
+        "name": "CertificateUsage",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PublicTLSServerAuth",
+            "value": "PublicTLSServerAuth",
+            "description": "Public TLS server authentication (issued via OneCertV2-PublicCA, EKU: ServerAuth)."
+          },
+          {
+            "name": "PublicClientAndServerAuth",
+            "value": "PublicClientAndServerAuth",
+            "description": "Public client and server authentication (issued via OneCertV2-PublicCA, EKUs: ServerAuth + ClientAuth)."
+          },
+          {
+            "name": "PrivateTLSServerAuth",
+            "value": "PrivateTLSServerAuth",
+            "description": "Private TLS server authentication (issued via OneCertV2-PrivateCA, EKU: ServerAuth)."
+          },
+          {
+            "name": "PrivateClientAndServerAuth",
+            "value": "PrivateClientAndServerAuth",
+            "description": "Private client and server authentication (issued via OneCertV2-PrivateCA, EKUs: ServerAuth + ClientAuth)."
+          },
+          {
+            "name": "STSTokenAcquisition",
+            "value": "STSTokenAcquisition",
+            "description": "STS token acquisition (DSTS or ESTS). Requires appId and stsType in metadata."
+          }
+        ]
+      }
+    },
     "Contact": {
       "type": "object",
       "description": "The contact information for the vault certificates.",
@@ -2360,18 +2402,73 @@
       "description": "Properties of the platform managed certificate. This feature is currently intended for internal use only.",
       "properties": {
         "certificateUsage": {
-          "type": "string",
-          "description": "The intended usage of the certificate."
+          "$ref": "#/definitions/CertificateUsage",
+          "description": "The intended usage of the certificate. The service uses this to determine the issuer,\nvalidity period, lifetime actions, EKUs, and key usage for the certificate."
         },
         "metadata": {
-          "type": "object",
-          "description": "JSON-formatted platform managed metadata. The schema is intentionally undefined as this feature is currently intended for internal use only.",
-          "additionalProperties": {}
+          "$ref": "#/definitions/PlatformManagedMetadata",
+          "description": "Structured metadata describing the platform-managed certificate. The required fields depend\non the value of certificateUsage."
         }
       },
       "required": [
         "certificateUsage"
       ]
+    },
+    "PlatformManagedMetadata": {
+      "type": "object",
+      "description": "Structured metadata for a platform-managed certificate.",
+      "properties": {
+        "subjectAlternateNames": {
+          "$ref": "#/definitions/SubjectAlternativeNames",
+          "description": "Subject Alternative Names. DNS names are required for standard (non-STSTokenAcquisition) usages;\nthe Subject is derived from the first DNS name."
+        },
+        "appId": {
+          "type": "string",
+          "description": "Application ID. Required when certificateUsage is STSTokenAcquisition."
+        },
+        "stsType": {
+          "$ref": "#/definitions/PlatformManagedStsType",
+          "description": "STS type. Required when certificateUsage is STSTokenAcquisition."
+        },
+        "overrides": {
+          "$ref": "#/definitions/PlatformManagedOverrides",
+          "description": "Optional overrides for platform-managed behavior."
+        }
+      }
+    },
+    "PlatformManagedOverrides": {
+      "type": "object",
+      "description": "Optional overrides for platform-managed certificate behavior.",
+      "properties": {
+        "fastRotation": {
+          "type": "boolean",
+          "description": "Explicit opt-in to fast rotation for subscriptions that have globally opted out of fast rotation\n(via the ReducedCertValidityOptOut AFEC flag). Must be set to true for those subscriptions;\nignored for subscriptions that already have fast rotation enabled. Not persisted - used only\nat request validation time."
+        }
+      }
+    },
+    "PlatformManagedStsType": {
+      "type": "string",
+      "description": "The STS type for platform-managed certificates with STSTokenAcquisition usage.",
+      "enum": [
+        "DSTS",
+        "ESTS"
+      ],
+      "x-ms-enum": {
+        "name": "PlatformManagedStsType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DSTS",
+            "value": "DSTS",
+            "description": "Microsoft dSTS."
+          },
+          {
+            "name": "ESTS",
+            "value": "ESTS",
+            "description": "Microsoft eSTS."
+          }
+        ]
+      }
     },
     "SecretProperties": {
       "type": "object",


### PR DESCRIPTION
## Summary

Aligns the `2026-03-01-preview` Key Vault Certificates spec for the `PlatformManaged` property with the shape actually deployed by the service (per the *Managed Certificate Distribution Compliance* design doc).

Without this change, the generated SDK surfaces (Java, .NET, Python, JS, Go) cannot construct a request body the deployed service will accept — every call returns `400 BadParameter`, blocking E2E recordings for all language SDKs.

## Changes

`specification/keyvault/data-plane/Certificates/models.tsp`

1. **`certificateUsage`**: `string` → new extensible `CertificateUsage` union with the 5 allowed values from the design doc:
   - `PublicTLSServerAuth`
   - `PublicClientAndServerAuth`
   - `PrivateTLSServerAuth`
   - `PrivateClientAndServerAuth`
   - `STSTokenAcquisition`

2. **`metadata`**: `Record<unknown>` (untyped) → typed `PlatformManagedMetadata`:
   ```
   PlatformManagedMetadata {
     subjectAlternateNames?: SubjectAlternativeNames  // reuses existing X.509 SANs model
     appId?: string                                    // required for STSTokenAcquisition
     stsType?: PlatformManagedStsType                  // required for STSTokenAcquisition
     overrides?: PlatformManagedOverrides
   }
   ```

3. **New** `PlatformManagedOverrides { fastRotation?: boolean }` — explicit opt-in to fast rotation for subscriptions that have opted out via the `ReducedCertValidityOptOut` AFEC flag.

4. **New** `PlatformManagedStsType` extensible union (`DSTS`, `ESTS`).

The regenerated `certificates.json` swagger is included.

## Why now

The merged spec (PR ea20c46) was reviewed against an earlier internal design where `metadata` was a free-form JSON bag. The service shipped with a typed shape (see *Managed Certificate Distribution Compliance.md* — Low-Level Design → `PlatformManaged` / `PlatformManagedMetadata` / `PlatformManagedOverrides` classes). All current SDK pipelines are blocked on this gap:
- Customer must be able to set `subjectAlternateNames.dnsNames` (required by the service for standard usages) — currently impossible through the generated typed surface.
- `certificateUsage` was being accepted as any string, leading to silent misuse — constraining it to the documented enum surfaces the right values via IntelliSense.

## Scope / risk

- Preview-only API version (`2026-03-01-preview`); no GA contract is affected.
- Feature is internal-tenant-only today, so no external customers depend on the existing untyped shape.
- Extensible enums preserve forward compatibility if additional usages or STS types are added later.

## Validation

- [x] `tsp compile` succeeds.
- [x] `certificates.json` regenerated and reviewed.
- [ ] Once merged, Java/.NET/Python/JS pipelines will regen and SDK E2E recordings can be captured against a vault running the deployed build.
