### PR TITLE
fix: add explicit json usage for DocumentTranslateContent

### DIFF
--- a/specification/translation/data-plane/DocumentTranslation/client.tsp
+++ b/specification/translation/data-plane/DocumentTranslation/client.tsp
@@ -331,3 +331,5 @@ interface SingleDocumentTranslationClient {
   "totalImagesChargedCount",
   "java"
 );
+
+@@usage(DocumentTranslation.DocumentTranslateContent, Usage.json, "csharp");


### PR DESCRIPTION
Adds explicit json usage for the DocumentTranslateContent model in c#.

This was found as part of the latest .net library regen https://github.com/Azure/azure-sdk-for-net/pull/59800