### PR TITLE
Import client.tsp from main.tsp for purviewdatagovernance DataAccess

### DIFF
--- a/specification/purviewdatagovernance/data-plane/DataAccess/client.tsp
+++ b/specification/purviewdatagovernance/data-plane/DataAccess/client.tsp
@@ -16,17 +16,27 @@ using PurviewDataAccess;
 
 namespace Customizations;
 
-@@clientName(DataSubscriptions.createOrReplace, "CreateOrUpdate");
-@@clientName(DataSubscriptions.replaceDraft, "Save");
-@@clientName(Workflows.createOrReplace, "CreateOrUpdate");
-@@clientName(Workflows.getRuns, "ListRuns");
+@@clientName(DataSubscriptions.createOrReplace, "CreateOrUpdate", "!autorest");
+@@clientName(DataSubscriptions.replaceDraft, "Save", "!autorest");
+@@clientName(Workflows.createOrReplace, "CreateOrUpdate", "!autorest");
+@@clientName(Workflows.getRuns, "ListRuns", "!autorest");
 @@clientName(
   DataProductPolicySets.createOrReplaceApplied,
-  "CreateOrUpdateApplied"
+  "CreateOrUpdateApplied",
+  "!autorest"
 );
-@@clientName(DomainPolicySets.createOrReplaceApplied, "CreateOrUpdateApplied");
-@@clientName(TermPolicySets.createOrReplaceApplied, "CreateOrUpdateApplied");
+@@clientName(
+  DomainPolicySets.createOrReplaceApplied,
+  "CreateOrUpdateApplied",
+  "!autorest"
+);
+@@clientName(
+  TermPolicySets.createOrReplaceApplied,
+  "CreateOrUpdateApplied",
+  "!autorest"
+);
 @@clientName(
   CriticalDataElementPolicySets.createOrReplaceApplied,
-  "CreateOrUpdateApplied"
+  "CreateOrUpdateApplied",
+  "!autorest"
 );

--- a/specification/purviewdatagovernance/data-plane/DataAccess/main.tsp
+++ b/specification/purviewdatagovernance/data-plane/DataAccess/main.tsp
@@ -2,6 +2,7 @@ import "@typespec/rest";
 import "@typespec/http";
 import "./routes.tsp";
 import "@azure-tools/typespec-azure-core";
+import "./client.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.Versioning;


### PR DESCRIPTION
## Summary

Make `main.tsp` import `./client.tsp` for **purviewdatagovernance / DataAccess**, so `main.tsp` is the single TypeSpec compilation entry point and client customizations are picked up.

The published OpenAPI/Swagger output is **byte-identical** (verified — no `*.json` drift).

## Change

- `main.tsp`: add `import "./client.tsp";`.
- `client.tsp`: scope the 8 operation-level `@@clientName` customizations with `"!autorest"`.

### Why the `"!autorest"` scope

`@@clientName` on an **operation** is honored by the autorest emitter: it rewrites the generated `operationId` (e.g. `DataSubscriptions_CreateOrReplace` → `DataSubscriptions_CreateOrUpdate`) and consequently drops the auto-matched `x-ms-examples`. Scoping each `@@clientName` `"!autorest"` keeps the SDK-facing method names while leaving the wire-level swagger unchanged.

## Verification

- `tsp compile <project> --warn-as-error` passes.
- No changes to any `*.json` swagger under the project.
