### PR TITLE
Suppress CustomerManagedKeyEncryption deprecation in devcenter spec

### DIFF
--- a/specification/devcenter/DevCenter.Management/client.tsp
+++ b/specification/devcenter/DevCenter.Management/client.tsp
@@ -223,6 +223,7 @@ using Microsoft.DevCenter;
 );
 @@clientName(CatalogSyncError, "DevCenterCatalogSyncError", "csharp");
 @@clientName(ConfigurationPolicies, "DevCenterConfigurationPolicies", "csharp");
+#suppress "deprecated" "Continuing to use v4 CustomerManagedKeyEncryption for backward compatibility"
 @@clientName(
   Azure.ResourceManager.CommonTypes.CustomerManagedKeyEncryption,
   "DevCenterCustomerManagedKeyEncryption",

--- a/specification/devcenter/DevCenter.Management/models.tsp
+++ b/specification/devcenter/DevCenter.Management/models.tsp
@@ -685,6 +685,7 @@ model DevCenterUpdateProperties {
 @doc("Encryption properties.")
 model Encryption {
   @doc("All Customer-managed key encryption properties for the resource.")
+  #suppress "deprecated" "Continuing to use v4 CustomerManagedKeyEncryption for backward compatibility"
   customerManagedKeyEncryption?: CustomerManagedKeyEncryption;
 }
 


### PR DESCRIPTION
## Summary
- add #suppress "deprecated" directives in the devcenter TypeSpec files that reference CustomerManagedKeyEncryption
- keep the existing v4 common-types references for backward compatibility
- align the spec with the accompanying typespec-azure deprecation change

Companion PR: https://github.com/Azure/typespec-azure/pull/4532