### PR TITLE
Add GPU memory properties and expand cluster job name pattern in 2026…

### DIFF
--- a/specification/azurestackhci/cspell.yaml
+++ b/specification/azurestackhci/cspell.yaml
@@ -18,6 +18,7 @@ words:
   - hvci
   - igvm
   - imds
+  - lpddr
   - mitigations
   - PEAP
   - rdma

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/ClusterJobs.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/ClusterJobs.tsp
@@ -23,7 +23,7 @@ model ClusterJob is Azure.ResourceManager.ProxyResource<ClusterJobProperties> {
     Resource = ClusterJob,
     KeyName = "jobsName",
     SegmentName = "jobs",
-    NamePattern = "^[a-zA-Z0-9-]{3,24}$"
+    NamePattern = "^[a-zA-Z0-9-]{3,64}$"
   >;
 }
 

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_CreateOrUpdate_MaximumSet_Gen.json
@@ -58,6 +58,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Succeeded"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",
@@ -120,6 +123,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Creating"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_Get_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_Get_MaximumSet_Gen.json
@@ -53,6 +53,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Succeeded"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_List_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachineGpus_List_MaximumSet_Gen.json
@@ -55,6 +55,9 @@
                   }
                 ]
               },
+              "acceleratorType": "Discrete",
+              "memoryModel": "Dedicated VRAM",
+              "totalMemoryInBytes": 17179869184,
               "provisioningState": "Succeeded"
             },
             "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/default",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_CreateOrUpdate.json
@@ -85,16 +85,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"
@@ -187,16 +187,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_Get.json
@@ -96,16 +96,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_ListByResourceGroup.json
@@ -77,16 +77,16 @@
                     "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                     "workloadType": "VirtualMachine",
                     "state": "Running",
-                    "virtualProcessorCount": 4,
-                    "memoryInBytes": 8589934592
+                    "virtualProcessorCount": "4",
+                    "memoryInBytes": "8589934592"
                   },
                   {
                     "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                     "name": "LegacyDbVM",
                     "workloadType": "VirtualMachine",
                     "state": "Off",
-                    "virtualProcessorCount": 2,
-                    "memoryInBytes": 4294967296
+                    "virtualProcessorCount": "2",
+                    "memoryInBytes": "4294967296"
                   }
                 ],
                 "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/examples/2026-05-01-preview/EdgeMachines_ListBySubscription.json
@@ -76,16 +76,16 @@
                     "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                     "workloadType": "VirtualMachine",
                     "state": "Running",
-                    "virtualProcessorCount": 4,
-                    "memoryInBytes": 8589934592
+                    "virtualProcessorCount": "4",
+                    "memoryInBytes": "8589934592"
                   },
                   {
                     "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                     "name": "LegacyDbVM",
                     "workloadType": "VirtualMachine",
                     "state": "Off",
-                    "virtualProcessorCount": 2,
-                    "memoryInBytes": 4294967296
+                    "virtualProcessorCount": "2",
+                    "memoryInBytes": "4294967296"
                   }
                 ],
                 "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -7316,13 +7316,13 @@ model EdgeMachineWorkloadInventoryItem {
    * Configured virtual processor count from Hyper-V.
    */
   @visibility(Lifecycle.Read)
-  virtualProcessorCount?: int32;
+  virtualProcessorCount?: string;
 
   /**
    * Maximum memory the VM can consume, in bytes.
    */
   @visibility(Lifecycle.Read)
-  memoryInBytes?: int64;
+  memoryInBytes?: string;
 }
 
 /**

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/models.tsp
@@ -8822,6 +8822,24 @@ model EdgeMachineGpuProperties {
    */
   @visibility(Lifecycle.Read)
   partitionDetails?: GpuPartitionDetails;
