### PR TITLE
feat(ai-foundry/evaluators): add supported_evaluation_levels to EvaluatorVersion

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -24935,7 +24935,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "definition": {
             "allOf": [
@@ -25026,7 +25026,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "definition": {
             "allOf": [
@@ -25076,7 +25076,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -24930,6 +24930,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+          },
           "definition": {
             "allOf": [
               {
@@ -25014,6 +25021,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+          },
           "definition": {
             "allOf": [
               {
@@ -25056,6 +25070,13 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
+          },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -24935,7 +24935,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "definition": {
             "allOf": [
@@ -25026,7 +25026,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "definition": {
             "allOf": [
@@ -25076,7 +25076,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -16870,6 +16870,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16928,6 +16933,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16957,6 +16967,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -16874,7 +16874,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16937,7 +16937,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16971,7 +16971,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -16874,7 +16874,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16937,7 +16937,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16971,7 +16971,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -29479,7 +29479,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "definition": {
             "allOf": [
@@ -29570,7 +29570,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "definition": {
             "allOf": [
@@ -29620,7 +29620,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -29479,7 +29479,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "definition": {
             "allOf": [
@@ -29570,7 +29570,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "definition": {
             "allOf": [
@@ -29620,7 +29620,7 @@
             "items": {
               "$ref": "#/components/schemas/EvaluationLevel"
             },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level."
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`)."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -29474,6 +29474,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+          },
           "definition": {
             "allOf": [
               {
@@ -29558,6 +29565,13 @@
             },
             "description": "The categories of the evaluator"
           },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
+          },
           "definition": {
             "allOf": [
               {
@@ -29600,6 +29614,13 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
+          },
+          "supported_evaluation_levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluationLevel"
+            },
+            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected."
           },
           "description": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -19933,7 +19933,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19996,7 +19996,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20030,7 +20030,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -19933,7 +19933,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19996,7 +19996,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20030,7 +20030,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -19929,6 +19929,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19987,6 +19992,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -20016,6 +20026,11 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
+        supported_evaluation_levels:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvaluationLevel'
+          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.
         description:
           type: string
           description: The asset description text.

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -292,7 +292,7 @@ model EvaluatorVersion {
   @doc("The categories of the evaluator")
   categories: EvaluatorCategory[];
 
-  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.")
+  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.")
   supported_evaluation_levels?: EvaluationLevel[];
 
   @doc("Definition of the evaluator")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -292,7 +292,7 @@ model EvaluatorVersion {
   @doc("The categories of the evaluator")
   categories: EvaluatorCategory[];
 
-  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom prompt-based and code-based evaluators support only a single level.")
+  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).")
   supported_evaluation_levels?: EvaluationLevel[];
 
   @doc("Definition of the evaluator")

--- a/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp
@@ -292,6 +292,9 @@ model EvaluatorVersion {
   @doc("The categories of the evaluator")
   categories: EvaluatorCategory[];
 
+  @doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.")
+  supported_evaluation_levels?: EvaluationLevel[];
+
   @doc("Definition of the evaluator")
   @visibility(Lifecycle.Create, Lifecycle.Read)
   definition: EvaluatorDefinition;


### PR DESCRIPTION
# Summary

Adds an optional `supported_evaluation_levels` field (array of `EvaluationLevel`) to `EvaluatorVersion` to surface a property the Foundry RAI evaluation service already accepts and validates on its evaluator contracts (`Evaluator` / `CreateEvaluatorRequest` / `UpdateEvaluatorRequest` in `RAISvc/Contracts/Evaluations/Evaluators.cs`).

Without this field on the wire, SDKs cannot expose the evaluation level a custom evaluator targets, and OpenAPI consumers cannot rely on it.

# Change

In `specification/ai-foundry/data-plane/Foundry/src/evaluators/models.tsp`, on `model EvaluatorVersion` (added next to `categories`, which is the analogous read+create field):

```typespec
@doc("Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]` for backward compatibility. On update, omitting this field leaves it unchanged; an empty list is rejected.")
supported_evaluation_levels?: EvaluationLevel[];
```

# Service-side behavior already in place

The Foundry RAI evaluation service already accepts and validates this property:

| Context | Type (C#) | Behavior |
|---|---|---|
| `Evaluator` (read) | `List<EvaluationLevel>` | Always present on responses; service defaults to `[turn]` when none are set |
| `CreateEvaluatorRequest` | `List<EvaluationLevel>?` | Optional; omitted → service defaults to `[turn]` |
| `UpdateEvaluatorRequest` | `List<EvaluationLevel>?` | Optional; omitted → no change. Empty list rejected. |

(Source: `RAISvc/Contracts/Evaluations/Evaluators.cs` — the C# property is plural `SupportedEvaluationLevels`, snake_cased to `supported_evaluation_levels` via `SnakeCaseNamingStrategy`.)

# Reuses the existing `EvaluationLevel` union

`EvaluationLevel` is already declared in `openai-evaluations/models.tsp` with values `turn` and `conversation`, in the same `Azure.AI.Projects` namespace, so no new union is introduced.

# Generated artifacts

Regenerated both `openapi3` outputs via `npx tsp compile .` from `specification/ai-foundry/data-plane/Foundry`:

- `openapi3/v1/microsoft-foundry-openapi3.{json,yaml}`
- `openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}`

The field appears on the Create, Read, and Update views of `EvaluatorVersion` as an array of `$ref: #/components/schemas/EvaluationLevel`.

# Validation

- `npx tsp compile . --warn-as-error` — passes, no new warnings.
- Diff stat: `5 files changed, 75 insertions(+)` — pure addition, no edits to existing fields.

# Branch target

Targeting `feature/foundry-release` (the working branch for the v1 Foundry surface), matching other recent Foundry PRs.