### PR TITLE
feat(ai-foundry/evaluators): add supported_evaluation_levels + List evaluator generation jobs propagation note

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -6460,7 +6460,7 @@
       "get": {
         "operationId": "EvaluatorGenerationJobs_list",
         "summary": "List evaluator generation jobs",
-        "description": "Returns a list of evaluator generation jobs.",
+        "description": "Returns a list of evaluator generation jobs. The List API has up to a few\nseconds of propagation delay, so a recently created job may not appear\nimmediately; use the Get evaluator generation job API with the job ID to\nretrieve a specific job without delay.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -24930,6 +24930,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+          },
           "definition": {
             "allOf": [
               {
@@ -25014,6 +25021,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+          },
           "definition": {
             "allOf": [
               {
@@ -25056,6 +25070,13 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
+          },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -24935,7 +24935,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "definition": {
             "allOf": [
@@ -25026,7 +25029,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "definition": {
             "allOf": [
@@ -25076,7 +25082,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4317,7 +4317,11 @@ paths:
     get:
       operationId: EvaluatorGenerationJobs_list
       summary: List evaluator generation jobs
-      description: Returns a list of evaluator generation jobs.
+      description: |-
+        Returns a list of evaluator generation jobs. The List API has up to a few
+        seconds of propagation delay, so a recently created job may not appear
+        immediately; use the Get evaluator generation job API with the job ID to
+        retrieve a specific job without delay.
       parameters:
         - name: Foundry-Features
           in: header
@@ -16870,6 +16874,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16928,6 +16937,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16957,6 +16971,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -16879,6 +16879,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16942,6 +16944,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16976,6 +16980,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -29479,7 +29479,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "definition": {
             "allOf": [
@@ -29570,7 +29573,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "definition": {
             "allOf": [
@@ -29620,7 +29626,10 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
+            "default": [
+              "turn"
+            ]
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -9141,7 +9141,7 @@
       "get": {
         "operationId": "EvaluatorGenerationJobs_list",
         "summary": "List evaluator generation jobs",
-        "description": "Returns a list of evaluator generation jobs.",
+        "description": "Returns a list of evaluator generation jobs. The List API has up to a few\nseconds of propagation delay, so a recently created job may not appear\nimmediately; use the Get evaluator generation job API with the job ID to\nretrieve a specific job without delay.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -29474,6 +29474,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+          },
           "definition": {
             "allOf": [
               {
@@ -29558,6 +29565,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
+          },
           "definition": {
             "allOf": [
               {
@@ -29600,6 +29614,13 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
+          },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -19938,6 +19938,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20001,6 +20003,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20035,6 +20039,8 @@ components:
           items:
             $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
+          default:
+            - turn
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -6088,7 +6088,11 @@ paths:
     get:
       operationId: EvaluatorGenerationJobs_list
       summary: List evaluator generation jobs
-      description: Returns a list of evaluator generation jobs.
+      description: |-
+        Returns a list of evaluator generation jobs. The List API has up to a few
+        seconds of propagation delay, so a recently created job may not appear
+        immediately; use the Get evaluator generation job API with the job ID to
+        retrieve a specific job without delay.
       parameters:
         - name: Foundry-Features
           in: header
@@ -19929,6 +19933,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19987,6 +19996,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20016,6 +20030,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -292,6 +292,9 @@ model EvaluatorVersion {
   @doc("The categories of the evaluator")
   categories: EvaluatorCategory[];
 
+  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).")
+  supported_evaluation_levels?: EvaluationLevel[];
+
   @doc("Definition of the evaluator")
   @visibility(Lifecycle.Create, Lifecycle.Read)
   definition: EvaluatorDefinition;

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -293,7 +293,7 @@ model EvaluatorVersion {
   categories: EvaluatorCategory[];
 
   @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).")
-  supported_evaluation_levels?: EvaluationLevel[];
+  supported_evaluation_levels?: EvaluationLevel[] = #[EvaluationLevel.turn];
 
   @doc("Definition of the evaluator")
   @visibility(Lifecycle.Create, Lifecycle.Read)

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp
@@ -217,7 +217,10 @@ interface EvaluatorGenerationJobs {
   >;
 
   /**
-   * Returns a list of evaluator generation jobs.
+   * Returns a list of evaluator generation jobs. The List API has up to a few
+   * seconds of propagation delay, so a recently created job may not appear
+   * immediately; use the Get evaluator generation job API with the job ID to
+   * retrieve a specific job without delay.
    */
   @summary("List evaluator generation jobs")
   @route("evaluator_generation_jobs")


### PR DESCRIPTION
# Summary

Two related evaluator-API changes:

1. **Add `supported_evaluation_levels` to `EvaluatorVersion`** — surface a field the Foundry RAI evaluation service already accepts and validates, so SDKs and OpenAPI consumers can rely on it.
2. **Note the List evaluator generation jobs propagation delay** — the List API has up to a few seconds of propagation delay; callers should use Get for an immediate read on a specific job.

# Changes

## 1. `supported_evaluation_levels` on `EvaluatorVersion`

In `specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp`, on `model EvaluatorVersion`, next to `categories`:

```typespec
@doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).")
supported_evaluation_levels?: EvaluationLevel[];
```

Service-side behavior already in place (source: `RAISvc/Contracts/Evaluations/Evaluators.cs`):

| Context | Type (C#) | Behavior |
|---|---|---|
| `Evaluator` (read) | `List<EvaluationLevel>` | Always present; service defaults to `[turn]` when none are set |
| `CreateEvaluatorRequest` | `List<EvaluationLevel>?` | Optional; omitted → service defaults to `[turn]` |
| `UpdateEvaluatorRequest` | `List<EvaluationLevel>?` | Optional; omitted → no change. Empty list rejected. |

Reuses the existing `EvaluationLevel` union (`turn` / `conversation`) declared in `openai-evaluations/models.tsp` (same `Azure.AI.Projects` namespace) — no new union introduced.

## 2. List evaluator generation jobs propagation delay note

In `specification/ai-foundry/data-plane/Foundry/src/evaluators/routes.tsp`, on `EvaluatorGenerationJobs.list`:

```diff
   /**
-   * Returns a list of evaluator generation jobs.
+   * Returns a list of evaluator generation jobs. The List API has up to a few
+   * seconds of propagation delay, so a recently created job may not appear
+   * immediately; use the Get evaluator generation job API with the job ID to
+   * retrieve a specific job without delay.
    */
   @summary("List evaluator generation jobs")
```

# Generated artifacts

Regenerated both `openapi3` outputs via `npx tsp compile .` from `specification/ai-foundry/data-plane/Foundry`:

- `openapi3/v1/microsoft-foundry-openapi3.{json,yaml}`
- `openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}`

# Validation

- `npx tsp compile . --warn-as-error` — passes, no new warnings.
- Diff stat: `6 files changed, 91 insertions(+), 5 deletions(-)` — pure addition modulo the propagation-delay docstring rewrite.

# Branch target

Targeting `feature/foundry-release` (the working branch for the v1 Foundry surface), matching other recent Foundry PRs.

# Supersedes

This PR now also covers the changes originally in #43792, which is being closed in favor of this combined PR.