### PR TITLE
Add protocol_configuration to AgentEndpointConfig

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -17005,6 +17005,10 @@
         ],
         "description": "The output of an A2A (Agent-to-Agent) tool call."
       },
+      "A2aProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the A2A protocol."
+      },
       "AISearchIndexResource": {
         "type": "object",
         "properties": {
@@ -17039,6 +17043,16 @@
           }
         },
         "description": "A AI Search Index resource."
+      },
+      "ActivityProtocolConfiguration": {
+        "type": "object",
+        "properties": {
+          "enable_m365_public_endpoint": {
+            "type": "boolean",
+            "description": "Whether to enable the M365 public endpoint for the activity protocol."
+          }
+        },
+        "description": "Configuration specific to the activity protocol."
       },
       "AgentBlueprintReference": {
         "type": "object",
@@ -17355,12 +17369,13 @@
             ],
             "description": "The version selector of the agent endpoint determines how traffic is routed to different versions of the agent."
           },
-          "protocols": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentEndpointProtocol"
-            },
-            "description": "The protocols that the agent supports"
+          "protocol_configuration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProtocolConfiguration"
+              }
+            ],
+            "description": "Per-protocol configuration for the agent endpoint."
           },
           "authorization_schemes": {
             "type": "array",
@@ -17382,12 +17397,13 @@
             ],
             "description": "The version selector of the agent endpoint determines how traffic is routed to different versions of the agent."
           },
-          "protocols": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AgentEndpointProtocol"
-            },
-            "description": "The protocols that the agent supports"
+          "protocol_configuration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProtocolConfiguration"
+              }
+            ],
+            "description": "Per-protocol configuration for the agent endpoint."
           },
           "authorization_schemes": {
             "type": "array",
@@ -17397,24 +17413,6 @@
             "description": "The authorization schemes supported by the agent endpoint"
           }
         }
-      },
-      "AgentEndpointProtocol": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "activity",
-              "responses",
-              "a2a",
-              "mcp",
-              "invocations",
-              "invocations_ws"
-            ]
-          }
-        ]
       },
       "AgentEvaluatorGenerationJobSource": {
         "type": "object",
@@ -25246,6 +25244,14 @@
         },
         "description": "Metadata about the insights."
       },
+      "InvocationsProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the invocations protocol."
+      },
+      "InvocationsWsProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the WebSocket-based invocations protocol."
+      },
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
@@ -25584,6 +25590,10 @@
           }
         ],
         "description": "Managed Azure AI Search Index Definition"
+      },
+      "McpProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the MCP protocol."
       },
       "MemoryCommandToolCall": {
         "type": "object",
@@ -51735,6 +51745,60 @@
         ],
         "description": "Prompt source for evaluator generation jobs — inline text provided by the user."
       },
+      "ProtocolConfiguration": {
+        "type": "object",
+        "properties": {
+          "activity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ActivityProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the activity protocol."
+          },
+          "responses": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponsesProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the responses protocol."
+          },
+          "a2a": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/A2aProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the A2A protocol."
+          },
+          "mcp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/McpProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the MCP protocol."
+          },
+          "invocations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvocationsProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the invocations protocol."
+          },
+          "invocations_ws": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvocationsWsProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the WebSocket-based invocations protocol."
+          }
+        },
+        "description": "Per-protocol configuration for the agent endpoint."
+      },
       "ProtocolVersionRecord": {
         "type": "object",
         "required": [
@@ -52166,6 +52230,10 @@
           }
         ],
         "description": "Represents the parameters for response retrieval item generation."
+      },
+      "ResponsesProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the responses protocol."
       },
       "RiskCategory": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -11190,6 +11190,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: The output of an A2A (Agent-to-Agent) tool call.
+    A2aProtocolConfiguration:
+      type: object
+      description: Configuration specific to the A2A protocol.
     AISearchIndexResource:
       type: object
       properties:
@@ -11214,6 +11217,13 @@ components:
           type: string
           description: Index asset id for search resource.
       description: A AI Search Index resource.
+    ActivityProtocolConfiguration:
+      type: object
+      properties:
+        enable_m365_public_endpoint:
+          type: boolean
+          description: Whether to enable the M365 public endpoint for the activity protocol.
+      description: Configuration specific to the activity protocol.
     AgentBlueprintReference:
       type: object
       required:
@@ -11427,11 +11437,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersionSelector'
           description: The version selector of the agent endpoint determines how traffic is routed to different versions of the agent.
-        protocols:
-          type: array
-          items:
-            $ref: '#/components/schemas/AgentEndpointProtocol'
-          description: The protocols that the agent supports
+        protocol_configuration:
+          allOf:
+            - $ref: '#/components/schemas/ProtocolConfiguration'
+          description: Per-protocol configuration for the agent endpoint.
         authorization_schemes:
           type: array
           items:
