### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-managednetworkfabric

### DIFF
--- a/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
+++ b/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
@@ -93,8 +93,11 @@ using Microsoft.ManagedNetworkFabric;
   "java"
 );
 
-// Python SDK mitigations for TypeSpec migration
-@@clientName(Microsoft.ManagedNetworkFabric, "ManagedNetworkFabricMgmtClient", "python");
+@@clientName(
+  Microsoft.ManagedNetworkFabric,
+  "ManagedNetworkFabricMgmtClient",
+  "python"
+);
 @@clientName(
   Microsoft.ManagedNetworkFabric.ManagementNetworkPatchConfiguration,
   "ManagementNetworkConfigurationPatchableProperties",

--- a/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
+++ b/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
@@ -92,3 +92,21 @@ using Microsoft.ManagedNetworkFabric;
   "hostname",
   "java"
 );
+
+// Python SDK mitigations for TypeSpec migration
+@@clientName(Microsoft.ManagedNetworkFabric, "ManagedNetworkFabricMgmtClient", "python");
+@@clientName(
+  Microsoft.ManagedNetworkFabric.ManagementNetworkPatchConfiguration,
+  "ManagementNetworkConfigurationPatchableProperties",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.TerminalServerPatchConfiguration,
+  "NetworkFabricPatchablePropertiesTerminalServerConfiguration",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.VpnOptionBProperties,
+  "OptionBProperties",
+  "python"
+);


### PR DESCRIPTION
Mitigate Python SDK breaking changes for azure-mgmt-managednetworkfabric during TypeSpec migration.

Mitigations applied in `client.tsp`:
- Restore client name `ManagedNetworkFabricMgmtClient` via `@@clientName`
- Rename `ManagementNetworkPatchConfiguration` back to `ManagementNetworkConfigurationPatchableProperties`
- Rename `TerminalServerPatchConfiguration` back to `NetworkFabricPatchablePropertiesTerminalServerConfiguration`
- Rename `VpnOptionBProperties` back to `OptionBProperties`
