### PR TITLE
ContainerService: csharp clientName naming polish for 2026-04-02-preview

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -1586,6 +1586,38 @@ namespace Azure.ResourceManager.Models {
   "csharp"
 );
 
+// .NET design guideline naming polish (azure-sdk-for-net PR #59887 review feedback)
+// Disambiguate overly-generic generated type names with a service-scoped prefix.
+@@clientName(Operator, "ManagedClusterLabelSelectorOperator", "csharp");
+@@clientName(
+  Azure.ResourceManager.ResourceProvisioningState,
+  "ContainerServiceProvisioningState",
+  "csharp"
+);
+@@clientName(
+  ResourceSkuCapacityScaleType,
+  "ContainerServiceSkuCapacityScaleType",
+  "csharp"
+);
+@@clientName(
+  ResourceSkuRestrictionsReasonCode,
+  "ContainerServiceSkuRestrictionsReasonCode",
+  "csharp"
+);
+@@clientName(
+  ResourceSkuRestrictionsType,
+  "ContainerServiceSkuRestrictionsType",
+  "csharp"
+);
+// Resource models: drop redundant "Resource" suffix / add service prefix so the
+// generated {Name}Resource/{Name}Data/{Name}Collection follow ARM conventions.
+@@clientName(MaintenanceWindowResource, "MaintenanceWindow", "csharp");
+@@clientName(
+  GuardrailsAvailableVersion,
+  "ContainerServiceGuardrailsAvailableVersion",
+  "csharp"
+);
+
 // TODO: drop the type replacement upon next major breaking change
 @@alternateType(
   ManagedClusterIdentity.type,


### PR DESCRIPTION
## Summary

Adds `@clientName` (csharp) augment decorators in `client.tsp` to disambiguate overly-generic generated type names for the .NET SDK. These renames address mgmt review feedback on the auto-generated SDK PR [Azure/azure-sdk-for-net#59887](https://github.com/Azure/azure-sdk-for-net/pull/59887).

Only `client.tsp` is modified — no wire/API surface changes.

## Renames (csharp only)

| Original | New |
| --- | --- |
| `Operator` | `ManagedClusterLabelSelectorOperator` |
| `Azure.ResourceManager.ResourceProvisioningState` | `ContainerServiceProvisioningState` |
| `ResourceSkuCapacityScaleType` | `ContainerServiceSkuCapacityScaleType` |
| `ResourceSkuRestrictionsReasonCode` | `ContainerServiceSkuRestrictionsReasonCode` |
| `ResourceSkuRestrictionsType` | `ContainerServiceSkuRestrictionsType` |
| `MaintenanceWindowResource` | `MaintenanceWindow` |
| `GuardrailsAvailableVersion` | `ContainerServiceGuardrailsAvailableVersion` |

All renames target types newly introduced in `2026-04-02-preview` and were validated locally by regenerating `Azure.ResourceManager.ContainerService`.