@@ -11444,27 +11453,15 @@ components:
           allOf:
             - $ref: '#/components/schemas/VersionSelectorUpdate'
           description: The version selector of the agent endpoint determines how traffic is routed to different versions of the agent.
-        protocols:
-          type: array
-          items:
-            $ref: '#/components/schemas/AgentEndpointProtocol'
-          description: The protocols that the agent supports
+        protocol_configuration:
+          allOf:
+            - $ref: '#/components/schemas/ProtocolConfiguration'
+          description: Per-protocol configuration for the agent endpoint.
         authorization_schemes:
           type: array
           items:
             $ref: '#/components/schemas/AgentEndpointAuthorizationScheme'
           description: The authorization schemes supported by the agent endpoint
-    AgentEndpointProtocol:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - activity
-            - responses
-            - a2a
-            - mcp
-            - invocations
-            - invocations_ws
     AgentEvaluatorGenerationJobSource:
       type: object
       required:
@@ -16962,6 +16959,12 @@ components:
           format: date-time
           description: The timestamp when the insights were completed.
       description: Metadata about the insights.
+    InvocationsProtocolConfiguration:
+      type: object
+      description: Configuration specific to the invocations protocol.
+    InvocationsWsProtocolConfiguration:
+      type: object
+      description: Configuration specific to the WebSocket-based invocations protocol.
     InvokeAgentInvocationsApiDispatchPayload:
       type: object
       required:
@@ -17183,6 +17186,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/IndexUpdate'
       description: Managed Azure AI Search Index Definition
+    McpProtocolConfiguration:
+      type: object
+      description: Configuration specific to the MCP protocol.
     MemoryCommandToolCall:
       type: object
       required:
@@ -35544,6 +35550,34 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvaluatorGenerationJobSource'
       description: Prompt source for evaluator generation jobs — inline text provided by the user.
+    ProtocolConfiguration:
+      type: object
+      properties:
+        activity:
+          allOf:
+            - $ref: '#/components/schemas/ActivityProtocolConfiguration'
+          description: Configuration for the activity protocol.
+        responses:
+          allOf:
+            - $ref: '#/components/schemas/ResponsesProtocolConfiguration'
+          description: Configuration for the responses protocol.
+        a2a:
+          allOf:
+            - $ref: '#/components/schemas/A2aProtocolConfiguration'
+          description: Configuration for the A2A protocol.
+        mcp:
+          allOf:
+            - $ref: '#/components/schemas/McpProtocolConfiguration'
+          description: Configuration for the MCP protocol.
+        invocations:
+          allOf:
+            - $ref: '#/components/schemas/InvocationsProtocolConfiguration'
+          description: Configuration for the invocations protocol.
+        invocations_ws:
+          allOf:
+            - $ref: '#/components/schemas/InvocationsWsProtocolConfiguration'
+          description: Configuration for the WebSocket-based invocations protocol.
+      description: Per-protocol configuration for the agent endpoint.
     ProtocolVersionRecord:
       type: object
       required:
@@ -35831,6 +35865,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for response retrieval item generation.
+    ResponsesProtocolConfiguration:
+      type: object
+      description: Configuration specific to the responses protocol.
     RiskCategory:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -19956,6 +19956,10 @@
         ],
         "description": "The output of an A2A (Agent-to-Agent) tool call."
       },
+      "A2aProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the A2A protocol."
+      },
       "AISearchIndexResource": {
         "type": "object",
         "properties": {
@@ -19990,6 +19994,16 @@
           }
         },
         "description": "A AI Search Index resource."
+      },
+      "ActivityProtocolConfiguration": {
+        "type": "object",
+        "properties": {
+          "enable_m365_public_endpoint": {
+            "type": "boolean",
+            "description": "Whether to enable the M365 public endpoint for the activity protocol."
+          }
+        },
+        "description": "Configuration specific to the activity protocol."
       },
       "AgentBlueprintReference": {
         "type": "object",
@@ -20517,7 +20531,15 @@
             "items": {
               "$ref": "#/components/schemas/AgentEndpointProtocol"
             },
-            "description": "The protocols that the agent supports"
+            "description": "Deprecated: Use protocol_configuration instead. The presence of a key in protocol_configuration declares the protocol is enabled."
+          },
+          "protocol_configuration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProtocolConfiguration"
+              }
+            ],
+            "description": "Per-protocol configuration for the agent endpoint."
           },
           "authorization_schemes": {
             "type": "array",
@@ -20544,7 +20566,15 @@
             "items": {
               "$ref": "#/components/schemas/AgentEndpointProtocol"
             },
-            "description": "The protocols that the agent supports"
+            "description": "Deprecated: Use protocol_configuration instead. The presence of a key in protocol_configuration declares the protocol is enabled."
+          },
+          "protocol_configuration": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProtocolConfiguration"
+              }
+            ],
+            "description": "Per-protocol configuration for the agent endpoint."
           },
           "authorization_schemes": {
             "type": "array",
@@ -29795,6 +29825,14 @@
         },
         "description": "Metadata about the insights."
       },
