### PR TITLE
Remove opt-in flags, in prep for 6/30 release

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/docs/foundry-features-flag-summary.md
+++ b/specification/ai-foundry/data-plane/Foundry/docs/foundry-features-flag-summary.md
@@ -15,9 +15,9 @@ in order to enable preview features on these GA routes.
 
 | Operation Group | Operation | Method | Path | Foundry-Features Header Value |
 |-----------------|-----------|--------|------|-------------------------------|
-| Agents | Create | POST | `/agents` | Optional: `ContainerAgents=V1Preview`, `CodeAgents=V1Preview`, `HostedAgents=V1Preview`, `WorkflowAgents=V1Preview` |
-| Agents | Update | POST | `/agents/{agent_name}` | Optional: `ContainerAgents=V1Preview`, `CodeAgents=V1Preview`, `HostedAgents=V1Preview`, `WorkflowAgents=V1Preview` |
-| Agents | Create Version | POST | `/agents/{agent_name}/versions` | Optional: `ContainerAgents=V1Preview`, `CodeAgents=V1Preview`, `HostedAgents=V1Preview`, `WorkflowAgents=V1Preview` |
+| Agents | Create | POST | `/agents` | Optional: `ContainerAgents=V1Preview`, `WorkflowAgents=V1Preview` |
+| Agents | Update | POST | `/agents/{agent_name}` | Optional: `ContainerAgents=V1Preview`, `WorkflowAgents=V1Preview` |
+| Agents | Create Version | POST | `/agents/{agent_name}/versions` | Optional: `ContainerAgents=V1Preview`, `WorkflowAgents=V1Preview` |
 | Evaluation Rules | CreateOrUpdate | PUT | `/evaluationrules/{id}` | Optional: `Evaluations=V1Preview` |
 
 Note that only v1 operations are included in the above table. If an operation (or interface) is decorated with `@removed(Versions.v1)` the are not included here.
@@ -66,19 +66,6 @@ in order to successfully complete operations using these routes.
 | Memory Stores | Update Memory Item | POST | `/memory_stores/{name}/items/{memory_id}` | Required: `MemoryStores=V1Preview` |
 | Memory Stores | Get Memory Item | GET | `/memory_stores/{name}/items/{memory_id}` | Required: `MemoryStores=V1Preview` |
 | Memory Stores | Delete Memory Item | DELETE | `/memory_stores/{name}/items/{memory_id}` | Required: `MemoryStores=V1Preview` |
-| Agents | Patch Agent | PATCH | `/agents/{agent_name}` | Required: `AgentEndpoints=V1Preview` |
-| Agent Sessions | Create Session | POST | `/agents/{agent_name}/endpoint/sessions` | Required: `AgentEndpoints=V1Preview` |
-| Agent Sessions | Get Session | GET | `/agents/{agent_name}/endpoint/sessions/{session_id}` | Required: `AgentEndpoints=V1Preview` |
-| Agent Sessions | Delete Session | DELETE | `/agents/{agent_name}/endpoint/sessions/{session_id}` | Required: `AgentEndpoints=V1Preview` |
-| Agent Sessions | List Sessions | GET | `/agents/{agent_name}/endpoint/sessions` | Required: `AgentEndpoints=V1Preview` |
-| Agent Invocations | Get OpenAPI Spec | GET | `/agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json` | Required: `HostedAgents=V1Preview` |
-| Agent Invocations | Create | POST | `/agents/{agent_name}/endpoint/protocols/invocations` | Required: `HostedAgents=V1Preview` |
-| Agent Invocations | Get | GET | `/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}` | Required: `HostedAgents=V1Preview` |
-| Agent Invocations | Cancel | POST | `/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel` | Required: `HostedAgents=V1Preview` |
-| Agent Session Files | Upload | PUT | `/agents/{agent_name}/endpoint/sessions/{session_id}/files/content` | Required: `HostedAgents=V1Preview` |
-| Agent Session Files | Download | GET | `/agents/{agent_name}/endpoint/sessions/{session_id}/files/content` | Required: `HostedAgents=V1Preview` |
-| Agent Session Files | List | GET | `/agents/{agent_name}/endpoint/sessions/{session_id}/files` | Required: `HostedAgents=V1Preview` |
-| Agent Session Files | Delete | DELETE | `/agents/{agent_name}/endpoint/sessions/{session_id}/files` | Required: `HostedAgents=V1Preview` |
 | Skills | Create | POST | `/skills` | Required: `Skills=V1Preview` |
 | Skills | Create From Package | POST | `/skills:import` | Required: `Skills=V1Preview` |
 | Skills | Get | GET | `/skills/{name}` | Required: `Skills=V1Preview` |
@@ -86,17 +73,6 @@ in order to successfully complete operations using these routes.
 | Skills | List | GET | `/skills` | Required: `Skills=V1Preview` |
 | Skills | Update | POST | `/skills/{name}` | Required: `Skills=V1Preview` |
 | Skills | Delete | DELETE | `/skills/{name}` | Required: `Skills=V1Preview` |
-| Toolboxes | Create Version | POST | `/toolboxes/{name}/versions` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | Get | GET | `/toolboxes/{name}` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | List | GET | `/toolboxes` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | List Versions | GET | `/toolboxes/{name}/versions` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | Get Version | GET | `/toolboxes/{name}/versions/{version}` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | Update | PATCH | `/toolboxes/{name}` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | Delete | DELETE | `/toolboxes/{name}` | Required: `Toolboxes=V1Preview` |
-| Toolboxes | Delete Version | DELETE | `/toolboxes/{name}/versions/{version}` | Required: `Toolboxes=V1Preview` |
-| Agents | Stream Session Logs | GET | `/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream` | Required: `HostedAgents=V1Preview` |
-| Agents | Download Version Code | GET | `/agents/{agent_name}/versions/{agent_version}/code:download` | Required: `CodeAgents=V1Preview` |
-| Agents | Download Code | GET | `/agents/{agent_name}/code:download` | Required: `CodeAgents=V1Preview` |
 | Data Generation Jobs | Get | GET | `/data_generation_jobs/{jobId}` | Required: `DataGenerationJobs=V1Preview` |
 | Data Generation Jobs | List | GET | `/data_generation_jobs` | Required: `DataGenerationJobs=V1Preview` |
 | Data Generation Jobs | Create | POST | `/data_generation_jobs` | Required: `DataGenerationJobs=V1Preview` |

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -803,8 +803,9 @@
         "x-ms-description-override": "Creates a new agent or a new version of an existing agent.",
         "x-ms-summary-override": "Create an agent",
         "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
+          "conditional_previews": [
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         },
         "tags": [
@@ -1101,11 +1102,6 @@
         },
         "x-ms-description-override": "Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.",
         "x-ms-summary-override": "Update an agent",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        },
         "tags": [
           "Agents"
         ],
@@ -1208,18 +1204,6 @@
         "description": "Applies a merge-patch update to the specified agent endpoint configuration.",
         "parameters": [
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "agent_name",
             "in": "path",
             "required": true,
@@ -1284,11 +1268,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       }
     },
@@ -1298,18 +1277,6 @@
         "summary": "Download agent code",
         "description": "Downloads the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "CodeAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -1383,12 +1350,7 @@
         },
         "tags": [
           "Agents"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations": {
@@ -1423,18 +1385,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1505,11 +1455,6 @@
             }
           },
           "description": "The request body."
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       }
     },
@@ -1526,18 +1471,6 @@
             "description": "The name of the agent.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1586,12 +1519,7 @@
         },
         "tags": [
           "Agent Invocations"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}": {
@@ -1625,18 +1553,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1691,12 +1607,7 @@
         },
         "tags": [
           "Agent Invocations"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel": {
@@ -1730,18 +1641,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1805,11 +1704,6 @@
             }
           },
           "description": "Optional request body."
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       }
     },
@@ -1819,18 +1713,6 @@
         "summary": "Create a session",
         "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -1904,11 +1786,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "get": {
@@ -1916,18 +1793,6 @@
         "summary": "List sessions for an agent",
         "description": "Returns a paged collection of sessions associated with the specified agent endpoint.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2059,12 +1924,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files": {
@@ -2073,18 +1933,6 @@
         "summary": "List session files",
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2209,30 +2057,13 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "AgentSessionFiles_deleteSessionFile",
         "summary": "Delete a session file",
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2319,12 +2150,7 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content": {
@@ -2333,18 +2159,6 @@
         "summary": "Upload a session file",
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2437,11 +2251,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       },
       "get": {
@@ -2449,18 +2258,6 @@
         "summary": "Download a session file",
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2543,12 +2340,7 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{session_id}": {
@@ -2557,18 +2349,6 @@
         "summary": "Get a session",
         "description": "Retrieves the details of a hosted agent session by agent name and session identifier.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2641,30 +2421,13 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "Agents_deleteSession",
         "summary": "Delete a session",
         "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2730,12 +2493,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
@@ -2744,18 +2502,6 @@
         "summary": "Stop a session",
         "description": "Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2812,12 +2558,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/import": {
@@ -2973,8 +2714,9 @@
         "x-ms-description-override": "Creates a new version for the specified agent and returns the created version resource.",
         "x-ms-summary-override": "Create an agent version",
         "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
+          "conditional_previews": [
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         },
         "tags": [
@@ -3291,18 +3033,6 @@
         "description": "Streams console logs (stdout / stderr) for a specific hosted agent session\nas a Server-Sent Events (SSE) stream.\n\nEach SSE frame contains:\n- `event`: always `\"log\"`\n- `data`: a plain-text log line (currently JSON-formatted, but the schema\nis not contractual and may include additional keys or change format\nover time — clients should treat it as an opaque string)\n\nExample SSE frames:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting FoundryCBAgent server on port 8088\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.130Z\",\"stream\":\"stderr\",\"message\":\"INFO: Application startup complete.\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:35:52.714Z\",\"stream\":\"status\",\"message\":\"No logs since last 60 seconds\"}\n```\n\nThe stream remains open until the client disconnects or the server\nterminates the connection. Clients should handle reconnection as needed.",
         "parameters": [
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "agent_name",
             "in": "path",
             "required": true,
@@ -3374,12 +3104,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/versions:import": {
@@ -16199,18 +15924,6 @@
             "explode": false
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -16281,12 +15994,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}": {
@@ -16302,18 +16010,6 @@
             "description": "The name of the toolbox to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16361,12 +16057,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "patch": {
         "operationId": "updateToolbox",
@@ -16375,18 +16066,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/UpdateToolboxRequest.name"
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -16443,11 +16122,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "delete": {
@@ -16462,18 +16136,6 @@
             "description": "The name of the toolbox to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16514,12 +16176,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions": {
@@ -16536,18 +16193,6 @@
             "schema": {
               "type": "string",
               "maxLength": 256
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16644,11 +16289,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "get": {
@@ -16706,18 +16346,6 @@
               "type": "string"
             },
             "explode": false
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -16790,12 +16418,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions/{version}": {
@@ -16820,18 +16443,6 @@
             "description": "The version identifier to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16879,12 +16490,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "deleteToolboxVersion",
@@ -16907,18 +16513,6 @@
             "description": "The version identifier to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16959,12 +16553,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     }
   },
@@ -17360,11 +16949,6 @@
           "mapping": {
             "ManagedAgentIdentityBlueprint": "#/components/schemas/ManagedAgentIdentityBlueprintReference"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentBlueprintReferenceType": {
@@ -17378,12 +16962,7 @@
               "ManagedAgentIdentityBlueprint"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "AgentCard": {
         "type": "object",
@@ -17412,11 +16991,6 @@
             "maxItems": 16,
             "description": "The set of skills that an agent can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentCardSkill": {
@@ -17459,31 +17033,16 @@
             "maxItems": 5,
             "description": "A list of example scenarios that the skill can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentCardSkillExample": {
         "type": "string",
         "maxLength": 1024,
-        "description": "A skill example string with a maximum length of 1024 characters.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "A skill example string with a maximum length of 1024 characters."
       },
       "AgentCardSkillTag": {
         "type": "string",
-        "maxLength": 32,
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "maxLength": 32
       },
       "AgentCardUpdate": {
         "type": "object",
@@ -17508,11 +17067,6 @@
             "maxItems": 16,
             "description": "The set of skills that an agent can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentClusterInsightRequest": {
@@ -17637,9 +17191,7 @@
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -17647,10 +17199,7 @@
       "AgentDefinitionOptInKeys": {
         "type": "string",
         "enum": [
-          "HostedAgents=V1Preview",
           "WorkflowAgents=V1Preview",
-          "AgentEndpoints=V1Preview",
-          "CodeAgents=V1Preview",
           "ExternalAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."
@@ -17672,11 +17221,6 @@
             "BotService": "#/components/schemas/BotServiceAuthorizationScheme",
             "BotServiceRbac": "#/components/schemas/BotServiceRbacAuthorizationScheme"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointAuthorizationSchemeType": {
@@ -17692,12 +17236,7 @@
               "BotServiceRbac"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "AgentEndpointConfig": {
         "type": "object",
@@ -17724,11 +17263,6 @@
             },
             "description": "The authorization schemes supported by the agent endpoint"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointConfigUpdate": {
@@ -17756,11 +17290,6 @@
             },
             "description": "The authorization schemes supported by the agent endpoint"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointProtocol": {
@@ -17892,11 +17421,6 @@
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentKind": {
@@ -17958,12 +17482,7 @@
                 "$ref": "#/components/schemas/AgentEndpointConfig"
               }
             ],
-            "description": "The endpoint configuration for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The endpoint configuration for the agent"
           },
           "instance_identity": {
             "allOf": [
@@ -17972,11 +17491,6 @@
               }
             ],
             "description": "The instance identity of the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint": {
@@ -17986,11 +17500,6 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint_reference": {
@@ -18000,24 +17509,10 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "agent_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentCard"
-              }
-            ],
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "$ref": "#/components/schemas/AgentCard"
           }
         }
       },
@@ -18113,12 +17608,7 @@
             "readOnly": true
           }
         },
-        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations."
       },
       "AgentSessionStatus": {
         "anyOf": [
@@ -18139,12 +17629,7 @@
             ]
           }
         ],
