### PR TITLE
Foundry data-plane: add draft flag to Agent versions

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -2728,6 +2728,17 @@
             "explode": false
           },
           {
+            "name": "include_drafts",
+            "in": "query",
+            "required": false,
+            "description": "(Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -17852,6 +17863,11 @@
           "definition": {
             "$ref": "#/components/schemas/AgentDefinition"
           },
+          "draft": {
+            "type": "boolean",
+            "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
+            "default": false
+          },
           "status": {
             "allOf": [
               {
@@ -20635,6 +20651,11 @@
             ],
             "description": "The blueprint reference for the agent."
           },
+          "draft": {
+            "type": "boolean",
+            "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "default": false
+          },
           "agent_endpoint": {
             "allOf": [
               {
@@ -20801,6 +20822,11 @@
               }
             ],
             "description": "The blueprint reference for the agent."
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "default": false
           }
         },
         "x-ms-foundry-meta": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -1863,6 +1863,14 @@ paths:
           schema:
             type: string
           explode: false
+        - name: include_drafts
+          in: query
+          required: false
+          description: (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).
+          schema:
+            type: boolean
+            default: false
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -11760,6 +11768,10 @@ components:
           description: The Unix timestamp (seconds) when the agent was created.
         definition:
           $ref: '#/components/schemas/AgentDefinition'
+        draft:
+          type: boolean
+          description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
+          default: false
         status:
           allOf:
             - $ref: '#/components/schemas/AgentVersionStatus'
@@ -13618,6 +13630,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
+        draft:
+          type: boolean
+          description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          default: false
         agent_endpoint:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
@@ -13747,6 +13763,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
+        draft:
+          type: boolean
+          description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -3092,6 +3092,17 @@
             "explode": false
           },
           {
+            "name": "include_drafts",
+            "in": "query",
+            "required": false,
+            "description": "(Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
+          },
+          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -21241,6 +21252,11 @@
           "definition": {
             "$ref": "#/components/schemas/AgentDefinition"
           },
+          "draft": {
+            "type": "boolean",
+            "description": "Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.",
+            "default": false
+          },
           "status": {
             "allOf": [
               {
@@ -24205,6 +24221,11 @@
             ],
             "description": "The blueprint reference for the agent."
           },
+          "draft": {
+            "type": "boolean",
+            "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "default": false
+          },
           "agent_endpoint": {
             "allOf": [
               {
@@ -24371,6 +24392,11 @@
               }
             ],
             "description": "The blueprint reference for the agent."
+          },
+          "draft": {
+            "type": "boolean",
+            "description": "(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.",
+            "default": false
           }
         },
         "x-ms-foundry-meta": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -2119,6 +2119,14 @@ paths:
           schema:
             type: string
           explode: false
+        - name: include_drafts
+          in: query
+          required: false
+          description: (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned).
+          schema:
+            type: boolean
+            default: false
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -14028,6 +14036,10 @@ components:
           description: The Unix timestamp (seconds) when the agent was created.
         definition:
           $ref: '#/components/schemas/AgentDefinition'
+        draft:
+          type: boolean
+          description: Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.
+          default: false
         status:
           allOf:
             - $ref: '#/components/schemas/AgentVersionStatus'
@@ -16008,6 +16020,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
+        draft:
+          type: boolean
+          description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          default: false
         agent_endpoint:
           allOf:
             - $ref: '#/components/schemas/AgentEndpointConfig'
@@ -16137,6 +16153,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentBlueprintReference'
           description: The blueprint reference for the agent.
+        draft:
+          type: boolean
+          description: (Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.
+          default: false
       x-ms-foundry-meta:
         conditional_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -28,6 +28,9 @@ model CreateAgentVersionRequest {
 
   @doc("The blueprint reference for the agent.")
   blueprint_reference?: AgentBlueprintReference;
+
+  @doc("(Preview) Whether this agent version is a draft (candidate) rather than a release. The service defaults to `false` if a value is not specified by the caller. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted.")
+  draft?: boolean = false;
 }
 
 model CreateAgentVersionFromManifestRequest {
@@ -85,7 +88,7 @@ model CreateAgentRequest {
 }
 
 model UpdateAgentRequest {
-  ...CreateAgentVersionRequest;
+  ...OmitProperties<CreateAgentVersionRequest, "draft">;
 }
 
 model PatchAgentRequest {
@@ -177,6 +180,9 @@ model AgentVersionObject {
   created_at: FoundryTimestamp;
 
   definition: AgentDefinition;
+
+  @doc("Whether this agent version is a draft (candidate) rather than a release. Draft versions are recorded but excluded from default 'latest' resolution and are not auto-promoted. Defaults to false.")
+  draft?: boolean = false;
 
   @doc("The provisioning status of the agent version. Defaults to 'active' for non-hosted agents. For hosted agents, reflects infrastructure readiness.")
   status?: AgentVersionStatus;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/routes.tsp
@@ -310,6 +310,9 @@ interface Agents {
       @path agent_name: string;
 
       ...CommonPageQueryParameters;
+
+      /** (Preview) Whether to include draft versions in the listing. The service defaults to `false` if a value is not specified by the caller (only non-draft versions are returned). */
+      @query include_drafts?: boolean = false;
     },
     AgentsPagedResult<AgentVersionObject>
   >;


### PR DESCRIPTION
## Summary

Adds an optional `draft: boolean` (default `false`) to the Foundry Agent
data-plane models so callers can mark a version as a draft/candidate
distinct from the version identifier itself.

## Models updated (`specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp`)

- `CreateAgentVersionRequest` — added `draft?: boolean = false`.
  Propagates automatically to `CreateAgentRequest` and `UpdateAgentRequest`
  via `...CreateAgentVersionRequest` spread.
- `AgentVersionObject` (response) — added `draft?: boolean = false`.

## Semantics

- Field is optional on both request and response; absent is equivalent to
  `false`.
- Set at version-creation time and immutable on a given version (each
  PATCH creates a new version, so customers re-state `draft` per call).
- Server semantics (separate service PRs): draft versions are recorded
  but excluded from default `latest` resolution and are not
  auto-promoted.

## Why a flag, not an identifier convention

This metadata flag is intentionally decoupled from the version-identifier
scheme (e.g. integer vs `major.minor` vs `draft-{timestamp}`). Callers
need a stable, explicit way to express "this is a candidate" without
overloading the identifier.

## Compatibility

Fully additive:
- No `required[]` changes.
- No removals, renames, or type changes.
- Both `v1` and `virtual-public-preview` swaggers updated by the
  emitter; diff is pure additions.

## Validation

- `npx tsp compile .` (from `data-plane/Foundry`) — compiles cleanly,
  no warnings.
- `npx tsp format` on the edited file — no formatting changes.
- Regenerated swaggers committed alongside the spec edit.

## Related

- Tracking design doc and downstream service implementation in the Vienna
  repo (internal): PR 2147685 (design), PR 2151464 (data-plane plumbing).