### PR TITLE
Fix Java hostname compatibility for ManagedNetworkFabric TypeSpec

### DIFF
--- a/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
+++ b/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
@@ -81,3 +81,14 @@ using Microsoft.ManagedNetworkFabric;
   "peerAsn",
   "java"
 );
+
+@@clientName(
+  Microsoft.ManagedNetworkFabric.NetworkDeviceProperties.hostName,
+  "hostname",
+  "java"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.NetworkDevicePatchableProperties.hostName,
+  "hostname",
+  "java"
+);


### PR DESCRIPTION
## Summary
- add a Java-specific client name override for NetworkDeviceProperties.hostName
- add a Java-specific client name override for NetworkDevicePatchableProperties.hostName
- preserve the historical Java hostname surface in the generated SDK

## Testing
- npx tsp compile .
- npx tsp format .
- generate Java SDK
