### PR TITLE
Example of Agent resource

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/Agent.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/Agent.tsp
@@ -1,0 +1,223 @@
+import "./main.tsp";
+import "./BaseType.tsp";
+
+using Azure.ResourceManager.BaseTypes;
+
+namespace Azure.ResourceManager.Agents;
+
+/** The base type specification for agents */
+model AgentBaseType extends BaseTypeInfo {
+  /** The baseType implemented */
+  baseType: BaseTypeValues.Agent;
+
+  /** Version of the base type */
+  version: "2024-06-01";
+}
+
+union FoundryToolType {
+  /** ChatGPT agent */
+  ChatGPT: "chatgpt",
+
+  /** Anthropic Agent */
+  Claude: "claude",
+
+  string,
+}
+
+model AgentToolTypeEntry {
+  type: FoundryToolType;
+  name: string;
+}
+
+model AgentToolProperty<ToolType extends AgentToolTypeEntry = AgentToolTypeEntry> {
+  /** The tools used for this agent */
+  tools?: ToolType[];
+}
+
+/**
+ * @dev May add ...ModelDeploymentRef or ...Instructions
+ */
+model AgentDefinition {
+  `model`: string;
+}
+
+/**
+ * @dev mix-in for AgentDefinition
+ */
+model ModelDeploymentRefProperty {
+  /** Agent model deployment reference */
+  modelDeploymentRef?: string;
+}
+
+/**
+ * @dev mix-in for Agent Definition
+ */
+model AgentInstructionsProperty {
+  /** The instructions */
+  instructions: string;
+}
+
+// need a decorator that identifies the base types for this agent,
+// serves as a key to enforce the base types and populates this list
+// the baseTypes from this list
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" ""
+model AgentProperties {
+  /** Implemented base types */
+  @visibility(Lifecycle.Read)
+  baseTypes: [AgentBaseType];
+
+  /** The Agent Display Name */
+  displayName: string;
+
+  /** The Agent description */
+  description: string;
+
+  /** The Agent Definition */
+  definition: AgentDefinition;
+}
+
+/**
+ * Properties for a Conversation
+ */
+model ConversationProperties {
+  /** The conversation id */
+  @visibility(Lifecycle.Read)
+  conversationId: string;
+
+  /** Creation date */
+  @visibility(Lifecycle.Read)
+  createdAt: unixTimestamp32;
+}
+
+/** OpenAI Message roles */
+union AgentRole {
+  /** The user */
+  User: "user",
+
+  /** A developer */
+  Developer: "developer",
+
+  /** An assistant */
+  Assistant: "assistant",
+
+  string,
+}
+
+/** Input to a conversation */
+model ConversationInput {
+  /** The role */
+  role: AgentRole;
+
+  /** The input content */
+  content: string;
+}
+
+/**
+ * @dev Optional type property for input
+ */
+model InputTypeProperty {
+  /** The input discriminator */
+  type?: string = "message";
+}
+
+model ConversationOutput {
+  id: string;
+}
+
+/** Status for responses */
+@Azure.Core.lroStatus
+union Status {
+  /** Successful completion */
+  @Azure.Core.lroSucceeded
+  Completed: "completed",
+
+  /** Terminated with failure */
+  @Azure.Core.lroFailed
+  Failed: "failed",
+
+  /** Cancelled by user */
+  @Azure.Core.lroCanceled
+  Cancelled: "cancelled",
+
+  /** Not finished */
+  Incomplete: "incomplete",
+
+  /** Ready for processing */
+  Queued: "queued",
+
+  /** Working */
+  InProgress: "in_progress",
+
+  string,
+}
+
+/** Properties for an agent response */
+model ResponseProperties {
+  /** The response Id */
+  @visibility(Lifecycle.Read)
+  responseId: string;
+
+  /** Creation date */
+  @visibility(Lifecycle.Read)
+  createdAt: unixTimestamp32;
+
+  /** The model */
+  `model`?: string;
+
+  /** Response status */
+  @visibility(Lifecycle.Read)
+  status: Status;
+
+  /** Input for this response */
+  input: ConversationInput;
+}
+
+model ResponseOutput {
+  /** Identifier */
+  @visibility(Lifecycle.Read)
+  id: string;
+
+  /** The type of response */
+  @visibility(Lifecycle.Read)
+  type: string;
+
+  /** The agent role */
+  @visibility(Lifecycle.Read)
+  role: AgentRole;
+
+  /** working status */
+  @visibility(Lifecycle.Read)
+  status: Status;
+
+  /** response content */
+  @visibility(Lifecycle.Read)
+  content: string;
+}
+
+/** Mix-in for the output property */
+model ResponseOutputProperty {
+  /** The output */
+  @visibility(Lifecycle.Read)
+  property: ResponseOutput[];
+}
+
+/** mix-in for the previous_response_id property */
+model PreviousResponseProperty {
+  /** The previous response identifier */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Wire property name"
+  previous_response_id?: string;
+}
+
+/**
+ * Mix-in for response instructions
+ */
+model ResponseInstructionsProperty {
+  /** The instructions */
+  instructions?: string;
+}
+
+/**
+ * Resource Type for Agents
+ * @param Properties RP-specific properties for the agent (must use AgentProperties)
+ */
+alias Agent<Properties extends AgentProperties> = TrackedResource<Properties>;