-        "description": "The status of an agent session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "The status of an agent session."
       },
       "AgentTaxonomyInput": {
         "type": "object",
@@ -18295,11 +17780,6 @@
               }
             ],
             "description": "The instance identity of the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint": {
@@ -18309,11 +17789,6 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint_reference": {
@@ -18323,21 +17798,11 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "agent_guid": {
             "type": "string",
             "description": "The unique GUID identifier of the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           }
         }
@@ -20187,12 +19652,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "BotServiceRbacAuthorizationScheme": {
         "type": "object",
@@ -20211,12 +19671,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "BrowserAutomationPreviewTool": {
         "type": "object",
@@ -20615,12 +20070,7 @@
             "readOnly": true
           }
         },
-        "description": "Code-based deployment configuration for a hosted agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "Code-based deployment configuration for a hosted agent."
       },
       "CodeDependencyResolution": {
         "anyOf": [
@@ -20764,12 +20214,7 @@
             ]
           }
         },
-        "description": "Container-based deployment configuration for a hosted agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "Container-based deployment configuration for a hosted agent."
       },
       "ContentFilterResult": {
         "type": "object",
@@ -21055,9 +20500,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -21068,12 +20511,7 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           },
           "agent_endpoint": {
             "allOf": [
@@ -21081,12 +20519,7 @@
                 "$ref": "#/components/schemas/AgentEndpointConfig"
               }
             ],
-            "description": "An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent"
           },
           "agent_card": {
             "allOf": [
@@ -21094,19 +20527,12 @@
                 "$ref": "#/components/schemas/AgentCard"
               }
             ],
-            "description": "Optional agent card for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "Optional agent card for the agent"
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -21130,12 +20556,7 @@
             "description": "Determines which agent version backs the session."
           }
         },
-        "description": "Request to create a new agent session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Request to create a new agent session."
       },
       "CreateAgentVersionFromCodeContent": {
         "type": "object",
@@ -21185,12 +20606,7 @@
             "description": "The hosted agent definition including code_configuration (runtime, entry_point), cpu, memory, and protocol_versions."
           }
         },
-        "description": "JSON metadata for code-based agent operations (create, update, create version).\nThe agent name comes from the URL path parameter or the `x-ms-agent-name` header,\nso it is not included in this model.\nThe content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "JSON metadata for code-based agent operations (create, update, create version).\nThe agent name comes from the URL path parameter or the `x-ms-agent-name` header,\nso it is not included in this model.\nThe content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header."
       },
       "CreateAgentVersionFromManifestRequest": {
         "type": "object",
@@ -21251,9 +20667,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -21264,19 +20678,12 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -22604,12 +22011,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "EntraIDCredentials": {
         "type": "object",
@@ -22650,12 +22052,7 @@
           {
             "$ref": "#/components/schemas/IsolationKeySource"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "Eval": {
         "type": "object",
@@ -24850,12 +24247,7 @@
           {
             "$ref": "#/components/schemas/VersionSelectionRule"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "FolderDatasetVersion": {
         "type": "object",
@@ -25109,12 +24501,7 @@
           {
             "$ref": "#/components/schemas/IsolationKeySource"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "HeaderTelemetryEndpointAuth": {
         "type": "object",
@@ -25159,12 +24546,7 @@
             "$ref": "#/components/schemas/TelemetryEndpointAuth"
           }
         ],
-        "description": "Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header."
       },
       "HostedAgentDefinition": {
         "type": "object",
@@ -25220,12 +24602,7 @@
                 "$ref": "#/components/schemas/ContainerConfiguration"
               }
             ],
-            "description": "Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            "description": "Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set."
           },
           "protocol_versions": {
             "type": "array",
@@ -25244,12 +24621,7 @@
                   "version": "v0.3.0"
                 }
               ]
-            ],
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            ]
           },
           "code_configuration": {
             "allOf": [
@@ -25257,12 +24629,7 @@
                 "$ref": "#/components/schemas/CodeConfiguration"
               }
             ],
-            "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set."
           },
           "telemetry_config": {
             "allOf": [
@@ -25278,12 +24645,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The hosted agent definition.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The hosted agent definition."
       },
       "HourlyRecurrenceSchedule": {
         "type": "object",
@@ -25908,11 +25270,6 @@
             "Entra": "#/components/schemas/EntraIsolationKeySource",
             "Header": "#/components/schemas/HeaderIsolationKeySource"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "IsolationKeySourceKind": {
@@ -25927,12 +25284,7 @@
               "Header"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "ItemGenerationParams": {
         "type": "object",
@@ -26049,12 +25401,7 @@
           {
             "$ref": "#/components/schemas/AgentBlueprintReference"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "ManagedAzureAISearchIndex": {
         "type": "object",
@@ -51661,12 +51008,7 @@
             "$ref": "#/components/schemas/TelemetryEndpoint"
           }
         ],
-        "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint."
       },
       "PageOrder": {
         "type": "string",
@@ -51946,11 +51288,6 @@
             ],
             "description": "Optional agent card for the agent"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "PendingUploadRequest": {
@@ -53590,12 +52927,7 @@
             ]
           }
         },
-        "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```"
       },
       "SessionLogEventType": {
         "anyOf": [
@@ -53609,12 +52941,7 @@
             ]
           }
         ],
-        "description": "Known SSE event types emitted by the hosted agent session log stream.\nAdditional event types may be introduced in future versions.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Known SSE event types emitted by the hosted agent session log stream.\nAdditional event types may be introduced in future versions."
       },
       "SharepointGroundingToolCall": {
         "type": "object",
@@ -54381,12 +53708,7 @@
             "description": "Customer-supplied telemetry export endpoint configurations."
           }
         },
-        "description": "Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
       },
       "TelemetryDataKind": {
         "anyOf": [
@@ -54402,12 +53724,7 @@
             ]
           }
         ],
-        "description": "The type of telemetry data to export.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The type of telemetry data to export."
       },
       "TelemetryEndpoint": {
         "type": "object",
@@ -54453,12 +53770,7 @@
             "OTLP": "#/components/schemas/OtlpTelemetryEndpoint"
           }
         },
-        "description": "A telemetry export endpoint configuration.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "A telemetry export endpoint configuration."
       },
       "TelemetryEndpointAuth": {
         "type": "object",
@@ -54481,12 +53793,7 @@
             "header": "#/components/schemas/HeaderTelemetryEndpointAuth"
           }
         },
-        "description": "Authentication configuration for a telemetry endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Authentication configuration for a telemetry endpoint."
       },
       "TelemetryEndpointAuthType": {
         "anyOf": [
@@ -54500,12 +53807,7 @@
             ]
           }
         ],
-        "description": "The type of authentication for a telemetry endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The type of authentication for a telemetry endpoint."
       },
       "TelemetryEndpointKind": {
         "anyOf": [
@@ -54519,12 +53821,7 @@
             ]
           }
         ],
-        "description": "The kind of telemetry export endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The kind of telemetry export endpoint."
       },
       "TelemetryTransportProtocol": {
         "anyOf": [
@@ -54539,12 +53836,7 @@
             ]
           }
         ],
-        "description": "The transport protocol for telemetry export.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The transport protocol for telemetry export."
       },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",
@@ -55299,9 +54591,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -55312,12 +54602,7 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           }
         }
       },
@@ -55422,12 +54707,7 @@
             "version_ref": "#/components/schemas/VersionRefIndicator"
           }
         },
-        "description": "Version indicator determining which agent version backs the session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Version indicator determining which agent version backs the session."
       },
       "VersionIndicatorType": {
         "anyOf": [
@@ -55441,12 +54721,7 @@
             ]
           }
         ],
-        "description": "The type of version indicator used to determine the agent version backing a session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "The type of version indicator used to determine the agent version backing a session."
       },
       "VersionRefIndicator": {
         "type": "object",
@@ -55472,12 +54747,7 @@
             "$ref": "#/components/schemas/VersionIndicator"
           }
         ],
