### PR TITLE
Add ARM leases for partner PRs: M365, Kore.AgentPlatform, EdgeOperator BillingConfigurations, Storage storageContextCache

### DIFF
--- a/.github/arm-leases/azure-native-integrations/Kore.AgentPlatform/AgentPlatform/lease.yaml
+++ b/.github/arm-leases/azure-native-integrations/Kore.AgentPlatform/AgentPlatform/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Kore.AgentPlatform
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/BillingConfigurations/lease.yaml
+++ b/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/BillingConfigurations/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.EdgeOperator
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/m365/Microsoft.M365/M365/lease.yaml
+++ b/.github/arm-leases/m365/Microsoft.M365/M365/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.M365
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/storage/Microsoft.Storage/storageContextCache/lease.yaml
+++ b/.github/arm-leases/storage/Microsoft.Storage/storageContextCache/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.Storage
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds ARM leases for 4 partner-PR services so their `arm-lease` check passes. Only modeling reviewers can add lease files, so doing this here on partners' behalf.

| RP / Service | Partner PR |
|---|---|
| `Microsoft.M365` / `M365` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28806 |
| `Kore.AgentPlatform` / `AgentPlatform` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28860 |
| `Microsoft.EdgeOperator` / `BillingConfigurations` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28871 |
| `Microsoft.Storage` / `storageContextCache` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28874 |

All four leases: startdate `2026-06-09`, duration `P180D`, reviewer `@vikeshi26`.

Other PRs in the batch:
- `Azure/azure-rest-api-specs-pr#28848` (EncryptedTransport) — already covered by lease added in #43785.
- `Azure/azure-rest-api-specs-pr#28858` (AIGrounding → WebIQ rename) — handled separately in #43848.

cc @TejaswiMinnu @mikeharder