### PR TITLE
Cosmos DB (Microsoft.DocumentDB): allow updating tags on Fleet PATCH

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/fleet/CosmosDBFleetUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-03-15/fleet/CosmosDBFleetUpdate.json
@@ -5,6 +5,10 @@
     "resourceGroupName": "rg1",
     "fleetName": "fleet1",
     "body": {
+      "tags": {
+        "Dept": "Finance",
+        "Environment": "Production"
+      },
       "properties": {}
     }
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/fleet/CosmosDBFleetUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/examples/2026-04-01-preview/fleet/CosmosDBFleetUpdate.json
@@ -2,6 +2,10 @@
   "parameters": {
     "api-version": "2026-04-01-preview",
     "body": {
+      "tags": {
+        "Dept": "Finance",
+        "Environment": "Production"
+      },
       "properties": {}
     },
     "fleetName": "fleet1",

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/models.tsp
@@ -8611,8 +8611,13 @@ model FleetResourceProperties {
 /**
  * Represents a fleet resource for updates.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/patch-envelope" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 model FleetResourceUpdate {
+  /**
+   * Resource tags. A dictionary of key-value pairs used to categorize and organize the Azure Cosmos DB fleet resource across resource groups and subscriptions.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Resource tags are defined by ARM as an open-ended string-to-string map, so Record<string> is the correct and required representation for the tags property."
+  tags?: Record<string>;
+
   /**
    * Properties to update Azure Cosmos DB fleet resource.
    */

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/fleet/CosmosDBFleetUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/examples/fleet/CosmosDBFleetUpdate.json
@@ -2,6 +2,10 @@
   "parameters": {
     "api-version": "2026-04-01-preview",
     "body": {
+      "tags": {
+        "Dept": "Finance",
+        "Environment": "Production"
+      },
       "properties": {}
     },
     "fleetName": "fleet1",

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/preview/2026-04-01-preview/openapi.json
@@ -26016,6 +26016,13 @@
       "type": "object",
       "description": "Represents a fleet resource for updates.",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags. A dictionary of key-value pairs used to categorize and organize the Azure Cosmos DB fleet resource across resource groups and subscriptions.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/FleetResourceProperties",
           "description": "Properties to update Azure Cosmos DB fleet resource.",

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/fleet/CosmosDBFleetUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/examples/fleet/CosmosDBFleetUpdate.json
@@ -5,6 +5,10 @@
     "resourceGroupName": "rg1",
     "fleetName": "fleet1",
     "body": {
+      "tags": {
+        "Dept": "Finance",
+        "Environment": "Production"
+      },
       "properties": {}
     }
   },

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/stable/2026-03-15/openapi.json
@@ -18951,6 +18951,13 @@
       "type": "object",
       "description": "Represents a fleet resource for updates.",
       "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags. A dictionary of key-value pairs used to categorize and organize the Azure Cosmos DB fleet resource across resource groups and subscriptions.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/FleetResourceProperties",
           "description": "Properties to update Azure Cosmos DB fleet resource.",


### PR DESCRIPTION
## Summary
The Cosmos DB Fleet (`Microsoft.DocumentDB/fleets`) PATCH (update) operation could not update resource `tags` because the custom patch model `FleetResourceUpdate` only exposed `properties`. This adds an optional `tags` property so tags can be updated via PATCH, which is the standard behavior for ARM tracked resources.

## Changes
- Add optional `tags` to `FleetResourceUpdate` (models.tsp).
- Remove the obsolete `patch-envelope` suppression (now satisfied by adding `tags`).
- Update `CosmosDBFleetUpdate` examples to demonstrate updating tags.
- Regenerate Swagger for the affected versions.

## API versions affected
- 2026-03-15 (stable)
- 2026-04-01-preview

## Compatibility
Non-breaking: `tags` is optional.

## Validation
- TypeSpec validation: passed
- tsp compile: passed (no warnings)
- Prettier (generated JSON): passed