### PR TITLE
[ResilienceManagement] Additional C# client.tsp overrides for SDK design-guideline compliance

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/client.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/client.tsp
@@ -3,6 +3,7 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 using Microsoft.AzureResilienceManagement;
+using Azure.Core;
 
 // @@usage(ChildJobProperties, Usage.input | Usage.output, "go");
 @@usage(JobProperties, Usage.input | Usage.output, "go");
@@ -78,7 +79,7 @@ using Microsoft.AzureResilienceManagement;
 );
 
 // CSharp: AZC0032 — *Data is reserved (collides with auto-generated *Data POCOs)
-@@clientName(GoalsData, "GoalsInfo", "csharp");
+@@clientName(GoalsData, "ResilienceManagementGoalsInfo", "csharp");
 @@clientName(
   RecommendationsHighAvailabilityData,
   "RecommendationsHighAvailabilityInfo",
@@ -87,5 +88,28 @@ using Microsoft.AzureResilienceManagement;
 
 // These three are reference/content models and must not use the *Resource suffix.
 @@clientName(IncludeOrUpdateResource, "IncludeOrUpdateContent", "csharp");
-@@clientName(MoboBrokerResource, "MoboBrokerTarget", "csharp");
+@@clientName(MoboBrokerResource, "ManagedBrokerTarget", "csharp");
 @@clientName(ServiceLevelResource, "ServiceLevelTarget", "csharp");
+
+@@clientName(RBACState, "ResilienceManagementRbacState", "csharp");
+@@clientName(RBACSetupMode, "ResilienceManagementRbacSetupMode", "csharp");
+@@clientName(VMPresent, "VmPresent", "csharp");
+@@clientName(HAStatus, "HighAvailabilityStatus", "csharp");
+@@clientName(ProvisioningState, "ResilienceManagementProvisioningState", "csharp");
+@@clientName(ErrorDetails, "ResilienceManagementErrorDetail", "csharp");
+@@clientName(SystemMetadata, "DrillSystemMetadata", "csharp");
+@@clientName(ActionTask, "ResilienceManagementActionTask", "csharp");
+@@clientName(ResourceLists, "DrillResourcesList", "csharp");
+@@clientName(SolutionDisplayName, "ResilienceManagementSolutionDisplayName", "csharp");
+@@alternateType(MoboBrokerResource.id, armResourceIdentifier, "csharp");
+@@clientName(RecoveryResourceProperties.needsAttention, "RequiresAttention", "csharp");
+@@clientName(DrillRunAddNotesRequest.timestamp, "RecordedOn", "csharp");
+@@alternateType(RecoveryResourceProperties.resourceLocation, azureLocation, "csharp");
+@@alternateType(ResourceProtectionSolutionSettings.activeLocation, azureLocation, "csharp");
+@@alternateType(ResourceProtectionSolutionSettings.activeLocations, azureLocation[], "csharp");
+@@clientName(ForceInclusionAndUpdate, "ForceInclusionState", "csharp");
+@@clientName(AssociatedIdentity, "ResilienceManagementAssociatedIdentity", "csharp");
+@@clientName(GoalResource, "GoalMembers", "csharp");
+@@clientName(RecoveryResource, "ResilienceMembers", "csharp");
+@@clientName(Drill, "ResilienceManagementDrill", "csharp");
+@@clientName(Enrollment, "UsagePlanEnrollment", "csharp");

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/client.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/client.tsp
@@ -95,20 +95,48 @@ using Azure.Core;
 @@clientName(RBACSetupMode, "ResilienceManagementRbacSetupMode", "csharp");
 @@clientName(VMPresent, "VmPresent", "csharp");
 @@clientName(HAStatus, "HighAvailabilityStatus", "csharp");
-@@clientName(ProvisioningState, "ResilienceManagementProvisioningState", "csharp");
+@@clientName(
+  ProvisioningState,
+  "ResilienceManagementProvisioningState",
+  "csharp"
+);
 @@clientName(ErrorDetails, "ResilienceManagementErrorDetail", "csharp");
 @@clientName(SystemMetadata, "DrillSystemMetadata", "csharp");
 @@clientName(ActionTask, "ResilienceManagementActionTask", "csharp");
 @@clientName(ResourceLists, "DrillResourcesList", "csharp");
-@@clientName(SolutionDisplayName, "ResilienceManagementSolutionDisplayName", "csharp");
+@@clientName(
+  SolutionDisplayName,
+  "ResilienceManagementSolutionDisplayName",
+  "csharp"
+);
 @@alternateType(MoboBrokerResource.id, armResourceIdentifier, "csharp");
-@@clientName(RecoveryResourceProperties.needsAttention, "RequiresAttention", "csharp");
+@@clientName(
+  RecoveryResourceProperties.needsAttention,
+  "RequiresAttention",
+  "csharp"
+);
 @@clientName(DrillRunAddNotesRequest.timestamp, "RecordedOn", "csharp");
-@@alternateType(RecoveryResourceProperties.resourceLocation, azureLocation, "csharp");
-@@alternateType(ResourceProtectionSolutionSettings.activeLocation, azureLocation, "csharp");
-@@alternateType(ResourceProtectionSolutionSettings.activeLocations, azureLocation[], "csharp");
+@@alternateType(
+  RecoveryResourceProperties.resourceLocation,
+  azureLocation,
+  "csharp"
+);
+@@alternateType(
+  ResourceProtectionSolutionSettings.activeLocation,
+  azureLocation,
+  "csharp"
+);
+@@alternateType(
+  ResourceProtectionSolutionSettings.activeLocations,
+  azureLocation[],
+  "csharp"
+);
 @@clientName(ForceInclusionAndUpdate, "ForceInclusionState", "csharp");
-@@clientName(AssociatedIdentity, "ResilienceManagementAssociatedIdentity", "csharp");
+@@clientName(
+  AssociatedIdentity,
+  "ResilienceManagementAssociatedIdentity",
+  "csharp"
+);
 @@clientName(GoalResource, "GoalMembers", "csharp");
 @@clientName(RecoveryResource, "ResilienceMembers", "csharp");
 @@clientName(Drill, "ResilienceManagementDrill", "csharp");


### PR DESCRIPTION
# SDK configuration pull request

## Purpose of this PR

- [x] Make changes to the SDK configuration only when there are no modifications to the API specification, eliminating the need for an ARM or Stewardship Board API review.

## Due diligence checklist

To merge this PR, you **must** go through the following checklist and confirm you understood
and followed the instructions by checking all the boxes:

- [x] I confirm this PR is modifying only SDK configurations, and not API related specifications.
- [x] I have reviewed and used the respective `tspconfig.yaml` templates:
  - [ARM tspconfig template](https://aka.ms/azsdk/tspconfig-sample-mpg)
  - [Data plane tspconfig template](https://aka.ms/azsdk/tspconfig-sample-dpg)

## Context

Follow-up to merged PR #43816 (Microsoft.AzureResilienceManagement SDK configuration). Touches only `client.tsp` under `specification/azureresiliencemanagement/...` — no `main.tsp`, no `openapi.json`, no API-surface changes. Surfaced during local .NET SDK generation against PR #43816's merged state.

### Changes

**`client.tsp`** — additional `@@clientName(..., "csharp")` and `@@alternateType(..., "csharp")` overrides for SDK design-guideline compliance.

#### Renames of previously-merged C# names

- `GoalsData` → **`ResilienceManagementGoalsInfo`** (was `GoalsInfo` — added service prefix to disambiguate; `GoalsInfo` is too generic for a public mgmt-plane type).
- `MoboBrokerResource` → **`ManagedBrokerTarget`** (was `MoboBrokerTarget` — "Mobo" is an internal abbreviation; renamed to the spelled-out public-friendly form).

#### New `@@clientName` for enums / models

- **Service-prefix additions** (avoid generic public names): `RBACState` → `ResilienceManagementRbacState`, `RBACSetupMode` → `ResilienceManagementRbacSetupMode`, `ProvisioningState` → `ResilienceManagementProvisioningState`, `ErrorDetails` → `ResilienceManagementErrorDetail`, `ActionTask` → `ResilienceManagementActionTask`, `SolutionDisplayName` → `ResilienceManagementSolutionDisplayName`, `AssociatedIdentity` → `ResilienceManagementAssociatedIdentity`, `Drill` → `ResilienceManagementDrill`.
- **PascalCase / acronym normalization** (C# naming conventions): `VMPresent` → `VmPresent`, `HAStatus` → `HighAvailabilityStatus`.
- **Disambiguation from ARM-generated `*Data` POCOs**: `SystemMetadata` → `DrillSystemMetadata`, `ResourceLists` → `DrillResourcesList`.
- **Domain-clearer names**: `ForceInclusionAndUpdate` → `ForceInclusionState`, `GoalResource` → `GoalMembers`, `RecoveryResource` → `ResilienceMembers`, `Enrollment` → `UsagePlanEnrollment`.

#### New `@@clientName` for properties

- `RecoveryResourceProperties.needsAttention` → `RequiresAttention` (C# property convention).
- `DrillRunAddNotesRequest.timestamp` → `RecordedOn` (C# property convention).

#### New `@@alternateType` for typing precision (C# only)

- `MoboBrokerResource.id` → `armResourceIdentifier`.
- `RecoveryResourceProperties.resourceLocation` → `azureLocation`.
- `ResourceProtectionSolutionSettings.activeLocation` → `azureLocation`.
- `ResourceProtectionSolutionSettings.activeLocations` → `azureLocation[]`.

Also added `using Azure.Core;` to make `armResourceIdentifier` / `azureLocation` available in `client.tsp`.

### Validation

Regenerated the .NET SDK against this branch (`@azure-typespec/http-client-csharp-mgmt`); package builds clean and is being tracked in `Azure/azure-sdk-for-net#59743`.

### Approvals (carried over from PR #43816)

- **Namespace approval:** https://github.com/Azure/azure-sdk/issues/9971
- **Release plan:** [Release plan 2247 — Public Preview — Resiliency in Azure](https://dev.azure.com/azure-sdk/internal/_workitems/edit/34484) (work item `34484`).


## Getting help

- First, carefully read through this PR description, from top to bottom. Fill out the `Purpose of this PR` and `Due diligence checklist`.
- If you don't have permissions to remove or add labels to the PR, request `write access` per [aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories](https://aka.ms/azsdk/access#request-access-to-rest-api-or-sdk-repositories)
- To understand what you must do next to merge this PR, see the `Next Steps to Merge` comment. It will appear within few minutes of submitting this PR and will continue to be up-to-date with current PR state.
- For guidance on fixing this PR CI check failures, see the hyperlinks provided in given failure and https://aka.ms/ci-fix.
- If the PR CI checks appear to be stuck in `queued` state, please add a comment with contents `/azp run`.
  This should result in a new comment denoting a `PR validation pipeline` has started and the checks should be updated after few minutes.
- If the help provided by the previous points is not enough, post to https://aka.ms/azsdk/support/specreview-channel and link to this PR.
