### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-managednetworkfabric

### DIFF
--- a/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
+++ b/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
@@ -99,17 +99,22 @@ using Microsoft.ManagedNetworkFabric;
   "python"
 );
 @@clientName(
-  Microsoft.ManagedNetworkFabric.ManagementNetworkPatchConfiguration,
-  "ManagementNetworkConfigurationPatchableProperties",
+  Microsoft.ManagedNetworkFabric.StaticRouteRoutePolicy,
+  "StaticRoutePolicy",
   "python"
 );
 @@clientName(
-  Microsoft.ManagedNetworkFabric.TerminalServerPatchConfiguration,
-  "NetworkFabricPatchablePropertiesTerminalServerConfiguration",
+  Microsoft.ManagedNetworkFabric.StaticRouteRoutePolicyPatch,
+  "StaticRoutePolicyPatch",
   "python"
 );
 @@clientName(
-  Microsoft.ManagedNetworkFabric.VpnOptionBProperties,
-  "OptionBProperties",
+  Microsoft.ManagedNetworkFabric.L3IsolationDomainProperties.staticRouteRoutePolicy,
+  "staticRoutePolicy",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.L3IsolationDomainPatchProperties.staticRouteRoutePolicy,
+  "staticRoutePolicy",
   "python"
 );


### PR DESCRIPTION
Mitigate Python SDK breaking changes for azure-mgmt-managednetworkfabric during TypeSpec migration.

Mitigations applied in `client.tsp`:
- Removed incorrect `@@clientName` entries that were renaming models away from their swagger-compatible names (`ManagementNetworkPatchConfiguration`, `TerminalServerPatchConfiguration`, `VpnOptionBProperties`)
- Added `@@clientName` for `StaticRouteRoutePolicy` -> `StaticRoutePolicy`
- Added `@@clientName` for `StaticRouteRoutePolicyPatch` -> `StaticRoutePolicyPatch`
- Added `@@clientName` for property `staticRouteRoutePolicy` -> `staticRoutePolicy` on `L3IsolationDomainProperties` and `L3IsolationDomainPatchProperties`