-        "description": "Version indicator that references a specific agent version by name.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Version indicator that references a specific agent version by name."
       },
       "VersionSelectionRule": {
         "type": "object",
@@ -55499,11 +54769,6 @@
           "mapping": {
             "FixedRatio": "#/components/schemas/FixedRatioVersionSelectionRule"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "VersionSelector": {
@@ -55518,11 +54783,6 @@
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "VersionSelectorType": {
@@ -55536,12 +54796,7 @@
               "FixedRatio"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "VersionSelectorUpdate": {
         "type": "object",
@@ -55552,11 +54807,6 @@
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "WebSearchConfiguration": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -513,8 +513,9 @@ paths:
       x-ms-description-override: Creates a new agent or a new version of an existing agent.
       x-ms-summary-override: Create an agent
       x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
+        conditional_previews:
+          - WorkflowAgents=V1Preview
+          - ExternalAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -724,9 +725,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       x-ms-description-override: Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.
       x-ms-summary-override: Update an agent
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -796,14 +794,6 @@ paths:
       summary: Update an agent endpoint
       description: Applies a merge-patch update to the specified agent endpoint configuration.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -845,9 +835,6 @@ paths:
           application/merge-patch+json:
             schema:
               $ref: '#/components/schemas/PatchAgentRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/code:download:
     get:
       operationId: Agents_downloadAgentCode
@@ -862,14 +849,6 @@ paths:
         The SHA-256 digest of the returned bytes matches the `content_hash` on the
         resolved version's `code_configuration`.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - CodeAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -923,9 +902,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agents
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations:
     post:
       operationId: AgentInvocations_createAgentInvocation
@@ -951,14 +927,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1003,9 +971,6 @@ paths:
           '*/*':
             schema: {}
         description: The request body.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationOpenApiSpec
@@ -1020,14 +985,6 @@ paths:
           description: The name of the agent.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1057,9 +1014,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}:
     get:
       operationId: AgentInvocations_getAgentInvocation
@@ -1086,14 +1040,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1127,9 +1073,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel:
     post:
       operationId: AgentInvocations_cancelAgentInvocation
@@ -1156,14 +1099,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1203,9 +1138,6 @@ paths:
           '*/*':
             schema: {}
         description: Optional request body.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions:
     post:
       operationId: Agents_createSession
@@ -1215,14 +1147,6 @@ paths:
         The endpoint resolves the backing agent version from `version_indicator` and
         enforces session ownership using the provided isolation key for session-mutating operations.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1269,22 +1193,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateAgentSessionRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     get:
       operationId: Agents_listSessions
       summary: List sessions for an agent
       description: Returns a paged collection of sessions associated with the specified agent endpoint.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1384,9 +1297,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
@@ -1395,14 +1305,6 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1496,9 +1398,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     delete:
       operationId: AgentSessionFiles_deleteSessionFile
       summary: Delete a session file
@@ -1506,14 +1405,6 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1571,9 +1462,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content:
     put:
       operationId: AgentSessionFiles_uploadSessionFile
@@ -1582,14 +1470,6 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1649,9 +1529,6 @@ paths:
           application/octet-stream:
             schema:
               contentMediaType: application/octet-stream
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     get:
       operationId: AgentSessionFiles_downloadSessionFile
       summary: Download a session file
@@ -1659,14 +1536,6 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1720,23 +1589,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:
     get:
       operationId: Agents_getSession
       summary: Get a session
       description: Retrieves the details of a hosted agent session by agent name and session identifier.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1783,9 +1641,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     delete:
       operationId: Agents_deleteSession
       summary: Delete a session
@@ -1793,14 +1648,6 @@ paths:
         Deletes a session synchronously.
         Returns 204 No Content when the session is deleted or does not exist.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1843,23 +1690,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:stop:
     post:
       operationId: Agents_stopSession
       summary: Stop a session
       description: Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1896,9 +1732,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/import:
     post:
       operationId: Agents_updateAgentFromManifest
@@ -2010,8 +1843,9 @@ paths:
       x-ms-description-override: Creates a new version for the specified agent and returns the created version resource.
       x-ms-summary-override: Create an agent version
       x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
+        conditional_previews:
+          - WorkflowAgents=V1Preview
+          - ExternalAgents=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -2258,14 +2092,6 @@ paths:
         The stream remains open until the client disconnects or the server
         terminates the connection. Clients should handle reconnection as needed.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -2312,9 +2138,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/versions:import:
     post:
       operationId: Agents_createAgentVersionFromManifest
@@ -10616,14 +10439,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10671,9 +10486,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}:
     get:
       operationId: getToolbox
@@ -10686,14 +10498,6 @@ paths:
           description: The name of the toolbox to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10722,23 +10526,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     patch:
       operationId: updateToolbox
       summary: Update a toolbox to point to a specific version
       description: Updates the toolbox's default version pointer to the specified version.
       parameters:
         - $ref: '#/components/parameters/UpdateToolboxRequest.name'
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10773,9 +10566,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateToolboxRequest'
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolbox
       summary: Delete a toolbox
@@ -10787,14 +10577,6 @@ paths:
           description: The name of the toolbox to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10819,9 +10601,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions:
     post:
       operationId: createToolboxVersion
@@ -10835,14 +10614,6 @@ paths:
           schema:
             type: string
             maxLength: 256
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10903,9 +10674,6 @@ paths:
                   description: Policy configuration for this toolbox version.
               required:
                 - tools
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     get:
       operationId: listToolboxVersions
       summary: List toolbox versions
@@ -10957,14 +10725,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -11012,9 +10772,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions/{version}:
     get:
       operationId: getToolboxVersion
@@ -11033,14 +10790,6 @@ paths:
           description: The version identifier to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -11069,9 +10818,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolboxVersion
       summary: Delete a specific version of a toolbox
@@ -11089,14 +10835,6 @@ paths:
           description: The version identifier to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -11121,9 +10859,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
 security:
   - OAuth2Auth:
       - https://ai.azure.com/.default
@@ -11417,18 +11152,12 @@ components:
         propertyName: type
         mapping:
           ManagedAgentIdentityBlueprint: '#/components/schemas/ManagedAgentIdentityBlueprintReference'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentBlueprintReferenceType:
       anyOf:
         - type: string
         - type: string
           enum:
             - ManagedAgentIdentityBlueprint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCard:
       type: object
       required:
@@ -11451,9 +11180,6 @@ components:
           minItems: 1
           maxItems: 16
           description: The set of skills that an agent can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkill:
       type: object
       required:
@@ -11486,22 +11212,13 @@ components:
             $ref: '#/components/schemas/AgentCardSkillExample'
           maxItems: 5
           description: A list of example scenarios that the skill can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkillExample:
       type: string
       maxLength: 1024
       description: A skill example string with a maximum length of 1024 characters.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkillTag:
       type: string
       maxLength: 32
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardUpdate:
       type: object
       properties:
@@ -11521,9 +11238,6 @@ components:
           minItems: 1
           maxItems: 16
           description: The set of skills that an agent can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentClusterInsightRequest:
       type: object
       required:
@@ -11604,17 +11318,12 @@ components:
           external: '#/components/schemas/ExternalAgentDefinition'
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
-        - HostedAgents=V1Preview
         - WorkflowAgents=V1Preview
-        - AgentEndpoints=V1Preview
-        - CodeAgents=V1Preview
         - ExternalAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
     AgentEndpointAuthorizationScheme:
@@ -11630,9 +11339,6 @@ components:
           Entra: '#/components/schemas/EntraAuthorizationScheme'
           BotService: '#/components/schemas/BotServiceAuthorizationScheme'
           BotServiceRbac: '#/components/schemas/BotServiceRbacAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointAuthorizationSchemeType:
       anyOf:
         - type: string
@@ -11641,9 +11347,6 @@ components:
             - Entra
             - BotService
             - BotServiceRbac
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointConfig:
       type: object
       properties:
@@ -11661,9 +11364,6 @@ components:
           items:
             $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
           description: The authorization schemes supported by the agent endpoint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointConfigUpdate:
       type: object
       properties:
@@ -11681,9 +11381,6 @@ components:
           items:
             $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
           description: The authorization schemes supported by the agent endpoint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointProtocol:
       anyOf:
         - type: string
@@ -11768,9 +11465,6 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentKind:
       anyOf:
         - type: string
@@ -11812,39 +11506,23 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
           description: The endpoint configuration for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         instance_identity:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The instance identity of the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         agent_card:
-          allOf:
-            - $ref: '#/components/schemas/AgentCard'
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
+          $ref: '#/components/schemas/AgentCard'
     AgentProtocol:
       anyOf:
         - type: string
@@ -11910,9 +11588,6 @@ components:
           description: The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).
           readOnly: true
       description: An agent session providing a long-lived compute sandbox for hosted agent invocations.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentSessionStatus:
       anyOf:
         - type: string
@@ -11927,9 +11602,6 @@ components:
             - deleted
             - expired
       description: The status of an agent session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentTaxonomyInput:
       type: object
       required:
@@ -12032,32 +11704,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The instance identity of the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         agent_guid:
           type: string
           description: The unique GUID identifier of the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
     AgentVersionStatus:
       type: string
@@ -13280,9 +12940,6 @@ components:
             - BotService
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     BotServiceRbacAuthorizationScheme:
       type: object
       required:
@@ -13294,9 +12951,6 @@ components:
             - BotServiceRbac
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     BrowserAutomationPreviewTool:
       type: object
       required:
@@ -13588,9 +13242,6 @@ components:
           description: The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.
           readOnly: true
       description: Code-based deployment configuration for a hosted agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     CodeDependencyResolution:
       anyOf:
         - type: string
@@ -13689,9 +13340,6 @@ components:
           examples:
             - my-registry.azurecr.io/my-hosted-agent:latest
       description: Container-based deployment configuration for a hosted agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     ContentFilterResult:
       type: object
       required:
@@ -13907,36 +13555,23 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         agent_endpoint:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
           description: An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         agent_card:
           allOf:
             - $ref: '#/components/schemas/AgentCard'
           description: Optional agent card for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     CreateAgentSessionRequest:
       type: object
@@ -13951,9 +13586,6 @@ components:
             - $ref: '#/components/schemas/VersionIndicator'
           description: Determines which agent version backs the session.
       description: Request to create a new agent session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     CreateAgentVersionFromCodeContent:
       type: object
       properties:
@@ -13996,9 +13628,6 @@ components:
         The agent name comes from the URL path parameter or the `x-ms-agent-name` header,
         so it is not included in this model.
         The content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     CreateAgentVersionFromManifestRequest:
       type: object
       required:
@@ -14055,22 +13684,15 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     CreateEvalRequest:
       type: object
@@ -14944,9 +14566,6 @@ components:
           description: The source from which the per-user isolation key is derived for requests authorized via this scheme. Defaults to Entra-based isolation when omitted.
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     EntraIDCredentials:
       type: object
       required:
@@ -14972,9 +14591,6 @@ components:
             - Entra
       allOf:
         - $ref: '#/components/schemas/IsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     Eval:
       type: object
       required:
@@ -16701,9 +16317,6 @@ components:
           description: The percentage of traffic to route to the version. Must be between 0 and 100.
       allOf:
         - $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     FolderDatasetVersion:
       type: object
       required:
@@ -16860,9 +16473,6 @@ components:
             - Header
       allOf:
         - $ref: '#/components/schemas/IsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     HeaderTelemetryEndpointAuth:
       type: object
       required:
@@ -16894,9 +16504,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpointAuth'
       description: Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     HostedAgentDefinition:
       type: object
       required:
@@ -16937,9 +16544,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'
           description: Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         protocol_versions:
           type: array
           items:
@@ -16950,16 +16554,10 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         code_configuration:
           allOf:
             - $ref: '#/components/schemas/CodeConfiguration'
           description: Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         telemetry_config:
           allOf:
             - $ref: '#/components/schemas/TelemetryConfig'
@@ -16967,9 +16565,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     HourlyRecurrenceSchedule:
       type: object
       required:
@@ -17385,9 +16980,6 @@ components:
         mapping:
           Entra: '#/components/schemas/EntraIsolationKeySource'
           Header: '#/components/schemas/HeaderIsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     IsolationKeySourceKind:
       anyOf:
         - type: string
@@ -17395,9 +16987,6 @@ components:
           enum:
             - Entra
             - Header
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     ItemGenerationParams:
       type: object
       required:
@@ -17476,9 +17065,6 @@ components:
           description: The ID of the managed blueprint
       allOf:
         - $ref: '#/components/schemas/AgentBlueprintReference'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     ManagedAzureAISearchIndex:
       type: object
       required:
@@ -35466,9 +35052,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     PageOrder:
       type: string
       enum:
@@ -35665,9 +35248,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentCardUpdate'
           description: Optional agent card for the agent
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     PendingUploadRequest:
       type: object
       required:
@@ -36764,9 +36344,6 @@ components:
         event: log
         data: {"timestamp":"2026-03-10T09:34:52.714Z","stream":"status","message":"Successfully connected to container"}
         ```
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     SessionLogEventType:
       anyOf:
         - type: string
@@ -36776,9 +36353,6 @@ components:
       description: |-
         Known SSE event types emitted by the hosted agent session log stream.
         Additional event types may be introduced in future versions.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     SharepointGroundingToolCall:
       type: object
       required:
@@ -37293,9 +36867,6 @@ components:
           maxItems: 3
           description: Customer-supplied telemetry export endpoint configurations.
       description: Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryDataKind:
       anyOf:
         - type: string
@@ -37305,9 +36876,6 @@ components:
             - ContainerOtel
             - Metrics
       description: The type of telemetry data to export.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpoint:
       type: object
       required:
@@ -37336,9 +36904,6 @@ components:
         mapping:
           OTLP: '#/components/schemas/OtlpTelemetryEndpoint'
       description: A telemetry export endpoint configuration.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointAuth:
       type: object
       required:
@@ -37353,9 +36918,6 @@ components:
         mapping:
           header: '#/components/schemas/HeaderTelemetryEndpointAuth'
       description: Authentication configuration for a telemetry endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointAuthType:
       anyOf:
         - type: string
@@ -37363,9 +36925,6 @@ components:
           enum:
             - header
       description: The type of authentication for a telemetry endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointKind:
       anyOf:
         - type: string
@@ -37373,9 +36932,6 @@ components:
           enum:
             - OTLP
       description: The kind of telemetry export endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryTransportProtocol:
       anyOf:
         - type: string
@@ -37384,9 +36940,6 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TestingCriterionAzureAIEvaluator:
       type: object
       required:
@@ -37916,17 +37469,12 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
     UpdateEvalParametersBody:
       type: object
       properties:
@@ -37993,9 +37541,6 @@ components:
         mapping:
           version_ref: '#/components/schemas/VersionRefIndicator'
       description: Version indicator determining which agent version backs the session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionIndicatorType:
       anyOf:
         - type: string
@@ -38003,9 +37548,6 @@ components:
           enum:
             - version_ref
       description: The type of version indicator used to determine the agent version backing a session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionRefIndicator:
       type: object
       required:
@@ -38023,9 +37565,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/VersionIndicator'
       description: Version indicator that references a specific agent version by name.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectionRule:
       type: object
       required:
@@ -38041,9 +37580,6 @@ components:
         propertyName: type
         mapping:
           FixedRatio: '#/components/schemas/FixedRatioVersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelector:
       type: object
       required:
@@ -38053,18 +37589,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectorType:
       anyOf:
         - type: string
         - type: string
           enum:
             - FixedRatio
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectorUpdate:
       type: object
       properties:
@@ -38072,9 +37602,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     WebSearchConfiguration:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -806,8 +806,9 @@
         "x-ms-description-override": "Creates a new agent or a new version of an existing agent.",
         "x-ms-summary-override": "Create an agent",
         "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
+          "conditional_previews": [
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         },
         "tags": [
@@ -1002,40 +1003,12 @@
             "explode": false
           },
           {
-            "name": "foundry_features",
-            "in": "query",
-            "required": false,
-            "description": "Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AgentDefinitionOptInKeys"
-              },
-              "default": [
-                "HostedAgents=V1Preview"
-              ]
-            },
-            "explode": false
-          },
-          {
             "name": "x-ms-user-isolation-key",
             "in": "header",
             "required": false,
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1090,12 +1063,7 @@
         },
         "tags": [
           "Agent Invocations WebSocket"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}": {
@@ -1237,11 +1205,6 @@
         },
         "x-ms-description-override": "Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.",
         "x-ms-summary-override": "Update an agent",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        },
         "tags": [
           "Agents"
         ],
@@ -1344,18 +1307,6 @@
         "description": "Applies a merge-patch update to the specified agent endpoint configuration.",
         "parameters": [
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "agent_name",
             "in": "path",
             "required": true,
@@ -1420,11 +1371,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       }
     },
@@ -1434,18 +1380,6 @@
         "summary": "Download agent code",
         "description": "Downloads the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "CodeAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -1519,12 +1453,7 @@
         },
         "tags": [
           "Agents"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations": {
@@ -1559,18 +1488,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1641,11 +1558,6 @@
             }
           },
           "description": "The request body."
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       }
     },
@@ -1662,18 +1574,6 @@
             "description": "The name of the agent.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1722,12 +1622,7 @@
         },
         "tags": [
           "Agent Invocations"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}": {
@@ -1761,18 +1656,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1827,12 +1710,7 @@
         },
         "tags": [
           "Agent Invocations"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel": {
@@ -1866,18 +1744,6 @@
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
             }
           },
           {
@@ -1941,11 +1807,6 @@
             }
           },
           "description": "Optional request body."
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       }
     },
@@ -1955,18 +1816,6 @@
         "summary": "Create a session",
         "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2040,11 +1889,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "get": {
@@ -2052,18 +1896,6 @@
         "summary": "List sessions for an agent",
         "description": "Returns a paged collection of sessions associated with the specified agent endpoint.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2195,12 +2027,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files": {
@@ -2209,18 +2036,6 @@
         "summary": "List session files",
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2345,30 +2160,13 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "AgentSessionFiles_deleteSessionFile",
         "summary": "Delete a session file",
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2455,12 +2253,7 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content": {
@@ -2469,18 +2262,6 @@
         "summary": "Upload a session file",
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2573,11 +2354,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
         }
       },
       "get": {
@@ -2585,18 +2361,6 @@
         "summary": "Download a session file",
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2679,12 +2443,7 @@
         },
         "tags": [
           "Agent Session Files"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{session_id}": {
@@ -2693,18 +2452,6 @@
         "summary": "Get a session",
         "description": "Retrieves the details of a hosted agent session by agent name and session identifier.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2777,30 +2524,13 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "Agents_deleteSession",
         "summary": "Delete a session",
         "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2866,12 +2596,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
@@ -2880,18 +2605,6 @@
         "summary": "Stop a session",
         "description": "Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "agent_name",
             "in": "path",
@@ -2948,12 +2661,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/import": {
@@ -3346,8 +3054,9 @@
         "x-ms-description-override": "Creates a new version for the specified agent and returns the created version resource.",
         "x-ms-summary-override": "Create an agent version",
         "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
+          "conditional_previews": [
+            "WorkflowAgents=V1Preview",
+            "ExternalAgents=V1Preview"
           ]
         },
         "tags": [
@@ -4461,18 +4170,6 @@
         "description": "Streams console logs (stdout / stderr) for a specific hosted agent session\nas a Server-Sent Events (SSE) stream.\n\nEach SSE frame contains:\n- `event`: always `\"log\"`\n- `data`: a plain-text log line (currently JSON-formatted, but the schema\nis not contractual and may include additional keys or change format\nover time — clients should treat it as an opaque string)\n\nExample SSE frames:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting FoundryCBAgent server on port 8088\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.130Z\",\"stream\":\"stderr\",\"message\":\"INFO: Application startup complete.\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:35:52.714Z\",\"stream\":\"status\",\"message\":\"No logs since last 60 seconds\"}\n```\n\nThe stream remains open until the client disconnects or the server\nterminates the connection. Clients should handle reconnection as needed.",
         "parameters": [
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": false,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "HostedAgents=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "agent_name",
             "in": "path",
             "required": true,
@@ -4544,12 +4241,7 @@
         },
         "tags": [
           "Agent Sessions"
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/agents/{agent_name}/versions:import": {
@@ -10505,18 +10197,6 @@
         "description": "Lists all managed agent identity blueprints.",
         "parameters": [
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "order",
             "in": "query",
             "required": false,
@@ -10580,11 +10260,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       }
     },
@@ -10594,18 +10269,6 @@
         "summary": "Create or update a blueprint",
         "description": "Creates or updates a managed agent identity blueprint.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "blueprint_name",
             "in": "path",
@@ -10667,11 +10330,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "get": {
@@ -10679,18 +10337,6 @@
         "summary": "Get a blueprint",
         "description": "Retrieves a managed agent identity blueprint by name.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "blueprint_name",
             "in": "path",
@@ -10742,11 +10388,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "delete": {
@@ -10754,18 +10395,6 @@
         "summary": "Delete a blueprint",
         "description": "Deletes a managed agent identity blueprint by name.",
         "parameters": [
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
-          },
           {
             "name": "blueprint_name",
             "in": "path",
@@ -10810,11 +10439,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       }
     },
@@ -19218,18 +18842,6 @@
             "explode": false
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -19300,12 +18912,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}": {
@@ -19321,18 +18928,6 @@
             "description": "The name of the toolbox to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19380,12 +18975,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "patch": {
         "operationId": "updateToolbox",
@@ -19394,18 +18984,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/UpdateToolboxRequest.name"
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -19462,11 +19040,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "delete": {
@@ -19481,18 +19054,6 @@
             "description": "The name of the toolbox to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19533,12 +19094,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions": {
@@ -19555,18 +19111,6 @@
             "schema": {
               "type": "string",
               "maxLength": 256
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19663,11 +19207,6 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "get": {
@@ -19725,18 +19264,6 @@
               "type": "string"
             },
             "explode": false
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -19809,12 +19336,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions/{version}": {
@@ -19839,18 +19361,6 @@
             "description": "The version identifier to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19898,12 +19408,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "deleteToolboxVersion",
@@ -19926,18 +19431,6 @@
             "description": "The version identifier to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19978,12 +19471,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     }
   },
@@ -20379,11 +19867,6 @@
           "mapping": {
             "ManagedAgentIdentityBlueprint": "#/components/schemas/ManagedAgentIdentityBlueprintReference"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentBlueprintReferenceType": {
@@ -20397,12 +19880,7 @@
               "ManagedAgentIdentityBlueprint"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "AgentCard": {
         "type": "object",
@@ -20431,11 +19909,6 @@
             "maxItems": 16,
             "description": "The set of skills that an agent can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentCardSkill": {
@@ -20478,31 +19951,16 @@
             "maxItems": 5,
             "description": "A list of example scenarios that the skill can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentCardSkillExample": {
         "type": "string",
         "maxLength": 1024,
-        "description": "A skill example string with a maximum length of 1024 characters.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "A skill example string with a maximum length of 1024 characters."
       },
       "AgentCardSkillTag": {
         "type": "string",
-        "maxLength": 32,
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "maxLength": 32
       },
       "AgentCardUpdate": {
         "type": "object",
@@ -20527,11 +19985,6 @@
             "maxItems": 16,
             "description": "The set of skills that an agent can perform."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentClusterInsightRequest": {
@@ -20860,9 +20313,7 @@
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -20870,10 +20321,7 @@
       "AgentDefinitionOptInKeys": {
         "type": "string",
         "enum": [
-          "HostedAgents=V1Preview",
           "WorkflowAgents=V1Preview",
-          "AgentEndpoints=V1Preview",
-          "CodeAgents=V1Preview",
           "ExternalAgents=V1Preview",
           "ContainerAgents=V1Preview"
         ],
@@ -20896,11 +20344,6 @@
             "BotService": "#/components/schemas/BotServiceAuthorizationScheme",
             "BotServiceRbac": "#/components/schemas/BotServiceRbacAuthorizationScheme"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointAuthorizationSchemeType": {
@@ -20916,12 +20359,7 @@
               "BotServiceRbac"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "AgentEndpointConfig": {
         "type": "object",
@@ -20948,11 +20386,6 @@
             },
             "description": "The authorization schemes supported by the agent endpoint"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointConfigUpdate": {
@@ -20980,11 +20413,6 @@
             },
             "description": "The authorization schemes supported by the agent endpoint"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentEndpointProtocol": {
@@ -21342,11 +20770,6 @@
             "type": "string",
             "description": "The client ID of the agent instance. Also referred to as the instance ID"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "AgentKind": {
@@ -21409,12 +20832,7 @@
                 "$ref": "#/components/schemas/AgentEndpointConfig"
               }
             ],
-            "description": "The endpoint configuration for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The endpoint configuration for the agent"
           },
           "instance_identity": {
             "allOf": [
@@ -21423,11 +20841,6 @@
               }
             ],
             "description": "The instance identity of the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint": {
@@ -21437,11 +20850,6 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint_reference": {
@@ -21451,24 +20859,10 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "agent_card": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AgentCard"
-              }
-            ],
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "$ref": "#/components/schemas/AgentCard"
           }
         }
       },
@@ -21564,12 +20958,7 @@
             "readOnly": true
           }
         },
