### PR TITLE
Monitor: set Python client name to MonitorWorkspacesMgmtClient

### DIFF
--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/client.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/client.tsp
@@ -9,6 +9,8 @@ using Azure.ResourceManager;
 using TypeSpec.Versioning;
 using Microsoft.Monitor;
 
+@@clientName(Microsoft.Monitor, "MonitorWorkspacesMgmtClient", "python");
+
 @@clientName(
   Azure.ResourceManager.CommonTypes.Origin,
   "ArmOrigin",


### PR DESCRIPTION
Sets the Python client name for `Microsoft.Monitor` (Accounts) to `MonitorWorkspacesMgmtClient` via `@@clientName` in `client.tsp`.

### Change
- `specification/monitoringservice/resource-manager/Microsoft.Monitor/Accounts/client.tsp`: add `@@clientName(Microsoft.Monitor, "MonitorWorkspacesMgmtClient", "python");`