+      "InvocationsProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the invocations protocol."
+      },
+      "InvocationsWsProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the WebSocket-based invocations protocol."
+      },
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
@@ -30145,6 +30183,10 @@
           }
         ],
         "description": "Managed Azure AI Search Index Definition"
+      },
+      "McpProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the MCP protocol."
       },
       "MemoryCommandToolCall": {
         "type": "object",
@@ -56509,6 +56551,60 @@
         ],
         "description": "Prompt source for evaluator generation jobs — inline text provided by the user."
       },
+      "ProtocolConfiguration": {
+        "type": "object",
+        "properties": {
+          "activity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ActivityProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the activity protocol."
+          },
+          "responses": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponsesProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the responses protocol."
+          },
+          "a2a": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/A2aProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the A2A protocol."
+          },
+          "mcp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/McpProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the MCP protocol."
+          },
+          "invocations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvocationsProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the invocations protocol."
+          },
+          "invocations_ws": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InvocationsWsProtocolConfiguration"
+              }
+            ],
+            "description": "Configuration for the WebSocket-based invocations protocol."
+          }
+        },
+        "description": "Per-protocol configuration for the agent endpoint."
+      },
       "ProtocolVersionRecord": {
         "type": "object",
         "required": [
@@ -56940,6 +57036,10 @@
           }
         ],
         "description": "Represents the parameters for response retrieval item generation."