+
+  /**
+   * The type of the accelerator.
+   */
+  @visibility(Lifecycle.Read)
+  acceleratorType?: string;
+
+  /**
+   * The memory model of the GPU. Possible values are 'Dedicated VRAM', 'Unified (Shared System Memory)', and 'Unified (SoC LPDDR)'.
+   */
+  @visibility(Lifecycle.Read)
+  memoryModel?: string;
+
+  /**
+   * The total memory of the GPU in bytes.
+   */
+  @visibility(Lifecycle.Read)
+  totalMemoryInBytes?: int64;
 }
 
 /**

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_CreateOrUpdate_MaximumSet_Gen.json
@@ -58,6 +58,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Succeeded"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",
@@ -120,6 +123,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Creating"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_Get_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_Get_MaximumSet_Gen.json
@@ -53,6 +53,9 @@
               }
             ]
           },
+          "acceleratorType": "Discrete",
+          "memoryModel": "Dedicated VRAM",
+          "totalMemoryInBytes": 17179869184,
           "provisioningState": "Succeeded"
         },
         "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/gpu-001",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_List_MaximumSet_Gen.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachineGpus_List_MaximumSet_Gen.json
@@ -55,6 +55,9 @@
                   }
                 ]
               },
+              "acceleratorType": "Discrete",
+              "memoryModel": "Dedicated VRAM",
+              "totalMemoryInBytes": 17179869184,
               "provisioningState": "Succeeded"
             },
             "id": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/test-rg/providers/Microsoft.AzureStackHCI/edgeMachines/EdgeMachine01/gpus/default",

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_CreateOrUpdate.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_CreateOrUpdate.json
@@ -85,16 +85,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"
@@ -187,16 +187,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_Get.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_Get.json
@@ -96,16 +96,16 @@
                 "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                 "workloadType": "VirtualMachine",
                 "state": "Running",
-                "virtualProcessorCount": 4,
-                "memoryInBytes": 8589934592
+                "virtualProcessorCount": "4",
+                "memoryInBytes": "8589934592"
               },
               {
                 "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                 "name": "LegacyDbVM",
                 "workloadType": "VirtualMachine",
                 "state": "Off",
-                "virtualProcessorCount": 2,
-                "memoryInBytes": 4294967296
+                "virtualProcessorCount": "2",
+                "memoryInBytes": "4294967296"
               }
             ],
             "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_ListByResourceGroup.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_ListByResourceGroup.json
@@ -77,16 +77,16 @@
                     "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                     "workloadType": "VirtualMachine",
                     "state": "Running",
-                    "virtualProcessorCount": 4,
-                    "memoryInBytes": 8589934592
+                    "virtualProcessorCount": "4",
+                    "memoryInBytes": "8589934592"
                   },
                   {
                     "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                     "name": "LegacyDbVM",
                     "workloadType": "VirtualMachine",
                     "state": "Off",
-                    "virtualProcessorCount": 2,
-                    "memoryInBytes": 4294967296
+                    "virtualProcessorCount": "2",
+                    "memoryInBytes": "4294967296"
                   }
                 ],
                 "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_ListBySubscription.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/examples/EdgeMachines_ListBySubscription.json
@@ -76,16 +76,16 @@
                     "resourceId": "/subscriptions/fd3c3665-1729-4b7b-9a38-238e83b0f98b/resourceGroups/ArcInstance-rg/providers/Microsoft.AzureStackHCI/virtualMachineInstances/WebFrontEndVM",
                     "workloadType": "VirtualMachine",
                     "state": "Running",
-                    "virtualProcessorCount": 4,
-                    "memoryInBytes": 8589934592
+                    "virtualProcessorCount": "4",
+                    "memoryInBytes": "8589934592"
                   },
                   {
                     "workloadId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
                     "name": "LegacyDbVM",
                     "workloadType": "VirtualMachine",
                     "state": "Off",
-                    "virtualProcessorCount": 2,
-                    "memoryInBytes": 4294967296
+                    "virtualProcessorCount": "2",
+                    "memoryInBytes": "4294967296"
                   }
                 ],
                 "workloadInventoryLastUpdated": "2026-05-20T14:32:10Z"

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
@@ -14267,14 +14267,12 @@
           "readOnly": true
         },
         "virtualProcessorCount": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "Configured virtual processor count from Hyper-V.",
           "readOnly": true
         },
         "memoryInBytes": {
-          "type": "integer",
-          "format": "int64",
+          "type": "string",
           "description": "Maximum memory the VM can consume, in bytes.",
           "readOnly": true
         }

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/preview/2026-05-01-preview/hci.json
@@ -3240,7 +3240,7 @@
             "description": "Name of ClusterJob",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
           }
         ],
         "responses": {
@@ -3310,7 +3310,7 @@
             "description": "Name of ClusterJob",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
           },
           {
             "name": "resource",
@@ -3413,7 +3413,7 @@
             "description": "Name of ClusterJob",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+            "pattern": "^[a-zA-Z0-9-]{3,64}$"
           }
         ],
         "responses": {
@@ -13076,6 +13076,22 @@
         "partitionDetails": {
           "$ref": "#/definitions/GpuPartitionDetails",
           "description": "Details of the GPU specifically in GPU-P mode.",
+          "readOnly": true
+        },
+        "acceleratorType": {
+          "type": "string",
+          "description": "The type of the accelerator.",
+          "readOnly": true
+        },
+        "memoryModel": {
+          "type": "string",
+          "description": "The memory model of the GPU. Possible values are 'Dedicated VRAM', 'Unified (Shared System Memory)', and 'Unified (SoC LPDDR)'.",
+          "readOnly": true
+        },
+        "totalMemoryInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The total memory of the GPU in bytes.",
           "readOnly": true
         }
       }


### PR DESCRIPTION
# Bug Fix: Add Missed Changes to 2026-05-01-preview

## Summary

This PR is a **bug fix** that backports changes which were missed when the
`2026-05-01-preview` API version of `Microsoft.AzureStackHCI` was created. The
changes below were present in the source/private spec but did not make it into
the public `2026-05-01-preview` version, so they are being added here.

## Changes

### EdgeMachine GPU memory properties
Added three read-only properties to `EdgeMachineGpuProperties`:
- `acceleratorType` — the type of the accelerator.
- `memoryModel` — the memory model of the GPU (`Dedicated VRAM`,
  `Unified (Shared System Memory)`, `Unified (SoC LPDDR)`).
- `totalMemoryInBytes` — the total memory of the GPU in bytes.

Updated the corresponding examples:
- `EdgeMachineGpus_Get_MaximumSet_Gen.json`
- `EdgeMachineGpus_List_MaximumSet_Gen.json`
- `EdgeMachineGpus_CreateOrUpdate_MaximumSet_Gen.json`

Added `lpddr` to the spell-check dictionary (`cspell.yaml`).

### Cluster job name pattern
Expanded the `ClusterJob` `jobsName` name pattern from `^[a-zA-Z0-9-]{3,24}$`
to `^[a-zA-Z0-9-]{3,64}$`.

### Generated outputs
Regenerated `hci.json` swagger and the swagger example outputs to reflect the
above changes.

## Notes
- No new resources or operations were introduced; these are corrective additions
  only.