### PR TITLE
Add securityGating to stable API version 2026-05-01

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -3332,7 +3332,7 @@ model ManagedClusterSecurityProfileDefender {
   /**
    * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
    */
-  @added(Versions.v2026_05_02_preview)
+  @added(Versions.v2026_05_01)
   securityGating?: ManagedClusterSecurityProfileDefenderSecurityGating;
 }
 
@@ -3349,7 +3349,7 @@ model ManagedClusterSecurityProfileDefenderSecurityMonitoring {
 /**
  * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
  */
-@added(Versions.v2026_05_02_preview)
+@added(Versions.v2026_05_01)
 model ManagedClusterSecurityProfileDefenderSecurityGating {
   /**
    * Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules.
@@ -3369,7 +3369,7 @@ model ManagedClusterSecurityProfileDefenderSecurityGating {
 }
 
 /** Identity information used by Defender security gating to access container registries. */
-@added(Versions.v2026_05_02_preview)
+@added(Versions.v2026_05_01)
 model ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem {
   /**
    * The container registry for which the identity will be used; the identity specified here should have a federated identity credential attached to it.

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -3330,7 +3330,7 @@ model ManagedClusterSecurityProfileDefender {
   securityMonitoring?: ManagedClusterSecurityProfileDefenderSecurityMonitoring;
 
   /**
-   * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
+   * Microsoft Defender settings for security gating. This validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards. For more information, see https://aka.ms/KubernetesDefenderAuditRule.
    */
   @added(Versions.v2026_05_01)
   securityGating?: ManagedClusterSecurityProfileDefenderSecurityGating;
@@ -3347,30 +3347,30 @@ model ManagedClusterSecurityProfileDefenderSecurityMonitoring {
 }
 
 /**
- * Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.
+ * Microsoft Defender settings for security gating. This validates container image eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards.
  */
 @added(Versions.v2026_05_01)
 model ManagedClusterSecurityProfileDefenderSecurityGating {
   /**
-   * Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules.
+   * Whether to enable Defender security gating. When enabled, the gating feature scans container images and audits or blocks deployment of images that do not meet security standards according to configured security rules. For more information, see https://aka.ms/KubernetesDefenderAuditRule.
    */
   enabled?: boolean;
 
   /**
-   * List of identities that the admission controller will make use of in order to pull security artifacts from the registry. These are the same identities used by the cluster to pull container images. Each identity provided should have federated identity credential attached to it.
+   * List of identities that the admission controller uses to pull security artifacts from registries. These are the same identities used by the cluster to pull container images. For more information on configuring this identity, see https://learn.microsoft.com/en-us/azure/defender-for-cloud/gated-deployment-infrastructure-as-code.
    */
   @identifiers(#[])
-  identities?: ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem[];
+  identities?: ManagedClusterSecurityProfileDefenderSecurityGatingIdentity[];
 
   /**
-   * In use only while registry access granted by secret rather than managed identity. Set whether to grant the Defender gating agent access to the cluster's secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform any image validation. Default value is false.
+   * In use only while registry access is granted by secret rather than managed identity. Sets whether to grant the Defender gating agent access to cluster secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform image validation. Default value is false.
    */
   allowSecretAccess?: boolean;
 }
 
-/** Identity information used by Defender security gating to access container registries. */
+/** Identity mapping used by Defender security gating for registry access. */
 @added(Versions.v2026_05_01)
-model ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem {
+model ManagedClusterSecurityProfileDefenderSecurityGatingIdentity {
   /**
    * The container registry for which the identity will be used; the identity specified here should have a federated identity credential attached to it.
    */

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-05-02-preview/managedClusters.json
@@ -12820,35 +12820,35 @@
         },
         "securityGating": {
           "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGating",
-          "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards."
+          "description": "Microsoft Defender settings for security gating. This validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards. For more information, see https://aka.ms/KubernetesDefenderAuditRule."
         }
       }
     },
     "ManagedClusterSecurityProfileDefenderSecurityGating": {
       "type": "object",
-      "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.",
+      "description": "Microsoft Defender settings for security gating. This validates container image eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards.",
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules."
+          "description": "Whether to enable Defender security gating. When enabled, the gating feature scans container images and audits or blocks deployment of images that do not meet security standards according to configured security rules. For more information, see https://aka.ms/KubernetesDefenderAuditRule."
         },
         "identities": {
           "type": "array",
-          "description": "List of identities that the admission controller will make use of in order to pull security artifacts from the registry. These are the same identities used by the cluster to pull container images. Each identity provided should have federated identity credential attached to it.",
+          "description": "List of identities that the admission controller uses to pull security artifacts from registries. These are the same identities used by the cluster to pull container images. For more information on configuring this identity, see https://learn.microsoft.com/en-us/azure/defender-for-cloud/gated-deployment-infrastructure-as-code.",
           "items": {
-            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem"
+            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentity"
           },
           "x-ms-identifiers": []
         },
         "allowSecretAccess": {
           "type": "boolean",
-          "description": "In use only while registry access granted by secret rather than managed identity. Set whether to grant the Defender gating agent access to the cluster's secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform any image validation. Default value is false."
+          "description": "In use only while registry access is granted by secret rather than managed identity. Sets whether to grant the Defender gating agent access to cluster secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform image validation. Default value is false."
         }
       }
     },
-    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem": {
+    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentity": {
       "type": "object",
-      "description": "Identity information used by Defender security gating to access container registries.",
+      "description": "Identity mapping used by Defender security gating for registry access.",
       "properties": {
         "azureContainerRegistry": {
           "type": "string",

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
@@ -8780,6 +8780,46 @@
         "securityMonitoring": {
           "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityMonitoring",
           "description": "Microsoft Defender threat detection for Cloud settings for the security profile."
+        },
+        "securityGating": {
+          "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGating",
+          "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityGating": {
+      "type": "object",
+      "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules."
+        },
+        "identities": {
+          "type": "array",
+          "description": "List of identities that the admission controller will make use of in order to pull security artifacts from the registry. These are the same identities used by the cluster to pull container images. Each identity provided should have federated identity credential attached to it.",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "allowSecretAccess": {
+          "type": "boolean",
+          "description": "In use only while registry access granted by secret rather than managed identity. Set whether to grant the Defender gating agent access to the cluster's secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform any image validation. Default value is false."
+        }
+      }
+    },
+    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem": {
+      "type": "object",
+      "description": "Identity information used by Defender security gating to access container registries.",
+      "properties": {
+        "azureContainerRegistry": {
+          "type": "string",
+          "description": "The container registry for which the identity will be used; the identity specified here should have a federated identity credential attached to it."
+        },
+        "identity": {
+          "$ref": "#/definitions/UserAssignedIdentity",
+          "description": "The identity object used to access the registry"
         }
       }
     },

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/stable/2026-05-01/managedClusters.json
@@ -8783,35 +8783,35 @@
         },
         "securityGating": {
           "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGating",
-          "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards."
+          "description": "Microsoft Defender settings for security gating. This validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards. For more information, see https://aka.ms/KubernetesDefenderAuditRule."
         }
       }
     },
     "ManagedClusterSecurityProfileDefenderSecurityGating": {
       "type": "object",
-      "description": "Microsoft Defender settings for security gating, validates container images eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents the deployment of images that do not meet security standards.",
+      "description": "Microsoft Defender settings for security gating. This validates container image eligibility for deployment based on Defender for Containers security findings. Using Admission Controller, it either audits or prevents deployment of images that do not meet security standards.",
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Whether to enable Defender security gating. When enabled, the gating feature will scan container images and audit or block the deployment of images that do not meet security standards according to the configured security rules."
+          "description": "Whether to enable Defender security gating. When enabled, the gating feature scans container images and audits or blocks deployment of images that do not meet security standards according to configured security rules. For more information, see https://aka.ms/KubernetesDefenderAuditRule."
         },
         "identities": {
           "type": "array",
-          "description": "List of identities that the admission controller will make use of in order to pull security artifacts from the registry. These are the same identities used by the cluster to pull container images. Each identity provided should have federated identity credential attached to it.",
+          "description": "List of identities that the admission controller uses to pull security artifacts from registries. These are the same identities used by the cluster to pull container images. For more information on configuring this identity, see https://learn.microsoft.com/en-us/azure/defender-for-cloud/gated-deployment-infrastructure-as-code.",
           "items": {
-            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem"
+            "$ref": "#/definitions/ManagedClusterSecurityProfileDefenderSecurityGatingIdentity"
           },
           "x-ms-identifiers": []
         },
         "allowSecretAccess": {
           "type": "boolean",
-          "description": "In use only while registry access granted by secret rather than managed identity. Set whether to grant the Defender gating agent access to the cluster's secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform any image validation. Default value is false."
+          "description": "In use only while registry access is granted by secret rather than managed identity. Sets whether to grant the Defender gating agent access to cluster secrets for pulling images from registries. If secret access is denied and the registry requires pull secrets, the add-on will not perform image validation. Default value is false."
         }
       }
     },
-    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem": {
+    "ManagedClusterSecurityProfileDefenderSecurityGatingIdentity": {
       "type": "object",
-      "description": "Identity information used by Defender security gating to access container registries.",
+      "description": "Identity mapping used by Defender security gating for registry access.",
       "properties": {
         "azureContainerRegistry": {
           "type": "string",


### PR DESCRIPTION
This PR promotes the securityGating feature from preview (2026-05-02-preview) to GA in the stable 2026-05-01 API version for Microsoft.ContainerService/aks.

### Changes
- Updated `@added` decorator from `Versions.v2026_05_02_preview` to `Versions.v2026_05_01` for:
  - `securityGating` property
  - `ManagedClusterSecurityProfileDefenderSecurityGating` model
  - `ManagedClusterSecurityProfileDefenderSecurityGatingIdentitiesItem` model
- Regenerated `stable/2026-05-01/managedClusters.json` with securityGating definitions