--- a/specification/contosowidgetmanager/Contoso.Management/BaseType.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/BaseType.tsp
@@ -1,0 +1,37 @@
+import "./main.tsp";
+
+/**
+ * A base type has the following characteristics
+ * 1. A name (taken from the array of known base types)
+ * 2. A version
+ * 3. A set of properties that are required to be supported and have a defined type, optionality, and visibility
+ * 4. A set of properties that are required to be supported and have a defined type, optionality, and user-selected visibility
+ * 4. A set of properties that are optional but must have a particular type and optionality and visibility, if supported
+ * 5. A set of properties that are optional but must have a particular type and optionality, if supported
+ *
+ * The current implementation is to have:
+ * - model templates with required properties
+ * - mixins for optional properties (with visibility if optional)
+ * - a decorator that applies required rules (type structure, child resources, operations)
+ */
+using Azure.ResourceManager;
+
+namespace Azure.ResourceManager.BaseTypes;
+
+union BaseTypeValues {
+  /** An Agent BaseType */
+  Agent: "agent",
+
+  string,
+}
+
+// need a decorator that identifies and populates the base types
+/** Base type definition */
+@discriminator("baseType")
+model BaseTypeInfo {
+  /** The base type */
+  baseType: BaseTypeValues;
+
+  /** The version */
+  version: string;
+}

