### PR TITLE
Add csharp customizations for PolicyInsights migration

### DIFF
--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Attestation.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Attestation.tsp
@@ -42,6 +42,43 @@ alias AttestationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperati
   }
 >;
 
+alias AttestationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    /** The name of the attestation. */
+    @path
+    @segment("attestations")
+    @key
+    attestationName: string;
+  }
+>;
+
+alias AttestationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+
+    /** Resource ID. */
+    @path(#{ allowReserved: true })
+    @key
+    resourceId: string;
+
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    /** The name of the attestation. */
+    @path
+    @segment("attestations")
+    @key
+    attestationName: string;
+  },
+  ErrorType = ErrorResponse
+>;
+
 @armResourceOperations(#{ omitTags: true })
 interface Attestations {
   /**
@@ -94,25 +131,7 @@ interface Attestations {
     },
     ErrorType = ErrorResponse
   >;
-}
-alias AttestationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
-  {
-    ...ApiVersionParameter;
-    ...SubscriptionIdParameter;
-    ...ResourceGroupParameter;
-    ...Azure.ResourceManager.Legacy.Provider;
-  },
-  {
-    /** The name of the attestation. */
-    @path
-    @segment("attestations")
-    @key
-    attestationName: string;
-  }
->;
 
-@armResourceOperations(#{ omitTags: true })
-interface AttestationResourceGroupOperations {
   /**
    * Gets an existing attestation at resource group scope.
    */
@@ -163,31 +182,7 @@ interface AttestationResourceGroupOperations {
     },
     OverrideErrorType = ErrorResponse
   >;
-}
 
-alias AttestationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
-  {
-    ...ApiVersionParameter;
-
-    /** Resource ID. */
-    @path(#{ allowReserved: true })
-    @key
-    resourceId: string;
-
-    ...Azure.ResourceManager.Legacy.Provider;
-  },
-  {
-    /** The name of the attestation. */
-    @path
-    @segment("attestations")
-    @key
-    attestationName: string;
-  },
-  ErrorType = ErrorResponse
->;
-
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-interface AttestationOperationGroup {
   /**
    * Gets an existing attestation at resource scope.
    */
@@ -254,10 +249,10 @@ interface AttestationOperationGroup {
   "The attestation parameters."
 );
 @@doc(
-  AttestationResourceGroupOperations.createOrUpdateAtResourceGroup::parameters.resource,
+  Attestations.createOrUpdateAtResourceGroup::parameters.resource,
   "The attestation parameters."
 );
 @@doc(
-  AttestationOperationGroup.createOrUpdateAtResource::parameters.resource,
+  Attestations.createOrUpdateAtResource::parameters.resource,
   "The attestation parameters."
 );

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Attestation.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Attestation.tsp
@@ -39,7 +39,8 @@ alias AttestationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperati
     @segment("attestations")
     @key
     attestationName: string;
-  }
+  },
+  ResourceName = "PolicyAttestation"
 >;
 
 alias AttestationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
@@ -55,7 +56,8 @@ alias AttestationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperation
     @segment("attestations")
     @key
     attestationName: string;
-  }
+  },
+  ResourceName = "PolicyAttestation"
 >;
 
 alias AttestationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
@@ -76,6 +78,7 @@ alias AttestationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @key
     attestationName: string;
   },
+  ResourceName = "PolicyAttestation",
   ErrorType = ErrorResponse
 >;
 

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Remediation.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Remediation.tsp
@@ -52,6 +52,64 @@ alias RemediationManagementGroupOps = Azure.ResourceManager.Legacy.ExtensionOper
   }
 >;
 
+alias RemediationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+
+    /** the provider namespace */
+    @path
+    @segment("providers")
+    @key
+    providerNamespace: "Microsoft.PolicyInsights";
+  },
+  {},
+  {
+    /** The name of the remediation. */
+    @path
+    @segment("remediations")
+    @key
+    remediationName: string;
+  }
+>;
+
+alias RemediationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    /** The name of the remediation. */
+    @path
+    @segment("remediations")
+    @key
+    remediationName: string;
+  }
+>;
+
+alias RemediationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+
+    /** Resource ID. */
+    @path(#{ allowReserved: true })
+    @key
+    resourceId: string;
+
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    /** The name of the remediation. */
+    @path
+    @segment("remediations")
+    @key
+    remediationName: string;
+  },
+  ErrorType = ErrorResponse
+>;
+
 @armResourceOperations(#{ omitTags: true })
 interface Remediations {
   /**
@@ -106,30 +164,7 @@ interface Remediations {
     },
     ErrorType = ErrorResponse
   >;
-}
-alias RemediationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperations<
-  {
-    ...ApiVersionParameter;
-    ...SubscriptionIdParameter;
 
-    /** the provider namespace */
-    @path
-    @segment("providers")
-    @key
-    providerNamespace: "Microsoft.PolicyInsights";
-  },
-  {},
-  {
-    /** The name of the remediation. */
-    @path
-    @segment("remediations")
-    @key
-    remediationName: string;
-  }
->;
-
-@armResourceOperations(#{ omitTags: true })
-interface RemediationSubscriptionOperations {
   /**
    * Gets an existing remediation at subscription scope.
    */
@@ -211,25 +246,7 @@ interface RemediationSubscriptionOperations {
     ArmResponse<Remediation>,
     ErrorType = ErrorResponse
   >;
-}
-alias RemediationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
-  {
-    ...ApiVersionParameter;
-    ...SubscriptionIdParameter;
-    ...ResourceGroupParameter;
-    ...Azure.ResourceManager.Legacy.Provider;
-  },
-  {
-    /** The name of the remediation. */
-    @path
-    @segment("remediations")
-    @key
-    remediationName: string;
-  }
->;
 
-@armResourceOperations(#{ omitTags: true })
-interface RemediationResourceGroupOperations {
   /**
    * Gets an existing remediation at resource group scope.
    */
@@ -311,31 +328,7 @@ interface RemediationResourceGroupOperations {
     ArmResponse<Remediation>,
     OverrideErrorType = ErrorResponse
   >;
-}
 
-alias RemediationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
-  {
-    ...ApiVersionParameter;
-
-    /** Resource ID. */
-    @path(#{ allowReserved: true })
-    @key
-    resourceId: string;
-
-    ...Azure.ResourceManager.Legacy.Provider;
-  },
-  {
-    /** The name of the remediation. */
-    @path
-    @segment("remediations")
-    @key
-    remediationName: string;
-  },
-  ErrorType = ErrorResponse
->;
-
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-interface RemediationResourceOperations {
   /**
    * Gets an existing remediation at resource scope.
    */
@@ -423,14 +416,14 @@ interface RemediationResourceOperations {
   "The remediation parameters."
 );
 @@doc(
-  RemediationSubscriptionOperations.createOrUpdateAtSubscription::parameters.resource,
+  Remediations.createOrUpdateAtSubscription::parameters.resource,
   "The remediation parameters."
 );
 @@doc(
-  RemediationResourceGroupOperations.createOrUpdateAtResourceGroup::parameters.resource,
+  Remediations.createOrUpdateAtResourceGroup::parameters.resource,
   "The remediation parameters."
 );
 @@doc(
-  RemediationResourceOperations.createOrUpdateAtResource::parameters.resource,
+  Remediations.createOrUpdateAtResource::parameters.resource,
   "The remediation parameters."
 );

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Remediation.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/Remediation.tsp
@@ -49,7 +49,8 @@ alias RemediationManagementGroupOps = Azure.ResourceManager.Legacy.ExtensionOper
     @segment("remediations")
     @key
     remediationName: string;
-  }
+  },
+  ResourceName = "PolicyRemediation"
 >;
 
 alias RemediationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperations<
@@ -70,7 +71,8 @@ alias RemediationSubscriptionOps = Azure.ResourceManager.Legacy.ExtensionOperati
     @segment("remediations")
     @key
     remediationName: string;
-  }
+  },
+  ResourceName = "PolicyRemediation"
 >;
 
 alias RemediationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperations<
@@ -86,7 +88,8 @@ alias RemediationResourceGroupOps = Azure.ResourceManager.Legacy.LegacyOperation
     @segment("remediations")
     @key
     remediationName: string;
-  }
+  },
+  ResourceName = "PolicyRemediation"
 >;
 
 alias RemediationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
@@ -107,7 +110,8 @@ alias RemediationAtResourceOps = Azure.ResourceManager.Legacy.LegacyOperations<
     @key
     remediationName: string;
   },
