### PR TITLE
DurableTask: refactor TypeSpec into per-resource files and add 2026-05-01-preview API version

### DIFF
--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Operations_List.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Operations_List.json
@@ -1,0 +1,36 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "display": {
+              "description": "Create or Update Durable Task Scheduler",
+              "operation": "Create or Update Durable Task Scheduler",
+              "provider": "Durable Task Scheduler",
+              "resource": "Scheduler"
+            },
+            "isDataAction": false,
+            "name": "Microsoft.DurableTask/schedulers/write"
+          },
+          {
+            "display": {
+              "description": "Delete Durable Task Scheduler",
+              "operation": "Delete Durable Task Scheduler",
+              "provider": "Durable Task Scheduler",
+              "resource": "Scheduler"
+            },
+            "isDataAction": false,
+            "name": "Microsoft.DurableTask/schedulers/delete"
+          }
+        ],
+        "nextLink": "https://microsoft.com/akpblld"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Create_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Create_MaximumSet_Gen.json
@@ -1,0 +1,84 @@
+{
+  "title": "PrivateEndpointConnections_Create_MaximumSet",
+  "operationId": "Schedulers_CreateOrUpdatePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu",
+    "resource": {
+      "properties": {
+        "privateEndpoint": {},
+        "privateLinkServiceConnectionState": {
+          "status": "Pending",
+          "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+          "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Delete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "PrivateEndpointConnections_Delete_MaximumSet",
+  "operationId": "Schedulers_DeletePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Get_MaximumSet_Gen.json
@@ -1,0 +1,42 @@
+{
+  "title": "PrivateEndpointConnections_Get_MaximumSet",
+  "operationId": "Schedulers_GetPrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_List_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_List_MaximumSet_Gen.json
@@ -1,0 +1,46 @@
+{
+  "title": "PrivateEndpointConnections_List_MaximumSet",
+  "operationId": "Schedulers_ListPrivateEndpointConnections",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "privateEndpoint": {
+                "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+              },
+              "privateLinkServiceConnectionState": {
+                "status": "Pending",
+                "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+                "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+              },
+              "groupIds": [
+                "xnnrzmowptxnijdojrntrbm"
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+            "name": "spzckqrbhfnabu",
+            "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/anend"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Update.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateEndpointConnections_Update.json
@@ -1,0 +1,54 @@
+{
+  "title": "PrivateEndpointConnections_Update",
+  "operationId": "Schedulers_UpdatePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "status": "Approved"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateLinkResources_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateLinkResources_Get_MaximumSet_Gen.json
@@ -1,0 +1,37 @@
+{
+  "title": "PrivateLinkResources_Get_MaximumSet",
+  "operationId": "Schedulers_GetPrivateLink",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateLinkResourceName": "ulbdiqhrmwnkejje"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "groupId": "mexetpneryldlrtmuxzxhwezfjkcvr",
+          "requiredMembers": [
+            "ftzshharzmwhcemnbdwlmyhtxkpa"
+          ],
+          "requiredZoneNames": [
+            "lkwwgycaduib"
+          ]
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateLinkResources/ulbdiqhrmwnkejje",
+        "name": "ulbdiqhrmwnkejje",
+        "type": "Microsoft.DurableTask/schedulers/privateLinkResources",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateLinkResources_List_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/PrivateLinkResources_List_MaximumSet_Gen.json
@@ -1,0 +1,41 @@
+{
+  "title": "PrivateLinkResources_List_MaximumSet",
+  "operationId": "Schedulers_ListPrivateLinks",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "groupId": "mexetpneryldlrtmuxzxhwezfjkcvr",
+              "requiredMembers": [
+                "ftzshharzmwhcemnbdwlmyhtxkpa"
+              ],
+              "requiredZoneNames": [
+                "lkwwgycaduib"
+              ]
+            },
+            "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateLinkResources/ulbdiqhrmwnkejje",
+            "name": "ulbdiqhrmwnkejje",
+            "type": "Microsoft.DurableTask/schedulers/privateLinkResources",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_CreateOrReplace_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_CreateOrReplace_MaximumSet_Gen.json
@@ -1,0 +1,83 @@
+{
+  "title": "RetentionPolicies_CreateOrReplace_MaximumSet",
+  "operationId": "RetentionPolicies_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default",
+    "resource": {
+      "properties": {
+        "retentionPolicies": [
+          {
+            "retentionPeriodInDays": 30
+          },
+          {
+            "retentionPeriodInDays": 10,
+            "orchestrationState": "Failed"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Delete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "RetentionPolicies_Delete_MaximumSet",
+  "operationId": "RetentionPolicies_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testcheduler",
+    "retentionPolicyName": "default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Get_MaximumSet_Gen.json
@@ -1,0 +1,40 @@
+{
+  "title": "RetentionPolicies_Get_MaximumSet",
+  "operationId": "RetentionPolicies_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_ListByScheduler_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_ListByScheduler_MaximumSet_Gen.json
@@ -1,0 +1,44 @@
+{
+  "title": "RetentionPolicies_ListByScheduler_MaximumSet",
+  "operationId": "RetentionPolicies_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "myscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "retentionPolicies": [
+                {
+                  "retentionPeriodInDays": 30
+                },
+                {
+                  "retentionPeriodInDays": 10,
+                  "orchestrationState": "Failed"
+                }
+              ]
+            },
+            "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+            "name": "default",
+            "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+            "systemData": {
+              "createdBy": "zshkmc",
+              "createdByType": "User",
+              "createdAt": "2025-03-31T23:34:09.612Z",
+              "lastModifiedBy": "ivqrae",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ai"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Update_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/RetentionPolicies_Update_MaximumSet_Gen.json
@@ -1,0 +1,65 @@
+{
+  "title": "RetentionPolicies_Update_MaximumSet",
+  "operationId": "RetentionPolicies_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default",
+    "properties": {
+      "properties": {
+        "retentionPolicies": [
+          {
+            "retentionPeriodInDays": 30
+          },
+          {
+            "retentionPeriodInDays": 10,
+            "orchestrationState": "Failed"
+          },
+          {
+            "retentionPeriodInDays": 24,
+            "orchestrationState": "Completed"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            },
+            {
+              "retentionPeriodInDays": 24,
+              "orchestrationState": "Completed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_CreateOrUpdate.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_CreateOrUpdate.json
@@ -1,0 +1,106 @@
+{
+  "title": "Schedulers_CreateOrUpdate",
+  "operationId": "Schedulers_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "resource": {
+      "location": "northcentralus",
+      "properties": {
+        "ipAllowlist": [
+          "10.0.0.0/8"
+        ],
+        "sku": {
+          "name": "Dedicated"
+        }
+      },
+      "tags": {
+        "department": "research",
+        "development": "true"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+          }
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Delete.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "Schedulers_Delete",
+  "operationId": "Schedulers_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Get.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Get.json
@@ -1,0 +1,46 @@
+{
+  "title": "Schedulers_Get",
+  "operationId": "Schedulers_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          },
+          "publicNetworkAccess": "Enabled",
+          "privateEndpointConnections": []
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_ListByResourceGroup.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_ListByResourceGroup.json
@@ -1,0 +1,50 @@
+{
+  "title": "Schedulers_ListByResourceGroup",
+  "operationId": "Schedulers_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+            "location": "northcentralus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "endpoint": "https://test.northcentralus.1.durabletask.io",
+              "ipAllowlist": [
+                "10.0.0.0/8"
+              ],
+              "sku": {
+                "name": "Dedicated",
+                "capacity": 3,
+                "redundancyState": "Zone"
+              },
+              "publicNetworkAccess": "Enabled",
+              "privateEndpointConnections": []
+            },
+            "tags": {
+              "department": "research",
+              "development": "true"
+            },
+            "name": "testscheduler",
+            "type": "Microsoft.DurableTask/schedulers",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_ListBySubscription.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_ListBySubscription.json
@@ -1,0 +1,49 @@
+{
+  "title": "Schedulers_ListBySubscription",
+  "operationId": "Schedulers_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+            "location": "northcentralus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "endpoint": "https://test.northcentralus.1.durabletask.io",
+              "ipAllowlist": [
+                "10.0.0.0/8"
+              ],
+              "sku": {
+                "name": "Dedicated",
+                "capacity": 3,
+                "redundancyState": "Zone"
+              },
+              "publicNetworkAccess": "Enabled",
+              "privateEndpointConnections": []
+            },
+            "tags": {
+              "department": "research",
+              "development": "true"
+            },
+            "name": "testscheduler",
+            "type": "Microsoft.DurableTask/schedulers",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Restart.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Restart.json
@@ -1,0 +1,13 @@
+{
+  "title": "Schedulers_Restart",
+  "operationId": "Schedulers_Restart",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Update.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/Schedulers_Update.json
@@ -1,0 +1,70 @@
+{
+  "title": "Schedulers_Update",
+  "operationId": "Schedulers_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "properties": {
+      "tags": {
+        "hello": "world"
+      },
+      "properties": {
+        "ipAllowlist": [
+          "10.0.0.0/8"
+        ],
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 3
+        }
+      },
+      "identity": {
+        "type": "None"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true",
+          "hello": "world"
+        },
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_CreateOrUpdate.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_CreateOrUpdate.json
@@ -1,0 +1,64 @@
+{
+  "title": "TaskHubs_CreateOrUpdate",
+  "operationId": "TaskHubs_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub",
+    "resource": {
+      "properties": {
+        "capabilities": [
+          "ExampleFutureCapability"
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub",
+          "capabilities": [
+            "ExampleFutureCapability"
+          ]
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub",
+          "capabilities": [
+            "ExampleFutureCapability"
+          ]
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_Delete.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "TaskHubs_Delete",
+  "operationId": "TaskHubs_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_Get.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_Get.json
@@ -1,0 +1,32 @@
+{
+  "title": "TaskHubs_Get",
+  "operationId": "TaskHubs_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_ListByScheduler.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TaskHubs_ListByScheduler.json
@@ -1,0 +1,36 @@
+{
+  "title": "TaskHubs_ListByScheduler",
+  "operationId": "TaskHubs_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub"
+            },
+            "name": "testtaskhub",
+            "type": "Microsoft.DurableTask/schedulers/taskHubs",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_CreateOrReplace_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_CreateOrReplace_MaximumSet_Gen.json
@@ -1,0 +1,61 @@
+{
+  "title": "TransparentDataEncryptions_CreateOrReplace_MaximumSet",
+  "operationId": "TransparentDataEncryptions_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "resource": {
+      "properties": {
+        "keySource": "CustomerManaged",
+        "keyVaultKeyUri": "https://microsoft.com/ap"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_Delete_MaximumSet_Gen.json
@@ -1,0 +1,18 @@
+{
+  "title": "TransparentDataEncryptions_Delete_MaximumSet",
+  "operationId": "TransparentDataEncryptions_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_Get_MaximumSet_Gen.json
@@ -1,0 +1,32 @@
+{
+  "title": "TransparentDataEncryptions_Get_MaximumSet",
+  "operationId": "TransparentDataEncryptions_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_ListByScheduler_MaximumSet_Gen.json
+++ b/specification/durabletask/DurableTask.Management/examples/2026-05-01-preview/TransparentDataEncryptions_ListByScheduler_MaximumSet_Gen.json
@@ -1,0 +1,37 @@
+{
+  "title": "TransparentDataEncryptions_ListByScheduler_MaximumSet",
+  "operationId": "TransparentDataEncryptions_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "keySource": "CustomerManaged",
+              "keyVaultKeyUri": "https://microsoft.com/ap"
+            },
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+            "name": "default",
+            "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/DurableTask.Management/main.tsp
+++ b/specification/durabletask/DurableTask.Management/main.tsp
@@ -2,6 +2,10 @@ import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-resource-manager";
+import "./scheduler.tsp";
+import "./taskhub.tsp";
+import "./retentionpolicy.tsp";
+import "./transparentDataEncryption.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Versioning;
@@ -13,12 +17,6 @@ using Azure.ResourceManager;
 namespace Microsoft.DurableTask;
 
 interface Operations extends Azure.ResourceManager.Operations {}
-
-model SchedulerPrivateLinkResource is PrivateLink;
-alias PrivateLinkOperations = PrivateLinks<SchedulerPrivateLinkResource>;
-
-model PrivateEndpointConnection is PrivateEndpointConnectionResource;
-alias PrivateEndpointOperations = PrivateEndpoints<PrivateEndpointConnection>;
 
 @doc("API Versions")
 enum Versions {
@@ -37,171 +35,10 @@ enum Versions {
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
   @doc("2026-02-01")
   v2026_02_01: "2026-02-01",
-}
 
-@doc("A Durable Task Scheduler resource")
-@added(Versions.v2024_10_01_Preview)
-model Scheduler is Azure.ResourceManager.TrackedResource<SchedulerProperties> {
-  ...ResourceNameParameter<
-    Scheduler,
-    "schedulerName",
-    "schedulers",
-    "^[a-zA-Z0-9-]{3,64}$"
-  >;
-}
-
-@doc("Details of the Scheduler")
-@added(Versions.v2024_10_01_Preview)
-model SchedulerProperties {
-  @visibility(Lifecycle.Read)
-  @doc("The status of the last operation")
-  provisioningState?: ProvisioningState;
-
-  @doc("URL of the durable task scheduler")
-  @visibility(Lifecycle.Read)
-  endpoint?: string;
-
-  @doc("IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR")
-  ipAllowlist: string[];
-
-  @doc("SKU of the durable task scheduler")
-  sku: SchedulerSku;
-
-  @added(Versions.v2026_02_01)
-  @doc("Allow or disallow public network access to durable task scheduler")
-  publicNetworkAccess?: PublicNetworkAccess;
-
-  /** The private endpoints exposed by this resource */
-  @added(Versions.v2026_02_01)
-  @visibility(Lifecycle.Read)
-  privateEndpointConnections?: PrivateEndpointConnection[];
-}
-
-@doc("The SKU (Stock Keeping Unit) assigned to this durable task scheduler")
-@added(Versions.v2024_10_01_Preview)
-model SchedulerSku {
-  @doc("The name of the SKU")
-  @typeChangedFrom(Versions.v2025_11_01, string)
-  name: SchedulerSkuName;
-
-  @doc("The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy")
-  capacity?: int32;
-
-  @doc("Indicates whether the current SKU configuration is zone redundant")
-  @visibility(Lifecycle.Read)
-  redundancyState?: RedundancyState;
-}
-
-@added(Versions.v2025_11_01)
-@doc("The name of the Stock Keeping Unit (SKU) of a Durable Task Scheduler")
-union SchedulerSkuName {
-  string,
-
-  @doc("Dedicated SKU")
-  Dedicated: "Dedicated",
-
-  @doc("Consumption SKU")
-  @added(Versions.v2025_04_01_Preview)
-  Consumption: "Consumption",
-}
-
-@doc("A Task Hub resource belonging to the scheduler")
-@added(Versions.v2024_10_01_Preview)
-@parentResource(Scheduler)
-model TaskHub is Azure.ResourceManager.ProxyResource<TaskHubProperties> {
-  ...ResourceNameParameter<
-    TaskHub,
-    "taskHubName",
-    "taskHubs",
-    "^[a-zA-Z0-9-]{3,64}$"
-  >;
-}
-
-@doc("The state of the resource redundancy")
-union RedundancyState {
-  string,
-
-  @doc("The resource is not redundant")
-  None: "None",
-
-  @doc("The resource is zone redundant")
-  Zone: "Zone",
-}
-
-@doc("The properties of Task Hub")
-model TaskHubProperties {
-  @visibility(Lifecycle.Read)
-  @doc("The status of the last operation")
-  provisioningState?: ProvisioningState;
-
-  @doc("URL of the durable task scheduler dashboard")
-  @visibility(Lifecycle.Read)
-  dashboardUrl?: url;
-}
-
-@doc("A retention policy resource belonging to the scheduler")
-@added(Versions.v2025_04_01_Preview)
-@parentResource(Scheduler)
-@singleton
-model RetentionPolicy
-  is Azure.ResourceManager.ProxyResource<RetentionPolicyProperties> {
-  ...ResourceNameParameter<
-    RetentionPolicy,
-    "retentionPolicyName",
-    "retentionPolicies"
-  >;
-}
-
-@doc("The retention policy settings for the resource")
-@added(Versions.v2025_04_01_Preview)
-model RetentionPolicyProperties {
-  @visibility(Lifecycle.Read)
-  @doc("The status of the last operation")
-  provisioningState?: ProvisioningState;
-
-  @doc("The orchestration retention policies")
-  @identifiers(#["retentionPeriodInDays", "orchestrationState"])
-  retentionPolicies?: RetentionPolicyDetails[];
-}
-
-@doc("The properties of a retention policy")
-@added(Versions.v2025_04_01_Preview)
-model RetentionPolicyDetails {
-  @doc("The retention period in days after which the orchestration will be purged automatically")
-  retentionPeriodInDays: int32;
-
-  @doc("The orchestration state to which this policy applies. If omitted, the policy applies to all purgeable orchestration states.")
-  orchestrationState?: PurgeableOrchestrationState;
-}
-
-@doc("State of the public network access.")
-@added(Versions.v2026_02_01)
-union PublicNetworkAccess {
-  string,
-
-  @doc("The public network access is enabled")
-  Enabled: "Enabled",
-
-  @doc("The public network access is disabled")
-  Disabled: "Disabled",
-}
-
-@doc("Purgeable orchestration state to be used in retention policies")
-@added(Versions.v2025_04_01_Preview)
-union PurgeableOrchestrationState {
-  string,
-
-  @doc("The orchestration is completed")
-  Completed: "Completed",
-
-  @doc("The orchestration is failed")
-  Failed: "Failed",
-
-  @doc("The orchestration is terminated")
-  Terminated: "Terminated",
-
-  @doc("The orchestration is canceled")
-  Canceled: "Canceled",
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+  @doc("2026-05-01-preview")
+  v2026_05_01_Preview: "2026-05-01-preview",
 }
 
 @doc("The status of the current operation")
@@ -221,117 +58,4 @@ union ProvisioningState {
 
   @doc("The resource create request has been accepted")
   Accepted: "Accepted",
-}
-
-@doc("The update request model for the Scheduler resource")
-model SchedulerUpdate
-  is UpdateableProperties<Azure.ResourceManager.TrackedResource<SchedulerPropertiesUpdate>>;
-
-@doc("The Scheduler resource properties to be updated")
-model SchedulerPropertiesUpdate {
-  @visibility(Lifecycle.Read)
-  @doc("The status of the last operation")
-  provisioningState?: ProvisioningState;
-
-  @doc("URL of the durable task scheduler")
-  @visibility(Lifecycle.Read)
-  endpoint?: string;
-
-  @doc("IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR")
-  ipAllowlist?: string[];
-
-  @doc("SKU of the durable task scheduler")
-  sku?: SchedulerSkuUpdate;
-
-  @added(Versions.v2026_02_01)
-  @doc("Allow or disallow public network access to durable task scheduler")
-  publicNetworkAccess?: PublicNetworkAccess;
-}
-
-@doc("The SKU (Stock Keeping Unit) properties to be updated")
-model SchedulerSkuUpdate {
-  @doc("The name of the SKU")
-  @typeChangedFrom(Versions.v2025_11_01, string)
-  name?: SchedulerSkuName;
-
-  @doc("The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy")
-  capacity?: int32;
-
-  @doc("Indicates whether the current SKU configuration is zone redundant")
-  @visibility(Lifecycle.Read)
-  redundancyState?: RedundancyState;
-}
-
-@armResourceOperations(Scheduler)
-interface Schedulers {
-  @doc("Get a Scheduler")
-  @errorsDoc("Not found error: resource does not exist")
-  get is ArmResourceRead<Scheduler>;
-  @doc("Create or update a Scheduler")
-  @errorsDoc("Validation error: required parameters are missing")
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<Scheduler>;
-  @doc("Update a Scheduler")
-  @errorsDoc("Validation error: required parameters are missing")
-  update is ArmCustomPatchAsync<Scheduler, SchedulerUpdate>;
-  @doc("Delete a Scheduler")
-  delete is ArmResourceDeleteWithoutOkAsync<Scheduler>;
-  @doc("List Schedulers by resource group")
-  listByResourceGroup is ArmResourceListByParent<Scheduler>;
-  @doc("List Schedulers by subscription")
-  listBySubscription is ArmListBySubscription<Scheduler>;
-
-  @added(Versions.v2026_02_01)
-  @doc("Get a private link resource for the durable task scheduler")
-  getPrivateLink is PrivateLinkOperations.Read<Scheduler>;
-  @added(Versions.v2026_02_01)
-  @doc("List private link resources for the durable task scheduler")
-  listPrivateLinks is PrivateLinkOperations.ListByParent<Scheduler>;
-
-  @added(Versions.v2026_02_01)
-  @doc("Get a private endpoint connection for the durable task scheduler")
-  getPrivateEndpointConnection is PrivateEndpointOperations.Read<Scheduler>;
-  @added(Versions.v2026_02_01)
-  @doc("Create or update a private endpoint connection for the durable task scheduler")
-  createOrUpdatePrivateEndpointConnection is PrivateEndpointOperations.CreateOrUpdateAsync<Scheduler>;
-  @added(Versions.v2026_02_01)
-  @doc("Update a private endpoint connection for the durable task scheduler")
-  updatePrivateEndpointConnection is PrivateEndpointOperations.CustomPatchAsync<Scheduler>;
-  @added(Versions.v2026_02_01)
-  @doc("Delete a private endpoint connection for the durable task scheduler")
-  deletePrivateEndpointConnection is PrivateEndpointOperations.DeleteAsync<Scheduler>;
-  @added(Versions.v2026_02_01)
-  @doc("List private endpoint connections for the durable task scheduler")
-  listPrivateEndpointConnections is PrivateEndpointOperations.ListByParent<Scheduler>;
-}
-
-@armResourceOperations(TaskHub)
-interface TaskHubs {
-  @doc("Get a Task Hub")
-  @errorsDoc("Not found error: resource does not exist")
-  get is ArmResourceRead<TaskHub>;
-  @doc("Create or Update a Task Hub")
-  @errorsDoc("Validation error: required parameters are missing")
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<TaskHub>;
-  @doc("Delete a Task Hub")
-  delete is ArmResourceDeleteWithoutOkAsync<TaskHub>;
-  @doc("List Task Hubs")
-  listByScheduler is ArmResourceListByParent<TaskHub>;
-}
-
-@added(Versions.v2025_04_01_Preview)
-@armResourceOperations(RetentionPolicy)
-interface RetentionPolicies {
-  @doc("Get a Retention Policy")
-  @errorsDoc("Not found error: resource does not exist")
-  get is ArmResourceRead<RetentionPolicy>;
-  @doc("Create or Update a Retention Policy")
-  @errorsDoc("Validation error: required parameters are missing")
-  createOrReplace is ArmResourceCreateOrReplaceAsync<RetentionPolicy>;
-  @doc("Update a Retention Policy")
-  @errorsDoc("Validation error: required parameters are missing")
-  update is ArmResourcePatchAsync<RetentionPolicy, RetentionPolicyProperties>;
-  @doc("Delete a Retention Policy")
-  delete is ArmResourceDeleteWithoutOkAsync<RetentionPolicy>;
-  @doc("List Retention Policies")
-  listByScheduler is ArmResourceListByParent<RetentionPolicy>;
 }

--- a/specification/durabletask/DurableTask.Management/retentionpolicy.tsp
+++ b/specification/durabletask/DurableTask.Management/retentionpolicy.tsp
@@ -1,0 +1,81 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.DurableTask;
+
+@doc("A retention policy resource belonging to the scheduler")
+@added(Versions.v2025_04_01_Preview)
+@parentResource(Scheduler)
+@singleton
+model RetentionPolicy
+  is Azure.ResourceManager.ProxyResource<RetentionPolicyProperties> {
+  ...ResourceNameParameter<
+    RetentionPolicy,
+    "retentionPolicyName",
+    "retentionPolicies"
+  >;
+}
+
+@doc("The retention policy settings for the resource")
+@added(Versions.v2025_04_01_Preview)
+model RetentionPolicyProperties {
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation")
+  provisioningState?: ProvisioningState;
+
+  @doc("The orchestration retention policies")
+  @identifiers(#["retentionPeriodInDays", "orchestrationState"])
+  retentionPolicies?: RetentionPolicyDetails[];
+}
+
+@doc("The properties of a retention policy")
+@added(Versions.v2025_04_01_Preview)
+model RetentionPolicyDetails {
+  @doc("The retention period in days after which the orchestration will be purged automatically")
+  retentionPeriodInDays: int32;
+
+  @doc("The orchestration state to which this policy applies. If omitted, the policy applies to all purgeable orchestration states.")
+  orchestrationState?: PurgeableOrchestrationState;
+}
+
+@doc("Purgeable orchestration state to be used in retention policies")
+@added(Versions.v2025_04_01_Preview)
+union PurgeableOrchestrationState {
+  string,
+
+  @doc("The orchestration is completed")
+  Completed: "Completed",
+
+  @doc("The orchestration is failed")
+  Failed: "Failed",
+
+  @doc("The orchestration is terminated")
+  Terminated: "Terminated",
+
+  @doc("The orchestration is canceled")
+  Canceled: "Canceled",
+}
+
+@added(Versions.v2025_04_01_Preview)
+@armResourceOperations(RetentionPolicy)
+interface RetentionPolicies {
+  @doc("Get a Retention Policy")
+  @errorsDoc("Not found error: resource does not exist")
+  get is ArmResourceRead<RetentionPolicy>;
+  @doc("Create or Update a Retention Policy")
+  @errorsDoc("Validation error: required parameters are missing")
+  createOrReplace is ArmResourceCreateOrReplaceAsync<RetentionPolicy>;
+  @doc("Update a Retention Policy")
+  @errorsDoc("Validation error: required parameters are missing")
+  update is ArmResourcePatchAsync<RetentionPolicy, RetentionPolicyProperties>;
+  @doc("Delete a Retention Policy")
+  delete is ArmResourceDeleteWithoutOkAsync<RetentionPolicy>;
+  @doc("List Retention Policies")
+  listByScheduler is ArmResourceListByParent<RetentionPolicy>;
+}

--- a/specification/durabletask/DurableTask.Management/scheduler.tsp
+++ b/specification/durabletask/DurableTask.Management/scheduler.tsp
@@ -1,0 +1,197 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.DurableTask;
+
+model SchedulerPrivateLinkResource is PrivateLink;
+alias PrivateLinkOperations = PrivateLinks<SchedulerPrivateLinkResource>;
+
+model PrivateEndpointConnection is PrivateEndpointConnectionResource;
+alias PrivateEndpointOperations = PrivateEndpoints<PrivateEndpointConnection>;
+
+@doc("A Durable Task Scheduler resource")
+@added(Versions.v2024_10_01_Preview)
+model Scheduler is Azure.ResourceManager.TrackedResource<SchedulerProperties> {
+  ...ResourceNameParameter<
+    Scheduler,
+    "schedulerName",
+    "schedulers",
+    "^[a-zA-Z0-9-]{3,64}$"
+  >;
+  ...ManagedServiceIdentityProperty;
+}
+
+@@added(Scheduler.identity, Versions.v2026_05_01_Preview);
+
+@doc("Details of the Scheduler")
+@added(Versions.v2024_10_01_Preview)
+model SchedulerProperties {
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation")
+  provisioningState?: ProvisioningState;
+
+  @doc("URL of the durable task scheduler")
+  @visibility(Lifecycle.Read)
+  endpoint?: string;
+
+  @doc("IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR")
+  ipAllowlist: string[];
+
+  @doc("SKU of the durable task scheduler")
+  sku: SchedulerSku;
+
+  @added(Versions.v2026_02_01)
+  @doc("Allow or disallow public network access to durable task scheduler")
+  publicNetworkAccess?: PublicNetworkAccess;
+
+  /** The private endpoints exposed by this resource */
+  @added(Versions.v2026_02_01)
+  @visibility(Lifecycle.Read)
+  privateEndpointConnections?: PrivateEndpointConnection[];
+}
+
+@doc("The SKU (Stock Keeping Unit) assigned to this durable task scheduler")
+@added(Versions.v2024_10_01_Preview)
+model SchedulerSku {
+  @doc("The name of the SKU")
+  @typeChangedFrom(Versions.v2025_11_01, string)
+  name: SchedulerSkuName;
+
+  @doc("The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy")
+  capacity?: int32;
+
+  @doc("Indicates whether the current SKU configuration is zone redundant")
+  @visibility(Lifecycle.Read)
+  redundancyState?: RedundancyState;
+}
+
+@added(Versions.v2025_11_01)
+@doc("The name of the Stock Keeping Unit (SKU) of a Durable Task Scheduler")
+union SchedulerSkuName {
+  string,
+
+  @doc("Dedicated SKU")
+  Dedicated: "Dedicated",
+
+  @doc("Consumption SKU")
+  @added(Versions.v2025_04_01_Preview)
+  Consumption: "Consumption",
+}
+
+@doc("The state of the resource redundancy")
+union RedundancyState {
+  string,
+
+  @doc("The resource is not redundant")
+  None: "None",
+
+  @doc("The resource is zone redundant")
+  Zone: "Zone",
+}
+
+@doc("State of the public network access.")
+@added(Versions.v2026_02_01)
+union PublicNetworkAccess {
+  string,
+
+  @doc("The public network access is enabled")
+  Enabled: "Enabled",
+
+  @doc("The public network access is disabled")
+  Disabled: "Disabled",
+}
+
+@doc("The update request model for the Scheduler resource")
+model SchedulerUpdate
+  is UpdateableProperties<Azure.ResourceManager.TrackedResource<SchedulerPropertiesUpdate>> {
+  ...ManagedServiceIdentityProperty;
+}
+
+@@added(SchedulerUpdate.identity, Versions.v2026_05_01_Preview);
+
+@doc("The Scheduler resource properties to be updated")
+model SchedulerPropertiesUpdate {
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation")
+  provisioningState?: ProvisioningState;
+
+  @doc("URL of the durable task scheduler")
+  @visibility(Lifecycle.Read)
+  endpoint?: string;
+
+  @doc("IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR")
+  ipAllowlist?: string[];
+
+  @doc("SKU of the durable task scheduler")
+  sku?: SchedulerSkuUpdate;
+
+  @added(Versions.v2026_02_01)
+  @doc("Allow or disallow public network access to durable task scheduler")
+  publicNetworkAccess?: PublicNetworkAccess;
+}
+
+@doc("The SKU (Stock Keeping Unit) properties to be updated")
+model SchedulerSkuUpdate {
+  @doc("The name of the SKU")
+  @typeChangedFrom(Versions.v2025_11_01, string)
+  name?: SchedulerSkuName;
+
+  @doc("The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy")
+  capacity?: int32;
+
+  @doc("Indicates whether the current SKU configuration is zone redundant")
+  @visibility(Lifecycle.Read)
+  redundancyState?: RedundancyState;
+}
+
+@armResourceOperations(Scheduler)
+interface Schedulers {
+  @doc("Get a Scheduler")
+  @errorsDoc("Not found error: resource does not exist")
+  get is ArmResourceRead<Scheduler>;
+  @doc("Create or update a Scheduler")
+  @errorsDoc("Validation error: required parameters are missing")
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Scheduler>;
+  @doc("Update a Scheduler")
+  @errorsDoc("Validation error: required parameters are missing")
+  update is ArmCustomPatchAsync<Scheduler, SchedulerUpdate>;
+  @doc("Delete a Scheduler")
+  delete is ArmResourceDeleteWithoutOkAsync<Scheduler>;
+  @doc("List Schedulers by resource group")
+  listByResourceGroup is ArmResourceListByParent<Scheduler>;
+  @doc("List Schedulers by subscription")
+  listBySubscription is ArmListBySubscription<Scheduler>;
+
+  @added(Versions.v2026_02_01)
+  @doc("Get a private link resource for the durable task scheduler")
+  getPrivateLink is PrivateLinkOperations.Read<Scheduler>;
+  @added(Versions.v2026_02_01)
+  @doc("List private link resources for the durable task scheduler")
+  listPrivateLinks is PrivateLinkOperations.ListByParent<Scheduler>;
+
+  @added(Versions.v2026_02_01)
+  @doc("Get a private endpoint connection for the durable task scheduler")
+  getPrivateEndpointConnection is PrivateEndpointOperations.Read<Scheduler>;
+  @added(Versions.v2026_02_01)
+  @doc("Create or update a private endpoint connection for the durable task scheduler")
+  createOrUpdatePrivateEndpointConnection is PrivateEndpointOperations.CreateOrUpdateAsync<Scheduler>;
+  @added(Versions.v2026_02_01)
+  @doc("Update a private endpoint connection for the durable task scheduler")
+  updatePrivateEndpointConnection is PrivateEndpointOperations.CustomPatchAsync<Scheduler>;
+  @added(Versions.v2026_02_01)
+  @doc("Delete a private endpoint connection for the durable task scheduler")
+  deletePrivateEndpointConnection is PrivateEndpointOperations.DeleteAsync<Scheduler>;
+  @added(Versions.v2026_02_01)
+  @doc("List private endpoint connections for the durable task scheduler")
+  listPrivateEndpointConnections is PrivateEndpointOperations.ListByParent<Scheduler>;
+
+  @added(Versions.v2026_05_01_Preview)
+  @doc("Restart a Scheduler")
+  restart is ArmResourceActionSync<Scheduler, void, void>;
+}

--- a/specification/durabletask/DurableTask.Management/taskhub.tsp
+++ b/specification/durabletask/DurableTask.Management/taskhub.tsp
@@ -1,0 +1,51 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.DurableTask;
+
+@doc("A Task Hub resource belonging to the scheduler")
+@added(Versions.v2024_10_01_Preview)
+@parentResource(Scheduler)
+model TaskHub is Azure.ResourceManager.ProxyResource<TaskHubProperties> {
+  ...ResourceNameParameter<
+    TaskHub,
+    "taskHubName",
+    "taskHubs",
+    "^[a-zA-Z0-9-]{3,64}$"
+  >;
+}
+
+@doc("The properties of Task Hub")
+model TaskHubProperties {
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation")
+  provisioningState?: ProvisioningState;
+
+  @doc("URL of the durable task scheduler dashboard")
+  @visibility(Lifecycle.Read)
+  dashboardUrl?: url;
+
+  @added(Versions.v2026_05_01_Preview)
+  @doc("A set of Task Hub capabilities that can be enabled or disabled for a Task Hub")
+  capabilities?: string[];
+}
+
+@armResourceOperations(TaskHub)
+interface TaskHubs {
+  @doc("Get a Task Hub")
+  @errorsDoc("Not found error: resource does not exist")
+  get is ArmResourceRead<TaskHub>;
+  @doc("Create or Update a Task Hub")
+  @errorsDoc("Validation error: required parameters are missing")
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<TaskHub>;
+  @doc("Delete a Task Hub")
+  delete is ArmResourceDeleteWithoutOkAsync<TaskHub>;
+  @doc("List Task Hubs")
+  listByScheduler is ArmResourceListByParent<TaskHub>;
+}

--- a/specification/durabletask/DurableTask.Management/transparentDataEncryption.tsp
+++ b/specification/durabletask/DurableTask.Management/transparentDataEncryption.tsp
@@ -1,0 +1,64 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.DurableTask;
+
+@doc("A transparent data encryption resource belonging to the scheduler")
+@added(Versions.v2026_05_01_Preview)
+@parentResource(Scheduler)
+@singleton
+model TransparentDataEncryption
+  is Azure.ResourceManager.ProxyResource<TransparentDataEncryptionProperties> {
+  ...ResourceNameParameter<
+    TransparentDataEncryption,
+    "transparentDataEncryptionName",
+    "transparentDataEncryptions"
+  >;
+}
+
+@doc("The transparent data encryption settings for the resource")
+@added(Versions.v2026_05_01_Preview)
+model TransparentDataEncryptionProperties {
+  @visibility(Lifecycle.Read)
+  @doc("The status of the last operation")
+  provisioningState?: ProvisioningState;
+
+  @doc("The key source for the transparent data encryption")
+  keySource: TransparentDataEncryptionKeySource;
+
+  @doc("The URI of the key in Key Vault to be used for transparent data encryption")
+  keyVaultKeyUri?: url;
+}
+
+@added(Versions.v2026_05_01_Preview)
+@doc("The key source for the transparent data encryption")
+union TransparentDataEncryptionKeySource {
+  string,
+
+  @doc("The key source is Microsoft-managed")
+  MicrosoftManaged: "MicrosoftManaged",
+
+  @doc("The key source is customer-managed")
+  CustomerManaged: "CustomerManaged",
+}
+
+@added(Versions.v2026_05_01_Preview)
+@armResourceOperations(TransparentDataEncryption)
+interface TransparentDataEncryptions {
+  @doc("Get a Transparent Data Encryption")
+  @errorsDoc("Not found error: resource does not exist")
+  get is ArmResourceRead<TransparentDataEncryption>;
+  @doc("Create or Update a Transparent Data Encryption")
+  @errorsDoc("Validation error: required parameters are missing")
+  createOrReplace is ArmResourceCreateOrReplaceAsync<TransparentDataEncryption>;
+  @doc("Delete a Transparent Data Encryption")
+  delete is ArmResourceDeleteWithoutOkAsync<TransparentDataEncryption>;
+  @doc("List Transparent Data Encryptions")
+  listByScheduler is ArmResourceListByParent<TransparentDataEncryption>;
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/durabletask.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/durabletask.json
@@ -1,0 +1,2326 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.DurableTask",
+    "version": "2026-05-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Schedulers"
+    },
+    {
+      "name": "TaskHubs"
+    },
+    {
+      "name": "RetentionPolicies"
+    },
+    {
+      "name": "TransparentDataEncryptions"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.DurableTask/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DurableTask/schedulers": {
+      "get": {
+        "operationId": "Schedulers_ListBySubscription",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "List Schedulers by subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SchedulerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_ListBySubscription": {
+            "$ref": "./examples/Schedulers_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers": {
+      "get": {
+        "operationId": "Schedulers_ListByResourceGroup",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "List Schedulers by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SchedulerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_ListByResourceGroup": {
+            "$ref": "./examples/Schedulers_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}": {
+      "get": {
+        "operationId": "Schedulers_Get",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Get a Scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Scheduler"
+            }
+          },
+          "default": {
+            "description": "Not found error: resource does not exist",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_Get": {
+            "$ref": "./examples/Schedulers_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Schedulers_CreateOrUpdate",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Create or update a Scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Scheduler"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Scheduler' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Scheduler"
+            }
+          },
+          "201": {
+            "description": "Resource 'Scheduler' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Scheduler"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_CreateOrUpdate": {
+            "$ref": "./examples/Schedulers_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Schedulers_Update",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Update a Scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SchedulerUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Scheduler"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_Update": {
+            "$ref": "./examples/Schedulers_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Schedulers_Delete",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Delete a Scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_Delete": {
+            "$ref": "./examples/Schedulers_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "Schedulers_ListPrivateEndpointConnections",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "List private endpoint connections for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_List_MaximumSet": {
+            "$ref": "./examples/PrivateEndpointConnections_List_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "Schedulers_GetPrivateEndpointConnection",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Get a private endpoint connection for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Get_MaximumSet": {
+            "$ref": "./examples/PrivateEndpointConnections_Get_MaximumSet_Gen.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Schedulers_CreateOrUpdatePrivateEndpointConnection",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Create or update a private endpoint connection for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Create_MaximumSet": {
+            "$ref": "./examples/PrivateEndpointConnections_Create_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Schedulers_UpdatePrivateEndpointConnection",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Update a private endpoint connection for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Azure.ResourceManager.PrivateEndpointConnectionUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Update": {
+            "$ref": "./examples/PrivateEndpointConnections_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Schedulers_DeletePrivateEndpointConnection",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Delete a private endpoint connection for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/parameters/PrivateEndpointConnectionName"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateEndpointConnections_Delete_MaximumSet": {
+            "$ref": "./examples/PrivateEndpointConnections_Delete_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateLinkResources": {
+      "get": {
+        "operationId": "Schedulers_ListPrivateLinks",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "List private link resources for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SchedulerPrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_List_MaximumSet": {
+            "$ref": "./examples/PrivateLinkResources_List_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateLinkResources/{privateLinkResourceName}": {
+      "get": {
+        "operationId": "Schedulers_GetPrivateLink",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Get a private link resource for the durable task scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "privateLinkResourceName",
+            "in": "path",
+            "description": "The name of the private link associated with the Azure resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateLinkResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PrivateLinkResources_Get_MaximumSet": {
+            "$ref": "./examples/PrivateLinkResources_Get_MaximumSet_Gen.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/restart": {
+      "post": {
+        "operationId": "Schedulers_Restart",
+        "tags": [
+          "Schedulers"
+        ],
+        "description": "Restart a Scheduler",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Azure operation completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Schedulers_Restart": {
+            "$ref": "./examples/Schedulers_Restart.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/retentionPolicies": {
+      "get": {
+        "operationId": "RetentionPolicies_ListByScheduler",
+        "tags": [
+          "RetentionPolicies"
+        ],
+        "description": "List Retention Policies",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RetentionPolicies_ListByScheduler_MaximumSet": {
+            "$ref": "./examples/RetentionPolicies_ListByScheduler_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/retentionPolicies/default": {
+      "get": {
+        "operationId": "RetentionPolicies_Get",
+        "tags": [
+          "RetentionPolicies"
+        ],
+        "description": "Get a Retention Policy",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicy"
+            }
+          },
+          "default": {
+            "description": "Not found error: resource does not exist",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RetentionPolicies_Get_MaximumSet": {
+            "$ref": "./examples/RetentionPolicies_Get_MaximumSet_Gen.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RetentionPolicies_CreateOrReplace",
+        "tags": [
+          "RetentionPolicies"
+        ],
+        "description": "Create or Update a Retention Policy",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RetentionPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'RetentionPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RetentionPolicies_CreateOrReplace_MaximumSet": {
+            "$ref": "./examples/RetentionPolicies_CreateOrReplace_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "RetentionPolicies_Update",
+        "tags": [
+          "RetentionPolicies"
+        ],
+        "description": "Update a Retention Policy",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicyUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RetentionPolicy"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RetentionPolicies_Update_MaximumSet": {
+            "$ref": "./examples/RetentionPolicies_Update_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "RetentionPolicies_Delete",
+        "tags": [
+          "RetentionPolicies"
+        ],
+        "description": "Delete a Retention Policy",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "RetentionPolicies_Delete_MaximumSet": {
+            "$ref": "./examples/RetentionPolicies_Delete_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/taskHubs": {
+      "get": {
+        "operationId": "TaskHubs_ListByScheduler",
+        "tags": [
+          "TaskHubs"
+        ],
+        "description": "List Task Hubs",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TaskHubListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TaskHubs_ListByScheduler": {
+            "$ref": "./examples/TaskHubs_ListByScheduler.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/taskHubs/{taskHubName}": {
+      "get": {
+        "operationId": "TaskHubs_Get",
+        "tags": [
+          "TaskHubs"
+        ],
+        "description": "Get a Task Hub",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "taskHubName",
+            "in": "path",
+            "description": "The name of the TaskHub",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TaskHub"
+            }
+          },
+          "default": {
+            "description": "Not found error: resource does not exist",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TaskHubs_Get": {
+            "$ref": "./examples/TaskHubs_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TaskHubs_CreateOrUpdate",
+        "tags": [
+          "TaskHubs"
+        ],
+        "description": "Create or Update a Task Hub",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "taskHubName",
+            "in": "path",
+            "description": "The name of the TaskHub",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TaskHub"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TaskHub' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TaskHub"
+            }
+          },
+          "201": {
+            "description": "Resource 'TaskHub' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TaskHub"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TaskHubs_CreateOrUpdate": {
+            "$ref": "./examples/TaskHubs_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TaskHubs_Delete",
+        "tags": [
+          "TaskHubs"
+        ],
+        "description": "Delete a Task Hub",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "taskHubName",
+            "in": "path",
+            "description": "The name of the TaskHub",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TaskHubs_Delete": {
+            "$ref": "./examples/TaskHubs_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/transparentDataEncryptions": {
+      "get": {
+        "operationId": "TransparentDataEncryptions_ListByScheduler",
+        "tags": [
+          "TransparentDataEncryptions"
+        ],
+        "description": "List Transparent Data Encryptions",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TransparentDataEncryptionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TransparentDataEncryptions_ListByScheduler_MaximumSet": {
+            "$ref": "./examples/TransparentDataEncryptions_ListByScheduler_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/transparentDataEncryptions/default": {
+      "get": {
+        "operationId": "TransparentDataEncryptions_Get",
+        "tags": [
+          "TransparentDataEncryptions"
+        ],
+        "description": "Get a Transparent Data Encryption",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TransparentDataEncryption"
+            }
+          },
+          "default": {
+            "description": "Not found error: resource does not exist",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TransparentDataEncryptions_Get_MaximumSet": {
+            "$ref": "./examples/TransparentDataEncryptions_Get_MaximumSet_Gen.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "TransparentDataEncryptions_CreateOrReplace",
+        "tags": [
+          "TransparentDataEncryptions"
+        ],
+        "description": "Create or Update a Transparent Data Encryption",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TransparentDataEncryption"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'TransparentDataEncryption' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TransparentDataEncryption"
+            }
+          },
+          "201": {
+            "description": "Resource 'TransparentDataEncryption' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/TransparentDataEncryption"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "Validation error: required parameters are missing",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TransparentDataEncryptions_CreateOrReplace_MaximumSet": {
+            "$ref": "./examples/TransparentDataEncryptions_CreateOrReplace_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "TransparentDataEncryptions_Delete",
+        "tags": [
+          "TransparentDataEncryptions"
+        ],
+        "description": "Delete a Transparent Data Encryption",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "schedulerName",
+            "in": "path",
+            "description": "The name of the Scheduler",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TransparentDataEncryptions_Delete_MaximumSet": {
+            "$ref": "./examples/TransparentDataEncryptions_Delete_MaximumSet_Gen.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.ResourceManager.PrivateEndpointConnectionUpdate": {
+      "type": "object",
+      "description": "PATCH model for private endpoint connections",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "description": "The private endpoint connection properties",
+          "properties": {
+            "privateEndpoint": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpoint",
+              "description": "The private endpoint resource."
+            },
+            "privateLinkServiceConnectionState": {
+              "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateLinkServiceConnectionState",
+              "description": "A collection of information about the state of the connection between service consumer and provider."
+            }
+          }
+        }
+      }
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The status of the current operation",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "The resource is being provisioned"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The resource is updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The resource create request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "State of the public network access.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "The public network access is enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "The public network access is disabled"
+          }
+        ]
+      }
+    },
+    "PurgeableOrchestrationState": {
+      "type": "string",
+      "description": "Purgeable orchestration state to be used in retention policies",
+      "enum": [
+        "Completed",
+        "Failed",
+        "Terminated",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "PurgeableOrchestrationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "The orchestration is completed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The orchestration is failed"
+          },
+          {
+            "name": "Terminated",
+            "value": "Terminated",
+            "description": "The orchestration is terminated"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The orchestration is canceled"
+          }
+        ]
+      }
+    },
+    "RedundancyState": {
+      "type": "string",
+      "description": "The state of the resource redundancy",
+      "enum": [
+        "None",
+        "Zone"
+      ],
+      "x-ms-enum": {
+        "name": "RedundancyState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "The resource is not redundant"
+          },
+          {
+            "name": "Zone",
+            "value": "Zone",
+            "description": "The resource is zone redundant"
+          }
+        ]
+      }
+    },
+    "RetentionPolicy": {
+      "type": "object",
+      "description": "A retention policy resource belonging to the scheduler",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RetentionPolicyProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RetentionPolicyDetails": {
+      "type": "object",
+      "description": "The properties of a retention policy",
+      "properties": {
+        "retentionPeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The retention period in days after which the orchestration will be purged automatically"
+        },
+        "orchestrationState": {
+          "$ref": "#/definitions/PurgeableOrchestrationState",
+          "description": "The orchestration state to which this policy applies. If omitted, the policy applies to all purgeable orchestration states."
+        }
+      },
+      "required": [
+        "retentionPeriodInDays"
+      ]
+    },
+    "RetentionPolicyListResult": {
+      "type": "object",
+      "description": "The response of a RetentionPolicy list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RetentionPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/RetentionPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RetentionPolicyProperties": {
+      "type": "object",
+      "description": "The retention policy settings for the resource",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation",
+          "readOnly": true
+        },
+        "retentionPolicies": {
+          "type": "array",
+          "description": "The orchestration retention policies",
+          "items": {
+            "$ref": "#/definitions/RetentionPolicyDetails"
+          },
+          "x-ms-identifiers": [
+            "retentionPeriodInDays",
+            "orchestrationState"
+          ]
+        }
+      }
+    },
+    "RetentionPolicyUpdate": {
+      "type": "object",
+      "description": "A retention policy resource belonging to the scheduler",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RetentionPolicyProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "Scheduler": {
+      "type": "object",
+      "description": "A Durable Task Scheduler resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SchedulerProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "SchedulerListResult": {
+      "type": "object",
+      "description": "The response of a Scheduler list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Scheduler items on this page",
+          "items": {
+            "$ref": "#/definitions/Scheduler"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SchedulerPrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "The response of a SchedulerPrivateLinkResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SchedulerPrivateLinkResource items on this page",
+          "items": {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SchedulerProperties": {
+      "type": "object",
+      "description": "Details of the Scheduler",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation",
+          "readOnly": true
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "URL of the durable task scheduler",
+          "readOnly": true
+        },
+        "ipAllowlist": {
+          "type": "array",
+          "description": "IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/SchedulerSku",
+          "description": "SKU of the durable task scheduler"
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Allow or disallow public network access to durable task scheduler"
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "The private endpoints exposed by this resource",
+          "items": {
+            "$ref": "../../../../../common-types/resource-management/v6/privatelinks.json#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "ipAllowlist",
+        "sku"
+      ]
+    },
+    "SchedulerPropertiesUpdate": {
+      "type": "object",
+      "description": "The Scheduler resource properties to be updated",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation",
+          "readOnly": true
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "URL of the durable task scheduler",
+          "readOnly": true
+        },
+        "ipAllowlist": {
+          "type": "array",
+          "description": "IP allow list for durable task scheduler. Values can be IPv4, IPv6 or CIDR",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sku": {
+          "$ref": "#/definitions/SchedulerSkuUpdate",
+          "description": "SKU of the durable task scheduler"
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Allow or disallow public network access to durable task scheduler"
+        }
+      }
+    },
+    "SchedulerSku": {
+      "type": "object",
+      "description": "The SKU (Stock Keeping Unit) assigned to this durable task scheduler",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SchedulerSkuName",
+          "description": "The name of the SKU"
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy"
+        },
+        "redundancyState": {
+          "$ref": "#/definitions/RedundancyState",
+          "description": "Indicates whether the current SKU configuration is zone redundant",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SchedulerSkuName": {
+      "type": "string",
+      "description": "The name of the Stock Keeping Unit (SKU) of a Durable Task Scheduler",
+      "enum": [
+        "Dedicated",
+        "Consumption"
+      ],
+      "x-ms-enum": {
+        "name": "SchedulerSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Dedicated",
+            "value": "Dedicated",
+            "description": "Dedicated SKU"
+          },
+          {
+            "name": "Consumption",
+            "value": "Consumption",
+            "description": "Consumption SKU"
+          }
+        ]
+      }
+    },
+    "SchedulerSkuUpdate": {
+      "type": "object",
+      "description": "The SKU (Stock Keeping Unit) properties to be updated",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SchedulerSkuName",
+          "description": "The name of the SKU"
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The SKU capacity. This allows scale out/in for the resource and impacts zone redundancy"
+        },
+        "redundancyState": {
+          "$ref": "#/definitions/RedundancyState",
+          "description": "Indicates whether the current SKU configuration is zone redundant",
+          "readOnly": true
+        }
+      }
+    },
+    "SchedulerUpdate": {
+      "type": "object",
+      "description": "The update request model for the Scheduler resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SchedulerPropertiesUpdate",
+          "description": "The resource-specific properties for this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      }
+    },
+    "TaskHub": {
+      "type": "object",
+      "description": "A Task Hub resource belonging to the scheduler",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TaskHubProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TaskHubListResult": {
+      "type": "object",
+      "description": "The response of a TaskHub list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TaskHub items on this page",
+          "items": {
+            "$ref": "#/definitions/TaskHub"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TaskHubProperties": {
+      "type": "object",
+      "description": "The properties of Task Hub",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation",
+          "readOnly": true
+        },
+        "dashboardUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the durable task scheduler dashboard",
+          "readOnly": true
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "A set of Task Hub capabilities that can be enabled or disabled for a Task Hub",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TransparentDataEncryption": {
+      "type": "object",
+      "description": "A transparent data encryption resource belonging to the scheduler",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TransparentDataEncryptionProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TransparentDataEncryptionKeySource": {
+      "type": "string",
+      "description": "The key source for the transparent data encryption",
+      "enum": [
+        "MicrosoftManaged",
+        "CustomerManaged"
+      ],
+      "x-ms-enum": {
+        "name": "TransparentDataEncryptionKeySource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MicrosoftManaged",
+            "value": "MicrosoftManaged",
+            "description": "The key source is Microsoft-managed"
+          },
+          {
+            "name": "CustomerManaged",
+            "value": "CustomerManaged",
+            "description": "The key source is customer-managed"
+          }
+        ]
+      }
+    },
+    "TransparentDataEncryptionListResult": {
+      "type": "object",
+      "description": "The response of a TransparentDataEncryption list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TransparentDataEncryption items on this page",
+          "items": {
+            "$ref": "#/definitions/TransparentDataEncryption"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TransparentDataEncryptionProperties": {
+      "type": "object",
+      "description": "The transparent data encryption settings for the resource",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation",
+          "readOnly": true
+        },
+        "keySource": {
+          "$ref": "#/definitions/TransparentDataEncryptionKeySource",
+          "description": "The key source for the transparent data encryption"
+        },
+        "keyVaultKeyUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URI of the key in Key Vault to be used for transparent data encryption"
+        }
+      },
+      "required": [
+        "keySource"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Operations_List.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Operations_List.json
@@ -1,0 +1,36 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "display": {
+              "description": "Create or Update Durable Task Scheduler",
+              "operation": "Create or Update Durable Task Scheduler",
+              "provider": "Durable Task Scheduler",
+              "resource": "Scheduler"
+            },
+            "isDataAction": false,
+            "name": "Microsoft.DurableTask/schedulers/write"
+          },
+          {
+            "display": {
+              "description": "Delete Durable Task Scheduler",
+              "operation": "Delete Durable Task Scheduler",
+              "provider": "Durable Task Scheduler",
+              "resource": "Scheduler"
+            },
+            "isDataAction": false,
+            "name": "Microsoft.DurableTask/schedulers/delete"
+          }
+        ],
+        "nextLink": "https://microsoft.com/akpblld"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Create_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Create_MaximumSet_Gen.json
@@ -1,0 +1,84 @@
+{
+  "title": "PrivateEndpointConnections_Create_MaximumSet",
+  "operationId": "Schedulers_CreateOrUpdatePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu",
+    "resource": {
+      "properties": {
+        "privateEndpoint": {},
+        "privateLinkServiceConnectionState": {
+          "status": "Pending",
+          "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+          "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Delete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "PrivateEndpointConnections_Delete_MaximumSet",
+  "operationId": "Schedulers_DeletePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Get_MaximumSet_Gen.json
@@ -1,0 +1,42 @@
+{
+  "title": "PrivateEndpointConnections_Get_MaximumSet",
+  "operationId": "Schedulers_GetPrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Pending",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_List_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_List_MaximumSet_Gen.json
@@ -1,0 +1,46 @@
+{
+  "title": "PrivateEndpointConnections_List_MaximumSet",
+  "operationId": "Schedulers_ListPrivateEndpointConnections",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "privateEndpoint": {
+                "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+              },
+              "privateLinkServiceConnectionState": {
+                "status": "Pending",
+                "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+                "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+              },
+              "groupIds": [
+                "xnnrzmowptxnijdojrntrbm"
+              ],
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+            "name": "spzckqrbhfnabu",
+            "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/anend"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Update.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateEndpointConnections_Update.json
@@ -1,0 +1,54 @@
+{
+  "title": "PrivateEndpointConnections_Update",
+  "operationId": "Schedulers_UpdatePrivateEndpointConnection",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateEndpointConnectionName": "spzckqrbhfnabu",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "status": "Approved"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "privateEndpoint": {
+            "id": "vjjxatyilmgjaervqztrmlpfodvbo"
+          },
+          "privateLinkServiceConnectionState": {
+            "status": "Approved",
+            "actionsRequired": "mxymqfbbmpwjxsroldlsd",
+            "description": "ujdcsoyxljivwsgfkexhotaxcmzq"
+          },
+          "groupIds": [
+            "xnnrzmowptxnijdojrntrbm"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateEndpointConnections/spzckqrbhfnabu",
+        "name": "spzckqrbhfnabu",
+        "type": "Microsoft.DurableTask/schedulers/privateEndpointConnections",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateLinkResources_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateLinkResources_Get_MaximumSet_Gen.json
@@ -1,0 +1,37 @@
+{
+  "title": "PrivateLinkResources_Get_MaximumSet",
+  "operationId": "Schedulers_GetPrivateLink",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "privateLinkResourceName": "ulbdiqhrmwnkejje"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "groupId": "mexetpneryldlrtmuxzxhwezfjkcvr",
+          "requiredMembers": [
+            "ftzshharzmwhcemnbdwlmyhtxkpa"
+          ],
+          "requiredZoneNames": [
+            "lkwwgycaduib"
+          ]
+        },
+        "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateLinkResources/ulbdiqhrmwnkejje",
+        "name": "ulbdiqhrmwnkejje",
+        "type": "Microsoft.DurableTask/schedulers/privateLinkResources",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateLinkResources_List_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/PrivateLinkResources_List_MaximumSet_Gen.json
@@ -1,0 +1,41 @@
+{
+  "title": "PrivateLinkResources_List_MaximumSet",
+  "operationId": "Schedulers_ListPrivateLinks",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "851A7597-D699-45CC-899B-7487A5B3B775",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "groupId": "mexetpneryldlrtmuxzxhwezfjkcvr",
+              "requiredMembers": [
+                "ftzshharzmwhcemnbdwlmyhtxkpa"
+              ],
+              "requiredZoneNames": [
+                "lkwwgycaduib"
+              ]
+            },
+            "id": "/subscriptions/851A7597-D699-45CC-899B-7487A5B3B775/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/privateLinkResources/ulbdiqhrmwnkejje",
+            "name": "ulbdiqhrmwnkejje",
+            "type": "Microsoft.DurableTask/schedulers/privateLinkResources",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_CreateOrReplace_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_CreateOrReplace_MaximumSet_Gen.json
@@ -1,0 +1,83 @@
+{
+  "title": "RetentionPolicies_CreateOrReplace_MaximumSet",
+  "operationId": "RetentionPolicies_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default",
+    "resource": {
+      "properties": {
+        "retentionPolicies": [
+          {
+            "retentionPeriodInDays": 30
+          },
+          {
+            "retentionPeriodInDays": 10,
+            "orchestrationState": "Failed"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Delete_MaximumSet_Gen.json
@@ -1,0 +1,19 @@
+{
+  "title": "RetentionPolicies_Delete_MaximumSet",
+  "operationId": "RetentionPolicies_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testcheduler",
+    "retentionPolicyName": "default"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Get_MaximumSet_Gen.json
@@ -1,0 +1,40 @@
+{
+  "title": "RetentionPolicies_Get_MaximumSet",
+  "operationId": "RetentionPolicies_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "zshkmc",
+          "createdByType": "User",
+          "createdAt": "2025-03-31T23:34:09.612Z",
+          "lastModifiedBy": "ivqrae",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_ListByScheduler_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_ListByScheduler_MaximumSet_Gen.json
@@ -1,0 +1,44 @@
+{
+  "title": "RetentionPolicies_ListByScheduler_MaximumSet",
+  "operationId": "RetentionPolicies_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "myscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "retentionPolicies": [
+                {
+                  "retentionPeriodInDays": 30
+                },
+                {
+                  "retentionPeriodInDays": 10,
+                  "orchestrationState": "Failed"
+                }
+              ]
+            },
+            "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+            "name": "default",
+            "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+            "systemData": {
+              "createdBy": "zshkmc",
+              "createdByType": "User",
+              "createdAt": "2025-03-31T23:34:09.612Z",
+              "lastModifiedBy": "ivqrae",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-03-31T23:34:09.612Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ai"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Update_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/RetentionPolicies_Update_MaximumSet_Gen.json
@@ -1,0 +1,65 @@
+{
+  "title": "RetentionPolicies_Update_MaximumSet",
+  "operationId": "RetentionPolicies_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "194D3C1E-462F-4738-9025-092A628C06EB",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "retentionPolicyName": "default",
+    "properties": {
+      "properties": {
+        "retentionPolicies": [
+          {
+            "retentionPeriodInDays": 30
+          },
+          {
+            "retentionPeriodInDays": 10,
+            "orchestrationState": "Failed"
+          },
+          {
+            "retentionPeriodInDays": 24,
+            "orchestrationState": "Completed"
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "retentionPolicies": [
+            {
+              "retentionPeriodInDays": 30
+            },
+            {
+              "retentionPeriodInDays": 10,
+              "orchestrationState": "Failed"
+            },
+            {
+              "retentionPeriodInDays": 24,
+              "orchestrationState": "Completed"
+            }
+          ]
+        },
+        "id": "/subscriptions/194D3C1E-462F-4738-9025-092A628C06EB/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/retentionPolicies/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/retentionPolicies",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_CreateOrUpdate.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_CreateOrUpdate.json
@@ -1,0 +1,106 @@
+{
+  "title": "Schedulers_CreateOrUpdate",
+  "operationId": "Schedulers_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "resource": {
+      "location": "northcentralus",
+      "properties": {
+        "ipAllowlist": [
+          "10.0.0.0/8"
+        ],
+        "sku": {
+          "name": "Dedicated"
+        }
+      },
+      "tags": {
+        "department": "research",
+        "development": "true"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testidentity": {}
+          }
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Delete.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "Schedulers_Delete",
+  "operationId": "Schedulers_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Get.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Get.json
@@ -1,0 +1,46 @@
+{
+  "title": "Schedulers_Get",
+  "operationId": "Schedulers_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          },
+          "publicNetworkAccess": "Enabled",
+          "privateEndpointConnections": []
+        },
+        "tags": {
+          "department": "research",
+          "development": "true"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_ListByResourceGroup.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_ListByResourceGroup.json
@@ -1,0 +1,50 @@
+{
+  "title": "Schedulers_ListByResourceGroup",
+  "operationId": "Schedulers_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+            "location": "northcentralus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "endpoint": "https://test.northcentralus.1.durabletask.io",
+              "ipAllowlist": [
+                "10.0.0.0/8"
+              ],
+              "sku": {
+                "name": "Dedicated",
+                "capacity": 3,
+                "redundancyState": "Zone"
+              },
+              "publicNetworkAccess": "Enabled",
+              "privateEndpointConnections": []
+            },
+            "tags": {
+              "department": "research",
+              "development": "true"
+            },
+            "name": "testscheduler",
+            "type": "Microsoft.DurableTask/schedulers",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_ListBySubscription.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_ListBySubscription.json
@@ -1,0 +1,49 @@
+{
+  "title": "Schedulers_ListBySubscription",
+  "operationId": "Schedulers_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+            "location": "northcentralus",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "endpoint": "https://test.northcentralus.1.durabletask.io",
+              "ipAllowlist": [
+                "10.0.0.0/8"
+              ],
+              "sku": {
+                "name": "Dedicated",
+                "capacity": 3,
+                "redundancyState": "Zone"
+              },
+              "publicNetworkAccess": "Enabled",
+              "privateEndpointConnections": []
+            },
+            "tags": {
+              "department": "research",
+              "development": "true"
+            },
+            "name": "testscheduler",
+            "type": "Microsoft.DurableTask/schedulers",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Restart.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Restart.json
@@ -1,0 +1,13 @@
+{
+  "title": "Schedulers_Restart",
+  "operationId": "Schedulers_Restart",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Update.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/Schedulers_Update.json
@@ -1,0 +1,70 @@
+{
+  "title": "Schedulers_Update",
+  "operationId": "Schedulers_Update",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "properties": {
+      "tags": {
+        "hello": "world"
+      },
+      "properties": {
+        "ipAllowlist": [
+          "10.0.0.0/8"
+        ],
+        "sku": {
+          "name": "Dedicated",
+          "capacity": 3
+        }
+      },
+      "identity": {
+        "type": "None"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "location": "northcentralus",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "endpoint": "https://test.northcentralus.1.durabletask.io",
+          "ipAllowlist": [
+            "10.0.0.0/8"
+          ],
+          "sku": {
+            "name": "Dedicated",
+            "capacity": 3,
+            "redundancyState": "Zone"
+          }
+        },
+        "tags": {
+          "department": "research",
+          "development": "true",
+          "hello": "world"
+        },
+        "identity": {
+          "type": "None"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler",
+        "name": "testscheduler",
+        "type": "Microsoft.DurableTask/schedulers",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_CreateOrUpdate.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_CreateOrUpdate.json
@@ -1,0 +1,64 @@
+{
+  "title": "TaskHubs_CreateOrUpdate",
+  "operationId": "TaskHubs_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub",
+    "resource": {
+      "properties": {
+        "capabilities": [
+          "ExampleFutureCapability"
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub",
+          "capabilities": [
+            "ExampleFutureCapability"
+          ]
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub",
+          "capabilities": [
+            "ExampleFutureCapability"
+          ]
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_Delete.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "TaskHubs_Delete",
+  "operationId": "TaskHubs_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_Get.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_Get.json
@@ -1,0 +1,32 @@
+{
+  "title": "TaskHubs_Get",
+  "operationId": "TaskHubs_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler",
+    "taskHubName": "testtaskhub"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+        "name": "testtaskhub",
+        "type": "Microsoft.DurableTask/schedulers/taskHubs",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_ListByScheduler.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TaskHubs_ListByScheduler.json
@@ -1,0 +1,36 @@
+{
+  "title": "TaskHubs_ListByScheduler",
+  "operationId": "TaskHubs_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgopenapi",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgopenapi/providers/Microsoft.DurableTask/schedulers/testscheduler/taskHubs/testtaskhub",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "dashboardUrl": "https://test-db.northcentralus.1.durabletask.io/taskhubs/testtaskhub"
+            },
+            "name": "testtaskhub",
+            "type": "Microsoft.DurableTask/schedulers/taskHubs",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_CreateOrReplace_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_CreateOrReplace_MaximumSet_Gen.json
@@ -1,0 +1,61 @@
+{
+  "title": "TransparentDataEncryptions_CreateOrReplace_MaximumSet",
+  "operationId": "TransparentDataEncryptions_CreateOrReplace",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler",
+    "resource": {
+      "properties": {
+        "keySource": "CustomerManaged",
+        "keyVaultKeyUri": "https://microsoft.com/ap"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_Delete_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_Delete_MaximumSet_Gen.json
@@ -1,0 +1,18 @@
+{
+  "title": "TransparentDataEncryptions_Delete_MaximumSet",
+  "operationId": "TransparentDataEncryptions_Delete",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_Get_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_Get_MaximumSet_Gen.json
@@ -1,0 +1,32 @@
+{
+  "title": "TransparentDataEncryptions_Get_MaximumSet",
+  "operationId": "TransparentDataEncryptions_Get",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "keySource": "CustomerManaged",
+          "keyVaultKeyUri": "https://microsoft.com/ap"
+        },
+        "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+        "name": "default",
+        "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+        "systemData": {
+          "createdBy": "tenmbevaunjzikxowqexrsx",
+          "createdByType": "User",
+          "createdAt": "2024-04-17T15:34:17.365Z",
+          "lastModifiedBy": "xfvdcegtj",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_ListByScheduler_MaximumSet_Gen.json
+++ b/specification/durabletask/resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/examples/TransparentDataEncryptions_ListByScheduler_MaximumSet_Gen.json
@@ -1,0 +1,37 @@
+{
+  "title": "TransparentDataEncryptions_ListByScheduler_MaximumSet",
+  "operationId": "TransparentDataEncryptions_ListByScheduler",
+  "parameters": {
+    "api-version": "2026-05-01-preview",
+    "subscriptionId": "EE9BD735-67CE-4A90-89C4-439D3F6A4C93",
+    "resourceGroupName": "rgdurabletask",
+    "schedulerName": "testscheduler"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded",
+              "keySource": "CustomerManaged",
+              "keyVaultKeyUri": "https://microsoft.com/ap"
+            },
+            "id": "/subscriptions/EE9BD735-67CE-4A90-89C4-439D3F6A4C93/resourceGroups/rgdurabletask/providers/Microsoft.DurableTask/schedulers/testscheduler/transparentDataEncryptions/default",
+            "name": "default",
+            "type": "Microsoft.DurableTask/schedulers/transparentDataEncryptions",
+            "systemData": {
+              "createdBy": "tenmbevaunjzikxowqexrsx",
+              "createdByType": "User",
+              "createdAt": "2024-04-17T15:34:17.365Z",
+              "lastModifiedBy": "xfvdcegtj",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-04-17T15:34:17.366Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/durabletask/resource-manager/readme.md
+++ b/specification/durabletask/resource-manager/readme.md
@@ -27,7 +27,55 @@ These are the global settings for the durabletask.
 ```yaml
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-2026-02-01
+tag: package-2026-05-01-preview
+```
+
+### Tag: package-2026-05-01-preview
+
+These settings apply only when `--tag=package-2026-05-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-05-01-preview'
+input-file:
+  - Microsoft.DurableTask/preview/2026-05-01-preview/durabletask.json
+suppressions:
+  - code: ArmResourcePropertiesBag
+    reason: Changing this property would constitute a breaking change. SKU property was approved in previous API versions.
+    from:
+      - durabletask.json
+    where:
+      - $.definitions.Scheduler
+      - $.definitions.SchedulerUpdate
+      - $.definitions.Scheduler.properties.sku
+      - $.definitions.Scheduler.properties.properties.sku
+      - $.definitions.SchedulerUpdate.properties.sku
+      - $.definition.SchedulerUpdate.properties.properties.sku
+      - $.definitions.SchedulerListResult
+      - $.definitions.SchedulerSku
+      - $.definitions.SchedulerSkuUpdate
+      - $.definitions.Scheduler.properties
+      - $.definitions.SchedulerUpdate.properties
+      - $.definitions.SchedulerProperties
+      - $.definitions.SchedulerPropertiesUpdate
+      - $.definitions.SchedulerProperties.properties
+      - $.definitions.SchedulerPropertiesUpdate.properties
+  - code: XMSSecretInResponse
+    reason: publicNetworkAccess is not a secret - it is a network configuration setting that controls public endpoint access.
+    from:
+      - durabletask.json
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}"].put.responses["200"].schema.properties.properties.properties.publicNetworkAccess
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}"].put.responses["201"].schema.properties.properties.properties.publicNetworkAccess
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}"].get.responses["200"].schema.properties.properties.properties.publicNetworkAccess
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}"].patch.responses["200"].schema.properties.properties.properties.publicNetworkAccess
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers"].get.responses["200"].schema.properties.properties.properties.publicNetworkAccess
+      - $.paths["/subscriptions/{subscriptionId}/providers/Microsoft.DurableTask/schedulers"].get.responses["200"].schema.properties.properties.properties.publicNetworkAccess
+  - code: ResourceNameRestriction
+    reason: The privateLinkResourceName parameter is determined by the Network Resource Provider service and does not require a pattern restriction.
+    from:
+      - durabletask.json
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateLinkResources/{privateLinkResourceName}"]
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DurableTask/schedulers/{schedulerName}/privateLinkResources/{privateLinkResourceName}"]
 ```
 
 ### Tag: package-2026-02-01


### PR DESCRIPTION
## Summary

This PR makes two changes to the `Microsoft.DurableTask` (DurableTask.Management) TypeSpec specification:

1. **Refactor** the monolithic `main.tsp` into several focused, per-resource `.tsp` files (no functional change to existing API versions).
2. **Add a new preview API version `2026-05-01-preview`** that introduces the `transparentDataEncryptions` resource type, a `capabilities` property on TaskHubs, and managed-identity support on Schedulers, among other additions.

All generated swagger and examples are produced by `npx tsp compile`; nothing under `resource-manager/` was hand-authored.

---

## 1. Refactor: split `main.tsp` into per-resource files

`main.tsp` previously held the entire service definition. It is now slimmed down to the service/namespace declaration, the `Versions` enum, the `Operations` interface, and the shared `ProvisioningState` union, and imports the following new files:

| File | Contents |
|------|----------|
| `scheduler.tsp` | `Scheduler` resource (+ identity), `SchedulerProperties`, SKU models, private endpoint/private link models and aliases, public network access, update models, and the `Schedulers` operations interface. |
| `taskhub.tsp` | `TaskHub` resource, `TaskHubProperties`, and the `TaskHubs` operations interface. |
| `retentionpolicy.tsp` | `RetentionPolicy` resource, properties, details, purgeable-state enum, and interface (moved verbatim out of `main.tsp`). |
| `transparentDataEncryption.tsp` | **New** `TransparentDataEncryption` resource (introduced in `2026-05-01-preview`). |

This is a pure reorganization — the emitted swagger for every pre-existing API version is byte-for-byte unchanged.

---

## 2. New API version: `2026-05-01-preview`

Added `v2026_05_01_Preview` to the `Versions` enum (using `commonTypes` v6). New surface area, all gated with `@added(Versions.v2026_05_01_Preview)`:

- **`transparentDataEncryptions` resource type** — a new child resource of the Scheduler for managing transparent data encryption (`transparentDataEncryption.tsp`).
- **`capabilities` property on TaskHubs** — `TaskHubProperties.capabilities?: string[]`.
- **Managed identity support on Schedulers** — `identity` (managed service identity) added to both `Scheduler` and `SchedulerUpdate`.
- **`restart` action on Schedulers** — `ArmResourceActionSync` action on the `Schedulers` interface.

### Config
- `resource-manager/readme.md`: added the `package-2026-05-01-preview` tag (input file + required suppressions) and set it as the new default tag. Existing tags are untouched.
- `resource-manager/Microsoft.DurableTask/preview/2026-05-01-preview/`: generated swagger + examples (output of `tsp compile`).
- `DurableTask.Management/examples/2026-05-01-preview/`: source example files for the new operations.

---

## Validation

- `npx tsp compile .` — succeeds; the new `2026-05-01-preview` swagger is generated and every `x-ms-examples` reference resolves. Existing-version swaggers are unchanged.
- `npx tsv specification/durabletask/DurableTask.Management` — all rules pass (FolderStructure, NpmPrefix, EmitAutorest, FlavorAzure, LinterRuleset, **Compile** with `--warn-as-error` on both `main.tsp` and `client.tsp`, **Format**, SdkTspConfigValidation).