### PR TITLE
[Python] Mitigate breaking changes for azure-mgmt-monitor

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
@@ -66,7 +66,12 @@ namespace Microsoft.InsightsCombinedClient;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "list should be pageable"
 @@Azure.ClientGenerator.Core.Legacy.markAsPageable(
   PrivateLinkScopesApi.PrivateEndpointConnections.listByPrivateLinkScope,
-  "java"
+  "java,python"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "list should be pageable"
+@@Azure.ClientGenerator.Core.Legacy.markAsPageable(
+  PrivateLinkScopesApi.PrivateLinkResources.listByPrivateLinkScope,
+  "python"
 );
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "list should be pageable"
 @@Azure.ClientGenerator.Core.Legacy.markAsPageable(
@@ -150,7 +155,7 @@ model MetricSettings {
 @@alternateType(
   ServiceDiagnosticsSettingsApi.MetricSettings,
   MetricSettings,
-  "java"
+  "java,python"
 );
 
 /**
@@ -178,7 +183,11 @@ model LogSettings {
   retentionPolicy?: Microsoft.Common.RetentionPolicy;
 }
 
-@@alternateType(ServiceDiagnosticsSettingsApi.LogSettings, LogSettings, "java");
+@@alternateType(
+  ServiceDiagnosticsSettingsApi.LogSettings,
+  LogSettings,
+  "java,python"
+);
 
 @@clientLocation(
   NetworkSecurityPerimeterApi.ScheduledQueryRule.getNSP,


### PR DESCRIPTION
Mitigate Python SDK breaking changes introduced by the Swagger→TypeSpec migration for `azure-mgmt-monitor` (see SDK PR https://github.com/Azure/azure-sdk-for-python/pull/47315).

Two existing mitigations in `client.tsp` were scoped to Java only; this extends them to Python:

- **Restore pagination** (`ItemPaged`) for `PrivateEndpointConnections.listByPrivateLinkScope` and `PrivateLinkResources.listByPrivateLinkScope` via `markAsPageable(..., "python")`.
- **Restore `MetricSettings.category` and `LogSettings.category_group`** by extending the corrected-model `@@alternateType` overrides to `"java,python"`.

Validated with `npx tsv` (compile + format pass).
