### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-loganalytics

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -4,36 +4,35 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 using Microsoft.OperationalInsights;
 
-@@clientName(
-  Microsoft.OperationalInsights,
+@@clientName(Microsoft.OperationalInsights,
   "OperationalInsightsManagementClient",
   "javascript,java"
+);
+@@clientName(Microsoft.OperationalInsights,
+  "LogAnalyticsManagementClient",
+  "python"
 );
 @@clientName(LogAnalyticsQueryPacks.search, "listSearch", "javascript");
 
 @@clientName(NetworkSecurityPerimeterConfigurations.getNSP, "getNsp", "java");
 @@clientName(NetworkSecurityPerimeterConfigurations.listNSP, "listNsp", "java");
-@@clientName(
-  NetworkSecurityPerimeterConfigurations.reconcileNSP,
+@@clientName(NetworkSecurityPerimeterConfigurations.reconcileNSP,
   "reconcileNsp",
   "java"
 );
 
 @@clientName(DestinationMetaData, "DestinationMetadata", "java");
 
-@@alternateType(
-  Azure.ResourceManager.CommonTypes.AccessRuleProperties.subscriptions,
+@@alternateType(Azure.ResourceManager.CommonTypes.AccessRuleProperties.subscriptions,
   global.AccessRulePropertiesSubscriptionsItem[],
   "java"
 );
 
-@@clientName(
-  Microsoft.OperationalInsights.ProvisioningStateEnum,
+@@clientName(Microsoft.OperationalInsights.ProvisioningStateEnum,
   "SummaryLogsProvisioningState",
   "java"
 );
-@@clientName(
-  OperationalInsightsTableProvisioningState,
+@@clientName(OperationalInsightsTableProvisioningState,
   "ProvisioningStateEnum",
   "java"
 );

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/client.tsp
@@ -39,3 +39,10 @@ using Microsoft.OperationalInsights;
 
 // Fix etag casing for backward compatibility
 @@clientName(Microsoft.OperationalInsights.SearchMetadata.eTag, "etag", "java");
+
+// Python: Keep original client name from swagger
+@@clientName(
+  Microsoft.OperationalInsights,
+  "LogAnalyticsManagementClient",
+  "python"
+);

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -15,8 +15,9 @@ options:
     namespace: "Azure.ResourceManager.OperationalInsights"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
-    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-operationalinsights"
-    namespace: "azure.mgmt.operationalinsights"
+    service-dir: "sdk/loganalytics"
+    emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-loganalytics"
+    namespace: "azure.mgmt.loganalytics"
     generate-test: true
     generate-sample: true
     flavor: "azure"


### PR DESCRIPTION
Mitigate Python SDK breaking changes for azure-mgmt-loganalytics during TypeSpec migration.

Mitigations:
- Updated tspconfig.yaml to keep original Python package name (`azure-mgmt-loganalytics`), namespace (`azure.mgmt.loganalytics`), and service-dir (`sdk/loganalytics`)
- Added `@@clientName` decorator to preserve client class name `LogAnalyticsManagementClient`
