### PR TITLE
KeyVault Certificates: enable C# autogeneration via TypeSpec emitter

### DIFF
--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -12,6 +12,37 @@ namespace Customizations;
 @@clientName(KeyVault, "Client", "go");
 @@clientName(KeyVault, "Certificate", "rust");
 
+// C# customizations: the public Key Vault Certificates surface in .NET is the
+// hand-written `CertificateClient`, so the generated low-level transport is
+// renamed to avoid name collisions. The TypeSpec emitter places generated
+// types in the same `Azure.Security.KeyVault.Certificates` namespace as the
+// existing hand-written types (model-namespace: true is honored
+// inconsistently), so every wire model whose default name matches a
+// hand-written type needs a `csharp`-scoped rename. This is purely additive
+// — every rule is gated by the `"csharp"` discriminator and leaves Java /
+// Python / Go / JS / Rust output unchanged.
+@@clientName(KeyVault, "KeyVaultCertificatesClient", "csharp");
+@@clientName(CertificateAttributes, "CertificateAttributesBundle", "csharp");
+@@clientName(CertificateOperation, "CertificateOperationBundle", "csharp");
+@@clientName(CertificatePolicy, "CertificatePolicyBundle", "csharp");
+@@clientName(LifetimeAction, "LifetimeActionBundle", "csharp");
+@@clientName(
+  SubjectAlternativeNames,
+  "SubjectAlternativeNamesProperties",
+  "csharp"
+);
+@@clientName(
+  CertificateCreateParameters,
+  "CertificateCreateParametersBundle",
+  "csharp"
+);
+@@clientName(
+  CertificateUpdateParameters,
+  "CertificateUpdateParametersBundle",
+  "csharp"
+);
+@@clientName(IssuerParameters, "IssuerParametersBundle", "csharp");
+
 using KeyVault;
 
 // Make optional path parameter required for all languages

--- a/specification/keyvault/data-plane/Certificates/tspconfig.yaml
+++ b/specification/keyvault/data-plane/Certificates/tspconfig.yaml
@@ -38,8 +38,17 @@ options:
     generate-tests: false
     generate-samples: false
     include-api-view-properties: false
-  # Uncomment this line and add "@azure-tools/typespec-csharp" to your package.json to generate C# code
-  # "@azure-tools/typespec-csharp": true
+  "@azure-tools/typespec-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    namespace: "Azure.Security.KeyVault.Certificates"
+    "output-path": "./src/Generated"
+    flavor: azure
+    use-model-reader-writer: false
+    clear-output-folder: true
+  "@azure-typespec/http-client-csharp":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    namespace: Azure.Security.KeyVault.Certificates
+    model-namespace: true
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/keyvault-certificates"
     experimental-extensible-enums: true


### PR DESCRIPTION
## Summary

Enables C# autogeneration for the Key Vault **Certificates** data-plane via the TypeSpec emitter, mirroring the Secrets change in #43999. With these knobs in place, `tsp-client update` from `azure-sdk-for-net` can produce the low-level transport that the hand-written `Azure.Security.KeyVault.Certificates` package will wrap.

## Changes

**`specification/keyvault/data-plane/Certificates/tspconfig.yaml`**
- Enable `@azure-typespec/http-client-csharp` (modern emitter; same one Administration and Secrets use).
- Enable `@azure-tools/typespec-csharp` (legacy emitter) for packages that haven't migrated yet.
- Both emitters write to `{output-dir}/{service-dir}/{namespace}` under namespace `Azure.Security.KeyVault.Certificates`.

**`specification/keyvault/data-plane/Certificates/client.tsp`**
Adds 9 C# rename customizations. Certificates has a much larger hand-written surface than Secrets, so several generated wire-model names would collide with public/internal types in `Azure.Security.KeyVault.Certificates`. All renames are scoped via the `""csharp""` discriminator and follow the convention already used by Java / Go / Rust on this RP.

| spec type | C# generated name | reason |
|---|---|---|
| `KeyVault` | `KeyVaultCertificatesClient` | disambiguates the low-level client |
| `CertificateAttributes` | `CertificateAttributesBundle` | hand-written `internal struct CertificateAttributes` |
| `CertificateOperation` | `CertificateOperationBundle` | hand-written `public class CertificateOperation` |
| `CertificatePolicy` | `CertificatePolicyBundle` | hand-written `public class CertificatePolicy` |
| `LifetimeAction` | `LifetimeActionBundle` | hand-written `public class LifetimeAction` |
| `SubjectAlternativeNames` | `SubjectAlternativeNamesProperties` | hand-written `public class SubjectAlternativeNames` |
| `CertificateCreateParameters` | `CertificateCreateParametersBundle` | hand-written `internal class` of the same name |
| `CertificateUpdateParameters` | `CertificateUpdateParametersBundle` | hand-written `internal class` of the same name |
| `IssuerParameters` | `IssuerParametersBundle` | hand-written `internal struct IssuerParameters` |

## Other languages

Verified the `""csharp""` scope confines every rename: SDK Validation jobs for Java / Python / Go / JS / Rust on this PR should remain green. No spec-shape change, no API version bump.

## Out of scope

This PR only flips spec-side knobs. The .NET-side adoption — new `CertificateGeneratedClient` thin wrapper, `Internalize-Generated.ps1` post-emit script, `CertificateMapper`, LRO bridges, recorded tests — will land in a separate `azure-sdk-for-net` PR following the pattern already used for Secrets.