--- a/specification/contosowidgetmanager/Contoso.Management/ContosoAgent.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/ContosoAgent.tsp
@@ -1,0 +1,84 @@
+import "@typespec/rest";
+import "@typespec/http";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "./Agent.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Agents;
+
+namespace Microsoft.Contoso;
+
+/** Note, we would need to alter this rule to allow the status property or add a provisioning state */
+/** rp-specific properties for contoso agent */
+model ContosoAgentProperties is AgentProperties {
+  ...AgentToolProperty;
+  ...DefaultProvisioningStateProperty;
+}
+
+model ContosoConversationProperties is ConversationProperties {
+  ...DefaultProvisioningStateProperty;
+  ...AgentInstructionsProperty;
+}
+
+model ContosoResponseProperties is ResponseProperties {
+  ...PreviousResponseProperty;
+  ...DefaultProvisioningStateProperty;
+}
+
+@@visibility(ContosoResponseProperties.previous_response_id, Lifecycle.Read);
+
+model ContosoAgent is Agent<ContosoAgentProperties> {
+  ...ResourceNameParameter<ContosoAgent>;
+}
+
+@parentResource(ContosoAgent)
+model ContosoResponse is ProxyResource<ContosoResponseProperties> {
+  ...ResourceNameParameter<ContosoResponse>;
+}
+
+@parentResource(ContosoAgent)
+model ContosoConversation is ProxyResource<ContosoConversationProperties> {
+  ...ResourceNameParameter<ContosoConversation>;
+}
+
+@armResourceOperations(ContosoAgent)
+interface ContosoAgents {
+  get is ArmResourceRead<ContosoAgent>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<ContosoAgent>;
+  update is ArmTagsPatchSync<ContosoAgent>;
+  delete is ArmResourceDeleteWithoutOkAsync<ContosoAgent>;
+  listBySubscription is ArmListBySubscription<ContosoAgent>;
+  listByResourceGroup is ArmResourceListByParent<ContosoAgent>;
+}
+
+@armResourceOperations(ContosoAgent)
+interface Conversations {
+  get is ArmResourceRead<ContosoConversation>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<ContosoConversation>;
+  update is ArmCustomPatchSync<
+    ContosoConversation,
+    Azure.ResourceManager.Foundations.ResourceUpdateModel<
+      ContosoConversation,
+      ContosoConversationProperties
+    >
+  >;
+  delete is ArmResourceDeleteWithoutOkAsync<ContosoConversation>;
+  listByAgent is ArmResourceListByParent<ContosoConversation>;
+}
+
+@armResourceOperations(ContosoAgent)
+interface Responses {
+  get is ArmResourceRead<ContosoResponse>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<ContosoResponse>;
+  update is ArmCustomPatchSync<
+    ContosoResponse,
+    Azure.ResourceManager.Foundations.ResourceUpdateModel<
+      ContosoResponse,
+      ContosoResponseProperties
+    >
+  >;
+  delete is ArmResourceDeleteWithoutOkAsync<ContosoResponse>;
+  listByAgent is ArmResourceListByParent<ContosoResponse>;
+}

