### PR TITLE
[Foundry] Add `a2a` to AgentProtocol union

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18423,6 +18423,7 @@
             "enum": [
               "activity_protocol",
               "responses",
+              "a2a",
               "mcp",
               "invocations",
               "invocations_ws"
@@ -22520,7 +22521,9 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {}
+          "mapping": {
+            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
+          }
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -26523,7 +26526,8 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
+            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -30633,7 +30637,8 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
+            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -41074,7 +41079,8 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
+            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
           }
         },
         "description": "A content part that makes up an input or output item."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12216,6 +12216,7 @@ components:
           enum:
             - activity_protocol
             - responses
+            - a2a
             - mcp
             - invocations
             - invocations_ws
@@ -14993,7 +14994,8 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping: {}
+        mapping:
+          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -17925,6 +17927,7 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
+          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -20791,6 +20794,7 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
+          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -28425,6 +28429,7 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
+          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -21876,6 +21876,7 @@
             "enum": [
               "activity_protocol",
               "responses",
+              "a2a",
               "mcp",
               "invocations",
               "invocations_ws"
@@ -26183,7 +26184,9 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {}
+          "mapping": {
+            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
+          }
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -31140,7 +31143,8 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
+            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -35357,7 +35361,8 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
+            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -45798,7 +45803,8 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
+            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
           }
         },
         "description": "A content part that makes up an input or output item."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14523,6 +14523,7 @@ components:
           enum:
             - activity_protocol
             - responses
+            - a2a
             - mcp
             - invocations
             - invocations_ws
@@ -17446,7 +17447,8 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping: {}
+        mapping:
+          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -21030,6 +21032,7 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
+          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -23974,6 +23977,7 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
+          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -31608,6 +31612,7 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
+          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -284,6 +284,7 @@ union AgentProtocol {
   string,
   activity_protocol: "activity_protocol",
   responses: "responses",
+  a2a: "a2a",
   mcp: "mcp",
   invocations: "invocations",
 


### PR DESCRIPTION
Adds a2a: "a2a" to the container-side AgentProtocol union in specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp, mirroring the existing a2a entry in AgentEndpointProtocol. This lets hosted agents declare that their container natively serves the A2A protocol, enabling the Azure ML Vienna Agents service to route A2A traffic directly to the container (passthrough) instead of translating it through the head. Today the two unions are asymmetric — AgentEndpointProtocol already supports a2a but AgentProtocol doesn't — so there's no way to express "this container speaks A2A natively."

The change is non-breaking: AgentProtocol is a string-extensible union, so adding a new known value extends the schema without invalidating existing clients or stored agent definitions. The diff is 5 lines total — one new union member in models.tsp plus a single-line enum addition in each of the four regenerated OpenAPI3 files (openapi3/v1/microsoft-foundry-openapi3.{json,yaml} and openapi3/virtual-public-preview/microsoft-foundry-openapi3.{json,yaml}).

Validation: merged the latest feature/foundry-release into the topic branch, ran npm ci, and regenerated via npx tsp compile . in specification/ai-foundry/data-plane/Foundry. Verified the OpenAPI3 diff vs. the base branch contains only the a2a enum addition.