-        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "An agent session providing a long-lived compute sandbox for hosted agent invocations."
       },
       "AgentSessionStatus": {
         "anyOf": [
@@ -21590,12 +20979,7 @@
             ]
           }
         ],
-        "description": "The status of an agent session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "The status of an agent session."
       },
       "AgentTaxonomyInput": {
         "type": "object",
@@ -21754,11 +21138,6 @@
               }
             ],
             "description": "The instance identity of the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint": {
@@ -21768,11 +21147,6 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "blueprint_reference": {
@@ -21782,21 +21156,11 @@
               }
             ],
             "description": "The blueprint for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           },
           "agent_guid": {
             "type": "string",
             "description": "The unique GUID identifier of the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            },
             "readOnly": true
           }
         }
@@ -23672,12 +23036,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "BotServiceRbacAuthorizationScheme": {
         "type": "object",
@@ -23696,12 +23055,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "BrowserAutomationPreviewTool": {
         "type": "object",
@@ -24100,12 +23454,7 @@
             "readOnly": true
           }
         },
-        "description": "Code-based deployment configuration for a hosted agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "Code-based deployment configuration for a hosted agent."
       },
       "CodeDependencyResolution": {
         "anyOf": [
@@ -24309,12 +23658,7 @@
             ]
           }
         },
-        "description": "Container-based deployment configuration for a hosted agent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "Container-based deployment configuration for a hosted agent."
       },
       "ContainerDetails": {
         "type": "object",
@@ -24687,9 +24031,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -24700,12 +24042,7 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           },
           "agent_endpoint": {
             "allOf": [
@@ -24713,12 +24050,7 @@
                 "$ref": "#/components/schemas/AgentEndpointConfig"
               }
             ],
-            "description": "An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent"
           },
           "agent_card": {
             "allOf": [
@@ -24726,19 +24058,12 @@
                 "$ref": "#/components/schemas/AgentCard"
               }
             ],
-            "description": "Optional agent card for the agent",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "Optional agent card for the agent"
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -24762,12 +24087,7 @@
             "description": "Determines which agent version backs the session."
           }
         },
-        "description": "Request to create a new agent session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Request to create a new agent session."
       },
       "CreateAgentVersionFromCodeContent": {
         "type": "object",
@@ -24817,12 +24137,7 @@
             "description": "The hosted agent definition including code_configuration (runtime, entry_point), cpu, memory, and protocol_versions."
           }
         },
-        "description": "JSON metadata for code-based agent operations (create, update, create version).\nThe agent name comes from the URL path parameter or the `x-ms-agent-name` header,\nso it is not included in this model.\nThe content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "CodeAgents=V1Preview"
-          ]
-        }
+        "description": "JSON metadata for code-based agent operations (create, update, create version).\nThe agent name comes from the URL path parameter or the `x-ms-agent-name` header,\nso it is not included in this model.\nThe content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header."
       },
       "CreateAgentVersionFromManifestRequest": {
         "type": "object",
@@ -24883,9 +24198,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -24896,19 +24209,12 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           }
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "HostedAgents=V1Preview",
             "WorkflowAgents=V1Preview",
-            "CodeAgents=V1Preview",
             "ExternalAgents=V1Preview"
           ]
         }
@@ -25057,11 +24363,6 @@
             "maxLength": 63,
             "description": "The unique name that identifies the managed agent identity blueprint.\nName can be used to retrieve/update/delete the managed agent identity blueprint.\n- Must start and end with alphanumeric characters,\n- Can contain hyphens in the middle\n- Must not exceed 63 characters."
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "CreateSkillVersionFromFilesBody": {
@@ -26331,12 +25632,7 @@
           {
             "$ref": "#/components/schemas/AgentEndpointAuthorizationScheme"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "EntraIDCredentials": {
         "type": "object",
@@ -26377,12 +25673,7 @@
           {
             "$ref": "#/components/schemas/IsolationKeySource"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "Eval": {
         "type": "object",
@@ -29398,12 +28689,7 @@
           {
             "$ref": "#/components/schemas/VersionSelectionRule"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "FolderDatasetVersion": {
         "type": "object",
@@ -29657,12 +28943,7 @@
           {
             "$ref": "#/components/schemas/IsolationKeySource"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "HeaderTelemetryEndpointAuth": {
         "type": "object",
@@ -29707,12 +28988,7 @@
             "$ref": "#/components/schemas/TelemetryEndpointAuth"
           }
         ],
-        "description": "Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header."
       },
       "HostedAgentDefinition": {
         "type": "object",
@@ -29768,12 +29044,7 @@
                 "$ref": "#/components/schemas/ContainerConfiguration"
               }
             ],
-            "description": "Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            "description": "Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set."
           },
           "protocol_versions": {
             "type": "array",
@@ -29792,12 +29063,7 @@
                   "version": "v0.3.0"
                 }
               ]
-            ],
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            ]
           },
           "code_configuration": {
             "allOf": [
@@ -29805,12 +29071,7 @@
                 "$ref": "#/components/schemas/CodeConfiguration"
               }
             ],
-            "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "CodeAgents=V1Preview"
-              ]
-            }
+            "description": "Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set."
           },
           "telemetry_config": {
             "allOf": [
@@ -29826,12 +29087,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The hosted agent definition.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The hosted agent definition."
       },
       "HourlyRecurrenceSchedule": {
         "type": "object",
@@ -30529,11 +29785,6 @@
             "Entra": "#/components/schemas/EntraIsolationKeySource",
             "Header": "#/components/schemas/HeaderIsolationKeySource"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "IsolationKeySourceKind": {
@@ -30548,12 +29799,7 @@
               "Header"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "ItemGenerationParams": {
         "type": "object",
@@ -30682,12 +29928,7 @@
           {
             "$ref": "#/components/schemas/AgentBlueprintReference"
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "ManagedAzureAISearchIndex": {
         "type": "object",
@@ -56414,12 +55655,7 @@
             "$ref": "#/components/schemas/TelemetryEndpoint"
           }
         ],
-        "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "An OTLP (OpenTelemetry Protocol) telemetry export endpoint."
       },
       "PageOrder": {
         "type": "string",
@@ -56762,11 +55998,6 @@
             ],
             "description": "Optional agent card for the agent"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "PendingUploadRequest": {
@@ -58436,12 +57667,7 @@
             ]
           }
         },
-        "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```"
       },
       "SessionLogEventType": {
         "anyOf": [
@@ -58455,12 +57681,7 @@
             ]
           }
         ],
-        "description": "Known SSE event types emitted by the hosted agent session log stream.\nAdditional event types may be introduced in future versions.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Known SSE event types emitted by the hosted agent session log stream.\nAdditional event types may be introduced in future versions."
       },
       "SharepointGroundingToolCall": {
         "type": "object",
@@ -59253,12 +58474,7 @@
             "description": "Customer-supplied telemetry export endpoint configurations."
           }
         },
-        "description": "Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Customer-supplied telemetry configuration for exporting container logs, traces, and metrics."
       },
       "TelemetryDataKind": {
         "anyOf": [
@@ -59274,12 +58490,7 @@
             ]
           }
         ],
-        "description": "The type of telemetry data to export.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The type of telemetry data to export."
       },
       "TelemetryEndpoint": {
         "type": "object",
@@ -59325,12 +58536,7 @@
             "OTLP": "#/components/schemas/OtlpTelemetryEndpoint"
           }
         },
-        "description": "A telemetry export endpoint configuration.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "A telemetry export endpoint configuration."
       },
       "TelemetryEndpointAuth": {
         "type": "object",
@@ -59353,12 +58559,7 @@
             "header": "#/components/schemas/HeaderTelemetryEndpointAuth"
           }
         },
-        "description": "Authentication configuration for a telemetry endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "Authentication configuration for a telemetry endpoint."
       },
       "TelemetryEndpointAuthType": {
         "anyOf": [
@@ -59372,12 +58573,7 @@
             ]
           }
         ],
-        "description": "The type of authentication for a telemetry endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The type of authentication for a telemetry endpoint."
       },
       "TelemetryEndpointKind": {
         "anyOf": [
@@ -59391,12 +58587,7 @@
             ]
           }
         ],
-        "description": "The kind of telemetry export endpoint.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The kind of telemetry export endpoint."
       },
       "TelemetryTransportProtocol": {
         "anyOf": [
@@ -59411,12 +58602,7 @@
             ]
           }
         ],
-        "description": "The transport protocol for telemetry export.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "HostedAgents=V1Preview"
-          ]
-        }
+        "description": "The transport protocol for telemetry export."
       },
       "TestingCriterionAzureAIEvaluator": {
         "type": "object",
@@ -60225,9 +59411,7 @@
             "description": "The agent definition. This can be a workflow, hosted agent, or a simple agent definition.",
             "x-ms-foundry-meta": {
               "conditional_previews": [
-                "HostedAgents=V1Preview",
                 "WorkflowAgents=V1Preview",
-                "CodeAgents=V1Preview",
                 "ExternalAgents=V1Preview"
               ]
             }
@@ -60238,12 +59422,7 @@
                 "$ref": "#/components/schemas/AgentBlueprintReference"
               }
             ],
