### PR TITLE
Add ARM leases for 5 partner PRs (M365, WebIQ rename, Kore.AgentPlatform, EdgeOperator, Storage contextCache)

### DIFF
--- a/.github/arm-leases/aigrounding/Microsoft.AIGrounding/AIGrounding/lease.yaml
+++ b/.github/arm-leases/aigrounding/Microsoft.AIGrounding/AIGrounding/lease.yaml
@@ -1,5 +1,0 @@
-lease:
-  resource-provider: Microsoft.AIGrounding
-  startdate: "2026-05-20"
-  duration: P180D
-  reviewer: "@vikeshi26"

--- a/.github/arm-leases/azure-native-integrations/Kore.AgentPlatform/AgentPlatform/lease.yaml
+++ b/.github/arm-leases/azure-native-integrations/Kore.AgentPlatform/AgentPlatform/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Kore.AgentPlatform
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/BillingConfigurations/lease.yaml
+++ b/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/BillingConfigurations/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.EdgeOperator
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/m365/Microsoft.M365/M365/lease.yaml
+++ b/.github/arm-leases/m365/Microsoft.M365/M365/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.M365
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/storage/Microsoft.Storage/storageContextCache/lease.yaml
+++ b/.github/arm-leases/storage/Microsoft.Storage/storageContextCache/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.Storage
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"

--- a/.github/arm-leases/webiq/Microsoft.WebIQ/WebIQ/lease.yaml
+++ b/.github/arm-leases/webiq/Microsoft.WebIQ/WebIQ/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.WebIQ
+  startdate: "2026-06-09"
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds ARM leases for partner PRs in `Azure/azure-rest-api-specs-pr` so their `arm-lease` checks pass. Only modeling reviewers can add lease files, so doing this here on partners' behalf.

| RP / Service | Partner PR |
|---|---|
| `Microsoft.M365` / `M365` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28806 |
| `Microsoft.WebIQ` / `WebIQ` (rename from AIGrounding) | https://github.com/Azure/azure-rest-api-specs-pr/pull/28858 |
| `Kore.AgentPlatform` / `AgentPlatform` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28860 |
| `Microsoft.EdgeOperator` / `BillingConfigurations` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28871 |
| `Microsoft.Storage` / `storageContextCache` | https://github.com/Azure/azure-rest-api-specs-pr/pull/28874 |

All 5 new leases: startdate `2026-06-09`, duration `P180D`, reviewer `@vikeshi26`.

Also deletes the obsolete `Microsoft.AIGrounding` lease (RP was renamed to `Microsoft.WebIQ` in #28858).

Note: `Azure/azure-rest-api-specs-pr#28848` (EncryptedTransport) is already covered by the lease added in #43785.

Supersedes #43848 and #43849.

cc @TejaswiMinnu @mikeharder