### PR TITLE
Add .NET emitter to Device Update for IoT Hub tspconfig

### DIFF
--- a/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
+++ b/specification/deviceupdate/data-plane/duiothub/tspconfig.yaml
@@ -39,3 +39,6 @@ options:
     package-details:
       name: "@azure/iot-device-update"
     flavor: azure
+  "@azure-typespec/http-client-csharp":
+    namespace: "Azure.IoT.DeviceUpdate"
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

## PR review workflow diagram

Please understand this diagram before proceeding. It explains how to get your PR approved & merged.

![spec_pr_review_workflow_diagram](https://github.com/Azure/azure-rest-api-specs/assets/4429827/5bb5e7ce-8aff-4dbb-a3f8-0d9b68fef5b1)

## API Info: The Basics
 
 Most of the information about your service should be captured in the issue that serves as your [*API Spec engagement record*](https://aka.ms/azsdk/onboarding/restapischedule).
 
 * Link to API Spec engagement record issue:
 
 Is this review for (select one):
 
 - [ ] a private preview
 - [ ] a public preview
 - [x] GA release
 
 ## Change Scope
 
 **Design Document:** N/A — no API surface changes. This PR only adds the `@azure-typespec/http-client-csharp` emitter configuration to the Device Update for IoT Hub data-plane TypeSpec project so that .NET SDKs can be generated for the existing GA API version `2022-10-01`.
 
 **Source of truth:** [`specification/deviceupdate/data-plane/duiothub/`](specification/deviceupdate/data-plane/duiothub/)
 
 **Updated paths:**
 - [`specification/deviceupdate/data-plane/duiothub/tspconfig.yaml`](specification/deviceupdate/data-plane/duiothub/tspconfig.yaml)
 
 ### What changed
 
 Added the `@azure-typespec/http-client-csharp` emitter block under `options:` in `tspconfig.yaml`:
 
 ```yaml
 "@azure-typespec/http-client-csharp":
   namespace: "Azure.IoT.DeviceUpdate"
   emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
 ```
 
 Previously only Python, Java, and JavaScript emitters were configured. With this change, .NET SDK generation will also be enabled when SDK automation runs on this spec.
 
 ### Viewing API changes
 
 For convenient view of the API changes made by this PR, refer to the URLs provided in the table
 in the `Generated ApiView` comment added to this PR. You can use ApiView to show API versions diff.
 
 ### Suppressing failures
 
 If one or multiple validation error/warning suppression(s) is detected in your PR, please follow the
 [Swagger-Suppression-Process](https://aka.ms/pr-suppressions)
 to get approval.
 
 ### Release planner
 This is an emitter configuration change — no new API surface is being added. Related release plan: [2239](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releaseplan=2239) (Device Update for IoT Hub, GA, June 2026).