-            "description": "The blueprint reference for the agent.",
-            "x-ms-foundry-meta": {
-              "required_previews": [
-                "AgentEndpoints=V1Preview"
-              ]
-            }
+            "description": "The blueprint reference for the agent."
           }
         }
       },
@@ -60374,12 +59553,7 @@
             "version_ref": "#/components/schemas/VersionRefIndicator"
           }
         },
-        "description": "Version indicator determining which agent version backs the session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Version indicator determining which agent version backs the session."
       },
       "VersionIndicatorType": {
         "anyOf": [
@@ -60393,12 +59567,7 @@
             ]
           }
         ],
-        "description": "The type of version indicator used to determine the agent version backing a session.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "The type of version indicator used to determine the agent version backing a session."
       },
       "VersionRefIndicator": {
         "type": "object",
@@ -60424,12 +59593,7 @@
             "$ref": "#/components/schemas/VersionIndicator"
           }
         ],
-        "description": "Version indicator that references a specific agent version by name.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        "description": "Version indicator that references a specific agent version by name."
       },
       "VersionSelectionRule": {
         "type": "object",
@@ -60451,11 +59615,6 @@
           "mapping": {
             "FixedRatio": "#/components/schemas/FixedRatioVersionSelectionRule"
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "VersionSelector": {
@@ -60470,11 +59629,6 @@
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "VersionSelectorType": {
@@ -60488,12 +59642,7 @@
               "FixedRatio"
             ]
           }
-        ],
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
-        }
+        ]
       },
       "VersionSelectorUpdate": {
         "type": "object",
@@ -60504,11 +59653,6 @@
               "$ref": "#/components/schemas/VersionSelectionRule"
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "AgentEndpoints=V1Preview"
-          ]
         }
       },
       "WebSearchConfiguration": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -1003,12 +1003,40 @@
             "explode": false
           },
           {
+            "name": "foundry_features",
+            "in": "query",
+            "required": false,
+            "description": "Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AgentDefinitionOptInKeys"
+              },
+              "default": [
+                "HostedAgents=V1Preview"
+              ]
+            },
+            "explode": false
+          },
+          {
             "name": "x-ms-user-isolation-key",
             "in": "header",
             "required": false,
             "description": "Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HostedAgents=V1Preview"
+              ]
             }
           },
           {
@@ -1063,7 +1091,12 @@
         },
         "tags": [
           "Agent Invocations WebSocket"
-        ]
+        ],
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "HostedAgents=V1Preview"
+          ]
+        }
       }
     },
     "/agents/{agent_name}": {
@@ -20323,6 +20356,7 @@
         "enum": [
           "WorkflowAgents=V1Preview",
           "ExternalAgents=V1Preview",
+          "HostedAgents=V1Preview",
           "ContainerAgents=V1Preview"
         ],
         "description": "Feature opt-in keys for agent definition operations supporting hosted or workflow agents."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -663,12 +663,31 @@ paths:
           schema:
             type: string
           explode: false
+        - name: foundry_features
+          in: query
+          required: false
+          description: Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/AgentDefinitionOptInKeys'
+            default:
+              - HostedAgents=V1Preview
+          explode: false
         - name: x-ms-user-isolation-key
           in: header
           required: false
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -702,6 +721,9 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations WebSocket
+      x-ms-foundry-meta:
+        required_previews:
+          - HostedAgents=V1Preview
   /agents/{agent_name}:
     get:
       operationId: Agents_getAgent
@@ -13403,6 +13425,7 @@ components:
       enum:
         - WorkflowAgents=V1Preview
         - ExternalAgents=V1Preview
+        - HostedAgents=V1Preview
         - ContainerAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
     AgentEndpointAuthorizationScheme:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -514,8 +514,9 @@ paths:
       x-ms-description-override: Creates a new agent or a new version of an existing agent.
       x-ms-summary-override: Create an agent
       x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
+        conditional_previews:
+          - WorkflowAgents=V1Preview
+          - ExternalAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -662,31 +663,12 @@ paths:
           schema:
             type: string
           explode: false
-        - name: foundry_features
-          in: query
-          required: false
-          description: Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`.
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/AgentDefinitionOptInKeys'
-            default:
-              - HostedAgents=V1Preview
-          explode: false
         - name: x-ms-user-isolation-key
           in: header
           required: false
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -720,9 +702,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations WebSocket
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}:
     get:
       operationId: Agents_getAgent
@@ -819,9 +798,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       x-ms-description-override: Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.
       x-ms-summary-override: Update an agent
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
       tags:
         - Agents
       requestBody:
@@ -891,14 +867,6 @@ paths:
       summary: Update an agent endpoint
       description: Applies a merge-patch update to the specified agent endpoint configuration.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -940,9 +908,6 @@ paths:
           application/merge-patch+json:
             schema:
               $ref: '#/components/schemas/PatchAgentRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/code:download:
     get:
       operationId: Agents_downloadAgentCode
@@ -957,14 +922,6 @@ paths:
         The SHA-256 digest of the returned bytes matches the `content_hash` on the
         resolved version's `code_configuration`.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - CodeAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1018,9 +975,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agents
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations:
     post:
       operationId: AgentInvocations_createAgentInvocation
@@ -1046,14 +1000,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1098,9 +1044,6 @@ paths:
           '*/*':
             schema: {}
         description: The request body.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationOpenApiSpec
@@ -1115,14 +1058,6 @@ paths:
           description: The name of the agent.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1152,9 +1087,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}:
     get:
       operationId: AgentInvocations_getAgentInvocation
@@ -1181,14 +1113,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1222,9 +1146,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Invocations
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel:
     post:
       operationId: AgentInvocations_cancelAgentInvocation
@@ -1251,14 +1172,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: api-version
           in: query
           required: true
@@ -1298,9 +1211,6 @@ paths:
           '*/*':
             schema: {}
         description: Optional request body.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions:
     post:
       operationId: Agents_createSession
@@ -1310,14 +1220,6 @@ paths:
         The endpoint resolves the backing agent version from `version_indicator` and
         enforces session ownership using the provided isolation key for session-mutating operations.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1364,22 +1266,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateAgentSessionRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     get:
       operationId: Agents_listSessions
       summary: List sessions for an agent
       description: Returns a paged collection of sessions associated with the specified agent endpoint.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1479,9 +1370,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
@@ -1490,14 +1378,6 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1591,9 +1471,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     delete:
       operationId: AgentSessionFiles_deleteSessionFile
       summary: Delete a session file
@@ -1601,14 +1478,6 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1666,9 +1535,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content:
     put:
       operationId: AgentSessionFiles_uploadSessionFile
@@ -1677,14 +1543,6 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1744,9 +1602,6 @@ paths:
           application/octet-stream:
             schema:
               contentMediaType: application/octet-stream
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     get:
       operationId: AgentSessionFiles_downloadSessionFile
       summary: Download a session file
@@ -1754,14 +1609,6 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1815,23 +1662,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Session Files
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:
     get:
       operationId: Agents_getSession
       summary: Get a session
       description: Retrieves the details of a hosted agent session by agent name and session identifier.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1878,9 +1714,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     delete:
       operationId: Agents_deleteSession
       summary: Delete a session
@@ -1888,14 +1721,6 @@ paths:
         Deletes a session synchronously.
         Returns 204 No Content when the session is deleted or does not exist.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1938,23 +1763,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:stop:
     post:
       operationId: Agents_stopSession
       summary: Stop a session
       description: Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -1991,9 +1805,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /agents/{agent_name}/import:
     post:
       operationId: Agents_updateAgentFromManifest
@@ -2272,8 +2083,9 @@ paths:
       x-ms-description-override: Creates a new version for the specified agent and returns the created version resource.
       x-ms-summary-override: Create an agent version
       x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
+        conditional_previews:
+          - WorkflowAgents=V1Preview
+          - ExternalAgents=V1Preview
       tags:
         - Agent Versions
       requestBody:
@@ -3064,14 +2876,6 @@ paths:
         The stream remains open until the client disconnects or the server
         terminates the connection. Clients should handle reconnection as needed.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: false
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - HostedAgents=V1Preview
         - name: agent_name
           in: path
           required: true
@@ -3118,9 +2922,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Agent Sessions
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
   /agents/{agent_name}/versions:import:
     post:
       operationId: Agents_createAgentVersionFromManifest
@@ -6946,14 +6747,6 @@ paths:
       summary: List blueprints
       description: Lists all managed agent identity blueprints.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: order
           in: query
           required: false
@@ -7000,23 +6793,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /managedAgentIdentityBlueprints/{blueprint_name}:
     put:
       operationId: ManagedAgentIdentityBlueprints_createOrUpdateManagedAgentIdentityBlueprint
       summary: Create or update a blueprint
       description: Creates or updates a managed agent identity blueprint.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: blueprint_name
           in: path
           required: true
@@ -7055,22 +6837,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateOrUpdateManagedAgentIdentityBlueprintRequest'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     get:
       operationId: ManagedAgentIdentityBlueprints_getManagedAgentIdentityBlueprint
       summary: Get a blueprint
       description: Retrieves a managed agent identity blueprint by name.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: blueprint_name
           in: path
           required: true
@@ -7103,22 +6874,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     delete:
       operationId: ManagedAgentIdentityBlueprints_deleteManagedAgentIdentityBlueprint
       summary: Delete a blueprint
       description: Deletes a managed agent identity blueprint by name.
       parameters:
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - AgentEndpoints=V1Preview
         - name: blueprint_name
           in: path
           required: true
@@ -7147,9 +6907,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
   /memory_stores:
     post:
       operationId: createMemoryStore
@@ -12620,14 +12377,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12675,9 +12424,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}:
     get:
       operationId: getToolbox
@@ -12690,14 +12436,6 @@ paths:
           description: The name of the toolbox to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12726,23 +12464,12 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     patch:
       operationId: updateToolbox
       summary: Update a toolbox to point to a specific version
       description: Updates the toolbox's default version pointer to the specified version.
       parameters:
         - $ref: '#/components/parameters/UpdateToolboxRequest.name'
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12777,9 +12504,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateToolboxRequest'
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolbox
       summary: Delete a toolbox
@@ -12791,14 +12515,6 @@ paths:
           description: The name of the toolbox to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12823,9 +12539,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions:
     post:
       operationId: createToolboxVersion
@@ -12839,14 +12552,6 @@ paths:
           schema:
             type: string
             maxLength: 256
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12907,9 +12612,6 @@ paths:
                   description: Policy configuration for this toolbox version.
               required:
                 - tools
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     get:
       operationId: listToolboxVersions
       summary: List toolbox versions
@@ -12961,14 +12663,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13016,9 +12710,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions/{version}:
     get:
       operationId: getToolboxVersion
@@ -13037,14 +12728,6 @@ paths:
           description: The version identifier to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13073,9 +12756,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolboxVersion
       summary: Delete a specific version of a toolbox
@@ -13093,14 +12773,6 @@ paths:
           description: The version identifier to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13125,9 +12797,6 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
 security:
   - OAuth2Auth:
       - https://ai.azure.com/.default
@@ -13421,18 +13090,12 @@ components:
         propertyName: type
         mapping:
           ManagedAgentIdentityBlueprint: '#/components/schemas/ManagedAgentIdentityBlueprintReference'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentBlueprintReferenceType:
       anyOf:
         - type: string
         - type: string
           enum:
             - ManagedAgentIdentityBlueprint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCard:
       type: object
       required:
@@ -13455,9 +13118,6 @@ components:
           minItems: 1
           maxItems: 16
           description: The set of skills that an agent can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkill:
       type: object
       required:
@@ -13490,22 +13150,13 @@ components:
             $ref: '#/components/schemas/AgentCardSkillExample'
           maxItems: 5
           description: A list of example scenarios that the skill can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkillExample:
       type: string
       maxLength: 1024
       description: A skill example string with a maximum length of 1024 characters.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardSkillTag:
       type: string
       maxLength: 32
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentCardUpdate:
       type: object
       properties:
@@ -13525,9 +13176,6 @@ components:
           minItems: 1
           maxItems: 16
           description: The set of skills that an agent can perform.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentClusterInsightRequest:
       type: object
       required:
@@ -13748,17 +13396,12 @@ components:
           container_app: '#/components/schemas/ContainerAppAgentDefinition'
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     AgentDefinitionOptInKeys:
       type: string
       enum:
-        - HostedAgents=V1Preview
         - WorkflowAgents=V1Preview
-        - AgentEndpoints=V1Preview
-        - CodeAgents=V1Preview
         - ExternalAgents=V1Preview
         - ContainerAgents=V1Preview
       description: Feature opt-in keys for agent definition operations supporting hosted or workflow agents.
@@ -13775,9 +13418,6 @@ components:
           Entra: '#/components/schemas/EntraAuthorizationScheme'
           BotService: '#/components/schemas/BotServiceAuthorizationScheme'
           BotServiceRbac: '#/components/schemas/BotServiceRbacAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointAuthorizationSchemeType:
       anyOf:
         - type: string
@@ -13786,9 +13426,6 @@ components:
             - Entra
             - BotService
             - BotServiceRbac
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointConfig:
       type: object
       properties:
@@ -13806,9 +13443,6 @@ components:
           items:
             $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
           description: The authorization schemes supported by the agent endpoint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointConfigUpdate:
       type: object
       properties:
@@ -13826,9 +13460,6 @@ components:
           items:
             $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
           description: The authorization schemes supported by the agent endpoint
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentEndpointProtocol:
       anyOf:
         - type: string
@@ -14074,9 +13705,6 @@ components:
         client_id:
           type: string
           description: The client ID of the agent instance. Also referred to as the instance ID
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentKind:
       anyOf:
         - type: string
@@ -14119,39 +13747,23 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
           description: The endpoint configuration for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         instance_identity:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The instance identity of the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         agent_card:
-          allOf:
-            - $ref: '#/components/schemas/AgentCard'
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
+          $ref: '#/components/schemas/AgentCard'
     AgentProtocol:
       anyOf:
         - type: string
@@ -14217,9 +13829,6 @@ components:
           description: The Unix timestamp (in seconds) when the session expires (rolling, 30 days from last activity).
           readOnly: true
       description: An agent session providing a long-lived compute sandbox for hosted agent invocations.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentSessionStatus:
       anyOf:
         - type: string
@@ -14234,9 +13843,6 @@ components:
             - deleted
             - expired
       description: The status of an agent session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     AgentTaxonomyInput:
       type: object
       required:
@@ -14343,32 +13949,20 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The instance identity of the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint:
           allOf:
             - $ref: '#/components/schemas/AgentIdentity'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
         agent_guid:
           type: string
           description: The unique GUID identifier of the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
           readOnly: true
     AgentVersionStatus:
       type: string
@@ -15608,9 +15202,6 @@ components:
             - BotService
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     BotServiceRbacAuthorizationScheme:
       type: object
       required:
@@ -15622,9 +15213,6 @@ components:
             - BotServiceRbac
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     BrowserAutomationPreviewTool:
       type: object
       required:
@@ -15916,9 +15504,6 @@ components:
           description: The SHA-256 hex digest of the uploaded code zip. Set by the service from the `x-ms-code-zip-sha256` request header; read-only in responses and never accepted in request payloads.
           readOnly: true
       description: Code-based deployment configuration for a hosted agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     CodeDependencyResolution:
       anyOf:
         - type: string
@@ -16055,9 +15640,6 @@ components:
           examples:
             - my-registry.azurecr.io/my-hosted-agent:latest
       description: Container-based deployment configuration for a hosted agent.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     ContainerDetails:
       type: object
       required:
@@ -16336,36 +15918,23 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         agent_endpoint:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
           description: An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
         agent_card:
           allOf:
             - $ref: '#/components/schemas/AgentCard'
           description: Optional agent card for the agent
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     CreateAgentSessionRequest:
       type: object
@@ -16380,9 +15949,6 @@ components:
             - $ref: '#/components/schemas/VersionIndicator'
           description: Determines which agent version backs the session.
       description: Request to create a new agent session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     CreateAgentVersionFromCodeContent:
       type: object
       properties:
@@ -16425,9 +15991,6 @@ components:
         The agent name comes from the URL path parameter or the `x-ms-agent-name` header,
         so it is not included in this model.
         The content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.
-      x-ms-foundry-meta:
-        required_previews:
-          - CodeAgents=V1Preview
     CreateAgentVersionFromManifestRequest:
       type: object
       required:
@@ -16484,22 +16047,15 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
       x-ms-foundry-meta:
         conditional_previews:
-          - HostedAgents=V1Preview
           - WorkflowAgents=V1Preview
-          - CodeAgents=V1Preview
           - ExternalAgents=V1Preview
     CreateEvalRequest:
       type: object
@@ -16587,9 +16143,6 @@ components:
             - Must start and end with alphanumeric characters,
             - Can contain hyphens in the middle
             - Must not exceed 63 characters.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     CreateSkillVersionFromFilesBody:
       type: object
       properties:
@@ -17440,9 +16993,6 @@ components:
           description: The source from which the per-user isolation key is derived for requests authorized via this scheme. Defaults to Entra-based isolation when omitted.
       allOf:
         - $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     EntraIDCredentials:
       type: object
       required:
@@ -17468,9 +17018,6 @@ components:
             - Entra
       allOf:
         - $ref: '#/components/schemas/IsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     Eval:
       type: object
       required:
@@ -19763,9 +19310,6 @@ components:
           description: The percentage of traffic to route to the version. Must be between 0 and 100.
       allOf:
         - $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     FolderDatasetVersion:
       type: object
       required:
@@ -19922,9 +19466,6 @@ components:
             - Header
       allOf:
         - $ref: '#/components/schemas/IsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     HeaderTelemetryEndpointAuth:
       type: object
       required:
@@ -19956,9 +19497,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpointAuth'
       description: Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     HostedAgentDefinition:
       type: object
       required:
@@ -19999,9 +19537,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'
           description: Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         protocol_versions:
           type: array
           items:
@@ -20012,16 +19547,10 @@ components:
                 version: v0.1.1
               - protocol: a2a
                 version: v0.3.0
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         code_configuration:
           allOf:
             - $ref: '#/components/schemas/CodeConfiguration'
           description: Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.
-          x-ms-foundry-meta:
-            required_previews:
-              - CodeAgents=V1Preview
         telemetry_config:
           allOf:
             - $ref: '#/components/schemas/TelemetryConfig'
@@ -20029,9 +19558,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The hosted agent definition.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     HourlyRecurrenceSchedule:
       type: object
       required:
@@ -20493,9 +20019,6 @@ components:
         mapping:
           Entra: '#/components/schemas/EntraIsolationKeySource'
           Header: '#/components/schemas/HeaderIsolationKeySource'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     IsolationKeySourceKind:
       anyOf:
         - type: string
@@ -20503,9 +20026,6 @@ components:
           enum:
             - Entra
             - Header
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     ItemGenerationParams:
       type: object
       required:
@@ -20592,9 +20112,6 @@ components:
           description: The ID of the managed blueprint
       allOf:
         - $ref: '#/components/schemas/AgentBlueprintReference'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     ManagedAzureAISearchIndex:
       type: object
       required:
@@ -38672,9 +38189,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     PageOrder:
       type: string
       enum:
@@ -38916,9 +38430,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentCardUpdate'
           description: Optional agent card for the agent
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     PendingUploadRequest:
       type: object
       required:
@@ -40035,9 +39546,6 @@ components:
         event: log
         data: {"timestamp":"2026-03-10T09:34:52.714Z","stream":"status","message":"Successfully connected to container"}
         ```
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     SessionLogEventType:
       anyOf:
         - type: string
@@ -40047,9 +39555,6 @@ components:
       description: |-
         Known SSE event types emitted by the hosted agent session log stream.
         Additional event types may be introduced in future versions.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     SharepointGroundingToolCall:
       type: object
       required:
@@ -40581,9 +40086,6 @@ components:
           maxItems: 3
           description: Customer-supplied telemetry export endpoint configurations.
       description: Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryDataKind:
       anyOf:
         - type: string
@@ -40593,9 +40095,6 @@ components:
             - ContainerOtel
             - Metrics
       description: The type of telemetry data to export.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpoint:
       type: object
       required:
@@ -40624,9 +40123,6 @@ components:
         mapping:
           OTLP: '#/components/schemas/OtlpTelemetryEndpoint'
       description: A telemetry export endpoint configuration.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointAuth:
       type: object
       required:
@@ -40641,9 +40137,6 @@ components:
         mapping:
           header: '#/components/schemas/HeaderTelemetryEndpointAuth'
       description: Authentication configuration for a telemetry endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointAuthType:
       anyOf:
         - type: string
@@ -40651,9 +40144,6 @@ components:
           enum:
             - header
       description: The type of authentication for a telemetry endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryEndpointKind:
       anyOf:
         - type: string
@@ -40661,9 +40151,6 @@ components:
           enum:
             - OTLP
       description: The kind of telemetry export endpoint.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TelemetryTransportProtocol:
       anyOf:
         - type: string
@@ -40672,9 +40159,6 @@ components:
             - Http
             - Grpc
       description: The transport protocol for telemetry export.
-      x-ms-foundry-meta:
-        required_previews:
-          - HostedAgents=V1Preview
     TestingCriterionAzureAIEvaluator:
       type: object
       required:
@@ -41238,17 +40722,12 @@ components:
           description: The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
           x-ms-foundry-meta:
             conditional_previews:
-              - HostedAgents=V1Preview
               - WorkflowAgents=V1Preview
-              - CodeAgents=V1Preview
               - ExternalAgents=V1Preview
         blueprint_reference:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
-          x-ms-foundry-meta:
-            required_previews:
-              - AgentEndpoints=V1Preview
     UpdateEvalParametersBody:
       type: object
       properties:
@@ -41332,9 +40811,6 @@ components:
         mapping:
           version_ref: '#/components/schemas/VersionRefIndicator'
       description: Version indicator determining which agent version backs the session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionIndicatorType:
       anyOf:
         - type: string
@@ -41342,9 +40818,6 @@ components:
           enum:
             - version_ref
       description: The type of version indicator used to determine the agent version backing a session.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionRefIndicator:
       type: object
       required:
@@ -41362,9 +40835,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/VersionIndicator'
       description: Version indicator that references a specific agent version by name.
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectionRule:
       type: object
       required:
@@ -41380,9 +40850,6 @@ components:
         propertyName: type
         mapping:
           FixedRatio: '#/components/schemas/FixedRatioVersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelector:
       type: object
       required:
@@ -41392,18 +40859,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectorType:
       anyOf:
         - type: string
         - type: string
           enum:
             - FixedRatio
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     VersionSelectorUpdate:
       type: object
       properties:
@@ -41411,9 +40872,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VersionSelectionRule'
-      x-ms-foundry-meta:
-        required_previews:
-          - AgentEndpoints=V1Preview
     WebSearchConfiguration:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations/routes.tsp
@@ -6,12 +6,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-alias AgentInvocationPreviewHeader = WithRequiredFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
-
-const AgentInvocationRequiredPreviews = #{
-  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
-};
-
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations")
 interface AgentInvocations {
@@ -22,12 +16,11 @@ interface AgentInvocations {
   @summary("Get an agent invocation OpenAPI spec")
   @get
   @route("/agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   getAgentInvocationOpenApiSpec is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       @header contentType: "application/json";
       @body spec: Record<unknown>;
@@ -40,7 +33,6 @@ interface AgentInvocations {
   @summary("Create an agent invocation")
   @post
   @route("/agents/{agent_name}/endpoint/protocols/invocations")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   createAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -56,7 +48,7 @@ interface AgentInvocations {
       @body request: unknown;
 
       ...UserIsolationKeyHeader;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Unique identifier for this invocation. */
       @header("x-agent-invocation-id") invocationId: string;
@@ -79,7 +71,6 @@ interface AgentInvocations {
   @summary("Get an agent invocation")
   @get
   @route("/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   getAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -89,7 +80,7 @@ interface AgentInvocations {
       @path invocation_id: string;
 
       ...UserIsolationKeyHeader;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */
       @header("x-agent-session-id") agentSessionId: string;
@@ -109,7 +100,6 @@ interface AgentInvocations {
   @summary("Cancel an agent invocation")
   @post
   @route("/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel")
-  @extension("x-ms-foundry-meta", AgentInvocationRequiredPreviews)
   cancelAgentInvocation is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
@@ -125,7 +115,7 @@ interface AgentInvocations {
       @body request?: unknown;
 
       ...UserIsolationKeyHeader;
-    } & AgentInvocationPreviewHeader,
+    },
     {
       /** Session ID for this invocation. Returns the session ID associated with the invocation. */
       @header("x-agent-session-id") agentSessionId: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -1,10 +1,16 @@
-import "../common/models.tsp";
+import "../common/models.tsp";  
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
+
+alias AgentWebsocketPreviewHeader = WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
+
+const AgentWebsocketRequiredPreviews = #{
+  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
+};
 
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations WebSocket")
@@ -21,6 +27,7 @@ interface AgentWebsocket {
   @summary("Establish a WebSocket connection to a hosted agent")
   @get
   @route("/agents/endpoint/protocols/invocations_ws")
+  @extension("x-ms-foundry-meta", AgentWebsocketRequiredPreviews)
   connectEndpointWebsocket is FoundryDataPlaneOperation<
     {
       /** The name of the project. */
@@ -32,8 +39,14 @@ interface AgentWebsocket {
       /** Optional session/conversation ID. Pass the same value on a subsequent connection to reattach to an existing session. If not provided, the service auto-generates one. */
       @query agent_session_id?: string;
 
+      /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
+      @query(#{ explode: false, name: "foundry_features" })
+      foundry_features_query?: AgentDefinitionOptInKeys[] = #[
+        AgentDefinitionOptInKeys.hosted_agents_v1_preview
+      ];
+
       ...UserIsolationKeyHeader;
-    },
+    } & AgentWebsocketPreviewHeader,
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */
       @header("x-agent-session-id") sessionId: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -1,4 +1,4 @@
-import "../common/models.tsp";  
+import "../common/models.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-invocations_ws/routes.tsp
@@ -6,12 +6,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-alias AgentWebsocketPreviewHeader = WithConditionalFoundryPreviewHeader<AgentDefinitionOptInKeys.hosted_agents_v1_preview>;
-
-const AgentWebsocketRequiredPreviews = #{
-  required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview],
-};
-
 #suppress "@azure-tools/typespec-azure-core/use-standard-operations" ""
 @tag("Agent Invocations WebSocket")
 @removed(Versions.v1)
@@ -27,7 +21,6 @@ interface AgentWebsocket {
   @summary("Establish a WebSocket connection to a hosted agent")
   @get
   @route("/agents/endpoint/protocols/invocations_ws")
-  @extension("x-ms-foundry-meta", AgentWebsocketRequiredPreviews)
   connectEndpointWebsocket is FoundryDataPlaneOperation<
     {
       /** The name of the project. */
@@ -39,14 +32,8 @@ interface AgentWebsocket {
       /** Optional session/conversation ID. Pass the same value on a subsequent connection to reattach to an existing session. If not provided, the service auto-generates one. */
       @query agent_session_id?: string;
 
-      /** Preview feature flag, accepted as an alternative to the `Foundry-Features` header for browser clients that cannot set custom headers. Either this query parameter or the header must be supplied with the value `HostedAgents=V1Preview`. */
-      @query(#{ explode: false, name: "foundry_features" })
-      foundry_features_query?: AgentDefinitionOptInKeys[] = #[
-        AgentDefinitionOptInKeys.hosted_agents_v1_preview
-      ];
-
       ...UserIsolationKeyHeader;
-    } & AgentWebsocketPreviewHeader,
+    },
     {
       /** Session ID for this WebSocket connection. Returns the provided session ID or an auto-generated one if not provided in the request. */
       @header("x-agent-session-id") sessionId: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -29,12 +29,7 @@ interface AgentSessionFiles {
   @summary("Upload a session file")
   @put
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  uploadSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  uploadSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -61,12 +56,7 @@ interface AgentSessionFiles {
   @summary("Download a session file")
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  downloadSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  downloadSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -90,12 +80,7 @@ interface AgentSessionFiles {
   @get
   @list
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  listSessionFiles is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  listSessionFiles is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -119,12 +104,7 @@ interface AgentSessionFiles {
   @summary("Delete a session file")
   @delete
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
-  deleteSessionFile is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  deleteSessionFile is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -9,9 +9,7 @@ namespace Azure.AI.Projects;
 
 const AllConditionalAgentDefinitionPreviews = #{
   conditional_previews: #[
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
     AgentDefinitionOptInKeys.workflow_agents_v1_preview,
-    AgentDefinitionOptInKeys.code_agents_v1_preview,
     AgentDefinitionOptInKeys.external_agents_v1_preview
   ],
 };
@@ -28,12 +26,6 @@ model CreateAgentVersionRequest {
   @extension("x-ms-foundry-meta", AllConditionalAgentDefinitionPreviews)
   definition: AgentDefinition;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint reference for the agent.")
   blueprint_reference?: AgentBlueprintReference;
 }
@@ -82,21 +74,9 @@ model CreateAgentRequest {
 
   ...CreateAgentVersionRequest;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("An optional endpoint configuration. If not specified, a default endpoint configuration will be set for the agent")
   agent_endpoint?: AgentEndpointConfig;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("Optional agent card for the agent")
   agent_card?: AgentCard;
 }
@@ -105,10 +85,6 @@ model UpdateAgentRequest {
   ...CreateAgentVersionRequest;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model PatchAgentRequest {
   @doc("The endpoint configuration for the agent")
   agent_endpoint?: AgentEndpointConfig;
@@ -141,51 +117,21 @@ model AgentObject {
     latest: AgentVersionObject;
   };
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The endpoint configuration for the agent")
   agent_endpoint?: AgentEndpointConfig;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The instance identity of the agent")
   @visibility(Lifecycle.Read)
   instance_identity?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint_reference?: AgentBlueprintReference;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   agent_card?: AgentCard;
 }
 
@@ -221,42 +167,18 @@ model AgentVersionObject {
   @doc("Error details if the agent version provisioning failed.")
   error?: ApiError;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The instance identity of the agent")
   @visibility(Lifecycle.Read)
   instance_identity?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint?: AgentIdentity;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The blueprint for the agent")
   @visibility(Lifecycle.Read)
   blueprint_reference?: AgentBlueprintReference;
 
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @doc("The unique GUID identifier of the agent.")
   @visibility(Lifecycle.Read)
   agent_guid?: string;
@@ -403,10 +325,6 @@ model WorkflowAgentDefinition extends AgentDefinition {
 }
 
 @doc("Container-based deployment configuration for a hosted agent.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model ContainerConfiguration {
   @doc("The container image for the hosted agent.")
   @example("my-registry.azurecr.io/my-hosted-agent:latest")
@@ -414,10 +332,6 @@ model ContainerConfiguration {
 }
 
 @doc("Code-based deployment configuration for a hosted agent.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model CodeConfiguration {
   @doc("The runtime identifier for code execution (e.g., 'python_3_11', 'python_3_12', 'python_3_13').")
   runtime: string;
@@ -472,10 +386,6 @@ model ExternalAgentDefinition extends AgentDefinition {
 }
 
 @doc("The hosted agent definition.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model HostedAgentDefinition extends AgentDefinition {
   kind: AgentKind.hosted;
 
@@ -502,17 +412,9 @@ model HostedAgentDefinition extends AgentDefinition {
   environment_variables?: Record<string>;
 
   @doc("Container-based deployment configuration. Provide this for image-based deployments. Mutually exclusive with code_configuration — the service validates that exactly one is set.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   container_configuration?: ContainerConfiguration;
 
   @doc("The protocols that the agent supports for ingress communication.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   @example(#[
     #{ protocol: "responses", version: "v0.1.1" },
     #{ protocol: "a2a", version: "v0.3.0" }
@@ -520,10 +422,6 @@ model HostedAgentDefinition extends AgentDefinition {
   protocol_versions?: ProtocolVersionRecord[];
 
   @doc("Code-based deployment configuration. Provide this for code-based deployments. Mutually exclusive with container_configuration — the service validates that exactly one is set.")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   code_configuration?: CodeConfiguration;
 
   @doc("Optional customer-supplied telemetry configuration for exporting container logs, traces, and metrics.")
@@ -640,27 +538,15 @@ union ContainerLogKind {
   system: "system",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union VersionSelectorType {
   string,
   FixedRatio: "FixedRatio",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model VersionSelector {
   version_selection_rules: VersionSelectionRule[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model VersionSelectionRule {
   type: VersionSelectorType;
@@ -669,10 +555,6 @@ model VersionSelectionRule {
   agent_version: string;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model FixedRatioVersionSelectionRule extends VersionSelectionRule {
   type: VersionSelectorType.FixedRatio;
 
@@ -682,19 +564,11 @@ model FixedRatioVersionSelectionRule extends VersionSelectionRule {
   traffic_percentage: int32;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model EntraAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.Entra;
 
@@ -702,52 +576,28 @@ model EntraAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   isolation_key_source?: IsolationKeySource;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model BotServiceAuthorizationScheme extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.BotService;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model BotServiceRbacAuthorizationScheme
   extends AgentEndpointAuthorizationScheme {
   type: AgentEndpointAuthorizationSchemeType.BotServiceRbac;
 }
 
 @discriminator("kind")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model IsolationKeySource {
   kind: IsolationKeySourceKind;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model EntraIsolationKeySource extends IsolationKeySource {
   kind: IsolationKeySourceKind.Entra;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model HeaderIsolationKeySource extends IsolationKeySource {
   kind: IsolationKeySourceKind.Header;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentEndpointAuthorizationSchemeType {
   string,
   Entra: "Entra",
@@ -755,20 +605,12 @@ union AgentEndpointAuthorizationSchemeType {
   BotServiceRbac: "BotServiceRbac",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union IsolationKeySourceKind {
   string,
   Entra: "Entra",
   Header: "Header",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentEndpointConfig {
   @doc("The version selector of the agent endpoint determines how traffic is routed to different versions of the agent.")
   version_selector?: VersionSelector;
@@ -780,10 +622,6 @@ model AgentEndpointConfig {
   authorization_schemes?: AgentEndpointAuthorizationScheme[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentIdentity {
   @doc("The principal ID of the agent instance")
   principal_id: string;
@@ -792,28 +630,16 @@ model AgentIdentity {
   client_id: string;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentBlueprintReferenceType {
   string,
   ManagedAgentIdentityBlueprint: "ManagedAgentIdentityBlueprint",
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model AgentBlueprintReference {
   type: AgentBlueprintReferenceType;
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model ManagedAgentIdentityBlueprintReference extends AgentBlueprintReference {
   type: AgentBlueprintReferenceType.ManagedAgentIdentityBlueprint;
 
@@ -822,24 +648,12 @@ model ManagedAgentIdentityBlueprintReference extends AgentBlueprintReference {
 }
 
 /** A skill example string with a maximum length of 1024 characters. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @maxLength(1024)
 scalar AgentCardSkillExample extends string;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @maxLength(32)
 scalar AgentCardSkillTag extends string;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentCardSkill {
   @doc("a unique identifier for the skill")
   @maxLength(64)
@@ -864,10 +678,6 @@ model AgentCardSkill {
   examples?: AgentCardSkillExample[];
 }
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentCard {
   @doc("The version of the agent card.")
   @maxLength(32)
@@ -890,10 +700,6 @@ model AgentCard {
  * so it is not included in this model.
  * The content hash (SHA-256 of the zip) is carried in the `x-ms-code-zip-sha256` header.
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model CreateAgentVersionFromCodeMetadata {
   @doc("A human-readable description of the agent.")
   @maxLength(512)
@@ -906,10 +712,6 @@ model CreateAgentVersionFromCodeMetadata {
 }
 
 /** Multipart request body for updating or versioning a code-based agent (POST /agents/{name} and POST /agents/{name}/versions). */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model CreateAgentVersionFromCodeContent {
   /** JSON metadata including description and hosted definition. */
   metadata: HttpPart<CreateAgentVersionFromCodeMetadata>;
@@ -919,10 +721,6 @@ model CreateAgentVersionFromCodeContent {
 }
 
 /** Multipart request body for creating a new code-based agent (POST /agents). Inherits from CreateAgentVersionFromCodeContent for future extensibility. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model CreateAgentFromCodeContent {
   ...CreateAgentVersionFromCodeContent;
 }
@@ -933,10 +731,6 @@ model CreateAgentFromCodeContent {
  * can route to a zip-aware handler. Streaming is preserved (`bytes` body) regardless
  * of the content-type label.
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-)
 model DownloadAgentCodeResponse {
   @doc("The media type of the returned package content.")
   @header("Content-Type")
@@ -958,10 +752,6 @@ model DownloadAgentCodeResponse {
 // ── Session Status ──────────────────────────────────────
 
 /** The status of an agent session. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union AgentSessionStatus {
   string,
 
@@ -993,10 +783,6 @@ union AgentSessionStatus {
 // ── Version Indicator ───────────────────────────────────
 
 /** The type of version indicator used to determine the agent version backing a session. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 union VersionIndicatorType {
   string,
 
@@ -1006,10 +792,6 @@ union VersionIndicatorType {
 
 /** Base class for version indicators. Uses type discriminator for polymorphism. */
 @doc("Version indicator determining which agent version backs the session.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 @discriminator("type")
 model VersionIndicator {
   /** The type of version indicator. */
@@ -1017,10 +799,6 @@ model VersionIndicator {
 }
 
 /** Version indicator that references a specific agent version by name. */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model VersionRefIndicator extends VersionIndicator {
   /** Discriminator value for version_ref. */
   type: VersionIndicatorType.VersionRef;
@@ -1033,10 +811,6 @@ model VersionRefIndicator extends VersionIndicator {
 
 /** Represents an agent session resource. */
 @doc("An agent session providing a long-lived compute sandbox for hosted agent invocations.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model AgentSessionResource {
   /** The session identifier. */
   agent_session_id: string;
@@ -1067,10 +841,6 @@ model AgentSessionResource {
 
 /** Request body for creating a new agent session. */
 @doc("Request to create a new agent session.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model CreateAgentSessionRequest {
   /** Optional caller-provided session ID. If specified, it must be unique within the agent endpoint. Auto-generated if omitted. */
   agent_session_id?: string;
@@ -1083,10 +853,6 @@ model CreateAgentSessionRequest {
  * Known SSE event types emitted by the hosted agent session log stream.
  * Additional event types may be introduced in future versions.
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union SessionLogEventType {
   string,
 
@@ -1115,10 +881,6 @@ union SessionLogEventType {
  * data: {"timestamp":"2026-03-10T09:34:52.714Z","stream":"status","message":"Successfully connected to container"}
  * ```
  */
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model SessionLogEvent {
   @doc("The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.")
   @example("log")
@@ -1131,10 +893,6 @@ model SessionLogEvent {
 // ── Telemetry Unions ────────────────────────────────────
 
 @doc("The kind of telemetry export endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryEndpointKind {
   string,
 
@@ -1143,10 +901,6 @@ union TelemetryEndpointKind {
 }
 
 @doc("The type of telemetry data to export.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryDataKind {
   string,
 
@@ -1161,10 +915,6 @@ union TelemetryDataKind {
 }
 
 @doc("The transport protocol for telemetry export.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryTransportProtocol {
   string,
 
@@ -1178,10 +928,6 @@ union TelemetryTransportProtocol {
 // ── Telemetry Auth (discriminated by "type") ────────────
 
 @doc("The type of authentication for a telemetry endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 union TelemetryEndpointAuthType {
   string,
 
@@ -1191,20 +937,12 @@ union TelemetryEndpointAuthType {
 
 @doc("Authentication configuration for a telemetry endpoint.")
 @discriminator("type")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryEndpointAuth {
   @doc("The authentication type.")
   type: TelemetryEndpointAuthType;
 }
 
 @doc("Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model HeaderTelemetryEndpointAuth extends TelemetryEndpointAuth {
   @doc("The authentication type, always 'header' for header-based secret authentication.")
   type: TelemetryEndpointAuthType.header;
@@ -1225,10 +963,6 @@ model HeaderTelemetryEndpointAuth extends TelemetryEndpointAuth {
 // ── Telemetry Config & Endpoint (discriminated by "kind") ─
 
 @doc("Customer-supplied telemetry configuration for exporting container logs, traces, and metrics.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryConfig {
   @doc("Customer-supplied telemetry export endpoint configurations.")
   @minItems(1)
@@ -1238,10 +972,6 @@ model TelemetryConfig {
 
 @doc("A telemetry export endpoint configuration.")
 @discriminator("kind")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model TelemetryEndpoint {
   @doc("The telemetry export endpoint kind.")
   kind: TelemetryEndpointKind;
@@ -1255,10 +985,6 @@ model TelemetryEndpoint {
 }
 
 @doc("An OTLP (OpenTelemetry Protocol) telemetry export endpoint.")
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-)
 model OtlpTelemetryEndpoint extends TelemetryEndpoint {
   @doc("The endpoint kind, always 'OTLP' for OpenTelemetry Protocol endpoints.")
   kind: TelemetryEndpointKind.OTLP;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -56,13 +56,8 @@ interface Agents {
   @post
   @route("/agents")
   @sharedRoute
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   @tag("Agents")
-  createAgentFromCode is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys,
+  createAgentFromCode is FoundryDataPlaneOperation<
     {
       @header contentType: "multipart/form-data";
 
@@ -116,13 +111,8 @@ interface Agents {
   @post
   @route("/agents/{agent_name}")
   @sharedRoute
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   @tag("Agents")
-  updateAgentFromCode is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys,
+  updateAgentFromCode is FoundryDataPlaneOperation<
     {
       /**
        * The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
@@ -331,15 +321,8 @@ interface Agents {
   @summary("Update an agent endpoint")
   @patch(#{ implicitOptionality: true })
   @route("/agents/{agent_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agents")
-  patchAgentObject is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  patchAgentObject is FoundryDataPlaneOperation<
     {
       /** The name of the agent to retrieve. */
       @summary("The name of the agent to retrieve")
@@ -364,13 +347,8 @@ interface Agents {
   @post
   @route("/agents/{agent_name}/versions")
   @sharedRoute
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   @tag("Agent Versions")
-  createAgentVersionFromCode is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys,
+  createAgentVersionFromCode is FoundryDataPlaneOperation<
     {
       /**
        * The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
@@ -406,13 +384,8 @@ interface Agents {
   @summary("Download agent code")
   @get
   @route("/agents/{agent_name}/code:download")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.code_agents_v1_preview] }
-  )
   @tag("Agents")
-  downloadAgentCode is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.code_agents_v1_preview,
+  downloadAgentCode is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -436,15 +409,8 @@ interface Agents {
   @summary("Create a session")
   @post
   @route("/agents/{agent_name}/endpoint/sessions")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agent Sessions")
-  createSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  createSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent to create a session for. */
       @path agent_name: string;
@@ -461,15 +427,8 @@ interface Agents {
   @summary("Get a session")
   @get
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agent Sessions")
-  getSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  getSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -489,15 +448,8 @@ interface Agents {
   @summary("Delete a session")
   @delete
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agent Sessions")
-  deleteSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  deleteSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -516,15 +468,8 @@ interface Agents {
   @summary("Stop a session")
   @post
   @route("/agents/{agent_name}/endpoint/sessions/{session_id}:stop")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agent Sessions")
-  stopSession is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  stopSession is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -542,15 +487,8 @@ interface Agents {
   @get
   @route("/agents/{agent_name}/endpoint/sessions")
   @list
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
   @tag("Agent Sessions")
-  listSessions is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  listSessions is FoundryDataPlaneOperation<
     {
       /** The name of the agent. */
       @path agent_name: string;
@@ -592,13 +530,8 @@ interface Agents {
   @summary("Stream console logs for a hosted agent session")
   @get
   @route("/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream")
-  @extension(
-    "x-ms-foundry-meta",
-    #{ required_previews: #[AgentDefinitionOptInKeys.hosted_agents_v1_preview] }
-  )
   @tag("Agent Sessions")
-  getSessionLogStream is FoundryDataPlanePreviewOperation<
-    AgentDefinitionOptInKeys.hosted_agents_v1_preview,
+  getSessionLogStream is FoundryDataPlaneOperation<
     {
       /** The name of the hosted agent. */
       @path agent_name: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -87,7 +87,8 @@ op FoundryDataPlaneOperation<
 union AgentDefinitionOptInKeys {
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
-
+  @removed(Versions.v1)
+  hosted_agents_v1_preview: "HostedAgents=V1Preview",
   @removed(Versions.v1)
   container_agents_v1_preview: "ContainerAgents=V1Preview",
 }

--- a/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/servicepatterns.tsp
@@ -85,10 +85,7 @@ op FoundryDataPlaneOperation<
 
 /** Feature opt-in keys for agent definition operations supporting hosted or workflow agents. */
 union AgentDefinitionOptInKeys {
-  hosted_agents_v1_preview: "HostedAgents=V1Preview",
   workflow_agents_v1_preview: "WorkflowAgents=V1Preview",
-  agent_endpoint_v1_preview: "AgentEndpoints=V1Preview",
-  code_agents_v1_preview: "CodeAgents=V1Preview",
   external_agents_v1_preview: "ExternalAgents=V1Preview",
 
   @removed(Versions.v1)
@@ -102,7 +99,6 @@ union FoundryFeaturesOptInKeys {
   insights_v1_preview: "Insights=V1Preview",
   memory_stores_v1_preview: "MemoryStores=V1Preview",
   routines_v1_preview: "Routines=V1Preview",
-  toolboxes_v1_preview: "Toolboxes=V1Preview",
   skills_v1_preview: "Skills=V1Preview",
   data_generation_jobs_v1_preview: "DataGenerationJobs=V1Preview",
   models_v1_preview: "Models=V1Preview",

--- a/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/models.tsp
@@ -8,10 +8,6 @@ using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
-@extension(
-  "x-ms-foundry-meta",
-  #{ required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview] }
-)
 model CreateOrUpdateManagedAgentIdentityBlueprintRequest {
   @doc("""
     The unique name that identifies the managed agent identity blueprint.

--- a/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/managed-blueprints/routes.tsp
@@ -17,14 +17,7 @@ interface ManagedAgentIdentityBlueprints {
   @summary("Create or update a blueprint")
   @put
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  createOrUpdateManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  createOrUpdateManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to create. */
       @path blueprint_name: string;
@@ -40,14 +33,7 @@ interface ManagedAgentIdentityBlueprints {
   @summary("Get a blueprint")
   @get
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  getManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  getManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to retrieve. */
       @path blueprint_name: string;
@@ -61,14 +47,7 @@ interface ManagedAgentIdentityBlueprints {
   @summary("Delete a blueprint")
   @delete
   @route("/managedAgentIdentityBlueprints/{blueprint_name}")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  deleteManagedAgentIdentityBlueprint is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  deleteManagedAgentIdentityBlueprint is FoundryDataPlaneOperation<
     {
       /** The name of the managed agent identity blueprint to delete. */
       @path blueprint_name: string;
@@ -82,14 +61,7 @@ interface ManagedAgentIdentityBlueprints {
   @summary("List blueprints")
   @get
   @route("/managedAgentIdentityBlueprints")
-  @extension(
-    "x-ms-foundry-meta",
-    #{
-      required_previews: #[AgentDefinitionOptInKeys.agent_endpoint_v1_preview],
-    }
-  )
-  listManagedAgentIdentityBlueprints is FoundryDataPlaneRequiredPreviewOperation<
-    AgentDefinitionOptInKeys.agent_endpoint_v1_preview,
+  listManagedAgentIdentityBlueprints is FoundryDataPlaneOperation<
     {
       ...PageOrderQueryParameter;
       ...PageLimitQueryParameter;

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-common/beta-ops-relocation-agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-common/beta-ops-relocation-agents.tsp
@@ -1,3 +1,6 @@
+// TODO: Rename this file to "relocate-operations.tsp" (or similar), as it now contains both 
+// GA and beta (preview) operations .
+
 // This file moves all beta operations (preview routes) from the Azure.AI.Projects namespace to
 // a new namespace Azure.AI.Projects.Beta, thus creating a sub-client ".beta" in the emitted SDKs.
 // It is imported by the client.tsp file, which is used for emitting the Python and JS clients.
@@ -5,7 +8,31 @@
 
 using Azure.ClientGenerator.Core;
 
-namespace Azure.AI.Projects.Beta;
+namespace Azure.AI.Projects {
+
+@@clientLocation(Azure.AI.Projects.AgentSessionFiles.uploadSessionFile, Agents);
+@@clientLocation(
+  Azure.AI.Projects.AgentSessionFiles.downloadSessionFile,
+  Agents
+);
+@@clientLocation(Azure.AI.Projects.AgentSessionFiles.listSessionFiles, Agents);
+@@clientLocation(Azure.AI.Projects.AgentSessionFiles.deleteSessionFile, Agents);
+
+@@clientLocation(Azure.AI.Projects.Agents.patchAgentObject, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.createSession, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.getSession, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.deleteSession, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.stopSession, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.listSessions, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.getSessionLogStream, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.createAgentFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.updateAgentFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.createAgentVersionFromCode, Agents);
+@@clientLocation(Azure.AI.Projects.Agents.downloadAgentCode, Agents);
+
+};
+
+namespace Azure.AI.Projects.Beta {
 
 interface MemoryStores {}
 @@clientLocation(
@@ -32,39 +59,12 @@ interface MemoryStores {}
 @@clientLocation(Azure.AI.Projects.MemoryStores.listMemories, MemoryStores);
 @@clientLocation(Azure.AI.Projects.MemoryStores.deleteMemory, MemoryStores);
 
-interface Toolboxes {}
-@@clientLocation(Azure.AI.Projects.Toolboxes.createToolboxVersion, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.updateToolbox, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.getToolbox, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.listToolboxes, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.listToolboxVersions, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.getToolboxVersion, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.deleteToolbox, Toolboxes);
-@@clientLocation(Azure.AI.Projects.Toolboxes.deleteToolboxVersion, Toolboxes);
 
 interface Agents {}
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.uploadSessionFile, Agents);
-@@clientLocation(
-  Azure.AI.Projects.AgentSessionFiles.downloadSessionFile,
-  Agents
-);
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.listSessionFiles, Agents);
-@@clientLocation(Azure.AI.Projects.AgentSessionFiles.deleteSessionFile, Agents);
-
-@@clientLocation(Azure.AI.Projects.Agents.patchAgentObject, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.createSession, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.getSession, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.deleteSession, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.stopSession, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.listSessions, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.getSessionLogStream, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.createAgentFromCode, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.updateAgentFromCode, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.createAgentVersionFromCode, Agents);
-@@clientLocation(Azure.AI.Projects.Agents.downloadAgentCode, Agents);
-
 @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.create, Agents);
 @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.get, Agents);
 @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.list, Agents);
 @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.cancel, Agents);
 @@clientLocation(Azure.AI.Projects.AgentOptimizationJobs.delete, Agents);
+
+};

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -7,10 +7,6 @@ using TypeSpec.Http;
 
 namespace Azure.AI.Projects;
 
-const ToolboxesRequiredPreviews = #{
-  conditional_previews: #[FoundryFeaturesOptInKeys.toolboxes_v1_preview],
-};
-
 @doc("Policy configuration for a toolbox, including content safety and other governance settings.")
 model ToolboxPolicies {
   @doc("Responsible AI content filtering configuration.")

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/routes.tsp
@@ -11,8 +11,6 @@ namespace Azure.AI.Projects;
 @@usage(UpdateToolboxRequest, Usage.input);
 @@access(UpdateToolboxRequest, Access.public);
 
-alias ToolboxesPreviewHeader = WithRequiredFoundryPreviewHeader<FoundryFeaturesOptInKeys.toolboxes_v1_preview>;
-
 @tag("Toolboxes")
 interface Toolboxes {
   /** Creates a new toolbox version, provisioning the toolbox itself if it does not already exist. */
@@ -21,9 +19,8 @@ interface Toolboxes {
   @operationId("createToolboxVersion")
   @post
   @route("/toolboxes/{name}/versions")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   createToolboxVersion is FoundryDataPlaneOperation<
-    CreateToolboxVersionRequest & ToolboxesPreviewHeader,
+    CreateToolboxVersionRequest,
     ToolboxVersionObject
   >;
 
@@ -33,9 +30,8 @@ interface Toolboxes {
   @operationId("getToolbox")
   @get
   @route("/toolboxes/{name}")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   getToolbox is FoundryDataPlaneOperation<
-    GetToolboxRequest & ToolboxesPreviewHeader,
+    GetToolboxRequest,
     ToolboxObject
   >;
 
@@ -46,9 +42,8 @@ interface Toolboxes {
   @get
   @list
   @route("/toolboxes")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   listToolboxes is FoundryDataPlaneOperation<
-    ListToolboxesRequest & ToolboxesPreviewHeader,
+    ListToolboxesRequest,
     AgentsPagedResult<ToolboxObject>
   >;
 
@@ -59,9 +54,8 @@ interface Toolboxes {
   @get
   @list
   @route("/toolboxes/{name}/versions")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   listToolboxVersions is FoundryDataPlaneOperation<
-    ListToolboxVersionsRequest & ToolboxesPreviewHeader,
+    ListToolboxVersionsRequest,
     AgentsPagedResult<ToolboxVersionObject>
   >;
 
@@ -71,9 +65,8 @@ interface Toolboxes {
   @operationId("getToolboxVersion")
   @get
   @route("/toolboxes/{name}/versions/{version}")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   getToolboxVersion is FoundryDataPlaneOperation<
-    GetToolboxVersionRequest & ToolboxesPreviewHeader,
+    GetToolboxVersionRequest,
     ToolboxVersionObject
   >;
 
@@ -83,9 +76,8 @@ interface Toolboxes {
   @operationId("updateToolbox")
   @patch
   @route("/toolboxes/{name}")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   updateToolbox is FoundryDataPlaneOperation<
-    UpdateToolboxRequest & ToolboxesPreviewHeader,
+    UpdateToolboxRequest,
     ToolboxObject
   >;
 
@@ -95,9 +87,8 @@ interface Toolboxes {
   @operationId("deleteToolbox")
   @delete
   @route("/toolboxes/{name}")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   deleteToolbox is FoundryDataPlaneOperation<
-    DeleteToolboxRequest & ToolboxesPreviewHeader,
+    DeleteToolboxRequest,
     void
   >;
 
@@ -107,9 +98,8 @@ interface Toolboxes {
   @operationId("deleteToolboxVersion")
   @delete
   @route("/toolboxes/{name}/versions/{version}")
-  @extension("x-ms-foundry-meta", ToolboxesRequiredPreviews)
   deleteToolboxVersion is FoundryDataPlaneOperation<
-    DeleteToolboxVersionRequest & ToolboxesPreviewHeader,
+    DeleteToolboxVersionRequest,
     void
   >;
 }


### PR DESCRIPTION
This PR removes the 3 flags

- `agent_endpoint_v1_preview: "AgentEndpoints=V1Preview"`
- `code_agents_v1_preview: "CodeAgents=V1Preview"`
- `toolboxes_v1_preview: "Toolboxes=V1Preview"`

And adds `@removed(Versions.v1)` to this flag, since invocation websockets will continue to use it (and is not part of `v1`):

- `hosted_agents_v1_preview: "HostedAgents=V1Preview"`
