### PR TITLE
Import client.tsp from main.tsp for services with no swagger impact

### DIFF
--- a/specification/applink/AppLink.Management/main.tsp
+++ b/specification/applink/AppLink.Management/main.tsp
@@ -7,6 +7,7 @@ import "./applink.tsp";
 import "./applinkmember.tsp";
 import "./applinkmemberupgradehistory.tsp";
 import "./applinkavailableversion.tsp";
+import "./client.tsp";
 
 using Versioning;
 using Azure.ResourceManager;

--- a/specification/applink/AppLink.Management/tspconfig.yaml
+++ b/specification/applink/AppLink.Management/tspconfig.yaml
@@ -3,6 +3,7 @@ emit:
 options:
   "@azure-tools/typespec-autorest":
     use-read-only-status-schema: true
+    omit-unreachable-types: true
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"

--- a/specification/edge/Microsoft.Edge.DisconnectedOperations.Management/main.tsp
+++ b/specification/edge/Microsoft.Edge.DisconnectedOperations.Management/main.tsp
@@ -7,6 +7,7 @@ import "./disconnectedOperations.tsp";
 import "./images.tsp";
 import "./artifacts.tsp";
 import "./hardwareSettings.tsp";
+import "./client.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;

--- a/specification/edge/Microsoft.Edge.DisconnectedOperations.Management/tspconfig.yaml
+++ b/specification/edge/Microsoft.Edge.DisconnectedOperations.Management/tspconfig.yaml
@@ -9,6 +9,7 @@ options:
       name: "@azure/arm-disconnectedoperations"
   "@azure-tools/typespec-autorest":
     use-read-only-status-schema: true
+    omit-unreachable-types: true
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/disconnectedOperations/{version-status}/{version}/disconnectedOperations.json"

--- a/specification/monitoringservice/resource-manager/Microsoft.Monitor/Agents/main.tsp
+++ b/specification/monitoringservice/resource-manager/Microsoft.Monitor/Agents/main.tsp
@@ -1,3 +1,4 @@
 import "./typespec/service.tsp";
 import "./typespec/models.tsp";
 import "./typespec/agents/agents.tsp";
+import "./client.tsp";

--- a/specification/napster/Napster.CompanionAPI.Management/main.tsp
+++ b/specification/napster/Napster.CompanionAPI.Management/main.tsp
@@ -4,6 +4,7 @@ import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-liftr-base";
+import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;

--- a/specification/programenrollment/resource-manager/Microsoft.ProgramEnrollment/ProgramEnrollment/main.tsp
+++ b/specification/programenrollment/resource-manager/Microsoft.ProgramEnrollment/ProgramEnrollment/main.tsp
@@ -3,6 +3,7 @@ import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;

--- a/specification/relationships/Relationships.Management/main.tsp
+++ b/specification/relationships/Relationships.Management/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;

--- a/specification/relationships/Relationships.Management/tspconfig.yaml
+++ b/specification/relationships/Relationships.Management/tspconfig.yaml
@@ -9,6 +9,7 @@ options:
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/relationships.json"
     use-read-only-status-schema: true
+    omit-unreachable-types: true
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-relationships"
     namespace: "azure.mgmt.relationships"


### PR DESCRIPTION
Missed a few simples cases from phase 1.a and 1.b of https://github.com/Azure/typespec-azure/issues/4564


## Summary

Makes `main.tsp` import `./client.tsp` for services where doing so has **no impact on the published OpenAPI**, so client customizations are picked up by `tsp compile main.tsp`.

### Group 1 — no config change needed
`client.tsp` contains only `@@clientName`/`@@alternateType` (client-emitter-only). Adding the import is byte-identical to the current swagger:
- `monitoringservice/resource-manager/Microsoft.Monitor/Agents`
- `napster/Napster.CompanionAPI.Management`
- `programenrollment/resource-manager/Microsoft.ProgramEnrollment/ProgramEnrollment`

### Group 2 — import + `omit-unreachable-types: true`
`client.tsp` declares shadow create/update models that are referenced only by `@@alternateType` (invisible to the autorest emitter), so the emitter treats them as unreachable. Enabling `omit-unreachable-types` drops them; enabling the option alone changes nothing in the current output, so the net swagger change is zero:
- `applink/AppLink.Management`
- `edge/Microsoft.Edge.DisconnectedOperations.Management`
- `relationships/Relationships.Management`

## Verification

For every service above, regenerating with the autorest emitter produces **byte-identical** OpenAPI output (verified current-vs-new), and all compile cleanly under `--warn-as-error`. Only `main.tsp` (and `tspconfig.yaml` for Group 2) change; no generated swagger changes.

## Not included

The remaining services that don't yet import `client.tsp` require more involved work and are intentionally excluded:
- **`@scope`-based operation customizations** (`resources/.../policy`, `resources/.../deploymentStacks`, `search`) — blocked on autorest honoring `@scope` (Azure/typespec-azure#4565).
- **Reachable shadow models / `@@override` / `@@clientName`-on-operation / property drift** (`frontdoor`, `migrate`, `purviewdatagovernance/DataAccess`, `storagecache`) — need restructuring or a decision on intended output.