--- a/specification/contosowidgetmanager/Contoso.Management/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/main.tsp
@@ -4,6 +4,8 @@ import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "./employee.tsp";
+import "./Agent.tsp";
+import "./ContosoAgent.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
@@ -44,6 +44,15 @@
     },
     {
       "name": "Employees"
+    },
+    {
+      "name": "ContosoAgents"
+    },
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Responses"
     }
   ],
   "paths": {
@@ -76,6 +85,40 @@
         "x-ms-examples": {
           "Operations_List": {
             "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Contoso/contosoAgents": {
+      "get": {
+        "operationId": "ContosoAgents_ListBySubscription",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "List ContosoAgent resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-pageable": {
@@ -120,6 +163,845 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents": {
+      "get": {
+        "operationId": "ContosoAgents_ListByResourceGroup",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "List ContosoAgent resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}": {
+      "get": {
+        "operationId": "ContosoAgents_Get",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Get a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContosoAgents_CreateOrUpdate",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Create a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoAgent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoAgent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContosoAgents_Update",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Update a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContosoAgents_Delete",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Delete a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoConversations": {
+      "get": {
+        "operationId": "Conversations_ListByAgent",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "List ContosoConversation resources by ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoConversations/{contosoConversationName}": {
+      "get": {
+        "operationId": "Conversations_Get",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Get a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Conversations_CreateOrUpdate",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Create a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoConversation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoConversation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Conversations_Update",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Update a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoConversationUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Conversations_Delete",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Delete a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoResponses": {
+      "get": {
+        "operationId": "Responses_ListByAgent",
+        "tags": [
+          "Responses"
+        ],
+        "description": "List ContosoResponse resources by ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponseListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoResponses/{contosoResponseName}": {
+      "get": {
+        "operationId": "Responses_Get",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Get a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Responses_CreateOrUpdate",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Create a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoResponse' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoResponse' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Responses_Update",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Update a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoResponseUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Responses_Delete",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Delete a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees": {
@@ -402,6 +1284,152 @@
     }
   },
   "definitions": {
+    "Azure.ResourceManager.Agents.AgentDefinition": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "model"
+      ]
+    },
+    "Azure.ResourceManager.Agents.AgentRole": {
+      "type": "string",
+      "description": "OpenAI Message roles",
+      "enum": [
+        "user",
+        "developer",
+        "assistant"
+      ],
+      "x-ms-enum": {
+        "name": "AgentRole",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "User",
+            "value": "user",
+            "description": "The user"
+          },
+          {
+            "name": "Developer",
+            "value": "developer",
+            "description": "A developer"
+          },
+          {
+            "name": "Assistant",
+            "value": "assistant",
+            "description": "An assistant"
+          }
+        ]
+      }
+    },
+    "Azure.ResourceManager.Agents.AgentToolTypeEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.FoundryToolType"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    "Azure.ResourceManager.Agents.ConversationInput": {
+      "type": "object",
+      "description": "Input to a conversation",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentRole",
+          "description": "The role"
+        },
+        "content": {
+          "type": "string",
+          "description": "The input content"
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ]
+    },
+    "Azure.ResourceManager.Agents.FoundryToolType": {
+      "type": "string",
+      "enum": [
+        "chatgpt",
+        "claude"
+      ],
+      "x-ms-enum": {
+        "name": "FoundryToolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ChatGPT",
+            "value": "chatgpt",
+            "description": "ChatGPT agent"
+          },
+          {
+            "name": "Claude",
+            "value": "claude",
+            "description": "Anthropic Agent"
+          }
+        ]
+      }
+    },
+    "Azure.ResourceManager.Agents.Status": {
+      "type": "string",
+      "description": "Status for responses",
+      "enum": [
+        "completed",
+        "failed",
+        "cancelled",
+        "incomplete",
+        "queued",
+        "in_progress"
+      ],
+      "x-ms-enum": {
+        "name": "Status",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Completed",
+            "value": "completed",
+            "description": "Successful completion"
+          },
+          {
+            "name": "Failed",
+            "value": "failed",
+            "description": "Terminated with failure"
+          },
+          {
+            "name": "Cancelled",
+            "value": "cancelled",
+            "description": "Cancelled by user"
+          },
+          {
+            "name": "Incomplete",
+            "value": "incomplete",
+            "description": "Not finished"
+          },
+          {
+            "name": "Queued",
+            "value": "queued",
+            "description": "Ready for processing"
+          },
+          {
+            "name": "InProgress",
+            "value": "in_progress",
+            "description": "Working"
+          }
+        ]
+      },
+      "readOnly": true
+    },
     "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
       "type": "object",
       "title": "Tracked Resource",
@@ -420,6 +1448,321 @@
           "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
         }
       ]
+    },
+    "Azure.ResourceManager.ResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of a resource type.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ContosoAgent": {
+      "type": "object",
+      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoAgentProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ContosoAgentListResult": {
+      "type": "object",
+      "description": "The response of a ContosoAgent list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoAgent items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoAgent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoAgentProperties": {
+      "type": "object",
+      "description": "Note, we would need to alter this rule to allow the status property or add a provisioning staterp-specific properties for contoso agent",
+      "properties": {
+        "baseTypes": {
+          "type": "array",
+          "description": "Implemented base types",
+          "items": {},
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The Agent Display Name"
+        },
+        "description": {
+          "type": "string",
+          "description": "The Agent description"
+        },
+        "definition": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentDefinition",
+          "description": "The Agent Definition"
+        },
+        "tools": {
+          "type": "array",
+          "description": "The tools used for this agent",
+          "items": {
+            "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentToolTypeEntry"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "baseTypes",
+        "displayName",
+        "description",
+        "definition"
+      ]
+    },
+    "ContosoAgentTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in ContosoAgent resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ContosoConversation": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoConversationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContosoConversationListResult": {
+      "type": "object",
+      "description": "The response of a ContosoConversation list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoConversation items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoConversation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoConversationProperties": {
+      "type": "object",
+      "description": "Properties for a Conversation",
+      "properties": {
+        "conversationId": {
+          "type": "string",
+          "description": "The conversation id",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Creation date",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The instructions"
+        }
+      },
+      "required": [
+        "conversationId",
+        "createdAt",
+        "instructions"
+      ]
+    },
+    "ContosoConversationUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the ContosoConversation.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoConversationUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "ContosoConversationUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the ContosoConversation.",
+      "properties": {
+        "instructions": {
+          "type": "string",
+          "description": "The instructions"
+        }
+      }
+    },
+    "ContosoResponse": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoResponseProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContosoResponseListResult": {
+      "type": "object",
+      "description": "The response of a ContosoResponse list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoResponse items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoResponse"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoResponseProperties": {
+      "type": "object",
+      "description": "Properties for an agent response",
+      "properties": {
+        "responseId": {
+          "type": "string",
+          "description": "The response Id",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Creation date",
+          "readOnly": true
+        },
+        "model": {
+          "type": "string",
+          "description": "The model"
+        },
+        "status": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.Status",
+          "description": "Response status",
+          "readOnly": true
+        },
+        "input": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.ConversationInput",
+          "description": "Input for this response"
+        },
+        "previous_response_id": {
+          "type": "string",
+          "description": "The previous response identifier",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "responseId",
+        "createdAt",
+        "status",
+        "input"
+      ]
+    },
+    "ContosoResponseUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the ContosoResponse.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoResponseUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "ContosoResponseUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the ContosoResponse.",
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "The model"
+        },
+        "input": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.ConversationInput",
+          "description": "Input for this response"
+        }
+      }
     },
     "Employee": {
       "type": "object",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
@@ -44,6 +44,15 @@
     },
     {
       "name": "Employees"
+    },
+    {
+      "name": "ContosoAgents"
+    },
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Responses"
     }
   ],
   "paths": {
@@ -76,6 +85,40 @@
         "x-ms-examples": {
           "Operations_List": {
             "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Contoso/contosoAgents": {
+      "get": {
+        "operationId": "ContosoAgents_ListBySubscription",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "List ContosoAgent resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
           }
         },
         "x-ms-pageable": {
@@ -120,6 +163,845 @@
         "x-ms-pageable": {
           "nextLinkName": "nextLink"
         }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents": {
+      "get": {
+        "operationId": "ContosoAgents_ListByResourceGroup",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "List ContosoAgent resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}": {
+      "get": {
+        "operationId": "ContosoAgents_Get",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Get a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContosoAgents_CreateOrUpdate",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Create a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoAgent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoAgent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContosoAgents_Update",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Update a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoAgentTagsUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoAgent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContosoAgents_Delete",
+        "tags": [
+          "ContosoAgents"
+        ],
+        "description": "Delete a ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoConversations": {
+      "get": {
+        "operationId": "Conversations_ListByAgent",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "List ContosoConversation resources by ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoConversations/{contosoConversationName}": {
+      "get": {
+        "operationId": "Conversations_Get",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Get a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Conversations_CreateOrUpdate",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Create a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoConversation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoConversation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Conversations_Update",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Update a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoConversationUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoConversation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Conversations_Delete",
+        "tags": [
+          "Conversations"
+        ],
+        "description": "Delete a ContosoConversation",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoConversationName",
+            "in": "path",
+            "description": "The name of the ContosoConversation",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoResponses": {
+      "get": {
+        "operationId": "Responses_ListByAgent",
+        "tags": [
+          "Responses"
+        ],
+        "description": "List ContosoResponse resources by ContosoAgent",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponseListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/contosoAgents/{contosoAgentName}/contosoResponses/{contosoResponseName}": {
+      "get": {
+        "operationId": "Responses_Get",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Get a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Responses_CreateOrUpdate",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Create a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContosoResponse' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContosoResponse' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Responses_Update",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Update a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContosoResponseUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContosoResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Responses_Delete",
+        "tags": [
+          "Responses"
+        ],
+        "description": "Delete a ContosoResponse",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "contosoAgentName",
+            "in": "path",
+            "description": "The name of the ContosoAgent",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "contosoResponseName",
+            "in": "path",
+            "description": "The name of the ContosoResponse",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
       }
     },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees": {
@@ -402,6 +1284,152 @@
     }
   },
   "definitions": {
+    "Azure.ResourceManager.Agents.AgentDefinition": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "model"
+      ]
+    },
+    "Azure.ResourceManager.Agents.AgentRole": {
+      "type": "string",
+      "description": "OpenAI Message roles",
+      "enum": [
+        "user",
+        "developer",
+        "assistant"
+      ],
+      "x-ms-enum": {
+        "name": "AgentRole",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "User",
+            "value": "user",
+            "description": "The user"
+          },
+          {
+            "name": "Developer",
+            "value": "developer",
+            "description": "A developer"
+          },
+          {
+            "name": "Assistant",
+            "value": "assistant",
+            "description": "An assistant"
+          }
+        ]
+      }
+    },
+    "Azure.ResourceManager.Agents.AgentToolTypeEntry": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.FoundryToolType"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    "Azure.ResourceManager.Agents.ConversationInput": {
+      "type": "object",
+      "description": "Input to a conversation",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentRole",
+          "description": "The role"
+        },
+        "content": {
+          "type": "string",
+          "description": "The input content"
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ]
+    },
+    "Azure.ResourceManager.Agents.FoundryToolType": {
+      "type": "string",
+      "enum": [
+        "chatgpt",
+        "claude"
+      ],
+      "x-ms-enum": {
+        "name": "FoundryToolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ChatGPT",
+            "value": "chatgpt",
+            "description": "ChatGPT agent"
+          },
+          {
+            "name": "Claude",
+            "value": "claude",
+            "description": "Anthropic Agent"
+          }
+        ]
+      }
+    },
+    "Azure.ResourceManager.Agents.Status": {
+      "type": "string",
+      "description": "Status for responses",
+      "enum": [
+        "completed",
+        "failed",
+        "cancelled",
+        "incomplete",
+        "queued",
+        "in_progress"
+      ],
+      "x-ms-enum": {
+        "name": "Status",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Completed",
+            "value": "completed",
+            "description": "Successful completion"
+          },
+          {
+            "name": "Failed",
+            "value": "failed",
+            "description": "Terminated with failure"
+          },
+          {
+            "name": "Cancelled",
+            "value": "cancelled",
+            "description": "Cancelled by user"
+          },
+          {
+            "name": "Incomplete",
+            "value": "incomplete",
+            "description": "Not finished"
+          },
+          {
+            "name": "Queued",
+            "value": "queued",
+            "description": "Ready for processing"
+          },
+          {
+            "name": "InProgress",
+            "value": "in_progress",
+            "description": "Working"
+          }
+        ]
+      },
+      "readOnly": true
+    },
     "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
       "type": "object",
       "title": "Tracked Resource",