-  ErrorType = ErrorResponse
+  ErrorType = ErrorResponse,
+  ResourceName = "PolicyRemediation"
 >;
 
 @armResourceOperations(#{ omitTags: true })

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/back-compatible.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/PolicyInsightsApi/back-compatible.tsp
@@ -38,78 +38,18 @@ using PolicyInsightsApi;
   Remediations.createOrUpdateAtManagementGroup::parameters.resource,
   "parameters"
 );
-@@clientLocation(
-  RemediationSubscriptionOperations.getAtSubscription,
-  Remediations
-);
-@@clientLocation(
-  RemediationSubscriptionOperations.createOrUpdateAtSubscription,
-  Remediations
-);
 @@clientName(
-  RemediationSubscriptionOperations.createOrUpdateAtSubscription::parameters.resource,
+  Remediations.createOrUpdateAtSubscription::parameters.resource,
   "parameters"
 );
-@@clientLocation(
-  RemediationSubscriptionOperations.deleteAtSubscription,
-  Remediations
-);
-@@clientLocation(
-  RemediationSubscriptionOperations.listForSubscription,
-  Remediations
-);
-@@clientLocation(
-  RemediationSubscriptionOperations.listDeploymentsAtSubscription,
-  Remediations
-);
-@@clientLocation(
-  RemediationSubscriptionOperations.cancelAtSubscription,
-  Remediations
-);
-@@clientLocation(
-  RemediationResourceGroupOperations.getAtResourceGroup,
-  Remediations
-);
-@@clientLocation(
-  RemediationResourceGroupOperations.createOrUpdateAtResourceGroup,
-  Remediations
-);
 @@clientName(
-  RemediationResourceGroupOperations.createOrUpdateAtResourceGroup::parameters.resource,
+  Remediations.createOrUpdateAtResourceGroup::parameters.resource,
   "parameters"
 );
-@@clientLocation(
-  RemediationResourceGroupOperations.deleteAtResourceGroup,
-  Remediations
-);
-@@clientLocation(
-  RemediationResourceGroupOperations.listForResourceGroup,
-  Remediations
-);
-@@clientLocation(
-  RemediationResourceGroupOperations.listDeploymentsAtResourceGroup,
-  Remediations
-);
-@@clientLocation(
-  RemediationResourceGroupOperations.cancelAtResourceGroup,
-  Remediations
-);
-@@clientLocation(RemediationResourceOperations.getAtResource, Remediations);
-@@clientLocation(
-  RemediationResourceOperations.createOrUpdateAtResource,
-  Remediations
-);
 @@clientName(
-  RemediationResourceOperations.createOrUpdateAtResource::parameters.resource,
+  Remediations.createOrUpdateAtResource::parameters.resource,
   "parameters"
 );
-@@clientLocation(RemediationResourceOperations.deleteAtResource, Remediations);
-@@clientLocation(RemediationResourceOperations.listForResource, Remediations);
-@@clientLocation(
-  RemediationResourceOperations.listDeploymentsAtResource,
-  Remediations
-);
-@@clientLocation(RemediationResourceOperations.cancelAtResource, Remediations);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(Remediation.properties);
 
@@ -121,37 +61,14 @@ using PolicyInsightsApi;
   Attestations.createOrUpdateAtSubscription::parameters.resource,
   "parameters"
 );
-@@clientLocation(
-  AttestationResourceGroupOperations.getAtResourceGroup,
-  Attestations
-);
-@@clientLocation(
-  AttestationResourceGroupOperations.createOrUpdateAtResourceGroup,
-  Attestations
-);
 @@clientName(
-  AttestationResourceGroupOperations.createOrUpdateAtResourceGroup::parameters.resource,
+  Attestations.createOrUpdateAtResourceGroup::parameters.resource,
   "parameters"
 );
-@@clientLocation(
-  AttestationResourceGroupOperations.deleteAtResourceGroup,
-  Attestations
-);
-@@clientLocation(
-  AttestationResourceGroupOperations.listForResourceGroup,
-  Attestations
-);
-@@clientLocation(AttestationOperationGroup.getAtResource, Attestations);
-@@clientLocation(
-  AttestationOperationGroup.createOrUpdateAtResource,
-  Attestations
-);
 @@clientName(
-  AttestationOperationGroup.createOrUpdateAtResource::parameters.resource,
+  Attestations.createOrUpdateAtResource::parameters.resource,
   "parameters"
 );
