### PR TITLE
ComputeSchedule: remove python from RecurringActionsResourceOperationResult client name

### DIFF
--- a/specification/computeschedule/ComputeSchedule.Management/client.tsp
+++ b/specification/computeschedule/ComputeSchedule.Management/client.tsp
@@ -343,7 +343,7 @@ using TypeSpec.Versioning;
 @@clientName(
   ResourceOperationResponse,
   "RecurringActionsResourceOperationResult",
-  "javascript,go,python,java"
+  "javascript,go,java"
 );
 @@clientName(
   Microsoft.ComputeSchedule.Versions.`2025-05-01`,


### PR DESCRIPTION
## Summary

Removes `python` from the `@@clientName` decorator for `ResourceOperationResponse` → `RecurringActionsResourceOperationResult` in the ComputeSchedule management spec, so the Python SDK no longer applies this client name override.

## Change

`specification/computeschedule/ComputeSchedule.Management/client.tsp`:
```diff
 @@clientName(
   ResourceOperationResponse,
   "RecurringActionsResourceOperationResult",
-  "javascript,go,python,java"
+  "javascript,go,java"
 );
```