+      },
+      "ResponsesProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the responses protocol."
       },
       "RiskCategory": {
         "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -13150,6 +13150,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: The output of an A2A (Agent-to-Agent) tool call.
+    A2aProtocolConfiguration:
+      type: object
+      description: Configuration specific to the A2A protocol.
     AISearchIndexResource:
       type: object
       properties:
@@ -13174,6 +13177,13 @@ components:
           type: string
           description: Index asset id for search resource.
       description: A AI Search Index resource.
+    ActivityProtocolConfiguration:
+      type: object
+      properties:
+        enable_m365_public_endpoint:
+          type: boolean
+          description: Whether to enable the M365 public endpoint for the activity protocol.
+      description: Configuration specific to the activity protocol.
     AgentBlueprintReference:
       type: object
       required:
@@ -13533,7 +13543,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgentEndpointProtocol'
-          description: The protocols that the agent supports
+          description: 'Deprecated: Use protocol_configuration instead. The presence of a key in protocol_configuration declares the protocol is enabled.'
+        protocol_configuration:
+          allOf:
+            - $ref: '#/components/schemas/ProtocolConfiguration'
+          description: Per-protocol configuration for the agent endpoint.
         authorization_schemes:
           type: array
           items:
@@ -13550,7 +13564,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgentEndpointProtocol'
-          description: The protocols that the agent supports
+          description: 'Deprecated: Use protocol_configuration instead. The presence of a key in protocol_configuration declares the protocol is enabled.'
+        protocol_configuration:
+          allOf:
+            - $ref: '#/components/schemas/ProtocolConfiguration'
+          description: Per-protocol configuration for the agent endpoint.
         authorization_schemes:
           type: array
           items:
@@ -20024,6 +20042,12 @@ components:
           format: date-time
           description: The timestamp when the insights were completed.
       description: Metadata about the insights.
+    InvocationsProtocolConfiguration:
+      type: object
+      description: Configuration specific to the invocations protocol.
+    InvocationsWsProtocolConfiguration:
+      type: object
+      description: Configuration specific to the WebSocket-based invocations protocol.
     InvokeAgentInvocationsApiDispatchPayload:
       type: object
       required:
@@ -20253,6 +20277,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/IndexUpdate'
       description: Managed Azure AI Search Index Definition
+    McpProtocolConfiguration:
+      type: object
+      description: Configuration specific to the MCP protocol.
     MemoryCommandToolCall:
       type: object
       required:
@@ -38769,6 +38796,34 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvaluatorGenerationJobSource'
       description: Prompt source for evaluator generation jobs — inline text provided by the user.
+    ProtocolConfiguration:
+      type: object
+      properties:
+        activity:
+          allOf:
+            - $ref: '#/components/schemas/ActivityProtocolConfiguration'
+          description: Configuration for the activity protocol.
+        responses:
+          allOf:
+            - $ref: '#/components/schemas/ResponsesProtocolConfiguration'
+          description: Configuration for the responses protocol.
+        a2a:
+          allOf:
+            - $ref: '#/components/schemas/A2aProtocolConfiguration'
+          description: Configuration for the A2A protocol.
+        mcp:
+          allOf:
+            - $ref: '#/components/schemas/McpProtocolConfiguration'
+          description: Configuration for the MCP protocol.
+        invocations:
+          allOf:
+            - $ref: '#/components/schemas/InvocationsProtocolConfiguration'
+          description: Configuration for the invocations protocol.
+        invocations_ws:
+          allOf:
+            - $ref: '#/components/schemas/InvocationsWsProtocolConfiguration'
+          description: Configuration for the WebSocket-based invocations protocol.
+      description: Per-protocol configuration for the agent endpoint.
     ProtocolVersionRecord:
       type: object
       required:
@@ -39056,6 +39111,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for response retrieval item generation.
+    ResponsesProtocolConfiguration:
+      type: object
+      description: Configuration specific to the responses protocol.
     RiskCategory:
       anyOf:
         - type: string

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -629,12 +629,58 @@ union IsolationKeySourceKind {
   Header: "Header",
 }
 
+@doc("Per-protocol configuration for the agent endpoint.")
+model ProtocolConfiguration {
+  @doc("Configuration for the activity protocol.")
+  activity?: ActivityProtocolConfiguration;
+
+  @doc("Configuration for the responses protocol.")
+  responses?: ResponsesProtocolConfiguration;
+
+  @doc("Configuration for the A2A protocol.")
+  a2a?: A2aProtocolConfiguration;
+
+  @doc("Configuration for the MCP protocol.")
+  mcp?: McpProtocolConfiguration;
+
+  @doc("Configuration for the invocations protocol.")
+  invocations?: InvocationsProtocolConfiguration;
+
+  @doc("Configuration for the WebSocket-based invocations protocol.")
+  invocations_ws?: InvocationsWsProtocolConfiguration;
+}
+
+@doc("Configuration specific to the activity protocol.")
+model ActivityProtocolConfiguration {
+  @doc("Whether to enable the M365 public endpoint for the activity protocol.")
+  enable_m365_public_endpoint?: boolean;
+}
+
+@doc("Configuration specific to the responses protocol.")
+model ResponsesProtocolConfiguration {}
+
+@doc("Configuration specific to the A2A protocol.")
+model A2aProtocolConfiguration {}
+
+@doc("Configuration specific to the MCP protocol.")
+model McpProtocolConfiguration {}
+
+@doc("Configuration specific to the invocations protocol.")
+model InvocationsProtocolConfiguration {}
+
+@doc("Configuration specific to the WebSocket-based invocations protocol.")
+model InvocationsWsProtocolConfiguration {}
+
 model AgentEndpointConfig {
   @doc("The version selector of the agent endpoint determines how traffic is routed to different versions of the agent.")
   version_selector?: VersionSelector;
 
-  @doc("The protocols that the agent supports")
+  @removed(Versions.v1)
+  @doc("Deprecated: Use protocol_configuration instead. The presence of a key in protocol_configuration declares the protocol is enabled.")
   protocols?: AgentEndpointProtocol[];
+
+  @doc("Per-protocol configuration for the agent endpoint.")
+  protocol_configuration?: ProtocolConfiguration;
 
   @doc("The authorization schemes supported by the agent endpoint")
   authorization_schemes?: AgentEndpointAuthorizationScheme[];


### PR DESCRIPTION
 ## Add protocol_configuration to AgentEndpointConfig
 
 ### Motivation
 
 Today, the `protocols` field on `AgentEndpointConfig` is a simple array of strings. This is too limiting — we need the ability to attach configuration to individual protocols.
 
 The immediate use case is for agents deployed in a VNET. These agents cannot be reached by M365 services (Teams, Copilot Studio) because they are isolated within the virtual network. By enabling `enable_m365_public_endpoint` on the activity protocol, a public-facing endpoint is provisioned so that M365 services can invoke the agent while the rest of the agent infrastructure remains within the VNET.
 
 ### Changes
 
 - **`ActivityProtocolConfiguration`** — new model with `enable_m365_public_endpoint?: boolean`
 - **`ProtocolConfiguration`** — new model with `activity?: ActivityProtocolConfiguration`
 - **`AgentEndpointConfig.protocol_configuration`** — new optional field of type `ProtocolConfiguration`
 
 All new models are gated behind the same `agent_endpoint_v1_preview` opt-in.
 
 ### Example usage
 
 ```yaml
 endpoint_configuration:
   protocols: [activity]
   protocol_configuration:
     activity:
       enable_m365_public_endpoint: true
 ```
 
 ### Notes
 
 - Non-breaking additive change — the existing `protocols` array remains unchanged
 - OpenAPI regeneration blocked by pre-existing `tag-definitions.tsp` compile error on the branch