-@@clientLocation(AttestationOperationGroup.deleteAtResource, Attestations);
-@@clientLocation(AttestationOperationGroup.listForResource, Attestations);
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Legacy.flattenProperty(Attestation.properties);
 

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2063,6 +2063,36 @@ op attestationsListForResource(
 // those markers. Accepted as additive new public surface; revisit if the
 // generator gains support for marking these as pageable without modifying
 // the shared models.tsp.
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForSubscription,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroup,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForPolicyDefinition,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment,
+  "csharp"
+);
 
 // Remediations: hide management-group, subscription, resource-group scope operations from C#
 @@scope(Remediations.getAtManagementGroup, "!csharp");

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2033,6 +2033,13 @@ op attestationsListForResource(
   Azure.Core.azureLocation,
   "csharp"
 );
+// GA autorest's `format-by-name-rules: '*Uri': 'Uri'` retyped the slim
+// metadata's additionalContentUrl to System.Uri; preserve that.
+@@alternateType(
+  PolicyMetadataSlimProperties.additionalContentUrl,
+  url,
+  "csharp"
+);
 
 @@access(CheckRestrictionEvaluationDetails, Access.public, "csharp");
 // The generator emits a model PolicyMetadataCollection (paging envelope for
@@ -2071,6 +2078,29 @@ op attestationsListForResource(
 @@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
 @@scope(Attestations.deleteAtResourceGroup, "!csharp");
 @@scope(Attestations.listForResourceGroup, "!csharp");
+
+// Restore ResourceData base class on response models that GA's autorest emitted
+// as ResourceData-derived (they have id/name/type fields).
+// NOTE: ComponentEventDetails and ComponentStateDetails also have id/name/type
+// fields and ResourceData-base in GA, but applying @@hierarchyBuilding to them
+// triggers a generator bug (CS0103 additionalProperties0 in *.Serialization.cs)
+// because they also have `...Record<unknown>` spread. Re-enable once fixed.
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "GA back-compat"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(
+  SlimPolicyMetadata,
+  Azure.ResourceManager.CommonTypes.Resource,
+  "csharp"
+);
+
+// TODO(generator-bug): @@hierarchyBuilding on ComponentEventDetails and
+// ComponentStateDetails would restore their GA ResourceData base, but the
+// C# mgmt generator currently emits broken deserialization code (an
+// undeclared `additionalProperties0` variable) when a model has both
+// `...Record<unknown>` and a hierarchy base. Tried swapping via
+// @@alternateType to a replacement model with the same `...Record<unknown>`
+// spread but it caused the original Models.ComponentEventDetails /
+// Models.ComponentStateDetails to be unemitted while factory code still
+// referenced them (CS0234). Filed upstream and re-visit once fixed.
 
 @@clientName(QueryOptions, "PolicyQuerySettings", "csharp");
 @@alternateType(

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2065,6 +2065,47 @@ op attestationsListForResource(
 // the shared models.tsp.
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
 @@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForResource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForResourceGroup,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForSubscription,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForManagementGroup,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForPolicyDefinition,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForPolicySetDefinition,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForResourceGroupLevelPolicyAssignment,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PolicyStatesOperationGroup.summarizeForSubscriptionLevelPolicyAssignment,
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "compat GA"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
   ComponentPolicyStatesOperationGroup.listQueryResultsForSubscription,
   "csharp"
 );

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2073,14 +2073,14 @@ op attestationsListForResource(
 @@scope(Remediations.cancelAtResourceGroup, "!csharp");
 
 // Attestations: hide subscription and resource-group scope operations from C#
-@@scope(Attestations.getAtSubscription, "!csharp");
-@@scope(Attestations.createOrUpdateAtSubscription, "!csharp");
-@@scope(Attestations.deleteAtSubscription, "!csharp");
-@@scope(Attestations.listForSubscription, "!csharp");
-@@scope(Attestations.getAtResourceGroup, "!csharp");
-@@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
-@@scope(Attestations.deleteAtResourceGroup, "!csharp");
-@@scope(Attestations.listForResourceGroup, "!csharp");
+// @@scope(Attestations.getAtSubscription, "!csharp");
+// @@scope(Attestations.createOrUpdateAtSubscription, "!csharp");
+// @@scope(Attestations.deleteAtSubscription, "!csharp");
+// @@scope(Attestations.listForSubscription, "!csharp");
+// @@scope(Attestations.getAtResourceGroup, "!csharp");
+// @@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
+// @@scope(Attestations.deleteAtResourceGroup, "!csharp");
+// @@scope(Attestations.listForResourceGroup, "!csharp");
 
 // Restore ResourceData base class on response models that GA's autorest emitted
 // as ResourceData-derived (they have id/name/type fields).

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -1490,7 +1490,7 @@ op remediationsListDeploymentsAtSubscription(
   | ArmResponse<RemediationDeploymentsListResult>
   | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationSubscriptionOperations.listDeploymentsAtSubscription,
+  Remediations.listDeploymentsAtSubscription,
   remediationsListDeploymentsAtSubscription,
   "!java,!python"
 );
@@ -1509,7 +1509,7 @@ op remediationsListForSubscription(
   queryOptions?: RemediationsListForSubscriptionQueryOptions,
 ): ArmResponse<RemediationListResult> | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationSubscriptionOperations.listForSubscription,
+  Remediations.listForSubscription,
   remediationsListForSubscription,
   "!java,!python"
 );
@@ -1533,7 +1533,7 @@ op remediationsListDeploymentsAtResourceGroup(
   | ArmResponse<RemediationDeploymentsListResult>
   | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationResourceGroupOperations.listDeploymentsAtResourceGroup,
+  Remediations.listDeploymentsAtResourceGroup,
   remediationsListDeploymentsAtResourceGroup,
   "!java,!python"
 );
@@ -1548,7 +1548,7 @@ op remediationsListForResourceGroup(
   queryOptions?: RemediationsListForResourceGroupQueryOptions,
 ): ArmResponse<RemediationListResult> | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationResourceGroupOperations.listForResourceGroup,
+  Remediations.listForResourceGroup,
   remediationsListForResourceGroup,
   "!java,!python"
 );
@@ -1572,7 +1572,7 @@ op remediationsListDeploymentsAtResource(
   | ArmResponse<RemediationDeploymentsListResult>
   | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationResourceOperations.listDeploymentsAtResource,
+  Remediations.listDeploymentsAtResource,
   remediationsListDeploymentsAtResource,
   "!java,!python"
 );
@@ -1589,7 +1589,7 @@ op remediationsListForResource(
   queryOptions?: RemediationsListForResourceQueryOptions,
 ): ArmResponse<RemediationListResult> | PolicyInsightsApi.ErrorResponse;
 @@override(
-  RemediationResourceOperations.listForResource,
+  Remediations.listForResource,
   remediationsListForResource,
   "!java,!python"
 );
@@ -1625,7 +1625,7 @@ op attestationsListForResourceGroup(
   queryOptions?: AttestationsListForResourceGroupQueryOptions,
 ): ArmResponse<AttestationListResult> | PolicyInsightsApi.ErrorResponse;
 @@override(
-  AttestationResourceGroupOperations.listForResourceGroup,
+  Attestations.listForResourceGroup,
   attestationsListForResourceGroup,
   "!java,!python"
 );
@@ -1642,7 +1642,7 @@ op attestationsListForResource(
   queryOptions?: AttestationsListForResourceQueryOptions,
 ): ArmResponse<AttestationListResult> | PolicyInsightsApi.ErrorResponse;
 @@override(
-  AttestationOperationGroup.listForResource,
+  Attestations.listForResource,
   attestationsListForResource,
   "!java,!python"
 );

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2106,6 +2106,46 @@ op attestationsListForResource(
 // referenced them (CS0234). Filed upstream and re-visit once fixed.
 
 @@clientName(QueryOptions, "PolicyQuerySettings", "csharp");
+
+// Rename auto-emitted Mockable*Resource / PolicyInsightsExtensions extension
+// method names back to GA. Per skill ref §9.35 the C# emitter ignores
+// @@clientName on the @@override-shimmed top-level ops (e.g.
+// policyStatesSummarizeForSubscriptionLevelPolicyAssignment) but DOES honour
+// @@clientName when applied to the ARM-template-derived interface op
+// (PolicyStatesOperationGroup.summarizeForSubscriptionLevelPolicyAssignment).
+//
+// NOTE: GA used the same C# name for the 4 scope-bound variants (sub/rg/mg/
+// resource) of each query/summarize family — autorest combined them at source
+// level. The new emitter emits one ArmClient extension + REST method per op,
+// so renaming all 4 to the same name causes CS0111 on the ArmClient extension
+// class and the REST operations class. The renames below avoid that pattern —
+// only ops whose default name doesn't already match GA AND whose new name does
+// not collide with another rename in the same target class.
+@@clientName(PolicyEventsOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionPolicyEvents", "csharp");
+@@clientName(PolicyEventsOperationGroup.listQueryResultsForPolicySetDefinition, "GetQueryResultsForPolicySetDefinitionPolicyEvents", "csharp");
+@@clientName(PolicyEventsOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyEvents", "csharp");
+@@clientName(PolicyEventsOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyEvents", "csharp");
+
+@@clientName(PolicyStatesOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.listQueryResultsForPolicySetDefinition, "GetQueryResultsForPolicySetDefinitionPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.summarizeForPolicyDefinition, "SummarizeForPolicyDefinitionPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.summarizeForPolicySetDefinition, "SummarizeForPolicySetDefinitionPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.summarizeForSubscriptionLevelPolicyAssignment, "SummarizeForSubscriptionLevelPolicyAssignmentPolicyStates", "csharp");
+@@clientName(PolicyStatesOperationGroup.summarizeForResourceGroupLevelPolicyAssignment, "SummarizeForResourceGroupLevelPolicyAssignmentPolicyStates", "csharp");
+
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForSubscription, "GetQueryResultsForSubscriptionComponentPolicyStates", "csharp");
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroup, "GetQueryResultsForResourceGroupComponentPolicyStates", "csharp");
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResource, "GetQueryResultsForResourceComponentPolicyStates", "csharp");
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionComponentPolicyStates", "csharp");
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentComponentPolicyStates", "csharp");
+@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentComponentPolicyStates", "csharp");
+
+@@clientName(PolicyMetadataNonResourceOperationGroup.list, "GetAll", "csharp");
+
+@@clientName(Remediations.listDeploymentsAtResource, "GetDeployments", "csharp");
+@@clientName(Remediations.cancelAtResource, "Cancel", "csharp");
 @@alternateType(
   attestationsListForResource::parameters.queryOptions,
   QueryOptions,

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -1887,11 +1887,6 @@ op attestationsListForResource(
 @@clientName(AttestationProperties.assessmentDate, "assessOn", "csharp");
 @@clientName(RemediationProperties.filters, "filter", "csharp");
 @@clientName(PolicyTrackedResource.lastUpdateUtc, "lastUpdateOn", "csharp");
-@@clientName(
-  PolicyEvaluationResult.evaluationDetails,
-  "checkRestrictionEvaluationDetails",
-  "csharp"
-);
 @@clientName(PolicyEvent.resourceType, "resourceTypeString", "csharp");
 @@clientName(PolicyState.resourceType, "resourceTypeString", "csharp");
 
@@ -2050,6 +2045,14 @@ op attestationsListForResource(
 @@access(PolicyInsightsApi.Operation, Access.internal, "csharp");
 @@access(OperationsListResults, Access.internal, "csharp");
 @@scope(PolicyInsightsApi.Operations.list, "!csharp");
+// NOTE: ComponentPolicyStatesQueryResults and SummarizeResults are paging
+// envelopes that GA hid by returning Pageable<T> (autorest's automatic
+// pageable detection via x-ms-pageable). The new spec ops are non-pageable
+// (no @pageItems / @nextLink on response models), so the C# emitter exposes
+// the envelopes directly. @@Legacy.markAsPageable is ineffective without
+// those markers. Accepted as additive new public surface; revisit if the
+// generator gains support for marking these as pageable without modifying
+// the shared models.tsp.
 
 // Remediations: hide management-group, subscription, resource-group scope operations from C#
 @@scope(Remediations.getAtManagementGroup, "!csharp");

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2059,6 +2059,8 @@ op attestationsListForResource(
 @@scope(Remediations.createOrUpdateAtManagementGroup, "!csharp");
 @@scope(Remediations.deleteAtManagementGroup, "!csharp");
 @@scope(Remediations.listForManagementGroup, "!csharp");
+@@scope(RemediationsOperationGroup.listDeploymentsAtManagementGroup, "!csharp");
+@@scope(RemediationsOperationGroup.cancelAtManagementGroup, "!csharp");
 @@scope(Remediations.getAtSubscription, "!csharp");
 @@scope(Remediations.createOrUpdateAtSubscription, "!csharp");
 @@scope(Remediations.deleteAtSubscription, "!csharp");
@@ -2073,14 +2075,14 @@ op attestationsListForResource(
 @@scope(Remediations.cancelAtResourceGroup, "!csharp");
 
 // Attestations: hide subscription and resource-group scope operations from C#
-// @@scope(Attestations.getAtSubscription, "!csharp");
-// @@scope(Attestations.createOrUpdateAtSubscription, "!csharp");
-// @@scope(Attestations.deleteAtSubscription, "!csharp");
-// @@scope(Attestations.listForSubscription, "!csharp");
-// @@scope(Attestations.getAtResourceGroup, "!csharp");
-// @@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
-// @@scope(Attestations.deleteAtResourceGroup, "!csharp");
-// @@scope(Attestations.listForResourceGroup, "!csharp");
+@@scope(Attestations.getAtSubscription, "!csharp");
+@@scope(Attestations.createOrUpdateAtSubscription, "!csharp");
+@@scope(Attestations.deleteAtSubscription, "!csharp");
+@@scope(Attestations.listForSubscription, "!csharp");
+@@scope(Attestations.getAtResourceGroup, "!csharp");
+@@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
+@@scope(Attestations.deleteAtResourceGroup, "!csharp");
+@@scope(Attestations.listForResourceGroup, "!csharp");
 
 // Restore ResourceData base class on response models that GA's autorest emitted
 // as ResourceData-derived (they have id/name/type fields).
@@ -2131,30 +2133,107 @@ op attestationsListForResource(
 // class and the REST operations class. The renames below avoid that pattern —
 // only ops whose default name doesn't already match GA AND whose new name does
 // not collide with another rename in the same target class.
-@@clientName(PolicyEventsOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionPolicyEvents", "csharp");
-@@clientName(PolicyEventsOperationGroup.listQueryResultsForPolicySetDefinition, "GetQueryResultsForPolicySetDefinitionPolicyEvents", "csharp");
-@@clientName(PolicyEventsOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyEvents", "csharp");
-@@clientName(PolicyEventsOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyEvents", "csharp");
 
-@@clientName(PolicyStatesOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.listQueryResultsForPolicySetDefinition, "GetQueryResultsForPolicySetDefinitionPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.summarizeForPolicyDefinition, "SummarizeForPolicyDefinitionPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.summarizeForPolicySetDefinition, "SummarizeForPolicySetDefinitionPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.summarizeForSubscriptionLevelPolicyAssignment, "SummarizeForSubscriptionLevelPolicyAssignmentPolicyStates", "csharp");
-@@clientName(PolicyStatesOperationGroup.summarizeForResourceGroupLevelPolicyAssignment, "SummarizeForResourceGroupLevelPolicyAssignmentPolicyStates", "csharp");
+@@clientName(
+  PolicyEventsOperationGroup.listQueryResultsForPolicyDefinition,
+  "GetQueryResultsForPolicyDefinitionPolicyEvents",
+  "csharp"
+);
+@@clientName(
+  PolicyEventsOperationGroup.listQueryResultsForPolicySetDefinition,
+  "GetQueryResultsForPolicySetDefinitionPolicyEvents",
+  "csharp"
+);
+@@clientName(
+  PolicyEventsOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment,
+  "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyEvents",
+  "csharp"
+);
+@@clientName(
+  PolicyEventsOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment,
+  "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyEvents",
+  "csharp"
+);
 
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForSubscription, "GetQueryResultsForSubscriptionComponentPolicyStates", "csharp");
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroup, "GetQueryResultsForResourceGroupComponentPolicyStates", "csharp");
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResource, "GetQueryResultsForResourceComponentPolicyStates", "csharp");
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForPolicyDefinition, "GetQueryResultsForPolicyDefinitionComponentPolicyStates", "csharp");
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment, "GetQueryResultsForSubscriptionLevelPolicyAssignmentComponentPolicyStates", "csharp");
-@@clientName(ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment, "GetQueryResultsForResourceGroupLevelPolicyAssignmentComponentPolicyStates", "csharp");
+@@clientName(
+  PolicyStatesOperationGroup.listQueryResultsForPolicyDefinition,
+  "GetQueryResultsForPolicyDefinitionPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.listQueryResultsForPolicySetDefinition,
+  "GetQueryResultsForPolicySetDefinitionPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment,
+  "GetQueryResultsForSubscriptionLevelPolicyAssignmentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment,
+  "GetQueryResultsForResourceGroupLevelPolicyAssignmentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.summarizeForPolicyDefinition,
+  "SummarizeForPolicyDefinitionPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.summarizeForPolicySetDefinition,
+  "SummarizeForPolicySetDefinitionPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.summarizeForSubscriptionLevelPolicyAssignment,
+  "SummarizeForSubscriptionLevelPolicyAssignmentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.summarizeForResourceGroupLevelPolicyAssignment,
+  "SummarizeForResourceGroupLevelPolicyAssignmentPolicyStates",
+  "csharp"
+);
+
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForSubscription,
+  "GetQueryResultsForSubscriptionComponentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroup,
+  "GetQueryResultsForResourceGroupComponentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResource,
+  "GetQueryResultsForResourceComponentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForPolicyDefinition,
+  "GetQueryResultsForPolicyDefinitionComponentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForSubscriptionLevelPolicyAssignment,
+  "GetQueryResultsForSubscriptionLevelPolicyAssignmentComponentPolicyStates",
+  "csharp"
+);
+@@clientName(
+  ComponentPolicyStatesOperationGroup.listQueryResultsForResourceGroupLevelPolicyAssignment,
+  "GetQueryResultsForResourceGroupLevelPolicyAssignmentComponentPolicyStates",
+  "csharp"
+);
 
 @@clientName(PolicyMetadataNonResourceOperationGroup.list, "GetAll", "csharp");
 
-@@clientName(Remediations.listDeploymentsAtResource, "GetDeployments", "csharp");
+@@clientName(
+  Remediations.listDeploymentsAtResource,
+  "GetDeployments",
+  "csharp"
+);
 @@clientName(Remediations.cancelAtResource, "Cancel", "csharp");
 @@alternateType(
   attestationsListForResource::parameters.queryOptions,

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2094,28 +2094,12 @@ op attestationsListForResource(
 @@scope(Attestations.deleteAtResourceGroup, "!csharp");
 @@scope(Attestations.listForResourceGroup, "!csharp");
 
-// Restore ResourceData base class on response models that GA's autorest emitted
-// as ResourceData-derived (they have id/name/type fields).
-// NOTE: ComponentEventDetails and ComponentStateDetails also have id/name/type
-// fields and ResourceData-base in GA, but applying @@hierarchyBuilding to them
-// triggers a generator bug (CS0103 additionalProperties0 in *.Serialization.cs)
-// because they also have `...Record<unknown>` spread. Re-enable once fixed.
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "GA back-compat"
 @@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(
   SlimPolicyMetadata,
   Azure.ResourceManager.CommonTypes.Resource,
   "csharp"
 );
-
-// TODO(generator-bug): @@hierarchyBuilding on ComponentEventDetails and
-// ComponentStateDetails would restore their GA ResourceData base, but the
-// C# mgmt generator currently emits broken deserialization code (an
-// undeclared `additionalProperties0` variable) when a model has both
-// `...Record<unknown>` and a hierarchy base. Tried swapping via
-// @@alternateType to a replacement model with the same `...Record<unknown>`
-// spread but it caused the original Models.ComponentEventDetails /
-// Models.ComponentStateDetails to be unemitted while factory code still
-// referenced them (CS0234). Filed upstream and re-visit once fixed.
 
 @@clientName(QueryOptions, "PolicyQuerySettings", "csharp");
 

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2107,6 +2107,16 @@ op attestationsListForResource(
 
 @@clientName(QueryOptions, "PolicyQuerySettings", "csharp");
 
+// Restore GA OData property names (uppercase D after O) on the user-facing models.
+@@clientName(PolicyEvent.`@odata.id`, "ODataId", "csharp");
+@@clientName(PolicyEvent.`@odata.context`, "ODataContext", "csharp");
+@@clientName(PolicyState.`@odata.id`, "ODataId", "csharp");
+@@clientName(PolicyState.`@odata.context`, "ODataContext", "csharp");
+@@clientName(ComponentPolicyState.`@odata.id`, "ODataId", "csharp");
+@@clientName(ComponentPolicyState.`@odata.context`, "ODataContext", "csharp");
+@@clientName(Summary.`@odata.id`, "ODataId", "csharp");
+@@clientName(Summary.`@odata.context`, "ODataContext", "csharp");
+
 // Rename auto-emitted Mockable*Resource / PolicyInsightsExtensions extension
 // method names back to GA. Per skill ref §9.35 the C# emitter ignores
 // @@clientName on the @@override-shimmed top-level ops (e.g.

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -1865,6 +1865,16 @@ op attestationsListForResource(
   "CheckPolicyRestrictionsResult",
   "csharp"
 );
+@@clientName(
+  CheckRestrictionsResult.contentEvaluationResult,
+  "PolicyEvaluations",
+  "csharp"
+);
+@@clientName(
+  PolicyEvaluationResult.evaluationDetails,
+  "CheckRestrictionEvaluationDetails",
+  "csharp"
+);
 // Back-compat class renames (previously done via the autorest rename-mapping).
 @@clientName(Attestation, "PolicyAttestation", "csharp");
 @@clientName(Remediation, "PolicyRemediation", "csharp");
@@ -2466,13 +2476,28 @@ op attestationsListForResource(
   "csharp"
 );
 
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "for csharp sdk compat"
 @@clientName(
   PolicyStatesOperationGroup.triggerResourceGroupEvaluation,
   "TriggerPolicyStateEvaluation",
   "csharp"
 );
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "for csharp sdk compat"
 @@clientName(
   PolicyStatesOperationGroup.triggerSubscriptionEvaluation,
   "TriggerPolicyStateEvaluation",
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "csharp sdk compat"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(
+  ComponentEventDetails,
+  Foundations.Resource,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "csharp sdk compat"
+@@Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(
+  ComponentStateDetails,
+  Foundations.Resource,
   "csharp"
 );

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -1850,25 +1850,33 @@ op attestationsListForResource(
 
 @@clientName(Summary, "PolicySummary", "csharp");
 @@clientName(SummaryResults, "PolicySummaryResults", "csharp");
-@@clientName(CheckRestrictionsRequest, "CheckPolicyRestrictionsContent", "csharp");
+@@clientName(
+  CheckRestrictionsRequest,
+  "CheckPolicyRestrictionsContent",
+  "csharp"
+);
 @@clientName(
   CheckManagementGroupRestrictionsRequest,
   "CheckManagementGroupPolicyRestrictionsContent",
   "csharp"
 );
-@@clientName(CheckRestrictionsResult, "CheckPolicyRestrictionsResult", "csharp");
+@@clientName(
+  CheckRestrictionsResult,
+  "CheckPolicyRestrictionsResult",
+  "csharp"
+);
 // Back-compat class renames (previously done via the autorest rename-mapping).
 @@clientName(Attestation, "PolicyAttestation", "csharp");
 @@clientName(Remediation, "PolicyRemediation", "csharp");
 @@clientName(ComplianceState, "PolicyComplianceState", "csharp");
 @@clientName(PolicyEventsResourceType, "PolicyEventType", "csharp");
 @@clientName(PolicyStatesResource, "PolicyStateType", "csharp");
-@@clientName(PolicyStatesSummaryResourceType, "PolicyStateSummaryType", "csharp");
 @@clientName(
-  PolicyTrackedResource,
-  "PolicyTrackedResourceRecord",
+  PolicyStatesSummaryResourceType,
+  "PolicyStateSummaryType",
   "csharp"
 );
+@@clientName(PolicyTrackedResource, "PolicyTrackedResourceRecord", "csharp");
 @@clientName(
   PolicyTrackedResourcesResourceType,
   "PolicyTrackedResourceType",
@@ -1888,8 +1896,16 @@ op attestationsListForResource(
 @@clientName(PolicyState.resourceType, "resourceTypeString", "csharp");
 
 // Back-compat property types: ARM ID strings should be typed as ResourceIdentifier.
-@@alternateType(AttestationProperties.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(RemediationProperties.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  AttestationProperties.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  RemediationProperties.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(
   PolicyAssignmentSummary.policyAssignmentId,
   Azure.Core.armResourceIdentifier,
@@ -1915,17 +1931,61 @@ op attestationsListForResource(
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(PolicyEvent.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyEvent.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyEvent.resourceId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyEvent.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyReference.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyReference.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyReference.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyState.resourceId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyState.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyState.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(PolicyState.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  PolicyEvent.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyEvent.policyDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyEvent.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyEvent.policySetDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyReference.policyDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyReference.policySetDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyReference.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyState.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyState.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyState.policyDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyState.policySetDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(
   IfNotExistsEvaluationDetails.resourceId,
   Azure.Core.armResourceIdentifier,
@@ -1936,13 +1996,21 @@ op attestationsListForResource(
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(PolicyTrackedResource.trackedResourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  PolicyTrackedResource.trackedResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(
   RemediationDeployment.remediatedResourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(RemediationDeployment.deploymentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  RemediationDeployment.deploymentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
 @@alternateType(
   TrackedResourceModificationDetails.deploymentId,
   Azure.Core.armResourceIdentifier,
@@ -1950,8 +2018,16 @@ op attestationsListForResource(
 );
 
 // Back-compat property types: location strings should be typed as AzureLocation.
-@@alternateType(PolicyEvent.resourceLocation, Azure.Core.azureLocation, "csharp");
-@@alternateType(PolicyState.resourceLocation, Azure.Core.azureLocation, "csharp");
+@@alternateType(
+  PolicyEvent.resourceLocation,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+@@alternateType(
+  PolicyState.resourceLocation,
+  Azure.Core.azureLocation,
+  "csharp"
+);
 @@alternateType(
   RemediationDeployment.resourceLocation,
   Azure.Core.azureLocation,
@@ -1996,3 +2072,234 @@ op attestationsListForResource(
 @@scope(Attestations.deleteAtResourceGroup, "!csharp");
 @@scope(Attestations.listForResourceGroup, "!csharp");
 
+@@clientName(QueryOptions, "PolicyQuerySettings", "csharp");
+@@alternateType(
+  attestationsListForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyTrackedResourcesListQueryResultsForManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyTrackedResourcesListQueryResultsForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyTrackedResourcesListQueryResultsForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyTrackedResourcesListQueryResultsForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForPolicySetDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForPolicyDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForSubscriptionLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyEventsListQueryResultsForResourceGroupLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForPolicySetDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForPolicySetDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForPolicyDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForPolicyDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForSubscriptionLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForSubscriptionLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesListQueryResultsForResourceGroupLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyStatesSummarizeForResourceGroupLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  policyMetadataList::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForPolicyDefinition::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForSubscriptionLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  componentPolicyStatesListQueryResultsForResourceGroupLevelPolicyAssignment::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListDeploymentsAtManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListForManagementGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListDeploymentsAtSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListDeploymentsAtResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListDeploymentsAtResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  remediationsListForResource::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  attestationsListForSubscription::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);
+@@alternateType(
+  attestationsListForResourceGroup::parameters.queryOptions,
+  QueryOptions,
+  "csharp"
+);

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -1823,3 +1823,176 @@ op attestationsListForResource(
   "javascript"
 );
 @@alternateType(ManagementGroupsNamespaceType, "Microsoft.Management");
+
+// ============================================================================
+// C# customizations
+//
+// Rationale:
+// 1) Back-compat renames preserve the GA C# SDK surface (Summary/SummaryResults
+//    were renamed to PolicySummary/PolicySummaryResults via the prior autorest
+//    config). Also works around a current C# mgmt generator inconsistency where
+//    ArmPolicyInsightsModelFactory references `Models.PolicySummaryResults`
+//    while only `Models.SummaryResults` is emitted.
+// 2) CheckRestrictionEvaluationDetails is referenced as a parameter on the
+//    public Arm*ModelFactory.PolicyEvaluationResult overload, but generated as
+//    internal. Make it public for C#.
+// 3) The spec defines per-scope LegacyOperations aliases (management group,
+//    subscription, resource group, and generic AtResource) for both Attestation
+//    and Remediation, all sharing the same ResourceName. The current C# mgmt
+//    generator emits one ArmClient extension set per alias, producing
+//    duplicate method signatures (CS0111) and per-scope helper extensions that
+//    did not exist on the GA C# SDK. Suppressing every alias except the
+//    generic AtResource one for C# only restores the GA surface (ArmClient
+//    extensions only) without changing the swagger emitted for other
+//    languages. The remaining AtResource alias uses `{resourceId}` which
+//    accepts any subscription/resource-group/management-group scope at runtime.
+// ============================================================================
+
+@@clientName(Summary, "PolicySummary", "csharp");
+@@clientName(SummaryResults, "PolicySummaryResults", "csharp");
+@@clientName(CheckRestrictionsRequest, "CheckPolicyRestrictionsContent", "csharp");
+@@clientName(
+  CheckManagementGroupRestrictionsRequest,
+  "CheckManagementGroupPolicyRestrictionsContent",
+  "csharp"
+);
+@@clientName(CheckRestrictionsResult, "CheckPolicyRestrictionsResult", "csharp");
+// Back-compat class renames (previously done via the autorest rename-mapping).
+@@clientName(Attestation, "PolicyAttestation", "csharp");
+@@clientName(Remediation, "PolicyRemediation", "csharp");
+@@clientName(ComplianceState, "PolicyComplianceState", "csharp");
+@@clientName(PolicyEventsResourceType, "PolicyEventType", "csharp");
+@@clientName(PolicyStatesResource, "PolicyStateType", "csharp");
+@@clientName(PolicyStatesSummaryResourceType, "PolicyStateSummaryType", "csharp");
+@@clientName(
+  PolicyTrackedResource,
+  "PolicyTrackedResourceRecord",
+  "csharp"
+);
+@@clientName(
+  PolicyTrackedResourcesResourceType,
+  "PolicyTrackedResourceType",
+  "csharp"
+);
+// Back-compat property renames.
+@@clientName(AttestationProperties.expiresOn, "expireOn", "csharp");
+@@clientName(AttestationProperties.assessmentDate, "assessOn", "csharp");
+@@clientName(RemediationProperties.filters, "filter", "csharp");
+@@clientName(PolicyTrackedResource.lastUpdateUtc, "lastUpdateOn", "csharp");
+@@clientName(
+  PolicyEvaluationResult.evaluationDetails,
+  "checkRestrictionEvaluationDetails",
+  "csharp"
+);
+@@clientName(PolicyEvent.resourceType, "resourceTypeString", "csharp");
+@@clientName(PolicyState.resourceType, "resourceTypeString", "csharp");
+
+// Back-compat property types: ARM ID strings should be typed as ResourceIdentifier.
+@@alternateType(AttestationProperties.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(RemediationProperties.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  PolicyAssignmentSummary.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyAssignmentSummary.policySetDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyDetails.policyDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyDetails.policyAssignmentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyDetails.policySetDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(PolicyEvent.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyEvent.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyEvent.resourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyEvent.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyReference.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyReference.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyReference.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyState.resourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyState.policyAssignmentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyState.policyDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(PolicyState.policySetDefinitionId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  IfNotExistsEvaluationDetails.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  PolicyDefinitionSummary.policyDefinitionId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(PolicyTrackedResource.trackedResourceId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  RemediationDeployment.remediatedResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(RemediationDeployment.deploymentId, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  TrackedResourceModificationDetails.deploymentId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+
+// Back-compat property types: location strings should be typed as AzureLocation.
+@@alternateType(PolicyEvent.resourceLocation, Azure.Core.azureLocation, "csharp");
+@@alternateType(PolicyState.resourceLocation, Azure.Core.azureLocation, "csharp");
+@@alternateType(
+  RemediationDeployment.resourceLocation,
+  Azure.Core.azureLocation,
+  "csharp"
+);
+
+@@access(CheckRestrictionEvaluationDetails, Access.public, "csharp");
+// The generator emits a model PolicyMetadataCollection (paging envelope for
+// SlimPolicyMetadata) that conflicts with the ArmCollection type of the same
+// name. The GA C# SDK only exposed the ArmCollection publicly.
+@@access(PolicyMetadataCollection, Access.internal, "csharp");
+// GA C# SDK did not expose the Operations RP model publicly.
+@@access(PolicyInsightsApi.Operation, Access.internal, "csharp");
+@@access(OperationsListResults, Access.internal, "csharp");
+@@scope(PolicyInsightsApi.Operations.list, "!csharp");
+
+// Remediations: hide management-group, subscription, resource-group scope operations from C#
+@@scope(Remediations.getAtManagementGroup, "!csharp");
+@@scope(Remediations.createOrUpdateAtManagementGroup, "!csharp");
+@@scope(Remediations.deleteAtManagementGroup, "!csharp");
+@@scope(Remediations.listForManagementGroup, "!csharp");
+@@scope(Remediations.getAtSubscription, "!csharp");
+@@scope(Remediations.createOrUpdateAtSubscription, "!csharp");
+@@scope(Remediations.deleteAtSubscription, "!csharp");
+@@scope(Remediations.listForSubscription, "!csharp");
+@@scope(Remediations.listDeploymentsAtSubscription, "!csharp");
+@@scope(Remediations.cancelAtSubscription, "!csharp");
+@@scope(Remediations.getAtResourceGroup, "!csharp");
+@@scope(Remediations.createOrUpdateAtResourceGroup, "!csharp");
+@@scope(Remediations.deleteAtResourceGroup, "!csharp");
+@@scope(Remediations.listForResourceGroup, "!csharp");
+@@scope(Remediations.listDeploymentsAtResourceGroup, "!csharp");
+@@scope(Remediations.cancelAtResourceGroup, "!csharp");
+
+// Attestations: hide subscription and resource-group scope operations from C#
+@@scope(Attestations.getAtSubscription, "!csharp");
+@@scope(Attestations.createOrUpdateAtSubscription, "!csharp");
+@@scope(Attestations.deleteAtSubscription, "!csharp");
+@@scope(Attestations.listForSubscription, "!csharp");
+@@scope(Attestations.getAtResourceGroup, "!csharp");
+@@scope(Attestations.createOrUpdateAtResourceGroup, "!csharp");
+@@scope(Attestations.deleteAtResourceGroup, "!csharp");
+@@scope(Attestations.listForResourceGroup, "!csharp");
+

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/client.tsp
@@ -2465,3 +2465,14 @@ op attestationsListForResource(
   QueryOptions,
   "csharp"
 );
+
+@@clientName(
+  PolicyStatesOperationGroup.triggerResourceGroupEvaluation,
+  "TriggerPolicyStateEvaluation",
+  "csharp"
+);
+@@clientName(
+  PolicyStatesOperationGroup.triggerSubscriptionEvaluation,
+  "TriggerPolicyStateEvaluation",
+  "csharp"
+);

--- a/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/tspconfig.yaml
+++ b/specification/policyinsights/resource-manager/Microsoft.PolicyInsights/PolicyInsights/tspconfig.yaml
@@ -32,6 +32,9 @@ options:
     head-as-boolean: true
     inject-spans: true
     factory-gather-all-params: true
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.PolicyInsights"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
Spec-side csharp customizations to support Azure.ResourceManager.PolicyInsights migration from AutoRest to TypeSpec.

Summary of changes in PolicyInsights/client.tsp (csharp-scoped):
- @@scope hides redundant per-scope Attestation/Remediation operations from C# to dedup ArmClient extensions (the C# mgmt generator emits one ArmClient extension set per Legacy.LegacyOperations alias sharing the same ResourceName; reported as a generator bug).
- @@clientName restores GA back-compat class names (PolicyAttestation, PolicyRemediation, PolicyComplianceState, PolicySummary, PolicySummaryResults, PolicyEventType, PolicyStateType, PolicyStateSummaryType, PolicyTrackedResourceType, PolicyTrackedResourceRecord, CheckPolicyRestrictionsContent, etc.) and property names (expireOn, assessOn, lastUpdateOn, filter, resourceTypeString).
- @@alternateType applies ResourceIdentifier / AzureLocation types for arm-id and azure-location properties.
- @@access(internal) hides Operations RP models and the PolicyMetadataCollection paging envelope (which conflicts with the ArmCollection of the same name).
- tspconfig.yaml: added @azure-typespec/http-client-csharp-mgmt emitter with namespace Azure.ResourceManager.PolicyInsights.

Tracks SDK PR: Azure/azure-sdk-for-net (to be created)