### PR TITLE
ComputeLimit: rename SetMemberCapOverridesRequest -> ComputeLimitSetMemberCapOverridesContent for .NET

### DIFF
--- a/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/client.tsp
+++ b/specification/computelimit/resource-manager/Microsoft.ComputeLimit/ComputeLimit/client.tsp
@@ -29,3 +29,8 @@ using Microsoft.ComputeLimit;
 );
 @@clientName(VmFamily, "ComputeLimitVmFamily", "csharp");
 @@clientName(VmFamilyProperties, "ComputeLimitVmFamilyProperties", "csharp");
+@@clientName(
+  SetMemberCapOverridesRequest,
+  "ComputeLimitSetMemberCapOverridesContent",
+  "csharp"
+);


### PR DESCRIPTION
ComputeLimit: rename SetMemberCapOverridesRequest -> ComputeLimitSetMemberCapOverridesContent for .NET

ARM .NET convention: request body models should use *Content suffix instead of *Request. Aligns with existing client.tsp pattern (e.g., FeatureEnableRequest -> ComputeLimitFeatureEnableContent).

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
