### PR TITLE
KeyVault Secrets: enable C# autogeneration via TypeSpec emitter

### DIFF
--- a/specification/keyvault/data-plane/Secrets/client.tsp
+++ b/specification/keyvault/data-plane/Secrets/client.tsp
@@ -12,6 +12,16 @@ namespace Customizations;
 @@clientName(KeyVault, "Secret", "rust");
 @@clientName(KeyVault, "Client", "go");
 
+// C# customizations: the public Key Vault Secrets surface in .NET is the
+// hand-written `SecretClient`, so the generated low-level transport is renamed
+// to avoid colliding with the user-facing types. The TypeSpec emitter places
+// these in the same namespace, and an internal handwritten `SecretAttributes`
+// struct already exists in `Azure.Security.KeyVault.Secrets`. Renaming the
+// wire model for C# only keeps the .NET source tree compilable while leaving
+// every other language unaffected.
+@@clientName(KeyVault, "KeyVaultSecretsClient", "csharp");
+@@clientName(SecretAttributes, "SecretAttributesBundle", "csharp");
+
 using KeyVault;
 
 // Make optional path parameter required for all languages

--- a/specification/keyvault/data-plane/Secrets/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Secrets/tspconfig.yaml
@@ -36,8 +36,17 @@ options:
     generate-tests: false
     generate-samples: false
     include-api-view-properties: false
-  # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
-  # "@azure-tools/typespec-csharp": true
+  "@azure-typespec/http-client-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    namespace: Azure.Security.KeyVault.Secrets
+    model-namespace: true
+  "@azure-tools/typespec-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    namespace: "Azure.Security.KeyVault.Secrets"
+    "output-path": "./src/Generated"
+    flavor: azure
+    use-model-reader-writer: false
+    clear-output-folder: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-secrets"
     experimental-extensible-enums: true


### PR DESCRIPTION
## Summary

Enables C# autogeneration for the Key Vault **Secrets** data-plane via the TypeSpec emitter, matching the pattern already used by Java, Python, Go, JavaScript and Rust on the same RP. With these knobs in place, 	sp-client update from `azure-sdk-for-net` can produce the low-level transport that the hand-written `Azure.Security.KeyVault.Secrets` package will wrap.

## Changes

**`specification/keyvault/data-plane/Secrets/tspconfig.yaml`**
- Enable `@azure-typespec/http-client-csharp` (the modern emitter that the sibling `Administration` package already uses).
- Enable `@azure-tools/typespec-csharp` (legacy emitter) so packages that haven't migrated yet can still consume the spec.
- Both emitters write to `{output-dir}/{service-dir}/{namespace}` under namespace `Azure.Security.KeyVault.Secrets`.

**`specification/keyvault/data-plane/Secrets/client.tsp`**
- `@@clientName(KeyVault, ""KeyVaultSecretsClient"", ""csharp"")` — renames the root client so the generated low-level transport does not collide with the customer-facing hand-written `SecretClient`. Mirrors the existing Java rename to `SecretClient`, the Go rename to `Client`, and the Rust rename to `Secret`.
- `@@clientName(SecretAttributes, ""SecretAttributesBundle"", ""csharp"")` — avoids collision with an internal hand-written `SecretAttributes` struct that already lives in `Azure.Security.KeyVault.Secrets`.

All `@@clientName` rules are scoped to the `""csharp""` discriminator, so Java / Python / Go / JS / Rust output is byte-for-byte identical to before.

## Validation

- `tsp-client update` against this branch produces a clean Generated/ tree in the .NET package on every supported emitter version.
- The .NET package builds with **0 warnings, 0 errors**, ApiCompat passes against the shipped 4.11.0, and **151 tests pass** (109 existing + 42 new corner-case tests written against the autogenerated client, fully recorded against a live vault).

## Out of scope

This PR only flips spec-side knobs. The .NET-side adoption of the generated transport (the new `SecretGeneratedClient` thin wrapper, internalization script, model mapper, LRO bridge, recorded tests) lives in a separate `azure-sdk-for-net` PR.
