### PR TITLE
Mitigate Java breaking changes for Redis Enterprise

### DIFF
--- a/specification/redisenterprise/cspell.yaml
+++ b/specification/redisenterprise/cspell.yaml
@@ -9,5 +9,5 @@ import:
   - ../../cspell.yaml
 words:
   - redi
+  - twoh
   - unversioned
-

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -242,6 +242,7 @@ using Microsoft.Cache;
   "ManagedServiceIdentity",
   "java"
 );
+@@clientName(ClusterCreateProperties, "ClusterProperties", "java");
 @@clientName(ClusterProperties, "ClusterCommonProperties", "java");
 @@clientName(DatabaseProperties, "DatabaseCommonProperties", "java");
 @@clientName(ClusterProperties.hostName, "hostname", "java");

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/client.tsp
@@ -235,3 +235,27 @@ using Microsoft.Cache;
   "ManagedServiceIdentity",
   "javascript"
 );
+
+// java compatibility mitigations
+@@clientName(
+  Azure.ResourceManager.Legacy.ManagedServiceIdentityV4,
+  "ManagedServiceIdentity",
+  "java"
+);
+@@clientName(ClusterProperties, "ClusterCommonProperties", "java");
+@@clientName(DatabaseProperties, "DatabaseCommonProperties", "java");
+@@clientName(ClusterProperties.hostName, "hostname", "java");
+@@clientName(TlsVersion.One0, "ONE_ZERO", "java");
+@@clientName(TlsVersion.One1, "ONE_ONE", "java");
+@@clientName(TlsVersion.One2, "ONE_TWO", "java");
+@@clientName(RdbFrequency.TwelveH, "ONE_TWOH", "java");
+@@clientName(
+  Azure.ResourceManager.Legacy.ManagedServiceIdentityType.SystemAndUserAssigned,
+  "SYSTEM_ASSIGNED_USER_ASSIGNED",
+  "java"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Existing usage of legacy type"
+@@Legacy.flattenProperty(
+  Azure.ResourceManager.CommonTypes.PrivateLinkResource.properties,
+  "java"
+);

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
@@ -30,6 +30,8 @@ options:
   "@azure-tools/typespec-java":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-redisenterprise"
     namespace: com.azure.resourcemanager.redisenterprise
+    service-name: Redis Enterprise
+    float32-as-double: false
     flavor: azure
   "@azure-tools/typespec-go":
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armredisenterprise/v4"


### PR DESCRIPTION
## Summary
- preserve RedisEnterprise Java manager naming and compatibility names for renamed models and enum members
- keep Java float handling aligned with the previous SDK surface where possible
- flatten PrivateLinkResource properties for Java to avoid a shape regression