### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-devhub

### DIFF
--- a/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/client.tsp
+++ b/specification/developerhub/resource-manager/Microsoft.DevHub/DeveloperHub/client.tsp
@@ -10,6 +10,7 @@ using Microsoft.DevHub;
 @@clientName(WorkflowRun.workflowRunURL, "workflowRunUrl", "java");
 @@clientName(PullRequest.prURL, "prUrl", "java");
 @@clientName(Microsoft.DevHub, "DeveloperHubServiceClient", "javascript,java");
+@@clientName(Microsoft.DevHub, "DevHubMgmtClient", "python");
 @@clientName(ACR, "Acr", "java,javascript");
 @@clientName(Deployment, "DeploymentProperties", "java,javascript");
 // consistency on "AdoOAuth"


### PR DESCRIPTION
Mitigate Python SDK breaking changes for azure-mgmt-devhub during TypeSpec migration.

Mitigations:
- Renamed client `DevHubMgmtClient` restored via `@@clientName(Microsoft.DevHub, "DevHubMgmtClient", "python")`
