### PR TITLE
Remove python clientLocation customization for ServiceDiagnosticSettingsResources

### DIFF
--- a/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
+++ b/specification/monitor/resource-manager/Microsoft.Insights/Insights/client.tsp
@@ -292,22 +292,6 @@ model AccessRulePropertiesSubscriptionsItem {
 @@clientName(AlertSeverity.`3`, "THREE", "python");
 @@clientName(AlertSeverity.`4`, "FOUR", "python");
 
-@@clientLocation(
-  ServiceDiagnosticSettingsResources.get,
-  "DiagnosticSettings",
-  "python"
-);
-@@clientLocation(
-  ServiceDiagnosticSettingsResources.createOrUpdate,
-  "DiagnosticSettings",
-  "python"
-);
-@@clientLocation(
-  ServiceDiagnosticSettingsResources.update,
-  "DiagnosticSettings",
-  "python"
-);
-
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "override"


### PR DESCRIPTION
mitigate unnecessary breaking for https://github.com/Azure/azure-sdk-for-python/pull/47315

## Summary

Removes the python `@@clientLocation` customizations for `ServiceDiagnosticSettingsResources` (`get`, `createOrUpdate`, `update`) in the Monitor `Microsoft.Insights` client.tsp.

## Changes

- Removed the three `@@clientLocation(...)` decorators that relocated `ServiceDiagnosticSettingsResources` operations to `DiagnosticSettings` for the python SDK.
