### PR TITLE
add Container-Native SLB API (service SKU, PodIP backend, natGatewayId)

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -967,6 +967,12 @@ union LoadBalancerSku {
   string,
 
   /**
+   * Use a service Load Balancer, with native pod-level load balancing. This SKU is specifically built to scale for container-based workloads, with a single instance utilized for each application. For more information, see https://aka.ms/aks/container-native-slb
+   */
+  @added(Versions.v2026_05_02_preview)
+  service: "service",
+
+  /**
    * Use a a standard Load Balancer. This is the recommended Load Balancer SKU. For more information about on working with the load balancer in the managed cluster, see the [standard Load Balancer](https://docs.microsoft.com/azure/aks/load-balancer-standard) article.
    */
   standard: "standard",
@@ -992,6 +998,12 @@ union BackendPoolType {
    * The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend.
    */
   NodeIP: "NodeIP",
+
+  /**
+   * The type of the managed inbound Load Balancer BackendPool. Used only when loadBalancerSku is specified as 'service'. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend.
+   */
+  @added(Versions.v2026_05_02_preview)
+  PodIP: "PodIP",
 }
 
 /**
@@ -2477,6 +2489,17 @@ model ContainerServiceNetworkProfile {
    * Profile of the cluster NAT gateway.
    */
   natGatewayProfile?: ManagedClusterNATGatewayProfile;
+
+  /**
+   * The ARM resource ID of the NAT gateway to use for egress at cluster startup when outboundType is 'userAssignedNATGateway' using StandardV2 Public IP, backend pool type is podIP, and load balancer type is service SKU. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}'. When using managed NATGateway this field is auto populated. For more information, see https://aka.ms/aks/container-native-slb
+   */
+  @added(Versions.v2026_05_02_preview)
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  natGatewayId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/natGateways";
+    }
+  ]>;
 
   /**
    * The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
@@ -8020,6 +8020,22 @@
           "$ref": "#/definitions/ManagedClusterNATGatewayProfile",
           "description": "Profile of the cluster NAT gateway."
         },
+        "natGatewayId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of the NAT gateway to use for egress at cluster startup when outboundType is 'userAssignedNATGateway' using StandardV2 Public IP, backend pool type is podIP, and load balancer type is service SKU. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}'. When using managed NATGateway this field is auto populated. For more information, see https://aka.ms/aks/container-native-slb",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/natGateways"
+              }
+            ]
+          }
+        },
         "staticEgressGatewayProfile": {
           "$ref": "#/definitions/ManagedClusterStaticEgressGatewayProfile",
           "description": "The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway."
@@ -9651,6 +9667,7 @@
       "type": "string",
       "description": "The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.",
       "enum": [
+        "service",
         "standard",
         "basic"
       ],
@@ -9658,6 +9675,11 @@
         "name": "LoadBalancerSku",
         "modelAsString": true,
         "values": [
+          {
+            "name": "service",
+            "value": "service",
+            "description": "Use a service Load Balancer, with native pod-level load balancing. This SKU is specifically built to scale for container-based workloads, with a single instance utilized for each application. For more information, see https://aka.ms/aks/container-native-slb"
+          },
           {
             "name": "standard",
             "value": "standard",
@@ -11736,7 +11758,8 @@
           "default": "NodeIPConfiguration",
           "enum": [
             "NodeIPConfiguration",
-            "NodeIP"
+            "NodeIP",
+            "PodIP"
           ],
           "x-ms-enum": {
             "name": "BackendPoolType",
@@ -11751,6 +11774,11 @@
                 "name": "NodeIP",
                 "value": "NodeIP",
                 "description": "The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend."
+              },
+              {
+                "name": "PodIP",
+                "value": "PodIP",
+                "description": "The type of the managed inbound Load Balancer BackendPool. Used only when loadBalancerSku is specified as 'service'. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend."
               }
             ]
           }


### PR DESCRIPTION
## Purpose of this PR
 
 - [x] Update existing version for a new feature. (Revising the `2026-05-02-preview` preview API version on the AKS May release dev branch.)
 
 ## Summary
 
 Adds the **Container-Native SLB** API to `Microsoft.ContainerService/aks` in `2026-05-02-preview`. Container-native Layer 4 load balancing with a zone-redundant NAT Gateway egress, enabling direct pod-level traffic management for AKS clusters.
 
 ## Changes (TypeSpec edits in `CommonModels.tsp`)
 
 | # | Location | Change | Gated by |
 |---|----------|--------|----------|
 | 1 | `union LoadBalancerSku` | Add `service: "service"` | `@added(Versions.v2026_05_02_preview)` |
 | 2 | `union BackendPoolType` | Add `PodIP: "PodIP"` (use only with `service` SKU) | `@added(Versions.v2026_05_02_preview)` |
 | 3 | `model ContainerServiceNetworkProfile` | Add optional `natGatewayId` (ARM resource ID of `Microsoft.Network/natGateways`); `@visibility(Lifecycle.Create, Lifecycle.Read)` | `@added(Versions.v2026_05_02_preview)` |
 
 Plus the regenerated `preview/2026-05-02-preview/managedClusters.json` (output of `tsp compile .`).
 
 ## Constraints (per design)
 
 - `PodIP` backend pool type and `service` LB SKU must be specified together.
 - Requires Standard v2 NAT Gateway (managed or user-assigned).
 - `natGatewayId` is required for user-assigned NAT Gateway scenarios; auto-populated when using managed NAT Gateway.
 - `natGatewayId` is immutable after cluster creation (create + read only).
 
 ## Related
 
 - API proposal (handbook): https://github.com/azure-management-and-platforms/aks-handbook/pull/106
 - Original design wiki: AKS - Container-native SLB (internal)
 
 ## Validation
 
 - `tsp compile .` succeeds with no errors or warnings.
 - Verified `service`, `PodIP`, and `natGatewayId` appear in `preview/2026-05-02-preview/managedClusters.json` and are correctly absent from older previews (`2026-01-02-preview`).
 
 ## Target branch
 
 This PR targets `dev-containerservice-Microsoft.ContainerService-2026-05` (the AKS May-release staging branch), **not** `main`. It will be brought into `main` as part of the standard May-release roll-up.
