### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-managednetworkfabric

### DIFF
--- a/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
+++ b/specification/managednetworkfabric/ManagedNetworkFabric.ResourceManager.Management/client.tsp
@@ -118,3 +118,25 @@ using Microsoft.ManagedNetworkFabric;
   "staticRoutePolicy",
   "python"
 );
+
+// Preserve pre-migration (swagger) Python model names to avoid breaking changes.
+@@clientName(
+  Microsoft.ManagedNetworkFabric.ManagementNetworkPatchConfiguration,
+  "ManagementNetworkConfigurationPatchableProperties",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.TerminalServerPatchConfiguration,
+  "NetworkFabricPatchablePropertiesTerminalServerConfiguration",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.VpnOptionAProperties,
+  "OptionAProperties",
+  "python"
+);
+@@clientName(
+  Microsoft.ManagedNetworkFabric.VpnOptionBProperties,
+  "OptionBProperties",
+  "python"
+);


### PR DESCRIPTION
Mitigate Python SDK breaking changes introduced by the Swagger → TypeSpec migration of `azure-mgmt-managednetworkfabric` by restoring pre-migration model names via `@@clientName` (python only) in `client.tsp`.

Mitigations:
- `ManagementNetworkPatchConfiguration` → restore `ManagementNetworkConfigurationPatchableProperties`
- `TerminalServerPatchConfiguration` → restore `NetworkFabricPatchablePropertiesTerminalServerConfiguration`
- `VpnOptionAProperties` → restore `OptionAProperties`
- `VpnOptionBProperties` → restore `OptionBProperties`
