### PR TITLE
Foundry: cleanup and deprecation/migration notes for ModelInference API

### DIFF
--- a/specification/ai/ModelInference/README.md
+++ b/specification/ai/ModelInference/README.md
@@ -1,4 +1,12 @@
 title: ModelInference
+
+> **⚠️ Deprecated**: The Azure AI Model Inference API is deprecated. New applications should use the
+> [OpenAI API](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration)
+> instead. Existing applications should migrate to the OpenAI SDK for broader model support and
+> unified API access. See the
+> [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration)
+> for details.
+
 clear-output-folder: false
 guessResourceKey: true
 isAzureSpec: true

--- a/specification/ai/ModelInference/main.tsp
+++ b/specification/ai/ModelInference/main.tsp
@@ -19,6 +19,12 @@ using TypeSpec.Versioning;
         }
       ]>
 )
+@doc("""
+  **Deprecated**: The Azure AI Model Inference API is deprecated and will be retired in the future.
+  Migrate to the OpenAI API, which provides equivalent functionality with broader model support and
+  unified SDK access. For migration guidance, see
+  [How to migrate from Azure AI Inference SDK to OpenAI SDK](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
+  """)
 @service(#{ title: "AI Model Inference" })
 @server(
   "https://{resource}.services.ai.azure.com/models",

--- a/specification/ai/ModelInference/models/chat_completions.tsp
+++ b/specification/ai/ModelInference/models/chat_completions.tsp
@@ -103,7 +103,7 @@ model ChatCompletionsOptions {
 
   @doc("""
     A list of tools the model may request to call. Currently, only functions are supported as a tool. The model
-    may response with a function call request and provide the input arguments in JSON format for that function.
+    may respond with a function call request and provide the input arguments in JSON format for that function.
     """)
   @minItems(1)
   tools?: ChatCompletionsToolDefinition[];
@@ -127,7 +127,7 @@ model ChatCompletionsOptions {
 
   @doc("""
     The modalities that the model is allowed to use for the chat completions response. The default modality
-    is `text`. Indicating an unsupported modality combination results in an 422 error.
+    is `text`.     Indicating an unsupported modality combination results in a 422 error.
     """)
   modalities?: ChatCompletionsModality[];
 
@@ -377,7 +377,7 @@ alias ChatChoiceCommon = {
 
   #suppress "@azure-tools/typespec-azure-core/no-nullable" "The operation already returns nulls"
   #suppress "@azure-tools/typespec-autorest/union-unsupported" "OpenAPI v2 support deferred"
-  @doc("The reason that this chat completions choice completed its generated.")
+  @doc("The reason that this chat completions choice completed its generation.")
   @visibility(Lifecycle.Read)
   finish_reason: CompletionsFinishReason | null;
 };
@@ -664,7 +664,7 @@ model ChatMessageImageContentItem extends ChatMessageContentItem {
   @doc("The discriminated object type: always 'image_url' for this type.")
   type: "image_url";
 
-  @doc("An internet location, which must be accessible to the model,from which the image may be retrieved.")
+  @doc("An internet location, which must be accessible to the model, from which the image may be retrieved.")
   @encodedName("application/json", "image_url")
   imageUrl: ChatMessageImageUrl;
 }
@@ -703,7 +703,7 @@ union ChatMessageImageDetailLevel {
 
 @doc("A structured chat content item containing an audio reference.")
 model ChatMessageAudioContentItem extends ChatMessageContentItem {
-  @doc("The discriminated object type: always 'image_url' for this type.")
+  @doc("The discriminated object type: always 'audio_url' for this type.")
   type: "audio_url";
 
   @doc("An internet location, which must be accessible to the model, from which the audio may be retrieved.")
@@ -711,7 +711,7 @@ model ChatMessageAudioContentItem extends ChatMessageContentItem {
   audioUrl: ChatMessageAudioUrl;
 }
 
-@doc("An internet location from which the model may retrieve an audio.")
+@doc("An internet location from which the model may retrieve audio.")
 model ChatMessageAudioUrl {
   @doc("The URL of the audio.")
   url: string;

--- a/specification/ai/ModelInference/models/embeddings.tsp
+++ b/specification/ai/ModelInference/models/embeddings.tsp
@@ -24,7 +24,7 @@ union EmbeddingInputType {
   Specifies the types of embeddings to generate. Compressed embeddings types like `uint8`, `int8`, `ubinary` and 
   `binary`, may reduce storage costs without sacrificing the integrity of the data. Returns a 422 error if the
   model doesn't support the value or parameter. Read the model's documentation to know the values supported by
-  the your model.
+  your model.
   """)
 union EmbeddingEncodingFormat {
   string,

--- a/specification/ai/ModelInference/models/image_embeddings.tsp
+++ b/specification/ai/ModelInference/models/image_embeddings.tsp
@@ -26,8 +26,7 @@ model ImageEmbeddingsOptions {
   dimensions?: int32;
 
   @doc("""
-    Optional. The number of dimensions the resulting output embeddings should have.
-    Passing null causes the model to use its default value.
+    Optional. The desired format for the returned embeddings.
     Returns a 422 error if the model doesn't support the value or parameter.
     """)
   encoding_format?: EmbeddingEncodingFormat;

--- a/specification/ai/ModelInference/routes.tsp
+++ b/specification/ai/ModelInference/routes.tsp
@@ -20,6 +20,9 @@ namespace ModelInference;
   Completions support a wide variety of tasks and generate text that continues from or "completes"
   provided prompt data. The method makes a REST API call to the `/chat/completions` route
   on the given endpoint.
+  
+  **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+  See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
   """)
 @actionSeparator("/")
 @route("chat/completions")
@@ -37,6 +40,9 @@ op getChatCompletions is Azure.Core.RpcOperation<
 @doc("""
   Return the embedding vectors for given text prompts.
   The method makes a REST API call to the `/embeddings` route on the given endpoint.
+  
+  **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+  See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
   """)
 @actionSeparator("/")
 @route("embeddings")
@@ -54,6 +60,9 @@ op getEmbeddings is Azure.Core.RpcOperation<
 @doc("""
   Return the embedding vectors for given images.
   The method makes a REST API call to the `/images/embeddings` route on the given endpoint.
+  
+  **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+  See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
   """)
 @actionSeparator("/")
 @route("images/embeddings")
@@ -71,8 +80,11 @@ op getImageEmbeddings is Azure.Core.RpcOperation<
 @doc("""
   Returns information about the AI model deployed.
   The method makes a REST API call to the `/info` route on the given endpoint.
-  This method will only work when using Serverless API, Managed Compute, or Model .
-  inference endpoint. Azure OpenAI endpoints don't support i.
+  This method will only work when using Serverless API, Managed Compute, or Model
+  Inference endpoints. Azure OpenAI endpoints don't support it.
+  
+  **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+  See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
   """)
 @get
 @route("/info")

--- a/specification/ai/data-plane/ModelInference/openapi/2024-05-01-preview/openapi.yaml
+++ b/specification/ai/data-plane/ModelInference/openapi/2024-05-01-preview/openapi.yaml
@@ -1,6 +1,11 @@
 openapi: 3.0.0
 info:
   title: AI Model Inference
+  description: |-
+    **Deprecated**: The Azure AI Model Inference API is deprecated and will be retired in the future.
+    Migrate to the OpenAI API, which provides equivalent functionality with broader model support and
+    unified SDK access. For migration guidance, see
+    [How to migrate from Azure AI Inference SDK to OpenAI SDK](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
   version: 2024-05-01-preview
 tags: []
 paths:
@@ -12,6 +17,9 @@ paths:
         Completions support a wide variety of tasks and generate text that continues from or "completes"
         provided prompt data. The method makes a REST API call to the `/chat/completions` route
         on the given endpoint.
+
+        **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+        See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: extra-parameters
@@ -55,6 +63,9 @@ paths:
       description: |-
         Return the embedding vectors for given text prompts.
         The method makes a REST API call to the `/embeddings` route on the given endpoint.
+
+        **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+        See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: extra-parameters
@@ -98,6 +109,9 @@ paths:
       description: |-
         Return the embedding vectors for given images.
         The method makes a REST API call to the `/images/embeddings` route on the given endpoint.
+
+        **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+        See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: extra-parameters
@@ -141,8 +155,11 @@ paths:
       description: |-
         Returns information about the AI model deployed.
         The method makes a REST API call to the `/info` route on the given endpoint.
-        This method will only work when using Serverless API, Managed Compute, or Model .
-        inference endpoint. Azure OpenAI endpoints don't support i.
+        This method will only work when using Serverless API, Managed Compute, or Model
+        Inference endpoints. Azure OpenAI endpoints don't support it.
+
+        **Deprecated**: This API is deprecated. Use the OpenAI API instead.
+        See [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
       responses:
@@ -250,7 +267,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/CompletionsFinishReason'
           nullable: true
-          description: The reason that this chat completions choice completed its generated.
+          description: The reason that this chat completions choice completed its generation.
           readOnly: true
         message:
           allOf:
@@ -477,7 +494,7 @@ components:
           minItems: 1
           description: |-
             A list of tools the model may request to call. Currently, only functions are supported as a tool. The model
-            may response with a function call request and provide the input arguments in JSON format for that function.
+            may respond with a function call request and provide the input arguments in JSON format for that function.
         tool_choice:
           anyOf:
             - $ref: '#/components/schemas/ChatCompletionsToolChoicePreset'
@@ -498,7 +515,7 @@ components:
             $ref: '#/components/schemas/ChatCompletionsModality'
           description: |-
             The modalities that the model is allowed to use for the chat completions response. The default modality
-            is `text`. Indicating an unsupported modality combination results in an 422 error.
+            is `text`.     Indicating an unsupported modality combination results in a 422 error.
       additionalProperties: {}
       description: |-
         The configuration information for a chat completions request.
@@ -650,7 +667,7 @@ components:
           type: string
           enum:
             - audio_url
-          description: "The discriminated object type: always 'image_url' for this type."
+          description: "The discriminated object type: always 'audio_url' for this type."
         audio_url:
           allOf:
             - $ref: '#/components/schemas/ChatMessageAudioUrl'
@@ -666,7 +683,7 @@ components:
         url:
           type: string
           description: The URL of the audio.
-      description: An internet location from which the model may retrieve an audio.
+      description: An internet location from which the model may retrieve audio.
     ChatMessageContentItem:
       type: object
       required:
@@ -697,7 +714,7 @@ components:
         image_url:
           allOf:
             - $ref: '#/components/schemas/ChatMessageImageUrl'
-          description: An internet location, which must be accessible to the model,from which the image may be retrieved.
+          description: An internet location, which must be accessible to the model, from which the image may be retrieved.
       allOf:
         - $ref: '#/components/schemas/ChatMessageContentItem'
       description: A structured chat content item containing an image reference.
@@ -1006,7 +1023,7 @@ components:
         Specifies the types of embeddings to generate. Compressed embeddings types like `uint8`, `int8`, `ubinary` and 
         `binary`, may reduce storage costs without sacrificing the integrity of the data. Returns a 422 error if the
         model doesn't support the value or parameter. Read the model's documentation to know the values supported by
-        the your model.
+        your model.
     EmbeddingInputType:
       anyOf:
         - type: string
@@ -1217,8 +1234,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/EmbeddingEncodingFormat'
           description: |-
-            Optional. The number of dimensions the resulting output embeddings should have.
-            Passing null causes the model to use its default value.
+            Optional. The desired format for the returned embeddings.
             Returns a 422 error if the model doesn't support the value or parameter.
         input_type:
           allOf:
@@ -1292,7 +1308,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/CompletionsFinishReason'
           nullable: true
-          description: The reason that this chat completions choice completed its generated.
+          description: The reason that this chat completions choice completed its generation.
           readOnly: true
         delta:
           allOf:

--- a/specification/ai/data-plane/ModelInference/preview/2024-05-01-preview/openapi.json
+++ b/specification/ai/data-plane/ModelInference/preview/2024-05-01-preview/openapi.json
@@ -3,6 +3,7 @@
   "info": {
     "title": "AI Model Inference",
     "version": "2024-05-01-preview",
+    "description": "**Deprecated**: The Azure AI Model Inference API is deprecated and will be retired in the future.\nMigrate to the OpenAI API, which provides equivalent functionality with broader model support and\nunified SDK access. For migration guidance, see\n[How to migrate from Azure AI Inference SDK to OpenAI SDK](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).",
     "x-typespec-generated": [
       {
         "emitter": "@azure-tools/typespec-autorest"
@@ -61,7 +62,7 @@
     "/chat/completions": {
       "post": {
         "operationId": "GetChatCompletions",
-        "description": "Gets chat completions for the provided chat messages.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data. The method makes a REST API call to the `/chat/completions` route\non the given endpoint.",
+        "description": "Gets chat completions for the provided chat messages.\nCompletions support a wide variety of tasks and generate text that continues from or \"completes\"\nprovided prompt data. The method makes a REST API call to the `/chat/completions` route\non the given endpoint.\n\n**Deprecated**: This API is deprecated. Use the OpenAI API instead.\nSee [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -146,7 +147,7 @@
     "/embeddings": {
       "post": {
         "operationId": "GetEmbeddings",
-        "description": "Return the embedding vectors for given text prompts.\nThe method makes a REST API call to the `/embeddings` route on the given endpoint.",
+        "description": "Return the embedding vectors for given text prompts.\nThe method makes a REST API call to the `/embeddings` route on the given endpoint.\n\n**Deprecated**: This API is deprecated. Use the OpenAI API instead.\nSee [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -228,7 +229,7 @@
     "/images/embeddings": {
       "post": {
         "operationId": "GetImageEmbeddings",
-        "description": "Return the embedding vectors for given images.\nThe method makes a REST API call to the `/images/embeddings` route on the given endpoint.",
+        "description": "Return the embedding vectors for given images.\nThe method makes a REST API call to the `/images/embeddings` route on the given endpoint.\n\n**Deprecated**: This API is deprecated. Use the OpenAI API instead.\nSee [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -310,7 +311,7 @@
     "/info": {
       "get": {
         "operationId": "GetModelInfo",
-        "description": "Returns information about the AI model deployed.\nThe method makes a REST API call to the `/info` route on the given endpoint.\nThis method will only work when using Serverless API, Managed Compute, or Model .\ninference endpoint. Azure OpenAI endpoints don't support i.",
+        "description": "Returns information about the AI model deployed.\nThe method makes a REST API call to the `/info` route on the given endpoint.\nThis method will only work when using Serverless API, Managed Compute, or Model\nInference endpoints. Azure OpenAI endpoints don't support it.\n\n**Deprecated**: This API is deprecated. Use the OpenAI API instead.\nSee [migration guide](https://learn.microsoft.com/azure/foundry/how-to/model-inference-to-openai-migration).",
         "parameters": [
           {
             "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -443,7 +444,7 @@
         },
         "finish_reason": {
           "$ref": "#/definitions/CompletionsFinishReason",
-          "description": "The reason that this chat completions choice completed its generated.",
+          "description": "The reason that this chat completions choice completed its generation.",
           "x-nullable": true,
           "readOnly": true
         },
@@ -680,7 +681,7 @@
         },
         "tools": {
           "type": "array",
-          "description": "A list of tools the model may request to call. Currently, only functions are supported as a tool. The model\nmay response with a function call request and provide the input arguments in JSON format for that function.",
+          "description": "A list of tools the model may request to call. Currently, only functions are supported as a tool. The model\nmay respond with a function call request and provide the input arguments in JSON format for that function.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/ChatCompletionsToolDefinition"
@@ -701,7 +702,7 @@
         },
         "modalities": {
           "type": "array",
-          "description": "The modalities that the model is allowed to use for the chat completions response. The default modality\nis `text`. Indicating an unsupported modality combination results in an 422 error.",
+          "description": "The modalities that the model is allowed to use for the chat completions response. The default modality\nis `text`.     Indicating an unsupported modality combination results in a 422 error.",
           "items": {
             "$ref": "#/definitions/ChatCompletionsModality"
           }
@@ -898,7 +899,7 @@
     },
     "ChatMessageAudioUrl": {
       "type": "object",
-      "description": "An internet location from which the model may retrieve an audio.",
+      "description": "An internet location from which the model may retrieve audio.",
       "properties": {
         "url": {
           "type": "string",
@@ -929,7 +930,7 @@
       "properties": {
         "image_url": {
           "$ref": "#/definitions/ChatMessageImageUrl",
-          "description": "An internet location, which must be accessible to the model,from which the image may be retrieved.",
+          "description": "An internet location, which must be accessible to the model, from which the image may be retrieved.",
           "x-ms-client-name": "imageUrl"
         }
       },
@@ -1338,7 +1339,7 @@
     },
     "EmbeddingEncodingFormat": {
       "type": "string",
-      "description": "Specifies the types of embeddings to generate. Compressed embeddings types like `uint8`, `int8`, `ubinary` and \n`binary`, may reduce storage costs without sacrificing the integrity of the data. Returns a 422 error if the\nmodel doesn't support the value or parameter. Read the model's documentation to know the values supported by\nthe your model.",
+      "description": "Specifies the types of embeddings to generate. Compressed embeddings types like `uint8`, `int8`, `ubinary` and \n`binary`, may reduce storage costs without sacrificing the integrity of the data. Returns a 422 error if the\nmodel doesn't support the value or parameter. Read the model's documentation to know the values supported by\nyour model.",
       "enum": [
         "base64",
         "binary",
@@ -1659,7 +1660,7 @@
         },
         "encoding_format": {
           "$ref": "#/definitions/EmbeddingEncodingFormat",
-          "description": "Optional. The number of dimensions the resulting output embeddings should have.\nPassing null causes the model to use its default value.\nReturns a 422 error if the model doesn't support the value or parameter."
+          "description": "Optional. The desired format for the returned embeddings.\nReturns a 422 error if the model doesn't support the value or parameter."
         },
         "input_type": {
           "$ref": "#/definitions/EmbeddingInputType",
@@ -1758,7 +1759,7 @@
         },
         "finish_reason": {
           "$ref": "#/definitions/CompletionsFinishReason",
-          "description": "The reason that this chat completions choice completed its generated.",
+          "description": "The reason that this chat completions choice completed its generation.",
           "x-nullable": true,
           "readOnly": true
         },


### PR DESCRIPTION
Retirement notices for the Azure AI Model Inference API (/models/**) were sent last month with the target date of 26 August 2026.

This change adds a few references to guidance, together with opportunistic typo fixes, into the specification collateral itself -- both for the spec and for the downstream generated API reference.