### PR TITLE
Add .NET emitter configuration for Microsoft.ProgramEnrollment

### DIFF
--- a/specification/programenrollment/resource-manager/Microsoft.ProgramEnrollment/ProgramEnrollment/tspconfig.yaml
+++ b/specification/programenrollment/resource-manager/Microsoft.ProgramEnrollment/ProgramEnrollment/tspconfig.yaml
@@ -10,6 +10,9 @@ options:
     examples-dir: "{project-root}/examples"
     output-file: "{version-status}/{version}/openapi.json"
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
+  "@azure-typespec/http-client-csharp-mgmt":
+    namespace: "Azure.ResourceManager.ProgramEnrollment"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-programenrollment"
     namespace: "azure.mgmt.programenrollment"


### PR DESCRIPTION
## Summary

Add the `@azure-typespec/http-client-csharp-mgmt` emitter configuration to the tspconfig.yaml for Microsoft.ProgramEnrollment to enable .NET SDK generation.

This is a follow-up to the merged spec PR https://github.com/Azure/azure-rest-api-specs/pull/43694 which was missing the .NET emitter block.

## Changes

- Added `@azure-typespec/http-client-csharp-mgmt` emitter configuration with namespace `Azure.ResourceManager.ProgramEnrollment`