### PR TITLE
Remove stale Microsoft.DBforPostgreSQL/PostgreSQL/ ARM lease (case-collision fix; supersedes #43887)

### DIFF
--- a/.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSQL/lease.yaml
+++ b/.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSQL/lease.yaml
@@ -1,5 +1,0 @@
-lease:
-  resource-provider: Microsoft.DBforPostgreSQL
-  startdate: "2026-05-22"
-  duration: P180D
-  reviewer: "@vikeshi26"


### PR DESCRIPTION
Removes `.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSQL/lease.yaml` which case-collides with sibling `PostgreSql/lease.yaml` on Windows/macOS filesystems and is no longer referenced by the spec layout.

## Context

PR #43785 added a `PostgreSql/lease.yaml` (lowercase `l`) to accompany the in-flight postgres folder restructure in https://github.com/Azure/azure-rest-api-specs-pr/pull/28858 (a.k.a. #43777, "Refactor(postgresql): migrate to unified folder structure"), which uses `PostgreSql` as the service folder name. We did not notice at the time that a sibling `PostgreSQL/lease.yaml` (uppercase `SQL`) already existed under the same RP.

Both folders coexist fine on Linux git, but Windows/macOS case-insensitive filesystems can only materialize one of them, producing phantom `M …/PostgreSQL/lease.yaml` (or `…/PostgreSql/lease.yaml`) entries in `git status` for any contributor on those platforms after a clone/pull.

## Decision

There is currently no service-named folder under `specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/` (only `preview/` and `stable/` exist on `main`), so neither casing is in active use today. The in-flight restructure PR #43777 introduces the service folder as `PostgreSql/` (lowercase l), and the lease checker in `.github/workflows/src/arm-modeling-review/detect-arm-leases.js` uses the exact-cased path — so the `PostgreSql/` lease is the one needed for that partner PR to clear `ARMModelingReviewRequired`. The uppercase `PostgreSQL/` lease, by contrast, does not match any spec folder that exists or is about to exist.

Therefore:
- Keep: `.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSql/lease.yaml` (matches partner restructure casing)
- Remove (this PR): `.github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/PostgreSQL/lease.yaml` (stale, case-only duplicate)

## Relationship to #43887

This supersedes #43887 by @timotheeguerin. That PR removes the lowercase `PostgreSql/` variant; doing so would re-trigger `ARMModelingReviewRequired` on #43777 because the lookup path is case-sensitive and the remaining uppercase `PostgreSQL/` lease would not be found at the partner-introduced `PostgreSql/` path. Suggest closing #43887 in favor of this PR.

## Verification

```
git ls-tree -r origin/main .github/arm-leases/postgresql/Microsoft.DBforPostgreSQL/
# PostgreSql/lease.yaml      ← kept (matches #43777 spec folder casing)
# PostgreSQL/lease.yaml      ← removed by this PR
# DBforPostgreSQL/lease.yaml ← unrelated, kept
# lease.yaml                 ← unrelated, kept

git ls-tree -d origin/main specification/postgresql/resource-manager/Microsoft.DBforPostgreSQL/
# preview/  stable/   (no service folder today)
```

cc @timotheeguerin @TejaswiMinnu @mikeharder
