### PR TITLE
Add ARM modeling leases for partner PRs 43780, 43777, 43606, 28816

### DIFF
--- a/.github/arm-leases/encryptedtransport/Microsoft.EncryptedTransport/EncryptedTransport/lease.yaml
+++ b/.github/arm-leases/encryptedtransport/Microsoft.EncryptedTransport/EncryptedTransport/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.EncryptedTransport
+  startdate: "2026-06-05"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/kubernetesconfiguration/Microsoft.KubernetesConfiguration/upgradeAssessment/lease.yaml
+++ b/.github/arm-leases/kubernetesconfiguration/Microsoft.KubernetesConfiguration/upgradeAssessment/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.KubernetesConfiguration
+  startdate: "2026-06-05"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/liftrmongodb/MongoDB.Atlas/lease.yaml
+++ b/.github/arm-leases/liftrmongodb/MongoDB.Atlas/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: MongoDB.Atlas
+  startdate: "2026-06-05"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSql/lease.yaml
+++ b/.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSql/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.DBforPostgreSQL
+  startdate: "2026-06-05"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds ARM modeling leases (180 days from 2026-05-28, reviewer `@vikeshi26`) for the following partner PRs:

| Partner PR | Lease path |
| --- | --- |
| Azure/azure-rest-api-specs#43780 — MongoDB.Atlas Projects/Clusters (2026-03-01-preview) | `.github/arm-leases/liftrmongodb/MongoDB.Atlas/lease.yaml` |
| Azure/azure-rest-api-specs#43777 — postgresql folder restructure (`PostgreSql` service) | `.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSql/lease.yaml` |
| Azure/azure-rest-api-specs#43606 — KubernetesConfiguration KubeInventory + UpgradeAssessment (2026-06-15-preview) | `.github/arm-leases/kubernetesconfiguration/Microsoft.KubernetesConfiguration/upgradeAssessment/lease.yaml` (kubeInventory lease already on main) |
| Azure/azure-rest-api-specs-pr#28816 — encryptedtransport folder restructure (`EncryptedTransport` service) | `.github/arm-leases/encryptedtransport/Microsoft.EncryptedTransport/EncryptedTransport/lease.yaml` |

Each lease:
```yaml
lease:
  resource-provider: <Microsoft.X | MongoDB.Atlas>
  startdate: "2026-05-28"
  duration: P180D
  reviewer: "@vikeshi26"
```