### PR TITLE
ContainerService: csharp clientName naming polish round 2 (Safeguards, Bastion)

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -1617,6 +1617,15 @@ namespace Azure.ResourceManager.Models {
   "ContainerServiceGuardrailsAvailableVersion",
   "csharp"
 );
+@@clientName(
+  SafeguardsAvailableVersion,
+  "ContainerServiceSafeguardsAvailableVersion",
+  "csharp"
+);
+// Profile models: add a service/resource prefix so they aren't confused with the
+// Network SDK's "Bastion*" types.
+@@clientName(BastionProfile, "ManagedClusterBastionProfile", "csharp");
+@@clientName(BastionSku, "ManagedClusterBastionSku", "csharp");
 
 // TODO: drop the type replacement upon next major breaking change
 @@alternateType(


### PR DESCRIPTION
## Summary

Follow-up to #43956. Adds `@clientName` (csharp) augment decorators in `client.tsp` to disambiguate more overly-generic generated type names for the .NET SDK, addressing the remaining mgmt review feedback on [Azure/azure-sdk-for-net#59887](https://github.com/Azure/azure-sdk-for-net/pull/59887).

Only `client.tsp` is modified — no wire/API surface changes.

## Renames (csharp only)

| Original | New |
| --- | --- |
| `SafeguardsAvailableVersion` | `ContainerServiceSafeguardsAvailableVersion` |
| `BastionProfile` | `ManagedClusterBastionProfile` |
| `BastionSku` | `ManagedClusterBastionSku` |

`SafeguardsAvailableVersion` is a resource model, so this renames the whole generated trio (`Resource`/`Data`/`Collection`) — consistent with the `GuardrailsAvailableVersion` → `ContainerServiceGuardrailsAvailableVersion` rename in #43956. The `Bastion*` prefix avoids collision with the Azure Network SDK's `Bastion*` types.