### PR TITLE
Add Python PyPI package validation for SDK PR checks

### DIFF
--- a/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/command-helpers.ts
@@ -272,6 +272,33 @@ export function logIssuesToPipeline(logPath: string, specConfigDisplayText: stri
 }
 
 /**
+ * Appends errors to an existing Azure DevOps pipeline log file.
+ * @param logPath - The vso log file path.
+ * @param key - The log entry key.
+ * @param errors - The errors to append.
+ */
+export function appendErrorsToVsoLog(logPath: string, key: string, errors: string[]): void {
+  if (errors.length === 0) {
+    return;
+  }
+
+  let logContent: Record<string, { errors?: string[]; warnings?: string[] }>;
+  try {
+    logContent = JSON.parse(fs.readFileSync(logPath, "utf8")) as Record<
+      string,
+      { errors?: string[]; warnings?: string[] }
+    >;
+  } catch (error) {
+    throw new Error(`Runner: error reading log at ${logPath}:${inspect(error)}`, { cause: error });
+  }
+
+  const logEntry = logContent[key] ?? {};
+  logEntry.errors = [...(logEntry.errors ?? []), ...errors];
+  logContent[key] = logEntry;
+  fs.writeFileSync(logPath, JSON.stringify(logContent, undefined, 2));
+}
+
+/**
  * Process the breaking change label artifacts.
  *
  * @param executionReport - The spec-gen-sdk execution report.

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -28,6 +28,7 @@ import {
 } from "./command-helpers.ts";
 import { checkEmitterEnabled, type EmitterCheckResult } from "./emitter-check.ts";
 import { LogLevel, logMessage, vsoAddAttachment, vsoLogIssue } from "./log.ts";
+import { validatePythonPackagesOnPyPI } from "./python-pypi-validation.ts";
 import { detectChangedSpecConfigFiles } from "./spec-helpers.ts";
 import { type CommandResult, type ExecutionReport, type SpecGenSdkCmdInput } from "./types.ts";
 import {
@@ -379,6 +380,15 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
 
       try {
         executionReport = getExecutionReport(commandInput);
+        if (commandInput.sdkLanguage === "azure-sdk-for-python") {
+          const pythonPackageValidationSucceeded = await validatePythonPackagesOnPyPI(
+            executionReport.packages,
+          );
+          if (!pythonPackageValidationSucceeded) {
+            statusCode = 1;
+            executionReport.executionResult = "failed";
+          }
+        }
       } catch (error) {
         logMessage(`Runner: error reading execution-report.json:${inspect(error)}`, LogLevel.Error);
         statusCode = 1;

--- a/eng/tools/spec-gen-sdk-runner/src/commands.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/commands.ts
@@ -10,6 +10,7 @@ import {
   parseAzsdkResponse,
 } from "./azsdk-adapter.ts";
 import {
+  appendErrorsToVsoLog,
   generateArtifact,
   getBreakingChangeInfo,
   getExecutionReport,
@@ -329,6 +330,7 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
     }
 
     logMessage(`Generating SDK from ${changedSpecPathText}`, LogLevel.Group);
+    let pipelineErrorsToLogAfterGroup: string[] = [];
 
     if (tool === "skipped") {
       logMessage(
@@ -381,12 +383,21 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
       try {
         executionReport = getExecutionReport(commandInput);
         if (commandInput.sdkLanguage === "azure-sdk-for-python") {
-          const pythonPackageValidationSucceeded = await validatePythonPackagesOnPyPI(
+          const pythonPackageValidation = await validatePythonPackagesOnPyPI(
             executionReport.packages,
           );
-          if (!pythonPackageValidationSucceeded) {
+          if (!pythonPackageValidation.succeeded) {
             statusCode = 1;
             executionReport.executionResult = "failed";
+            if (executionReport.vsoLogPath) {
+              appendErrorsToVsoLog(
+                executionReport.vsoLogPath,
+                "Python package namespace validation",
+                pythonPackageValidation.errors,
+              );
+            } else {
+              pipelineErrorsToLogAfterGroup = pythonPackageValidation.errors;
+            }
           }
         }
       } catch (error) {
@@ -436,6 +447,10 @@ export async function generateSdkForSpecPr(): Promise<CommandResult> {
     logMessage("ending group logging", LogLevel.EndGroup);
     if (executionReport?.vsoLogPath) {
       logIssuesToPipeline(executionReport.vsoLogPath, changedSpecPathText);
+    } else {
+      for (const error of pipelineErrorsToLogAfterGroup) {
+        vsoLogIssue(error);
+      }
     }
   }
   // Process the spec-gen-sdk artifacts

--- a/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
@@ -1,4 +1,5 @@
-import { LogLevel, logMessage } from "./log.ts";
+import { inspect } from "node:util";
+import { LogLevel, logMessage, vsoLogIssue } from "./log.ts";
 import { type ExecutionReportPackage } from "./types.ts";
 
 export type PyPIPackageValidationStatus = "registered" | "notRegistered" | "checkFailed";
@@ -44,7 +45,7 @@ export async function checkPackageOnPyPI(
       status: "checkFailed",
       packageName,
       packageUrl,
-      reason: error instanceof Error ? error.message : String(error),
+      reason: inspect(error),
     };
   }
 }
@@ -78,14 +79,12 @@ export async function validatePythonPackagesOnPyPI(
 
     allPackagesRegistered = false;
     if (result.status === "notRegistered") {
-      logMessage(
+      vsoLogIssue(
         `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
-        LogLevel.Error,
       );
     } else {
-      logMessage(
+      vsoLogIssue(
         `Unable to verify whether Python package '${pkg.packageName}' is registered on PyPI.org. Treating this as a validation failure. Details: ${result.reason ?? "Unknown error"}`,
-        LogLevel.Error,
       );
     }
   }

--- a/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import { LogLevel, logMessage, vsoLogIssue } from "./log.ts";
+import { LogLevel, logMessage } from "./log.ts";
 import { type ExecutionReportPackage } from "./types.ts";
 
 export type PyPIPackageValidationStatus = "registered" | "notRegistered" | "checkFailed";
@@ -9,6 +9,11 @@ export interface PyPIPackageValidationResult {
   packageName: string;
   packageUrl: string;
   reason?: string;
+}
+
+export interface PythonPackagesPyPIValidationResult {
+  succeeded: boolean;
+  errors: string[];
 }
 
 type Fetch = typeof fetch;
@@ -52,12 +57,13 @@ export async function checkPackageOnPyPI(
 
 export async function validatePythonPackagesOnPyPI(
   packages: ExecutionReportPackage[],
-): Promise<boolean> {
+): Promise<PythonPackagesPyPIValidationResult> {
+  const errors: string[] = [];
+
   if (packages.length === 0) {
-    return true;
+    return { succeeded: true, errors };
   }
 
-  let allPackagesRegistered = true;
   for (const pkg of packages) {
     if (!pkg.packageName) {
       continue;
@@ -77,17 +83,16 @@ export async function validatePythonPackagesOnPyPI(
       continue;
     }
 
-    allPackagesRegistered = false;
     if (result.status === "notRegistered") {
-      vsoLogIssue(
+      errors.push(
         `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
       );
     } else {
-      vsoLogIssue(
+      errors.push(
         `Unable to verify whether Python package '${pkg.packageName}' is registered on PyPI.org. Treating this as a validation failure. Details: ${result.reason ?? "Unknown error"}`,
       );
     }
   }
 
-  return allPackagesRegistered;
+  return { succeeded: errors.length === 0, errors };
 }

--- a/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
@@ -17,8 +17,13 @@ export interface PythonPackagesPyPIValidationResult {
 }
 
 type Fetch = typeof fetch;
+type Sleep = (ms: number) => Promise<void>;
 
 const PYPI_PACKAGE_BASE_URL = "https://pypi.org/pypi";
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+const RETRYABLE_HTTP_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const defaultSleep: Sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function getPackageUrl(packageName: string): string {
   return `${PYPI_PACKAGE_BASE_URL}/${encodeURIComponent(packageName)}/json`;
@@ -27,36 +32,48 @@ function getPackageUrl(packageName: string): string {
 export async function checkPackageOnPyPI(
   packageName: string,
   fetchImpl: Fetch = fetch,
+  sleep: Sleep = defaultSleep,
 ): Promise<PyPIPackageValidationResult> {
   const packageUrl = getPackageUrl(packageName);
+  let lastFailureReason = "";
 
-  try {
-    const response = await fetchImpl(packageUrl);
-    if (response.status === 200) {
-      return { status: "registered", packageName, packageUrl };
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await sleep(RETRY_DELAY_MS);
     }
-    if (response.status === 404) {
-      return { status: "notRegistered", packageName, packageUrl };
+    try {
+      const response = await fetchImpl(packageUrl);
+      if (response.status === 200) {
+        return { status: "registered", packageName, packageUrl };
+      }
+      if (response.status === 404) {
+        return { status: "notRegistered", packageName, packageUrl };
+      }
+      if (!RETRYABLE_HTTP_STATUS_CODES.has(response.status)) {
+        return {
+          status: "checkFailed",
+          packageName,
+          packageUrl,
+          reason: `PyPI returned HTTP ${response.status}`,
+        };
+      }
+      lastFailureReason = `PyPI returned HTTP ${response.status}`;
+    } catch (error) {
+      lastFailureReason = inspect(error);
     }
-
-    return {
-      status: "checkFailed",
-      packageName,
-      packageUrl,
-      reason: `PyPI returned HTTP ${response.status}`,
-    };
-  } catch (error) {
-    return {
-      status: "checkFailed",
-      packageName,
-      packageUrl,
-      reason: inspect(error),
-    };
   }
+
+  return {
+    status: "checkFailed",
+    packageName,
+    packageUrl,
+    reason: lastFailureReason,
+  };
 }
 
 export async function validatePythonPackagesOnPyPI(
   packages: ExecutionReportPackage[],
+  sleep: Sleep = defaultSleep,
 ): Promise<PythonPackagesPyPIValidationResult> {
   const errors: string[] = [];
 
@@ -73,7 +90,7 @@ export async function validatePythonPackagesOnPyPI(
       `Checking whether Python package '${pkg.packageName}' is registered on PyPI.org...`,
       LogLevel.Info,
     );
-    const result = await checkPackageOnPyPI(pkg.packageName);
+    const result = await checkPackageOnPyPI(pkg.packageName, fetch, sleep);
 
     if (result.status === "registered") {
       logMessage(
@@ -85,7 +102,7 @@ export async function validatePythonPackagesOnPyPI(
 
     if (result.status === "notRegistered") {
       errors.push(
-        `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
+        `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review; 2. After namespace approval, trigger the package-name reservation pipeline: aka.ms/python-reserve-pkg`,
       );
     } else {
       errors.push(

--- a/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
@@ -85,7 +85,7 @@ export async function validatePythonPackagesOnPyPI(
 
     if (result.status === "notRegistered") {
       errors.push(
-        `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
+        `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
       );
     } else {
       errors.push(

--- a/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
+++ b/eng/tools/spec-gen-sdk-runner/src/python-pypi-validation.ts
@@ -1,0 +1,94 @@
+import { LogLevel, logMessage } from "./log.ts";
+import { type ExecutionReportPackage } from "./types.ts";
+
+export type PyPIPackageValidationStatus = "registered" | "notRegistered" | "checkFailed";
+
+export interface PyPIPackageValidationResult {
+  status: PyPIPackageValidationStatus;
+  packageName: string;
+  packageUrl: string;
+  reason?: string;
+}
+
+type Fetch = typeof fetch;
+
+const PYPI_PACKAGE_BASE_URL = "https://pypi.org/pypi";
+
+function getPackageUrl(packageName: string): string {
+  return `${PYPI_PACKAGE_BASE_URL}/${encodeURIComponent(packageName)}/json`;
+}
+
+export async function checkPackageOnPyPI(
+  packageName: string,
+  fetchImpl: Fetch = fetch,
+): Promise<PyPIPackageValidationResult> {
+  const packageUrl = getPackageUrl(packageName);
+
+  try {
+    const response = await fetchImpl(packageUrl);
+    if (response.status === 200) {
+      return { status: "registered", packageName, packageUrl };
+    }
+    if (response.status === 404) {
+      return { status: "notRegistered", packageName, packageUrl };
+    }
+
+    return {
+      status: "checkFailed",
+      packageName,
+      packageUrl,
+      reason: `PyPI returned HTTP ${response.status}`,
+    };
+  } catch (error) {
+    return {
+      status: "checkFailed",
+      packageName,
+      packageUrl,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function validatePythonPackagesOnPyPI(
+  packages: ExecutionReportPackage[],
+): Promise<boolean> {
+  if (packages.length === 0) {
+    return true;
+  }
+
+  let allPackagesRegistered = true;
+  for (const pkg of packages) {
+    if (!pkg.packageName) {
+      continue;
+    }
+
+    logMessage(
+      `Checking whether Python package '${pkg.packageName}' is registered on PyPI.org...`,
+      LogLevel.Info,
+    );
+    const result = await checkPackageOnPyPI(pkg.packageName);
+
+    if (result.status === "registered") {
+      logMessage(
+        `Python package '${pkg.packageName}' is already registered on PyPI.org.`,
+        LogLevel.Info,
+      );
+      continue;
+    }
+
+    allPackagesRegistered = false;
+    if (result.status === "notRegistered") {
+      logMessage(
+        `Python package '${pkg.packageName}' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.`,
+        LogLevel.Error,
+      );
+    } else {
+      logMessage(
+        `Unable to verify whether Python package '${pkg.packageName}' is registered on PyPI.org. Treating this as a validation failure. Details: ${result.reason ?? "Unknown error"}`,
+        LogLevel.Error,
+      );
+    }
+  }
+
+  return allPackagesRegistered;
+}

--- a/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/command-helpers.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  appendErrorsToVsoLog,
   generateArtifact,
   getBreakingChangeInfo,
   getRequiredSettingValue,
@@ -364,6 +365,51 @@ describe("commands.ts", () => {
       }).toThrow(`Runner: error reading log at ${mockLogPath}:Error: ${mockLogError}`);
       expect(log.logMessage).not.toHaveBeenCalled();
       expect(log.vsoLogIssue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("appendErrorsToVsoLog", () => {
+    test("should append errors to an existing log entry", () => {
+      const mockLogContent = {
+        key1: { errors: ["error1"], warnings: ["warning1"] },
+      };
+      vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(mockLogContent));
+      const writeFileSyncSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+
+      appendErrorsToVsoLog("/log/path", "key1", ["error2"]);
+
+      expect(writeFileSyncSpy).toHaveBeenCalledWith(
+        "/log/path",
+        JSON.stringify(
+          {
+            key1: { errors: ["error1", "error2"], warnings: ["warning1"] },
+          },
+          undefined,
+          2,
+        ),
+      );
+    });
+
+    test("should create a new log entry when the key does not exist", () => {
+      vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify({}));
+      const writeFileSyncSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+
+      appendErrorsToVsoLog("/log/path", "Python package namespace validation", ["error1"]);
+
+      expect(writeFileSyncSpy).toHaveBeenCalledWith(
+        "/log/path",
+        JSON.stringify(
+          {
+            "Python package namespace validation": { errors: ["error1"] },
+          },
+          undefined,
+          2,
+        ),
+      );
     });
   });
 

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -335,7 +335,7 @@ describe("generateSdkForSpecPr", () => {
     });
     const pypiValidationSpy = vi
       .spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI")
-      .mockResolvedValue(true);
+      .mockResolvedValue({ succeeded: true, errors: [] });
     vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
@@ -396,7 +396,15 @@ describe("generateSdkForSpecPr", () => {
     vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
-    vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI").mockResolvedValue(false);
+    const appendErrorsToVsoLogSpy = vi
+      .spyOn(commandHelpers, "appendErrorsToVsoLog")
+      .mockImplementation(() => {
+        // mock implementation intentionally left blank
+      });
+    vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI").mockResolvedValue({
+      succeeded: false,
+      errors: ["Python package validation failed"],
+    });
     vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
@@ -405,6 +413,11 @@ describe("generateSdkForSpecPr", () => {
 
     expect(statusCode).toBe(1);
     expect(executionResult).toBe("failed");
+    expect(appendErrorsToVsoLogSpy).toHaveBeenCalledWith(
+      "path/to/log",
+      "Python package namespace validation",
+      ["Python package validation failed"],
+    );
     expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
       mockCommandInput,
       "failed",

--- a/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/commands.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/commands.ts";
 import * as log from "../src/log.ts";
 import { LogLevel } from "../src/log.ts";
+import * as pythonPypiValidation from "../src/python-pypi-validation.ts";
 import * as changeFiles from "../src/spec-helpers.ts";
 import type { ExecutionReport } from "../src/types.ts";
 import * as utils from "../src/utils.ts";
@@ -195,6 +196,7 @@ describe("generateSdkForSingleSpec", () => {
     vi.spyOn(commandHelpers, "setPipelineVariables").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const pypiValidationSpy = vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI");
     vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
@@ -207,6 +209,7 @@ describe("generateSdkForSingleSpec", () => {
       `SDK generation from OpenAPI (readme.md) is not supported for ${mockCommandInput.sdkRepoName}. Skipping spec.`,
       LogLevel.Info,
     );
+    expect(pypiValidationSpy).not.toHaveBeenCalled();
     expect(utils.runSpecGenSdkCommand).not.toHaveBeenCalled();
   });
 });
@@ -255,6 +258,7 @@ describe("generateSdkForSpecPr", () => {
     vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const pypiValidationSpy = vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI");
     vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
@@ -277,6 +281,7 @@ describe("generateSdkForSpecPr", () => {
       mockExecutionReport.vsoLogPath,
       serviceFolderPath,
     );
+    expect(pypiValidationSpy).not.toHaveBeenCalled();
     expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
       mockCommandInput,
       "succeeded", // overallExecutionResult
@@ -286,6 +291,129 @@ describe("generateSdkForSpecPr", () => {
       "", // stagedArtifactsFolder
       [], // apiViewRequestData
       true, // sdkGenerationExecuted
+    );
+  });
+
+  test("should validate Python PR package registration on PyPI", async () => {
+    const mockCommandInput = {
+      localSdkRepoPath: "path/to/local/repo",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "spec-pull-request",
+      sdkRepoName: "azure-sdk-for-python",
+      sdkLanguage: SdkName.Python,
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+    const mockChangedSpecs = [
+      {
+        specs: [
+          "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/examples/Employees_Get.json",
+        ],
+        typespecProject: "specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml",
+        readmeMd: "specification/contosowidgetmanager/resource-manager/readme.md",
+      },
+    ];
+    const mockExecutionReport = {
+      executionResult: "succeeded",
+      packages: [{ packageName: "azure-mgmt-widget" }],
+      vsoLogPath: "path/to/log",
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
+    vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
+    vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
+      mockExecutionReport as ExecutionReport,
+    );
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
+    vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
+    vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    const pypiValidationSpy = vi
+      .spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI")
+      .mockResolvedValue(true);
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const { statusCode, executionResult } = await generateSdkForSpecPr();
+
+    expect(statusCode).toBe(0);
+    expect(executionResult).toBe("succeeded");
+    expect(pypiValidationSpy).toHaveBeenCalledWith(mockExecutionReport.packages);
+    expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
+      mockCommandInput,
+      "succeeded",
+      false,
+      true,
+      false,
+      "",
+      [],
+      true,
+    );
+  });
+
+  test("should fail Python PR validation when package is not registered on PyPI", async () => {
+    const mockCommandInput = {
+      localSdkRepoPath: "path/to/local/repo",
+      localSpecRepoPath: "/spec/path",
+      workingFolder: "/working/folder",
+      runMode: "spec-pull-request",
+      sdkRepoName: "azure-sdk-for-python-pr",
+      sdkLanguage: SdkName.Python,
+      specCommitSha: "",
+      specRepoHttpsUrl: "",
+    };
+    const mockChangedSpecs = [
+      {
+        specs: [
+          "specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/examples/Employees_Get.json",
+        ],
+        typespecProject: "specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml",
+        readmeMd: "specification/contosowidgetmanager/resource-manager/readme.md",
+      },
+    ];
+    const mockExecutionReport = {
+      executionResult: "succeeded",
+      packages: [{ packageName: "azure-mgmt-newwidget" }],
+      vsoLogPath: "path/to/log",
+    };
+
+    vi.spyOn(commandHelpers, "parseArguments").mockReturnValue(mockCommandInput);
+    vi.spyOn(commandHelpers, "prepareSpecGenSdkCommand").mockReturnValue(["mock-command"]);
+    vi.spyOn(changeFiles, "detectChangedSpecConfigFiles").mockResolvedValue(mockChangedSpecs);
+    vi.spyOn(utils, "resetGitRepo").mockResolvedValue(undefined);
+    vi.spyOn(utils, "runSpecGenSdkCommand").mockResolvedValue(undefined);
+    vi.spyOn(commandHelpers, "getExecutionReport").mockReturnValue(
+      mockExecutionReport as ExecutionReport,
+    );
+    vi.spyOn(commandHelpers, "getBreakingChangeInfo").mockReturnValue(false);
+    vi.spyOn(commandHelpers, "generateArtifact").mockReturnValue(0);
+    vi.spyOn(commandHelpers, "logIssuesToPipeline").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+    vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI").mockResolvedValue(false);
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const { statusCode, executionResult } = await generateSdkForSpecPr();
+
+    expect(statusCode).toBe(1);
+    expect(executionResult).toBe("failed");
+    expect(commandHelpers.generateArtifact).toHaveBeenCalledWith(
+      mockCommandInput,
+      "failed",
+      false,
+      true,
+      false,
+      "",
+      [],
+      true,
     );
   });
 
@@ -672,6 +800,7 @@ describe("generateSdkForBatchSpecs", () => {
     vi.spyOn(log, "vsoAddAttachment").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const pypiValidationSpy = vi.spyOn(pythonPypiValidation, "validatePythonPackagesOnPyPI");
 
     const code = await generateSdkForBatchSpecs(mockBatchType);
     expect(commandHelpers.getSpecPaths).toHaveBeenCalledWith(mockBatchType, "/spec/path");
@@ -685,6 +814,7 @@ describe("generateSdkForBatchSpecs", () => {
       `Runner: markdown file written to ${markdownFilePath}`,
     );
     expect(log.vsoAddAttachment).toHaveBeenCalledWith("Generation Summary", markdownFilePath);
+    expect(pypiValidationSpy).not.toHaveBeenCalled();
 
     const calls = getNormalizedFsCalls(fs.writeFileSync as Mock);
     expect(calls).toMatchSnapshot();

--- a/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as log from "../src/log.ts";
+import { LogLevel } from "../src/log.ts";
+import { checkPackageOnPyPI, validatePythonPackagesOnPyPI } from "../src/python-pypi-validation.ts";
+
+function createFetchResponse(status: number): Response {
+  return { status } as Response;
+}
+
+describe("checkPackageOnPyPI", () => {
+  test("returns registered for HTTP 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(200));
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+
+    expect(result.status).toBe("registered");
+    expect(result.packageName).toBe("azure-mgmt-widget");
+    expect(result.packageUrl).toBe("https://pypi.org/pypi/azure-mgmt-widget/json");
+  });
+
+  test("returns notRegistered for HTTP 404", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(404));
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+
+    expect(result.status).toBe("notRegistered");
+  });
+
+  test("returns checkFailed for non-200 and non-404 responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(500));
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+    expect(result.status).toBe("checkFailed");
+    expect(result.reason).toBe("PyPI returned HTTP 500");
+  });
+
+  test("returns checkFailed for fetch errors", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network unavailable"));
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+    expect(result.status).toBe("checkFailed");
+    expect(result.reason).toBe("network unavailable");
+  });
+
+  test("URL-encodes package names", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(200));
+
+    await checkPackageOnPyPI("@azure/widget package", fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://pypi.org/pypi/%40azure%2Fwidget%20package/json",
+    );
+  });
+});
+
+describe("validatePythonPackagesOnPyPI", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("succeeds with no packages", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await validatePythonPackagesOnPyPI([]);
+
+    expect(result).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("logs success when a Python package is registered", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createFetchResponse(200)));
+    const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
+
+    expect(result).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
+      LogLevel.Info,
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "Python package 'azure-mgmt-widget' is already registered on PyPI.org.",
+      LogLevel.Info,
+    );
+  });
+
+  test("logs guidance when a Python package is not registered", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createFetchResponse(404)));
+    const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
+
+    expect(result).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+      LogLevel.Error,
+    );
+  });
+
+  test("logs validation failure when the PyPI check fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createFetchResponse(503)));
+    const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
+
+    expect(result).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      "Unable to verify whether Python package 'azure-mgmt-widget' is registered on PyPI.org. Treating this as a validation failure. Details: PyPI returned HTTP 503",
+      LogLevel.Error,
+    );
+  });
+
+  test("fails when any Python package is not registered", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createFetchResponse(200))
+      .mockResolvedValueOnce(createFetchResponse(404));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(log, "logMessage").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
+
+    const result = await validatePythonPackagesOnPyPI([
+      { packageName: "azure-mgmt-registered" },
+      { packageName: "azure-mgmt-new" },
+    ]);
+
+    expect(result).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
@@ -99,7 +99,7 @@ describe("validatePythonPackagesOnPyPI", () => {
     expect(result).toEqual({
       succeeded: false,
       errors: [
-        "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+        "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
       ],
     });
     expect(logSpy).toHaveBeenCalledWith(
@@ -145,7 +145,7 @@ describe("validatePythonPackagesOnPyPI", () => {
 
     expect(result.succeeded).toBe(false);
     expect(result.errors).toEqual([
-      "Python package 'azure-mgmt-new' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+      "Python package 'azure-mgmt-new' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
@@ -65,7 +65,7 @@ describe("validatePythonPackagesOnPyPI", () => {
 
     const result = await validatePythonPackagesOnPyPI([]);
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ succeeded: true, errors: [] });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -77,7 +77,7 @@ describe("validatePythonPackagesOnPyPI", () => {
 
     const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ succeeded: true, errors: [] });
     expect(logSpy).toHaveBeenCalledWith(
       "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
       LogLevel.Info,
@@ -93,19 +93,18 @@ describe("validatePythonPackagesOnPyPI", () => {
     const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
-    const vsoLogIssueSpy = vi.spyOn(log, "vsoLogIssue").mockImplementation(() => {
-      // mock implementation intentionally left blank
-    });
 
     const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({
+      succeeded: false,
+      errors: [
+        "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+      ],
+    });
     expect(logSpy).toHaveBeenCalledWith(
       "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
       LogLevel.Info,
-    );
-    expect(vsoLogIssueSpy).toHaveBeenCalledWith(
-      "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
     );
   });
 
@@ -114,19 +113,18 @@ describe("validatePythonPackagesOnPyPI", () => {
     const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
-    const vsoLogIssueSpy = vi.spyOn(log, "vsoLogIssue").mockImplementation(() => {
-      // mock implementation intentionally left blank
-    });
 
     const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
 
-    expect(result).toBe(false);
+    expect(result).toEqual({
+      succeeded: false,
+      errors: [
+        "Unable to verify whether Python package 'azure-mgmt-widget' is registered on PyPI.org. Treating this as a validation failure. Details: PyPI returned HTTP 503",
+      ],
+    });
     expect(logSpy).toHaveBeenCalledWith(
       "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
       LogLevel.Info,
-    );
-    expect(vsoLogIssueSpy).toHaveBeenCalledWith(
-      "Unable to verify whether Python package 'azure-mgmt-widget' is registered on PyPI.org. Treating this as a validation failure. Details: PyPI returned HTTP 503",
     );
   });
 
@@ -145,7 +143,10 @@ describe("validatePythonPackagesOnPyPI", () => {
       { packageName: "azure-mgmt-new" },
     ]);
 
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
+    expect(result.errors).toEqual([
+      "Python package 'azure-mgmt-new' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+    ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
@@ -39,7 +39,7 @@ describe("checkPackageOnPyPI", () => {
 
     const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
     expect(result.status).toBe("checkFailed");
-    expect(result.reason).toBe("network unavailable");
+    expect(result.reason).toContain("Error: network unavailable");
   });
 
   test("URL-encodes package names", async () => {
@@ -93,13 +93,19 @@ describe("validatePythonPackagesOnPyPI", () => {
     const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const vsoLogIssueSpy = vi.spyOn(log, "vsoLogIssue").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
 
     const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
 
     expect(result).toBe(false);
     expect(logSpy).toHaveBeenCalledWith(
+      "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
+      LogLevel.Info,
+    );
+    expect(vsoLogIssueSpy).toHaveBeenCalledWith(
       "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
-      LogLevel.Error,
     );
   });
 
@@ -108,13 +114,19 @@ describe("validatePythonPackagesOnPyPI", () => {
     const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const vsoLogIssueSpy = vi.spyOn(log, "vsoLogIssue").mockImplementation(() => {
+      // mock implementation intentionally left blank
+    });
 
     const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
 
     expect(result).toBe(false);
     expect(logSpy).toHaveBeenCalledWith(
+      "Checking whether Python package 'azure-mgmt-widget' is registered on PyPI.org...",
+      LogLevel.Info,
+    );
+    expect(vsoLogIssueSpy).toHaveBeenCalledWith(
       "Unable to verify whether Python package 'azure-mgmt-widget' is registered on PyPI.org. Treating this as a validation failure. Details: PyPI returned HTTP 503",
-      LogLevel.Error,
     );
   });
 

--- a/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
+++ b/eng/tools/spec-gen-sdk-runner/test/python-pypi-validation.test.ts
@@ -26,20 +26,55 @@ describe("checkPackageOnPyPI", () => {
     expect(result.status).toBe("notRegistered");
   });
 
-  test("returns checkFailed for non-200 and non-404 responses", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(500));
+  test("returns checkFailed immediately for non-retryable HTTP errors", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(400));
+    const noSleep = vi.fn().mockResolvedValue(undefined);
 
-    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock, noSleep);
+
     expect(result.status).toBe("checkFailed");
-    expect(result.reason).toBe("PyPI returned HTTP 500");
+    expect(result.reason).toBe("PyPI returned HTTP 400");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(noSleep).not.toHaveBeenCalled();
   });
 
-  test("returns checkFailed for fetch errors", async () => {
-    const fetchMock = vi.fn().mockRejectedValue(new Error("network unavailable"));
+  test("retries on retryable HTTP status codes and returns checkFailed after max retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(503));
+    const noSleep = vi.fn().mockResolvedValue(undefined);
 
-    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock);
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock, noSleep);
+
+    expect(result.status).toBe("checkFailed");
+    expect(result.reason).toBe("PyPI returned HTTP 503");
+    expect(fetchMock).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+    expect(noSleep).toHaveBeenCalledTimes(3);
+    expect(noSleep).toHaveBeenCalledWith(1000);
+  });
+
+  test("succeeds on retry after transient failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createFetchResponse(503))
+      .mockResolvedValueOnce(createFetchResponse(200));
+    const noSleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock, noSleep);
+
+    expect(result.status).toBe("registered");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(noSleep).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on fetch errors and returns checkFailed after max retries", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network unavailable"));
+    const noSleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await checkPackageOnPyPI("azure-mgmt-widget", fetchMock, noSleep);
+
     expect(result.status).toBe("checkFailed");
     expect(result.reason).toContain("Error: network unavailable");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(noSleep).toHaveBeenCalledTimes(3);
   });
 
   test("URL-encodes package names", async () => {
@@ -99,7 +134,7 @@ describe("validatePythonPackagesOnPyPI", () => {
     expect(result).toEqual({
       succeeded: false,
       errors: [
-        "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+        "Python package 'azure-mgmt-widget' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review; 2. After namespace approval, trigger the package-name reservation pipeline: aka.ms/python-reserve-pkg",
       ],
     });
     expect(logSpy).toHaveBeenCalledWith(
@@ -113,8 +148,12 @@ describe("validatePythonPackagesOnPyPI", () => {
     const logSpy = vi.spyOn(log, "logMessage").mockImplementation(() => {
       // mock implementation intentionally left blank
     });
+    const noSleep = vi.fn().mockResolvedValue(undefined);
 
-    const result = await validatePythonPackagesOnPyPI([{ packageName: "azure-mgmt-widget" }]);
+    const result = await validatePythonPackagesOnPyPI(
+      [{ packageName: "azure-mgmt-widget" }],
+      noSleep,
+    );
 
     expect(result).toEqual({
       succeeded: false,
@@ -145,7 +184,7 @@ describe("validatePythonPackagesOnPyPI", () => {
 
     expect(result.succeeded).toBe(false);
     expect(result.errors).toEqual([
-      "Python package 'azure-mgmt-new' is not registered on PyPI.org yet. To reserve this package name, complete these actions:\n1. Request namespace review at aka.ms/azsdk/ns-review. 2. After namespace approval, trigger the package-name reservation pipeline: https://dev.azure.com/azure-sdk/internal/_build?definitionId=8013.",
+      "Python package 'azure-mgmt-new' is not registered on PyPI.org yet. To reserve this package name, complete these actions: 1. Request namespace review at aka.ms/azsdk/ns-review; 2. After namespace approval, trigger the package-name reservation pipeline: aka.ms/python-reserve-pkg",
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary
- Add PR-only Python package registration validation against PyPI.org for spec-gen-sdk-runner.
- Mark Python SDK PR validation failed when generated package names are not registered or PyPI registration cannot be verified.
- Keep validation in a reusable package-level helper so it can be called from runAzsdkGeneration when Python/all-language migration happens later.

## Verification
- Run with registered package: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6438210&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692
- Run with un-registered package: 
  https://github.com/Azure/azure-rest-api-specs/pull/43989/checks?check_run_id=81570860217

## Screenshot
<img width="1639" height="251" alt="image" src="https://github.com/user-attachments/assets/fb2cae64-6b3a-49fa-ad13-072323a4a74e" />
