### PR TITLE
Add 2026-03-02/04-02/05-02-preview API versions to preparedimagespecification

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-03-02-preview/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-04-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-04-02-preview/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/examples/2026-05-02-preview/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/main.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/main.tsp
@@ -18,4 +18,16 @@ enum Versions {
   @doc("Azure Kubernetes Prepared Image Specification api version 2026-02-02-preview.")
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
   v2026_02_02_preview: "2026-02-02-preview",
+
+  @doc("Azure Kubernetes Prepared Image Specification api version 2026-03-02-preview.")
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+  v2026_03_02_preview: "2026-03-02-preview",
+
+  @doc("Azure Kubernetes Prepared Image Specification api version 2026-04-02-preview.")
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+  v2026_04_02_preview: "2026-04-02-preview",
+
+  @doc("Azure Kubernetes Prepared Image Specification api version 2026-05-02-preview.")
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
+  v2026_05_02_preview: "2026-05-02-preview",
 }

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/examples/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-03-02-preview/preparedimagespecification.json
@@ -1,0 +1,965 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServicePreparedImageSpecificationClient",
+    "version": "2026-03-02-preview",
+    "description": "Azure Kubernetes Prepared Image Specification api client.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PreparedImageSpecifications"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ContainerService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListBySubscription",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a subscription at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListBySubscription": {
+            "$ref": "./examples/PreparedImageSpecifications_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a resource group at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListByResourceGroup": {
+            "$ref": "./examples/PreparedImageSpecifications_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_Get",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Get": {
+            "$ref": "./examples/PreparedImageSpecifications_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Create or update a prepared image specification resource with a client-provided version. Created versions are immutable; provide a different properties.version value to create a new version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag does not match the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PreparedImageSpecification' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "201": {
+            "description": "Resource 'PreparedImageSpecification' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_CreateOrUpdate": {
+            "$ref": "./examples/PreparedImageSpecifications_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PreparedImageSpecifications_Update",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Update the tags of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Update": {
+            "$ref": "./examples/PreparedImageSpecifications_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_Delete",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification. This operation will be blocked if the resource is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Delete": {
+            "$ref": "./examples/PreparedImageSpecifications_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListVersions",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List all versions of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListVersions": {
+            "$ref": "./examples/PreparedImageSpecifications_ListVersions.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions/{version}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_GetVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at a particular version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersion"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_GetVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_GetVersion.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_DeleteVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification version. This operation will be blocked if the prepared image specification version is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_DeleteVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_DeleteVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ExecutionPoint": {
+      "type": "string",
+      "description": "The execution point for the script.",
+      "enum": [
+        "NodeImageBuildTime",
+        "NodeProvisionTime"
+      ],
+      "x-ms-enum": {
+        "name": "ExecutionPoint",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "nodeImageBuildTime",
+            "value": "NodeImageBuildTime",
+            "description": "Execute during node image build time."
+          },
+          {
+            "name": "nodeProvisionTime",
+            "value": "NodeProvisionTime",
+            "description": "Execute during node provisioning time."
+          }
+        ]
+      }
+    },
+    "PostScriptAction": {
+      "type": "string",
+      "description": "The action to take after the script finishes successfully.",
+      "enum": [
+        "None",
+        "RebootAfter"
+      ],
+      "x-ms-enum": {
+        "name": "PostScriptAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "None",
+            "description": "No post-script action is taken."
+          },
+          {
+            "name": "rebootAfter",
+            "value": "RebootAfter",
+            "description": "Reboot the node after the script completes."
+          }
+        ]
+      }
+    },
+    "PreparedImageSpecification": {
+      "type": "object",
+      "description": "The Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecification list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecification items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecification"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PreparedImageSpecificationManagedIdentityProfile": {
+      "type": "object",
+      "description": "The managed identity profile used by the prepared image specification.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "objectId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The object ID of the managed identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The client ID of the managed identity.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "PreparedImageSpecificationPatch": {
+      "type": "object",
+      "description": "Prepared image specification patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PreparedImageSpecificationProperties": {
+      "type": "object",
+      "description": "The properties of the Prepared Image Specification resource.",
+      "properties": {
+        "containerImages": {
+          "type": "array",
+          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityProfile": {
+          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfile",
+          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
+        },
+        "version": {
+          "type": "string",
+          "description": "The client-provided version of the prepared image specification.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the prepared image specification.",
+          "readOnly": true
+        },
+        "customizationScripts": {
+          "type": "array",
+          "description": "The scripts to customize the node before or after image capture.",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationScript"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PreparedImageSpecificationScript": {
+      "type": "object",
+      "description": "Prepared image specification script",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the customization script. \nMust be unique within the prepared image specification resource.\nCan only contain lowercase alphanumeric,'-' or '.' characters.",
+          "maxLength": 263,
+          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "executionPoint": {
+          "$ref": "#/definitions/ExecutionPoint",
+          "description": "The stage at which the script is executed.\nSpecifying `NodeImageBuildTime` will ensure changes are persisted into the node image."
+        },
+        "scriptType": {
+          "$ref": "#/definitions/ScriptType",
+          "description": "The runtime environment for the script (e.g. Bash).",
+          "example": "Bash"
+        },
+        "script": {
+          "type": "string",
+          "description": "The script content to be executed in plain text. Do not include secrets.",
+          "example": "echo 'initializing node'"
+        },
+        "postScriptAction": {
+          "$ref": "#/definitions/PostScriptAction",
+          "description": "The action to take after successful script execution."
+        }
+      },
+      "required": [
+        "name",
+        "executionPoint",
+        "scriptType"
+      ]
+    },
+    "PreparedImageSpecificationVersion": {
+      "type": "object",
+      "description": "A version of the Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationVersionListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecificationVersion list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecificationVersion items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationVersion"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the image customization.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning the resource is in progress"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Resource is being updated"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The change request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScriptType": {
+      "type": "string",
+      "description": "The script type.",
+      "enum": [
+        "Bash",
+        "PowerShell"
+      ],
+      "x-ms-enum": {
+        "name": "ScriptType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "bash",
+            "value": "Bash",
+            "description": "Bash script."
+          },
+          {
+            "name": "powerShell",
+            "value": "PowerShell",
+            "description": "PowerShell script."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-04-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/examples/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-04-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-04-02-preview/preparedimagespecification.json
@@ -1,0 +1,965 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServicePreparedImageSpecificationClient",
+    "version": "2026-04-02-preview",
+    "description": "Azure Kubernetes Prepared Image Specification api client.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PreparedImageSpecifications"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ContainerService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListBySubscription",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a subscription at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListBySubscription": {
+            "$ref": "./examples/PreparedImageSpecifications_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a resource group at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListByResourceGroup": {
+            "$ref": "./examples/PreparedImageSpecifications_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_Get",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Get": {
+            "$ref": "./examples/PreparedImageSpecifications_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Create or update a prepared image specification resource with a client-provided version. Created versions are immutable; provide a different properties.version value to create a new version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag does not match the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PreparedImageSpecification' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "201": {
+            "description": "Resource 'PreparedImageSpecification' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_CreateOrUpdate": {
+            "$ref": "./examples/PreparedImageSpecifications_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PreparedImageSpecifications_Update",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Update the tags of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Update": {
+            "$ref": "./examples/PreparedImageSpecifications_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_Delete",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification. This operation will be blocked if the resource is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Delete": {
+            "$ref": "./examples/PreparedImageSpecifications_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListVersions",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List all versions of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListVersions": {
+            "$ref": "./examples/PreparedImageSpecifications_ListVersions.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions/{version}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_GetVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at a particular version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersion"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_GetVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_GetVersion.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_DeleteVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification version. This operation will be blocked if the prepared image specification version is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_DeleteVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_DeleteVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ExecutionPoint": {
+      "type": "string",
+      "description": "The execution point for the script.",
+      "enum": [
+        "NodeImageBuildTime",
+        "NodeProvisionTime"
+      ],
+      "x-ms-enum": {
+        "name": "ExecutionPoint",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "nodeImageBuildTime",
+            "value": "NodeImageBuildTime",
+            "description": "Execute during node image build time."
+          },
+          {
+            "name": "nodeProvisionTime",
+            "value": "NodeProvisionTime",
+            "description": "Execute during node provisioning time."
+          }
+        ]
+      }
+    },
+    "PostScriptAction": {
+      "type": "string",
+      "description": "The action to take after the script finishes successfully.",
+      "enum": [
+        "None",
+        "RebootAfter"
+      ],
+      "x-ms-enum": {
+        "name": "PostScriptAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "None",
+            "description": "No post-script action is taken."
+          },
+          {
+            "name": "rebootAfter",
+            "value": "RebootAfter",
+            "description": "Reboot the node after the script completes."
+          }
+        ]
+      }
+    },
+    "PreparedImageSpecification": {
+      "type": "object",
+      "description": "The Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecification list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecification items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecification"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PreparedImageSpecificationManagedIdentityProfile": {
+      "type": "object",
+      "description": "The managed identity profile used by the prepared image specification.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "objectId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The object ID of the managed identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The client ID of the managed identity.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "PreparedImageSpecificationPatch": {
+      "type": "object",
+      "description": "Prepared image specification patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PreparedImageSpecificationProperties": {
+      "type": "object",
+      "description": "The properties of the Prepared Image Specification resource.",
+      "properties": {
+        "containerImages": {
+          "type": "array",
+          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityProfile": {
+          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfile",
+          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
+        },
+        "version": {
+          "type": "string",
+          "description": "The client-provided version of the prepared image specification.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the prepared image specification.",
+          "readOnly": true
+        },
+        "customizationScripts": {
+          "type": "array",
+          "description": "The scripts to customize the node before or after image capture.",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationScript"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PreparedImageSpecificationScript": {
+      "type": "object",
+      "description": "Prepared image specification script",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the customization script. \nMust be unique within the prepared image specification resource.\nCan only contain lowercase alphanumeric,'-' or '.' characters.",
+          "maxLength": 263,
+          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "executionPoint": {
+          "$ref": "#/definitions/ExecutionPoint",
+          "description": "The stage at which the script is executed.\nSpecifying `NodeImageBuildTime` will ensure changes are persisted into the node image."
+        },
+        "scriptType": {
+          "$ref": "#/definitions/ScriptType",
+          "description": "The runtime environment for the script (e.g. Bash).",
+          "example": "Bash"
+        },
+        "script": {
+          "type": "string",
+          "description": "The script content to be executed in plain text. Do not include secrets.",
+          "example": "echo 'initializing node'"
+        },
+        "postScriptAction": {
+          "$ref": "#/definitions/PostScriptAction",
+          "description": "The action to take after successful script execution."
+        }
+      },
+      "required": [
+        "name",
+        "executionPoint",
+        "scriptType"
+      ]
+    },
+    "PreparedImageSpecificationVersion": {
+      "type": "object",
+      "description": "A version of the Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationVersionListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecificationVersion list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecificationVersion items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationVersion"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the image customization.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning the resource is in progress"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Resource is being updated"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The change request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScriptType": {
+      "type": "string",
+      "description": "The script type.",
+      "enum": [
+        "Bash",
+        "PowerShell"
+      ],
+      "x-ms-enum": {
+        "name": "ScriptType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "bash",
+            "value": "Bash",
+            "description": "Bash script."
+          },
+          {
+            "name": "powerShell",
+            "value": "PowerShell",
+            "description": "PowerShell script."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/Operations_List.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-05-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.ContainerService/locations/operations/read",
+            "isDataAction": true,
+            "display": {
+              "provider": "Microsoft Container Service",
+              "resource": "Operation",
+              "operation": "Get Operation",
+              "description": "tulzcjyupeonkxrou"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "http://nextlink.contoso.com"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_CreateOrUpdate.json
@@ -1,0 +1,118 @@
+{
+  "title": "PreparedImageSpecifications_CreateOrUpdate",
+  "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "resource": {
+      "properties": {
+        "version": "20250101-abcd1234",
+        "containerImages": [
+          "redis:8.0.0"
+        ],
+        "customizationScripts": [
+          {
+            "name": "initialize-node",
+            "executionPoint": "NodeImageBuildTime",
+            "scriptType": "Bash",
+            "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+          }
+        ],
+        "identityProfile": {
+          "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+        }
+      },
+      "tags": {
+        "team": "blue"
+      },
+      "location": "westus2"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Delete.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "PreparedImageSpecifications_Delete",
+  "operationId": "PreparedImageSpecifications_Delete",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_DeleteVersion.json
@@ -1,0 +1,19 @@
+{
+  "title": "PreparedImageSpecifications_DeleteVersion",
+  "operationId": "PreparedImageSpecifications_DeleteVersion",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Get.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_Get",
+  "operationId": "PreparedImageSpecifications_Get",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_GetVersion.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_GetVersion.json
@@ -1,0 +1,49 @@
+{
+  "title": "PreparedImageSpecifications_GetVersion",
+  "operationId": "PreparedImageSpecifications_GetVersion",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "version": "20250101-abcd1234"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "redis:8.0.0"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+              "postScriptAction": "None"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+        "name": "20250101-abcd1234",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListByResourceGroup.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_ListByResourceGroup",
+  "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "title": "PreparedImageSpecifications_ListBySubscription",
+  "operationId": "PreparedImageSpecifications_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt",
+                  "postScriptAction": "None"
+                }
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded"
+            },
+            "eTag": "ETagValue",
+            "tags": {
+              "team": "blue"
+            },
+            "location": "westus2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+            "name": "my-prepared-image-specification",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/ah"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListVersions.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_ListVersions.json
@@ -1,0 +1,53 @@
+{
+  "title": "PreparedImageSpecifications_ListVersions",
+  "operationId": "PreparedImageSpecifications_ListVersions",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "containerImages": [
+                "redis:8.0.0"
+              ],
+              "identityProfile": {
+                "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+                "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+              },
+              "version": "20250101-abcd1234",
+              "provisioningState": "Succeeded",
+              "customizationScripts": [
+                {
+                  "name": "initialize-node",
+                  "executionPoint": "NodeImageBuildTime",
+                  "scriptType": "Bash",
+                  "script": "echo 'Hello World'",
+                  "postScriptAction": "None"
+                }
+              ]
+            },
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification/versions/20250101-abcd1234",
+            "name": "20250101-abcd1234",
+            "type": "Microsoft.ContainerService/preparedImageSpecifications/versions",
+            "systemData": {
+              "createdBy": "someUser",
+              "createdByType": "User",
+              "createdAt": "2025-05-02T04:08:43.702Z",
+              "lastModifiedBy": "someOtherUser",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Update.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/examples/PreparedImageSpecifications_Update.json
@@ -1,0 +1,57 @@
+{
+  "title": "PreparedImageSpecifications_Update",
+  "operationId": "PreparedImageSpecifications_Update",
+  "parameters": {
+    "api-version": "2026-05-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroupName": "rg1",
+    "preparedImageSpecificationName": "my-prepared-image-specification",
+    "properties": {
+      "tags": {
+        "key5558": "xufgvdnarflvwbcdkmhqhgbop"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "containerImages": [
+            "qmetlvqgbvhjnncyraxlhs"
+          ],
+          "customizationScripts": [
+            {
+              "name": "initialize-node",
+              "executionPoint": "NodeImageBuildTime",
+              "scriptType": "Bash",
+              "script": "echo \"test prepared image specification\" > /var/log/test-node-customization.txt"
+            }
+          ],
+          "identityProfile": {
+            "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+            "objectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "clientId": "df4316d4-0ef3-45a3-99d0-2d13a6543aff"
+          },
+          "version": "20250101-abcd1234",
+          "provisioningState": "Succeeded"
+        },
+        "eTag": "ETagValue",
+        "tags": {
+          "team": "blue"
+        },
+        "location": "westus2",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ContainerService/preparedImageSpecifications/my-prepared-image-specification",
+        "name": "my-prepared-image-specification",
+        "type": "Microsoft.ContainerService/preparedImageSpecifications",
+        "systemData": {
+          "createdBy": "someUser",
+          "createdByType": "User",
+          "createdAt": "2025-05-02T04:08:43.702Z",
+          "lastModifiedBy": "someOtherUser",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2025-05-02T04:08:43.702Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/preparedimagespecification.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/preview/2026-05-02-preview/preparedimagespecification.json
@@ -1,0 +1,965 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerServicePreparedImageSpecificationClient",
+    "version": "2026-05-02-preview",
+    "description": "Azure Kubernetes Prepared Image Specification api client.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PreparedImageSpecifications"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.ContainerService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListBySubscription",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a subscription at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListBySubscription": {
+            "$ref": "./examples/PreparedImageSpecifications_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListByResourceGroup",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List the prepared image specifications in a resource group at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListByResourceGroup": {
+            "$ref": "./examples/PreparedImageSpecifications_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_Get",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at the latest version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Get": {
+            "$ref": "./examples/PreparedImageSpecifications_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PreparedImageSpecifications_CreateOrUpdate",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Create or update a prepared image specification resource with a client-provided version. Created versions are immutable; provide a different properties.version value to create a new version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag does not match the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifNoneMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PreparedImageSpecification' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "201": {
+            "description": "Resource 'PreparedImageSpecification' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_CreateOrUpdate": {
+            "$ref": "./examples/PreparedImageSpecifications_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PreparedImageSpecifications_Update",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Update the tags of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecification"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Update": {
+            "$ref": "./examples/PreparedImageSpecifications_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_Delete",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification. This operation will be blocked if the resource is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_Delete": {
+            "$ref": "./examples/PreparedImageSpecifications_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_ListVersions",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "List all versions of a prepared image specification.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_ListVersions": {
+            "$ref": "./examples/PreparedImageSpecifications_ListVersions.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/preparedImageSpecifications/{preparedImageSpecificationName}/versions/{version}": {
+      "get": {
+        "operationId": "PreparedImageSpecifications_GetVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Get a prepared image specification at a particular version.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PreparedImageSpecificationVersion"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_GetVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_GetVersion.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PreparedImageSpecifications_DeleteVersion",
+        "tags": [
+          "PreparedImageSpecifications"
+        ],
+        "description": "Delete a prepared image specification version. This operation will be blocked if the prepared image specification version is in use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The request should only proceed if the targeted resource's etag matches the value provided.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "ifMatch"
+          },
+          {
+            "name": "preparedImageSpecificationName",
+            "in": "path",
+            "description": "The name of the Prepared Image Specification resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "The version of the Prepared Image Specification.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PreparedImageSpecifications_DeleteVersion": {
+            "$ref": "./examples/PreparedImageSpecifications_DeleteVersion.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "ExecutionPoint": {
+      "type": "string",
+      "description": "The execution point for the script.",
+      "enum": [
+        "NodeImageBuildTime",
+        "NodeProvisionTime"
+      ],
+      "x-ms-enum": {
+        "name": "ExecutionPoint",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "nodeImageBuildTime",
+            "value": "NodeImageBuildTime",
+            "description": "Execute during node image build time."
+          },
+          {
+            "name": "nodeProvisionTime",
+            "value": "NodeProvisionTime",
+            "description": "Execute during node provisioning time."
+          }
+        ]
+      }
+    },
+    "PostScriptAction": {
+      "type": "string",
+      "description": "The action to take after the script finishes successfully.",
+      "enum": [
+        "None",
+        "RebootAfter"
+      ],
+      "x-ms-enum": {
+        "name": "PostScriptAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "None",
+            "description": "No post-script action is taken."
+          },
+          {
+            "name": "rebootAfter",
+            "value": "RebootAfter",
+            "description": "Reboot the node after the script completes."
+          }
+        ]
+      }
+    },
+    "PreparedImageSpecification": {
+      "type": "object",
+      "description": "The Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "eTag": {
+          "type": "string",
+          "description": "If eTag is provided in the response body, it may also be provided as a header per the normal etag convention.  Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecification list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecification items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecification"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PreparedImageSpecificationManagedIdentityProfile": {
+      "type": "object",
+      "description": "The managed identity profile used by the prepared image specification.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        },
+        "objectId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The object ID of the managed identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The client ID of the managed identity.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "PreparedImageSpecificationPatch": {
+      "type": "object",
+      "description": "Prepared image specification patch resource",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PreparedImageSpecificationProperties": {
+      "type": "object",
+      "description": "The properties of the Prepared Image Specification resource.",
+      "properties": {
+        "containerImages": {
+          "type": "array",
+          "description": "The list of container images to cache on nodes. See https://kubernetes.io/docs/concepts/containers/images/#image-names",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identityProfile": {
+          "$ref": "#/definitions/PreparedImageSpecificationManagedIdentityProfile",
+          "description": "The identity used to execute prepared image specification tasks during image build time and provisioning time. \nIf not specified the default agentpool identity will be used.\nThis does not affect provisioned nodes."
+        },
+        "version": {
+          "type": "string",
+          "description": "The client-provided version of the prepared image specification.",
+          "pattern": "^(?![.-])[A-Za-z0-9_.-]{1,63}$"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the prepared image specification.",
+          "readOnly": true
+        },
+        "customizationScripts": {
+          "type": "array",
+          "description": "The scripts to customize the node before or after image capture.",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationScript"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PreparedImageSpecificationScript": {
+      "type": "object",
+      "description": "Prepared image specification script",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name for the customization script. \nMust be unique within the prepared image specification resource.\nCan only contain lowercase alphanumeric,'-' or '.' characters.",
+          "maxLength": 263,
+          "pattern": "^[a-z0-9]([a-z0-9\\.\\-]*[a-z0-9])?$",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "executionPoint": {
+          "$ref": "#/definitions/ExecutionPoint",
+          "description": "The stage at which the script is executed.\nSpecifying `NodeImageBuildTime` will ensure changes are persisted into the node image."
+        },
+        "scriptType": {
+          "$ref": "#/definitions/ScriptType",
+          "description": "The runtime environment for the script (e.g. Bash).",
+          "example": "Bash"
+        },
+        "script": {
+          "type": "string",
+          "description": "The script content to be executed in plain text. Do not include secrets.",
+          "example": "echo 'initializing node'"
+        },
+        "postScriptAction": {
+          "$ref": "#/definitions/PostScriptAction",
+          "description": "The action to take after successful script execution."
+        }
+      },
+      "required": [
+        "name",
+        "executionPoint",
+        "scriptType"
+      ]
+    },
+    "PreparedImageSpecificationVersion": {
+      "type": "object",
+      "description": "A version of the Prepared Image Specification resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PreparedImageSpecificationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PreparedImageSpecificationVersionListResult": {
+      "type": "object",
+      "description": "The response of a PreparedImageSpecificationVersion list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PreparedImageSpecificationVersion items on this page",
+          "items": {
+            "$ref": "#/definitions/PreparedImageSpecificationVersion"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the image customization.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning the resource is in progress"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Resource is being updated"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The change request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScriptType": {
+      "type": "string",
+      "description": "The script type.",
+      "enum": [
+        "Bash",
+        "PowerShell"
+      ],
+      "x-ms-enum": {
+        "name": "ScriptType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "bash",
+            "value": "Bash",
+            "description": "Bash script."
+          },
+          {
+            "name": "powerShell",
+            "value": "PowerShell",
+            "description": "PowerShell script."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.java.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.java.md
@@ -19,6 +19,9 @@ description: "Azure Kubernetes Prepared Image Specification Manager Client"
 ```yaml $(java) && $(multiapi)
 batch:
   - tag: package-2026-02-02-preview
+  - tag: package-2026-03-02-preview
+  - tag: package-2026-04-02-preview
+  - tag: package-2026-05-02-preview
 ```
 
 ### Tag: package-2026-02-02-preview and java
@@ -30,6 +33,45 @@ Please also specify `--azure-libraries-for-java-folder=<path to the root directo
 java:
   namespace: com.azure.resourcemanager.containerservice.preparedimgspec.v2026_02_02_preview
   output-folder: $(azure-libraries-for-java-folder)/sdk/containerservice/mgmt-v2026_02_02_preview
+regenerate-manager: true
+generate-interface: true
+```
+
+### Tag: package-2026-03-02-preview and java
+
+These settings apply only when `--tag=package-2026-03-02-preview` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+```yaml $(tag) == 'package-2026-03-02-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.azure.resourcemanager.containerservice.preparedimgspec.v2026_03_02_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/containerservice/mgmt-v2026_03_02_preview
+regenerate-manager: true
+generate-interface: true
+```
+
+### Tag: package-2026-04-02-preview and java
+
+These settings apply only when `--tag=package-2026-04-02-preview` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+```yaml $(tag) == 'package-2026-04-02-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.azure.resourcemanager.containerservice.preparedimgspec.v2026_04_02_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/containerservice/mgmt-v2026_04_02_preview
+regenerate-manager: true
+generate-interface: true
+```
+
+### Tag: package-2026-05-02-preview and java
+
+These settings apply only when `--tag=package-2026-05-02-preview` is specified on the command line.
+Please also specify `--azure-libraries-for-java-folder=<path to the root directory of your azure-sdk-for-java clone>`.
+
+```yaml $(tag) == 'package-2026-05-02-preview' && $(java) && $(multiapi)
+java:
+  namespace: com.azure.resourcemanager.containerservice.preparedimgspec.v2026_05_02_preview
+  output-folder: $(azure-libraries-for-java-folder)/sdk/containerservice/mgmt-v2026_05_02_preview
 regenerate-manager: true
 generate-interface: true
 ```

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.md
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/preparedimagespecification/readme.md
@@ -23,7 +23,7 @@ These are the global settings for the ContainerServices API.
 
 ```yaml
 openapi-type: arm
-tag: package-2026-02-02-preview
+tag: package-2026-05-02-preview
 ```
 
 ### Tag: package-2026-02-02-preview
@@ -33,6 +33,33 @@ These settings apply only when `--tag=package-2026-02-02-preview` is specified o
 ```yaml $(tag) == 'package-2026-02-02-preview'
 input-file:
   - preview/2026-02-02-preview/preparedimagespecification.json
+```
+
+### Tag: package-2026-03-02-preview
+
+These settings apply only when `--tag=package-2026-03-02-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-03-02-preview'
+input-file:
+  - preview/2026-03-02-preview/preparedimagespecification.json
+```
+
+### Tag: package-2026-04-02-preview
+
+These settings apply only when `--tag=package-2026-04-02-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-04-02-preview'
+input-file:
+  - preview/2026-04-02-preview/preparedimagespecification.json
+```
+
+### Tag: package-2026-05-02-preview
+
+These settings apply only when `--tag=package-2026-05-02-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-05-02-preview'
+input-file:
+  - preview/2026-05-02-preview/preparedimagespecification.json
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds three new preview API versions to the `Microsoft.ContainerService` **preparedimagespecification** ARM TypeSpec project:

- `2026-03-02-preview`
- `2026-04-02-preview`
- `2026-05-02-preview`

These are pure version bumps carrying over the existing `2026-02-02-preview` surface unchanged (no model/operation changes). Each new swagger is byte-identical to the baseline apart from version strings.

## Changes (separate commits per concern)

1. **TypeSpec** — added the three entries to the `Versions` enum in `main.tsp` (each `@armCommonTypesVersion v6`, matching the existing style); added `package-*` tags to `readme.md` and per-version Java multi-api blocks in `readme.java.md`; default tag bumped to `package-2026-05-02-preview`.
2. **Examples** — added source `examples/<version>/` folders (copied from `2026-02-02-preview`, `api-version` updated).
3. **Swagger** — regenerated `preview/<version>/preparedimagespecification.json` + example copies via `tsp compile`.

## Validation

- `npx tsp compile . --warn-as-error` passes cleanly (resource-manager linter ruleset).
- Each generated swagger references all 10 operation examples.
- Normalized diff vs `2026-02-02-preview` confirms version-string-only changes.

## Notes

- Targets the AKS release branch `dev-containerservice-Microsoft.ContainerService-2026-05` (same base as #43857).
- Kept as **DRAFT**.