### PR TITLE
Add Microsoft.WebIQ ARM lease, remove Microsoft.AIGrounding lease (rename)

### DIFF
--- a/.github/arm-leases/aigrounding/Microsoft.AIGrounding/AIGrounding/lease.yaml
+++ b/.github/arm-leases/aigrounding/Microsoft.AIGrounding/AIGrounding/lease.yaml
@@ -1,5 +1,0 @@
-lease:
-  resource-provider: Microsoft.AIGrounding
-  startdate: "2026-05-20"
-  duration: P180D
-  reviewer: "@vikeshi26"

--- a/.github/arm-leases/webiq/Microsoft.WebIQ/WebIQ/lease.yaml
+++ b/.github/arm-leases/webiq/Microsoft.WebIQ/WebIQ/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.WebIQ
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds ARM lease for the renamed RP `Microsoft.WebIQ` and removes the obsolete `Microsoft.AIGrounding` lease.

Companion to private PR https://github.com/Azure/azure-rest-api-specs-pr/pull/28858 (AIGrounding -> WebIQ rebrand). Per @TejaswiMinnu, only modeling reviewers add/remove lease files, so doing it here so the partner PR's arm-lease check can pass.

- Add: `.github/arm-leases/webiq/Microsoft.WebIQ/WebIQ/lease.yaml` (startdate 2026-06-09, P180D, reviewer @vikeshi26)
- Delete: `.github/arm-leases/aigrounding/Microsoft.AIGrounding/AIGrounding/lease.yaml`

cc @TejaswiMinnu @mikeharder