### PR TITLE
Arm address 2

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/Snapshot.tsp
@@ -139,7 +139,10 @@ interface Snapshots {
   >;
 
   /**
-   * Locks the immutability policy of a snapshot. Once locked, the policy cannot be reduced or removed until the lock period expires.
+   * Locks or updates the immutability policy of a snapshot. This action requires elevated roles such as 'Owner' or 'Administrator'.
+   * When type is set to 'Locked', the policy is locked and the immutability duration cannot be reduced until expiry.
+   * When type is set to 'Unlocked', the policy is set or updated as an unlocked policy — this is functionally equivalent to calling
+   * updateImmutabilityPolicy, but requires elevated privileges. This action has all the privileges of updateImmutabilityPolicy.
    */
   @added(Versions.v2026_03_02)
   @action("updateImmutabilityPolicyLock")

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
@@ -1174,7 +1174,10 @@ model ImmutabilityPolicyData {
 }
 
 /**
- * Data used for locking the immutability policy of a snapshot.
+ * Data used for locking the immutability policy of a snapshot. This action has elevated privileges and can both lock and unlock policies.
+ * When type is set to 'Locked', the policy is locked and cannot be reduced until expiry. When type is set to 'Unlocked', the policy is
+ * set or updated as an unlocked policy, equivalent to calling updateImmutabilityPolicy. This action requires elevated roles such as
+ * 'Owner' or 'Administrator' regardless of the type value.
  */
 @added(Versions.v2026_03_02)
 model ImmutabilityPolicyLockData {
@@ -1185,7 +1188,10 @@ model ImmutabilityPolicyLockData {
   immutabilityDurationDays: int32;
 
   /**
-   * The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period.
+   * The type of the immutability policy to apply. When set to 'Locked', the policy is locked and the immutability duration cannot be
+   * reduced (only extended). When set to 'Unlocked', the policy is set or updated as an unlocked policy — this is functionally equivalent
+   * to calling updateImmutabilityPolicy but requires the elevated privileges of the lock action. Both values are accepted because
+   * updateImmutabilityPolicyLock has all the privileges of updateImmutabilityPolicy.
    */
   type: ImmutabilityPolicyType;
 }

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeDisk/models.tsp
@@ -1164,7 +1164,7 @@ model ImmutabilityPolicyData {
   /**
    * The immutability duration for the snapshot, in number of days.
    */
-  @minValue(1)
+  @minValue(0)
   immutabilityDurationDays: int32;
 
   /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
@@ -2561,7 +2561,7 @@
         "tags": [
           "Snapshots"
         ],
-        "description": "Locks the immutability policy of a snapshot. Once locked, the policy cannot be reduced or removed until the lock period expires.",
+        "description": "Locks or updates the immutability policy of a snapshot. This action requires elevated roles such as 'Owner' or 'Administrator'.\nWhen type is set to 'Locked', the policy is locked and the immutability duration cannot be reduced until expiry.\nWhen type is set to 'Unlocked', the policy is set or updated as an unlocked policy — this is functionally equivalent to calling\nupdateImmutabilityPolicy, but requires elevated privileges. This action has all the privileges of updateImmutabilityPolicy.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -4281,7 +4281,7 @@
     },
     "ImmutabilityPolicyLockData": {
       "type": "object",
-      "description": "Data used for locking the immutability policy of a snapshot.",
+      "description": "Data used for locking the immutability policy of a snapshot. This action has elevated privileges and can both lock and unlock policies.\nWhen type is set to 'Locked', the policy is locked and cannot be reduced until expiry. When type is set to 'Unlocked', the policy is\nset or updated as an unlocked policy, equivalent to calling updateImmutabilityPolicy. This action requires elevated roles such as\n'Owner' or 'Administrator' regardless of the type value.",
       "properties": {
         "immutabilityDurationDays": {
           "type": "integer",
@@ -4291,7 +4291,7 @@
         },
         "type": {
           "$ref": "#/definitions/ImmutabilityPolicyType",
-          "description": "The type of the immutability policy. 'Unlocked' allows the policy to be modified by privileged users; 'Locked' prevents reduction of the immutability duration but allows extension of the lock period."
+          "description": "The type of the immutability policy to apply. When set to 'Locked', the policy is locked and the immutability duration cannot be\nreduced (only extended). When set to 'Unlocked', the policy is set or updated as an unlocked policy — this is functionally equivalent\nto calling updateImmutabilityPolicy but requires the elevated privileges of the lock action. Both values are accepted because\nupdateImmutabilityPolicyLock has all the privileges of updateImmutabilityPolicy."
         }
       },
       "required": [

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-02/DiskRP.json
@@ -4267,7 +4267,7 @@
           "type": "integer",
           "format": "int32",
           "description": "The immutability duration for the snapshot, in number of days.",
-          "minimum": 1
+          "minimum": 0
         },
         "type": {
           "$ref": "#/definitions/ImmutabilityPolicyType",


### PR DESCRIPTION
to doc  (in both the action description and the ImmutabilityPolicyLockData model description) what happens when type: "Unlocked" is sent to the lock action.
https://github.com/Azure/azure-rest-api-specs/pull/40595#discussion_r3327399027