### PR TITLE
Add alertConfigurations child resource to managedClusters (2026-05-02-preview)

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
@@ -153,9 +153,11 @@ interface AlertConfigurations {
 }
 
 @@doc(AlertConfiguration.name, "The name of the alert configuration.");
-@@doc(AlertConfiguration.properties,
+@@doc(
+  AlertConfiguration.properties,
   "The resource-specific properties for this resource."
 );
-@@doc(AlertConfigurations.createOrUpdate::parameters.resource,
+@@doc(
+  AlertConfigurations.createOrUpdate::parameters.resource,
   "The alert configuration to create or update."
 );

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AlertConfiguration.tsp
@@ -1,0 +1,161 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
+import "./ManagedCluster.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using Versioning;
+
+namespace Microsoft.ContainerService;
+
+/**
+ * The mode of the alert configuration.
+ */
+@added(Versions.v2026_05_02_preview)
+union AlertConfigurationMode {
+  string,
+
+  /**
+   * Alerts are disabled.
+   */
+  Disabled: "Disabled",
+
+  /**
+   * AKS manages the alerts lifecycle including creation, updates, and deletion.
+   * Users receive alerts through the configured notification channel.
+   */
+  Managed: "Managed",
+}
+
+/**
+ * The current provisioning state of the alert configuration.
+ */
+@added(Versions.v2026_05_02_preview)
+union AlertConfigurationProvisioningState {
+  string,
+
+  /**
+   * The alert configuration is being created.
+   */
+  Creating: "Creating",
+
+  /**
+   * The alert configuration is being updated.
+   */
+  Updating: "Updating",
+
+  /**
+   * The alert configuration is being deleted.
+   */
+  Deleting: "Deleting",
+
+  /**
+   * The alert configuration has been successfully provisioned.
+   */
+  Succeeded: "Succeeded",
+
+  /**
+   * The alert configuration provisioning failed.
+   */
+  Failed: "Failed",
+
+  /**
+   * The alert configuration provisioning was canceled.
+   */
+  Canceled: "Canceled",
+}
+
+/**
+ * Notification settings for the alert configuration.
+ */
+@added(Versions.v2026_05_02_preview)
+model AlertNotification {
+  /**
+   * The resource ID of the Azure Monitor action group to send notifications to.
+   */
+  actionGroupId: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Insights/actionGroups";
+    }
+  ]>;
+}
+
+/**
+ * Properties of the alert configuration.
+ */
+@added(Versions.v2026_05_02_preview)
+model AlertConfigurationProperties {
+  /**
+   * The mode of the alert configuration. Specifies how AKS manages the alerts.
+   */
+  mode: AlertConfigurationMode;
+
+  /**
+   * Notification settings for the alert configuration.
+   */
+  notification: AlertNotification;
+
+  /**
+   * The current provisioning state of the alert configuration.
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: AlertConfigurationProvisioningState;
+}
+
+/**
+ * Alert configuration for a managed cluster. Allows configuring AKS-managed alerts
+ * that notify users of important cluster events and conditions.
+ */
+@added(Versions.v2026_05_02_preview)
+@parentResource(ManagedCluster)
+model AlertConfiguration
+  is Azure.ResourceManager.ProxyResource<AlertConfigurationProperties> {
+  ...ResourceNameParameter<
+    Resource = AlertConfiguration,
+    KeyName = "configurationName",
+    SegmentName = "alertConfigurations",
+    NamePattern = "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+  >;
+}
+
+@armResourceOperations
+@added(Versions.v2026_05_02_preview)
+interface AlertConfigurations {
+  /**
+   * Gets the specified alert configuration of a managed cluster.
+   */
+  get is ArmResourceRead<AlertConfiguration>;
+
+  /**
+   * Creates or updates an alert configuration in the specified managed cluster.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
+    AlertConfiguration,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = AlertConfiguration> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+
+  /**
+   * Deletes an alert configuration.
+   */
+  delete is ArmResourceDeleteWithoutOkAsync<
+    AlertConfiguration,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = void> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+
+  /**
+   * Gets a list of alert configurations in the specified managed cluster.
+   */
+  listByManagedCluster is ArmResourceListByParent<AlertConfiguration>;
+}
+
+@@doc(AlertConfiguration.name, "The name of the alert configuration.");
+@@doc(AlertConfiguration.properties,
+  "The resource-specific properties for this resource."
+);
+@@doc(AlertConfigurations.createOrUpdate::parameters.resource,
+  "The alert configuration to create or update."
+);

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_CreateOrUpdate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resource": {
+      "properties": {
+        "mode": "Managed",
+        "notification": {
+          "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_CreateOrUpdate",
+  "title": "Create or Update Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-01-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AlertConfigurations_Delete",
+  "title": "Delete Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Delete.json
@@ -9,7 +9,7 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-01-02-preview"
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-05-02-preview"
       }
     },
     "204": {}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_Get",
+  "title": "Get Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_ListByManagedCluster.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-02-preview/AlertConfigurations_ListByManagedCluster.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "alertconfig1",
+            "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+            "properties": {
+              "mode": "Managed",
+              "notification": {
+                "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.0000000Z",
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_ListByManagedCluster",
+  "title": "List Alert Configurations by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/main.tsp
@@ -36,6 +36,7 @@ import "./JWTAuthenticator.tsp";
 import "./MeshMembership.tsp";
 import "./Operations.tsp";
 import "./LocationRoutes.tsp";
+import "./AlertConfiguration.tsp";
 
 using Azure.ResourceManager;
 using TypeSpec.Versioning;

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_CreateOrUpdate.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resource": {
+      "properties": {
+        "mode": "Managed",
+        "notification": {
+          "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_CreateOrUpdate",
+  "title": "Create or Update Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-01-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "AlertConfigurations_Delete",
+  "title": "Delete Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Delete.json
@@ -9,7 +9,7 @@
   "responses": {
     "202": {
       "headers": {
-        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-01-02-preview"
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/locations/eastus/operationStatus/default/operationId/00000000-0000-0000-0000-000000000000?api-version=2026-05-02-preview"
       }
     },
     "204": {}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "configurationName": "alertconfig1",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "alertconfig1",
+        "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+        "properties": {
+          "mode": "Managed",
+          "notification": {
+            "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_Get",
+  "title": "Get Alert Configuration"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_ListByManagedCluster.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/examples/AlertConfigurations_ListByManagedCluster.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "alertconfig1",
+            "type": "Microsoft.ContainerService/managedClusters/alertConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/alertConfigurations/alertconfig1",
+            "properties": {
+              "mode": "Managed",
+              "notification": {
+                "actionGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Insights/actionGroups/actiongroup1"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.0000000Z",
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AlertConfigurations_ListByManagedCluster",
+  "title": "List Alert Configurations by Managed Cluster"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
@@ -7962,6 +7962,8 @@
       },
       "required": [
         "actionGroupId"
+      ]
+    },
     "AllowedSubject": {
       "type": "object",
       "description": "A subject authorized to use the identity binding for token exchange.\nThe namespace selector is required and must be non-empty. The service\naccount selector is optional; when omitted, all service accounts in\nmatching namespaces are authorized. Selectors within a single\nAllowedSubject are AND'd; multiple AllowedSubjects on an\nIdentityBinding are OR'd.",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
@@ -95,6 +95,9 @@
     },
     {
       "name": "Skus"
+    },
+    {
+      "name": "AlertConfigurations"
     }
   ],
   "paths": {
@@ -2686,6 +2689,281 @@
             "$ref": "./examples/AgentPoolsGetUpgradeProfile.json"
           }
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/alertConfigurations": {
+      "get": {
+        "operationId": "AlertConfigurations_ListByManagedCluster",
+        "tags": [
+          "AlertConfigurations"
+        ],
+        "description": "Gets a list of alert configurations in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AlertConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Alert Configurations by Managed Cluster": {
+            "$ref": "./examples/AlertConfigurations_ListByManagedCluster.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/alertConfigurations/{configurationName}": {
+      "get": {
+        "operationId": "AlertConfigurations_Get",
+        "tags": [
+          "AlertConfigurations"
+        ],
+        "description": "Gets the specified alert configuration of a managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the alert configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AlertConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Alert Configuration": {
+            "$ref": "./examples/AlertConfigurations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AlertConfigurations_CreateOrUpdate",
+        "tags": [
+          "AlertConfigurations"
+        ],
+        "description": "Creates or updates an alert configuration in the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the alert configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "The alert configuration to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AlertConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AlertConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AlertConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'AlertConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AlertConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Alert Configuration": {
+            "$ref": "./examples/AlertConfigurations_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AlertConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AlertConfigurations_Delete",
+        "tags": [
+          "AlertConfigurations"
+        ],
+        "description": "Deletes an alert configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the managed cluster resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the alert configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Alert Configuration": {
+            "$ref": "./examples/AlertConfigurations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/managedClusters/{resourceName}/availableAgentPoolVersions": {
@@ -7523,6 +7801,159 @@
           "description": "Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled."
         }
       }
+    },
+    "AlertConfiguration": {
+      "type": "object",
+      "description": "Alert configuration for a managed cluster. Allows configuring AKS-managed alerts\nthat notify users of important cluster events and conditions.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AlertConfigurationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AlertConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a AlertConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AlertConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/AlertConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AlertConfigurationMode": {
+      "type": "string",
+      "description": "The mode of the alert configuration.",
+      "enum": [
+        "Disabled",
+        "Managed"
+      ],
+      "x-ms-enum": {
+        "name": "AlertConfigurationMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Alerts are disabled."
+          },
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "AKS manages the alerts lifecycle including creation, updates, and deletion.\nUsers receive alerts through the configured notification channel."
+          }
+        ]
+      }
+    },
+    "AlertConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of the alert configuration.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/AlertConfigurationMode",
+          "description": "The mode of the alert configuration. Specifies how AKS manages the alerts."
+        },
+        "notification": {
+          "$ref": "#/definitions/AlertNotification",
+          "description": "Notification settings for the alert configuration."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AlertConfigurationProvisioningState",
+          "description": "The current provisioning state of the alert configuration.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "mode",
+        "notification"
+      ]
+    },
+    "AlertConfigurationProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state of the alert configuration.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "AlertConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The alert configuration is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The alert configuration is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The alert configuration is being deleted."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The alert configuration has been successfully provisioned."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The alert configuration provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The alert configuration provisioning was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AlertNotification": {
+      "type": "object",
+      "description": "Notification settings for the alert configuration.",
+      "properties": {
+        "actionGroupId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Azure Monitor action group to send notifications to.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Insights/actionGroups"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "actionGroupId"
+      ]
     },
     "AutoScaleProfile": {
       "type": "object",


### PR DESCRIPTION
## Summary
Adds an \`AlertConfiguration\` ARM proxy resource under \`managedClusters\`, gated to API version \`2026-05-02-preview\`.

## Scope
This PR contains **TypeSpec changes only**:
- \`aks/AlertConfiguration.tsp\` (new)
- \`aks/main.tsp\` (adds 1 import)
- \`aks/examples/2026-05-02-preview/AlertConfigurations_*.json\` (4 TypeSpec example inputs)

Generated OpenAPI (\`preview/2026-05-02-preview/managedClusters.json\` and OpenAPI examples) is intentionally omitted and will be produced via the SDK pipeline.

## Origin
Ported from \`user/mamortat/aks-alert-configurations\` (originally targeted at \`2026-01-02-preview\`), retargeted to \`2026-05-02-preview\` to match the current state of this dev branch.

https://github.com/azure-management-and-platforms/aks-handbook/blob/main/api/2026-05-02-preview/default-alerts.md