### PR TITLE
[AKS] Support CAS for Mixed SKU Agent Pools GA API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/AgentPoolModels.tsp
@@ -1014,7 +1014,7 @@ model ScaleProfile {
    * Scaling decisions across profiles are governed by the cluster autoscaler expander,
    * configurable via `ManagedCluster.properties.autoScalerProfile.expander`.
    */
-  @added(Versions.v2026_05_02_preview)
+  @added(Versions.v2026_05_01)
   @identifiers(#[])
   autoscale?: AutoScaleProfile[];
 }
@@ -1037,7 +1037,7 @@ model ManualScaleProfile {
 /**
  * Specifications on auto-scaling.
  */
-@added(Versions.v2026_05_02_preview)
+@added(Versions.v2026_05_01)
 model AutoScaleProfile {
   /**
    * VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-01/AgentPoolsCreate_TypeVirtualMachines_Autoscale.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/examples/2026-05-01/AgentPoolsCreate_TypeVirtualMachines_Autoscale.json
@@ -1,0 +1,124 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-05-01",
+    "parameters": {
+      "properties": {
+        "type": "VirtualMachines",
+        "nodeLabels": {
+          "key1": "val1"
+        },
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "1.29.0",
+        "osType": "Linux",
+        "tags": {
+          "name1": "val1"
+        },
+        "virtualMachinesProfile": {
+          "scale": {
+            "autoscale": [
+              {
+                "maxCount": 5,
+                "minCount": 1,
+                "size": "Standard_D2_v2"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.29.0",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.29.0",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 1,
+              "size": "Standard_D2_v2"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "autoscale": [
+                {
+                  "maxCount": 5,
+                  "minCount": 1,
+                  "size": "Standard_D2_v2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.29.0",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.29.0",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 1,
+              "size": "Standard_D2_v2"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "autoscale": [
+                {
+                  "maxCount": 5,
+                  "minCount": 1,
+                  "size": "Standard_D2_v2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with VirtualMachines pool type with autoscaling enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/examples/AgentPoolsCreate_TypeVirtualMachines_Autoscale.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/examples/AgentPoolsCreate_TypeVirtualMachines_Autoscale.json
@@ -1,0 +1,124 @@
+{
+  "parameters": {
+    "agentPoolName": "agentpool1",
+    "api-version": "2026-05-01",
+    "parameters": {
+      "properties": {
+        "type": "VirtualMachines",
+        "nodeLabels": {
+          "key1": "val1"
+        },
+        "nodeTaints": [
+          "Key1=Value1:NoSchedule"
+        ],
+        "orchestratorVersion": "1.29.0",
+        "osType": "Linux",
+        "tags": {
+          "name1": "val1"
+        },
+        "virtualMachinesProfile": {
+          "scale": {
+            "autoscale": [
+              {
+                "maxCount": 5,
+                "minCount": 1,
+                "size": "Standard_D2_v2"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "resourceName": "clustername1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.29.0",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.29.0",
+          "osType": "Linux",
+          "provisioningState": "Succeeded",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 1,
+              "size": "Standard_D2_v2"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "autoscale": [
+                {
+                  "maxCount": 5,
+                  "minCount": 1,
+                  "size": "Standard_D2_v2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "agentpool1",
+        "type": "Microsoft.ContainerService/managedClusters/agentPools",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/managedClusters/clustername1/agentPools/agentpool1",
+        "properties": {
+          "type": "VirtualMachines",
+          "currentOrchestratorVersion": "1.29.0",
+          "maxPods": 110,
+          "nodeImageVersion": "AKSUbuntu-1804gen2containerd-2021.09.11",
+          "nodeLabels": {
+            "key1": "val1"
+          },
+          "nodeTaints": [
+            "Key1=Value1:NoSchedule"
+          ],
+          "orchestratorVersion": "1.29.0",
+          "osType": "Linux",
+          "provisioningState": "Creating",
+          "tags": {
+            "name1": "val1"
+          },
+          "virtualMachineNodesStatus": [
+            {
+              "count": 1,
+              "size": "Standard_D2_v2"
+            }
+          ],
+          "virtualMachinesProfile": {
+            "scale": {
+              "autoscale": [
+                {
+                  "maxCount": 5,
+                  "minCount": 1,
+                  "size": "Standard_D2_v2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "AgentPools_CreateOrUpdate",
+  "title": "Create Agent Pool with VirtualMachines pool type with autoscaling enabled"
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
@@ -1169,6 +1169,9 @@
           "Create Agent Pool with VirtualMachines pool type": {
             "$ref": "./examples/AgentPoolsCreate_TypeVirtualMachines.json"
           },
+          "Create Agent Pool with VirtualMachines pool type with autoscaling enabled": {
+            "$ref": "./examples/AgentPoolsCreate_TypeVirtualMachines_Autoscale.json"
+          },
           "Create Agent Pool with Windows OSSKU": {
             "$ref": "./examples/AgentPoolsCreate_WindowsOSSKU.json"
           },
@@ -5164,6 +5167,26 @@
         "disableOutboundNat": {
           "type": "boolean",
           "description": "Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled."
+        }
+      }
+    },
+    "AutoScaleProfile": {
+      "type": "object",
+      "description": "Specifications on auto-scaling.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'."
+        },
+        "minCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of nodes of the specified sizes."
+        },
+        "maxCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of nodes of the specified sizes."
         }
       }
     },
@@ -10313,6 +10336,14 @@
           "description": "Specifications on how to scale the VirtualMachines agent pool to a fixed size.",
           "items": {
             "$ref": "#/definitions/ManualScaleProfile"
+          },
+          "x-ms-identifiers": []
+        },
+        "autoscale": {
+          "type": "array",
+          "description": "Specifications on how to auto-scale the VirtualMachines agent pool within a predefined size range.\nEach profile targets a specific VM SKU and is evaluated independently.\nScaling decisions across profiles are governed by the cluster autoscaler expander,\nconfigurable via `ManagedCluster.properties.autoScalerProfile.expander`.",
+          "items": {
+            "$ref": "#/definitions/AutoScaleProfile"
           },
           "x-ms-identifiers": []
         }


### PR DESCRIPTION
Approved aks-handbook GA API review https://github.com/azure-management-and-platforms/aks-handbook/pull/126/changes

Backports the `AutoScaleProfile` model and the `ScaleProfile.autoscale` array property from `2026-05-02-preview` to the stable `2026-05-01` API version of Microsoft.ContainerService/aks. This enables VirtualMachines-type agent pools to use cluster autoscaler with per-SKU min/max bounds in the GA surface.