@@ -420,6 +1448,321 @@
           "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
         }
       ]
+    },
+    "Azure.ResourceManager.ResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of a resource type.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ContosoAgent": {
+      "type": "object",
+      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoAgentProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ContosoAgentListResult": {
+      "type": "object",
+      "description": "The response of a ContosoAgent list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoAgent items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoAgent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoAgentProperties": {
+      "type": "object",
+      "description": "Note, we would need to alter this rule to allow the status property or add a provisioning staterp-specific properties for contoso agent",
+      "properties": {
+        "baseTypes": {
+          "type": "array",
+          "description": "Implemented base types",
+          "items": {},
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The Agent Display Name"
+        },
+        "description": {
+          "type": "string",
+          "description": "The Agent description"
+        },
+        "definition": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentDefinition",
+          "description": "The Agent Definition"
+        },
+        "tools": {
+          "type": "array",
+          "description": "The tools used for this agent",
+          "items": {
+            "$ref": "#/definitions/Azure.ResourceManager.Agents.AgentToolTypeEntry"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "baseTypes",
+        "displayName",
+        "description",
+        "definition"
+      ]
+    },
+    "ContosoAgentTagsUpdate": {
+      "type": "object",
+      "description": "The type used for updating tags in ContosoAgent resources.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ContosoConversation": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoConversationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContosoConversationListResult": {
+      "type": "object",
+      "description": "The response of a ContosoConversation list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoConversation items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoConversation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoConversationProperties": {
+      "type": "object",
+      "description": "Properties for a Conversation",
+      "properties": {
+        "conversationId": {
+          "type": "string",
+          "description": "The conversation id",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Creation date",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The instructions"
+        }
+      },
+      "required": [
+        "conversationId",
+        "createdAt",
+        "instructions"
+      ]
+    },
+    "ContosoConversationUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the ContosoConversation.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoConversationUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "ContosoConversationUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the ContosoConversation.",
+      "properties": {
+        "instructions": {
+          "type": "string",
+          "description": "The instructions"
+        }
+      }
+    },
+    "ContosoResponse": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoResponseProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContosoResponseListResult": {
+      "type": "object",
+      "description": "The response of a ContosoResponse list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContosoResponse items on this page",
+          "items": {
+            "$ref": "#/definitions/ContosoResponse"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContosoResponseProperties": {
+      "type": "object",
+      "description": "Properties for an agent response",
+      "properties": {
+        "responseId": {
+          "type": "string",
+          "description": "The response Id",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Creation date",
+          "readOnly": true
+        },
+        "model": {
+          "type": "string",
+          "description": "The model"
+        },
+        "status": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.Status",
+          "description": "Response status",
+          "readOnly": true
+        },
+        "input": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.ConversationInput",
+          "description": "Input for this response"
+        },
+        "previous_response_id": {
+          "type": "string",
+          "description": "The previous response identifier",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "responseId",
+        "createdAt",
+        "status",
+        "input"
+      ]
+    },
+    "ContosoResponseUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the ContosoResponse.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContosoResponseUpdateProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      }
+    },
+    "ContosoResponseUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the ContosoResponse.",
+      "properties": {
+        "model": {
+          "type": "string",
+          "description": "The model"
+        },
+        "input": {
+          "$ref": "#/definitions/Azure.ResourceManager.Agents.ConversationInput",
+          "description": "Input for this response"
+        }
+      }
     },
     "Employee": {
       "type": "object",


### PR DESCRIPTION
This is a low-tech example of that templates for base types might look like.

The 'BaseType.tsp and Agent.tsp  files would be in the typespec-azure-resource-manager library.

At the minimum we would also add a new decorator that identifies a base type by identity, fills in the 'baseTypes' array property automatically, and applies checks over the structure.

Here I have provided properties in the templates for all required properties,  mix-ins for all the properties that are *optional* but have a defined schema, and left out any optional properties without a defined schema.  The practical upshot is that, because there is a defined type for the properties, you can't construct an Agent property without providing at least the required types.

I showed how to use mix-ins and how to alter the mutability (visibility) of a property.

I *did not* add a resource type for conversations or responses, but this could be easily done.

There are some options for completely constructing the types using an options bag.

Also, I was unsure what to do with 'provisioningState'  so I just added it.  Most of these have a 'status' proeprty that serves the same purpose, and, if we want to use that for resources, this would require a minor update in the existing linting rule to accommodate.

Also, I did not implement the PUT for Responses, as it wasn't clear whether the examples provided the entire request payload or just the rp-specific property bags part.   The three options can easily be modeled, but soem SDKs might not have the best experience with a union type.