### PR TITLE
Addressing review comments: Refactor toolbox tool type aliases and update Foundry previews

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1,220 +1,84 @@
 {
-  "openapi": "3.2.0",
+  "openapi": "3.0.0",
   "info": {
     "title": "Microsoft Foundry",
     "version": "v1"
   },
   "tags": [
     {
+      "name": "Agents"
+    },
+    {
+      "name": "Agent Session Files"
+    },
+    {
+      "name": "Agent Invocations"
+    },
+    {
+      "name": "Connections"
+    },
+    {
+      "name": "Datasets"
+    },
+    {
+      "name": "Deployments"
+    },
+    {
+      "name": "Evaluation Taxonomies"
+    },
+    {
+      "name": "Evaluation Rules"
+    },
+    {
+      "name": "Evaluators"
+    },
+    {
+      "name": "EvaluatorGenerationJobs"
+    },
+    {
+      "name": "Indexes"
+    },
+    {
+      "name": "Insights"
+    },
+    {
+      "name": "Models"
+    },
+    {
+      "name": "Memory Stores"
+    },
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Evals"
+    },
+    {
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Responses"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Redteams"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Routines"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Schedules"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Skills"
     },
     {
-      "name": "Agent Invocations",
-      "parent": "Agents Root"
+      "name": "Toolboxes"
     },
     {
-      "name": "Agent Invocations WebSocket",
-      "parent": "Agents Root",
-      "description": "Agent Invocations (WebSocket)"
+      "name": "DataGenerationJobs"
     },
     {
-      "name": "Agent Sessions",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Platform APIs"
-    },
-    {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "AgentOptimizationJobs"
     }
   ],
   "paths": {
@@ -232,7 +96,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -283,18 +147,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -312,22 +166,22 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/OptimizationJob"
+                "$ref": "#/components/schemas/OptimizationJobInputs"
               }
             }
           },
-          "description": "The job to create."
+          "description": "The optimization job inputs."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       },
       "get": {
         "operationId": "AgentOptimizationJobs_list",
         "summary": "Returns a list of agent optimization jobs.",
-        "description": "List optimization jobs. Supports cursor pagination and optional status / agent_name filters.",
+        "description": "List optimization jobs. Supports cursor pagination and optional status / agentName filters.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -337,7 +191,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -394,7 +248,7 @@
             "explode": false
           },
           {
-            "name": "agent_name",
+            "name": "agentName",
             "in": "query",
             "required": false,
             "description": "Filter to jobs targeting this agent name.",
@@ -429,7 +283,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/OptimizationJobListItem"
+                        "$ref": "#/components/schemas/OptimizationJob"
                       },
                       "description": "The requested list of items."
                     },
@@ -451,18 +305,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -477,7 +321,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
@@ -486,7 +330,7 @@
       "get": {
         "operationId": "AgentOptimizationJobs_get",
         "summary": "Get info about an agent optimization job.",
-        "description": "Get an optimization job by id.",
+        "description": "Get an optimization job by id. Returns 202 while in progress, 200 when terminal.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -496,7 +340,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -526,7 +370,6 @@
             "headers": {
               "Retry-After": {
                 "required": false,
-                "description": "Recommended number of seconds to wait before polling again.",
                 "schema": {
                   "type": "integer",
                   "format": "int32"
@@ -541,18 +384,27 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "headers": {
+              "Retry-After": {
+                "required": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
+                  "$ref": "#/components/schemas/OptimizationJob"
                 }
               }
             }
           },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -567,7 +419,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       },
@@ -584,7 +436,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -596,6 +448,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "When true, force-delete even if the job is in a non-terminal state.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -612,18 +474,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -638,16 +490,16 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
     },
-    "/agent_optimization_jobs/{jobId}:cancel": {
-      "post": {
-        "operationId": "AgentOptimizationJobs_cancel",
-        "summary": "Cancels an agent optimization job.",
-        "description": "Request cancellation of a running or queued job. Returns an error if the job is already in a terminal state.",
+    "/agent_optimization_jobs/{jobId}/candidates": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_listCandidates",
+        "summary": "Returns a list of candidates for an optimization job.",
+        "description": "List candidates produced by a job.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -657,7 +509,562 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/OptimizationCandidate"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidate",
+        "summary": "Get a candidate by id.",
+        "description": "Get a single candidate's metadata, manifest, and promotion info.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateMetadata"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/config": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateConfig",
+        "summary": "Get candidate deploy config.",
+        "description": "Get the candidate's deploy config JSON. Used to compose `agents.create_version(...)` from a candidate.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateDeployConfig"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/files": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateFile",
+        "summary": "Get a candidate file.",
+        "description": "Stream a specific file from the candidate's blob directory.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "Relative path of the file to download (e.g. 'files/examples.jsonl').",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/results": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateResults",
+        "summary": "Get candidate evaluation results.",
+        "description": "Get full per-task evaluation results for a candidate.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateResults"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}:promote": {
+      "post": {
+        "operationId": "AgentOptimizationJobs_promoteCandidate",
+        "summary": "Promote a candidate.",
+        "description": "Promotes a candidate, recording the deployment timestamp and target agent version.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id to promote.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromoteCandidateResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteCandidateRequest"
+              }
+            }
+          },
+          "description": "Promotion details."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}:cancel": {
+      "post": {
+        "operationId": "AgentOptimizationJobs_cancel",
+        "summary": "Cancels an agent optimization job.",
+        "description": "Request cancellation. Idempotent on terminal states.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -692,18 +1099,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -718,7 +1115,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
@@ -766,8 +1163,7 @@
             }
           }
         ],
-        "description": "Creates a new agent or a new version of an existing agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.\nThe agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.\nThe SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Create an agent Create a new code-based agent",
+        "description": "Creates the agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.\nThe agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.\nThe SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -779,18 +1175,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -800,8 +1186,6 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new agent or a new version of an existing agent.",
-        "x-ms-summary-override": "Create an agent",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
@@ -833,8 +1217,7 @@
       },
       "get": {
         "operationId": "Agents_listAgents",
-        "summary": "List agents",
-        "description": "Returns a paged collection of agent resources.",
+        "description": "Returns the list of all agents.",
         "parameters": [
           {
             "name": "kind",
@@ -936,18 +1319,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -965,8 +1338,7 @@
     "/agents/{agent_name}": {
       "get": {
         "operationId": "Agents_getAgent",
-        "summary": "Get an agent",
-        "description": "Retrieves an agent definition by its unique name.",
+        "description": "Retrieves the agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -999,18 +1371,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1066,7 +1428,6 @@
           }
         ],
         "description": "Updates the agent by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version. Updates a code-based agent by uploading new code and creating a new version.\nIf the code and definition are unchanged (matched by x-ms-code-zip-sha256 header), returns the existing version.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Update an agent Update a code-based agent",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -1078,18 +1439,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1099,8 +1450,6 @@
             }
           }
         },
-        "x-ms-description-override": "Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.",
-        "x-ms-summary-override": "Update an agent",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
@@ -1132,7 +1481,6 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgent",
-        "summary": "Delete an agent",
         "description": "Deletes an agent. For hosted agents, if any version has active sessions, the request\nis rejected with HTTP 409 unless `force` is set to true. When force is true, all\nassociated sessions are cascade-deleted along with the agent and its versions.",
         "parameters": [
           {
@@ -1148,7 +1496,7 @@
             "name": "force",
             "in": "query",
             "required": false,
-            "description": "For Hosted Agents, if `true`, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.",
+            "description": "For Hosted Agents, if true, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -1177,18 +1525,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1204,8 +1542,7 @@
       },
       "patch": {
         "operationId": "Agents_patchAgentObject",
-        "summary": "Update an agent endpoint",
-        "description": "Applies a merge-patch update to the specified agent endpoint configuration.",
+        "description": "Updates an agent endpoint.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -1225,8 +1562,7 @@
             "required": true,
             "description": "The name of the agent to retrieve.",
             "schema": {
-              "type": "string",
-              "title": "The name of the agent to retrieve"
+              "type": "string"
             }
           },
           {
@@ -1251,18 +1587,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1295,8 +1621,7 @@
     "/agents/{agent_name}/code:download": {
       "get": {
         "operationId": "Agents_downloadAgentCode",
-        "summary": "Download agent code",
-        "description": "Downloads the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
+        "description": "Download the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -1355,23 +1680,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1394,7 +1710,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations": {
       "post": {
         "operationId": "AgentInvocations_createAgentInvocation",
-        "summary": "Create an agent invocation",
         "description": "Creates an invocation for the specified agent version.",
         "parameters": [
           {
@@ -1473,18 +1788,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1516,7 +1821,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationOpenApiSpec",
-        "summary": "Get an agent invocation OpenAPI spec",
         "description": "Retrieves the OpenAPI specification for an agent version's invocation contract.\nReturns 404 if the agent does not expose an OpenAPI specification.",
         "parameters": [
           {
@@ -1558,23 +1862,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "unevaluatedProperties": {}
+                  "additionalProperties": {}
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1597,7 +1891,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocation",
-        "summary": "Get an agent invocation",
         "description": "Retrieves the invocation with the given ID.\nReturns 404 if the agent does not support this operation or if the invocation ID is not found.",
         "parameters": [
           {
@@ -1668,18 +1961,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1702,7 +1985,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel": {
       "post": {
         "operationId": "AgentInvocations_cancelAgentInvocation",
-        "summary": "Cancel an agent invocation",
         "description": "Cancels an invocation.\nReturns 404 if the agent does not support this operation or if the invocation ID is not found.",
         "parameters": [
           {
@@ -1773,18 +2055,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1816,7 +2088,6 @@
     "/agents/{agent_name}/endpoint/sessions": {
       "post": {
         "operationId": "Agents_createSession",
-        "summary": "Create a session",
         "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
         "parameters": [
           {
@@ -1871,18 +2142,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1893,7 +2154,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -1913,8 +2174,7 @@
       },
       "get": {
         "operationId": "Agents_listSessions",
-        "summary": "List sessions for an agent",
-        "description": "Returns a paged collection of sessions associated with the specified agent endpoint.",
+        "description": "Returns a list of sessions for the specified agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2036,18 +2296,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2058,7 +2308,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2070,8 +2320,7 @@
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files": {
       "get": {
         "operationId": "AgentSessionFiles_listSessionFiles",
-        "summary": "List session files",
-        "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
+        "description": "List files and directories at a given path in the session sandbox.\nReturns only the immediate children of the specified directory (non-recursive).",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2106,8 +2355,8 @@
           {
             "name": "path",
             "in": "query",
-            "required": false,
-            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+            "required": true,
+            "description": "The directory path to list, relative to the session home directory.",
             "schema": {
               "type": "string"
             },
@@ -2121,48 +2370,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
           },
           {
             "name": "api-version",
@@ -2186,18 +2393,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2218,8 +2415,7 @@
       },
       "delete": {
         "operationId": "AgentSessionFiles_deleteSessionFile",
-        "summary": "Delete a session file",
-        "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
+        "description": "Delete a file or directory from the session sandbox.\nIf `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2265,7 +2461,7 @@
             "name": "recursive",
             "in": "query",
             "required": false,
-            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Whether to recursively delete directory contents. Defaults to false.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -2296,18 +2492,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2330,8 +2516,7 @@
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content": {
       "put": {
         "operationId": "AgentSessionFiles_uploadSessionFile",
-        "summary": "Upload a session file",
-        "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
+        "description": "Upload a file to the session sandbox via binary stream.\nMaximum file size is 50 MB. Uploads exceeding this limit return 413 Payload Too Large.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2404,18 +2589,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2433,7 +2608,8 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "contentMediaType": "application/octet-stream"
+                "type": "string",
+                "format": "binary"
               }
             }
           }
@@ -2446,8 +2622,7 @@
       },
       "get": {
         "operationId": "AgentSessionFiles_downloadSessionFile",
-        "summary": "Download a session file",
-        "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
+        "description": "Download a file from the session sandbox as a binary stream.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2515,23 +2690,14 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "contentMediaType": "application/octet-stream"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2554,8 +2720,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}": {
       "get": {
         "operationId": "Agents_getSession",
-        "summary": "Get a session",
-        "description": "Retrieves the details of a hosted agent session by agent name and session identifier.",
+        "description": "Retrieves a session by ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2618,18 +2783,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2640,7 +2795,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2650,7 +2805,6 @@
       },
       "delete": {
         "operationId": "Agents_deleteSession",
-        "summary": "Delete a session",
         "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
         "parameters": [
           {
@@ -2707,18 +2861,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2729,7 +2873,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2741,8 +2885,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
       "post": {
         "operationId": "Agents_stopSession",
-        "summary": "Stop a session",
-        "description": "Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.",
+        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2789,18 +2932,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2811,7 +2944,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2823,7 +2956,6 @@
     "/agents/{agent_name}/import": {
       "post": {
         "operationId": "Agents_updateAgentFromManifest",
-        "summary": "Update an agent from a manifest",
         "description": "Updates the agent from a manifest by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version.",
         "parameters": [
           {
@@ -2857,18 +2989,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2936,8 +3058,7 @@
             }
           }
         ],
-        "description": "Creates a new version for the specified agent and returns the created version resource. Creates a new agent version from code. Uploads the code zip and creates a new version\nfor an existing agent. The SHA-256 hex digest of the zip is provided in the\n`x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Create an agent version Create an agent version from code",
+        "description": "Create a new agent version.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -2949,18 +3070,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2970,15 +3081,13 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new version for the specified agent and returns the created version resource.",
-        "x-ms-summary-override": "Create an agent version",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
           ]
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -3003,8 +3112,7 @@
       },
       "get": {
         "operationId": "Agents_listAgentVersions",
-        "summary": "List agent versions",
-        "description": "Returns a paged collection of versions for the specified agent.",
+        "description": "Returns the list of versions of an agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -3105,18 +3213,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3127,15 +3225,14 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       }
     },
     "/agents/{agent_name}/versions/{agent_version}": {
       "get": {
         "operationId": "Agents_getAgentVersion",
-        "summary": "Get an agent version",
-        "description": "Retrieves the specified version of an agent by its agent name and version identifier.",
+        "description": "Retrieves a specific version of an agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -3177,18 +3274,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3199,12 +3286,11 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       },
       "delete": {
         "operationId": "Agents_deleteAgentVersion",
-        "summary": "Delete an agent version",
         "description": "Deletes a specific version of an agent. For hosted agents, if the version has active\nsessions, the request is rejected with HTTP 409 unless `force` is set to true. When\nforce is true, all sessions associated with this version are cascade-deleted.",
         "parameters": [
           {
@@ -3229,7 +3315,7 @@
             "name": "force",
             "in": "query",
             "required": false,
-            "description": "For Hosted Agents, if `true`, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.",
+            "description": "For Hosted Agents, if true, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -3258,18 +3344,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3280,14 +3356,13 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       }
     },
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",
-        "summary": "Stream console logs for a hosted agent session",
         "description": "Streams console logs (stdout / stderr) for a specific hosted agent session\nas a Server-Sent Events (SSE) stream.\n\nEach SSE frame contains:\n- `event`: always `\"log\"`\n- `data`: a plain-text log line (currently JSON-formatted, but the schema\nis not contractual and may include additional keys or change format\nover time — clients should treat it as an opaque string)\n\nExample SSE frames:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting FoundryCBAgent server on port 8088\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.130Z\",\"stream\":\"stderr\",\"message\":\"INFO: Application startup complete.\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:35:52.714Z\",\"stream\":\"status\",\"message\":\"No logs since last 60 seconds\"}\n```\n\nThe stream remains open until the client disconnects or the server\nterminates the connection. Clients should handle reconnection as needed.",
         "parameters": [
           {
@@ -3351,18 +3426,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3373,7 +3438,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -3385,8 +3450,7 @@
     "/agents/{agent_name}/versions:import": {
       "post": {
         "operationId": "Agents_createAgentVersionFromManifest",
-        "summary": "Create an agent version from manifest",
-        "description": "Imports the provided manifest to create a new version for the specified agent.",
+        "description": "Create a new agent version from a manifest.",
         "parameters": [
           {
             "name": "agent_name",
@@ -3420,18 +3484,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3442,7 +3496,7 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -3459,8 +3513,7 @@
     "/agents:import": {
       "post": {
         "operationId": "Agents_createAgentFromManifest",
-        "summary": "Create an agent from a manifest",
-        "description": "Imports the provided manifest to create an agent and returns the created resource.",
+        "description": "Creates an agent from a manifest.",
         "parameters": [
           {
             "name": "api-version",
@@ -3484,18 +3537,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3523,8 +3566,7 @@
     "/connections": {
       "get": {
         "operationId": "Connections_list",
-        "summary": "List connections",
-        "description": "Returns the connections available in the current project, optionally filtered by type or default status.",
+        "description": "List all connections in the project, without populating connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3533,7 +3575,7 @@
             "name": "connectionType",
             "in": "query",
             "required": false,
-            "description": "Lists connections of this specific type",
+            "description": "List connections of this specific type",
             "schema": {
               "$ref": "#/components/schemas/ConnectionType"
             },
@@ -3543,7 +3585,7 @@
             "name": "defaultConnection",
             "in": "query",
             "required": false,
-            "description": "Lists connections that are default connections",
+            "description": "List connections that are default connections",
             "schema": {
               "type": "boolean"
             },
@@ -3573,27 +3615,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -3620,8 +3643,7 @@
     "/connections/{name}": {
       "get": {
         "operationId": "Connections_get",
-        "summary": "Get a connection",
-        "description": "Retrieves the specified connection and its configuration details without including credential values.",
+        "description": "Get a connection by name, without populating connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3659,27 +3681,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -3706,8 +3709,7 @@
     "/connections/{name}/getConnectionWithCredentials": {
       "post": {
         "operationId": "Connections_getWithCredentials",
-        "summary": "Get a connection with credentials",
-        "description": "Retrieves the specified connection together with its credential values.",
+        "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -3745,27 +3747,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -3792,7 +3775,7 @@
     "/data_generation_jobs": {
       "get": {
         "operationId": "DataGenerationJobs_list",
-        "summary": "List data generation jobs",
+        "summary": "Returns a list of data generation jobs",
         "description": "Returns a list of data generation jobs.",
         "parameters": [
           {
@@ -3897,18 +3880,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3929,8 +3902,8 @@
       },
       "post": {
         "operationId": "DataGenerationJobs_create",
-        "summary": "Create a data generation job",
-        "description": "Submits a new data generation job for asynchronous execution.",
+        "summary": "Creates a data generation job.",
+        "description": "Creates a data generation job.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3991,18 +3964,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4036,8 +3999,8 @@
     "/data_generation_jobs/{jobId}": {
       "get": {
         "operationId": "DataGenerationJobs_get",
-        "summary": "Get a data generation job",
-        "description": "Retrieves the specified data generation job and its current status.",
+        "summary": "Get info about a data generation job.",
+        "description": "Gets the details of a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4092,18 +4055,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4124,8 +4077,8 @@
       },
       "delete": {
         "operationId": "DataGenerationJobs_delete",
-        "summary": "Delete a data generation job",
-        "description": "Removes the specified data generation job and its associated output.",
+        "summary": "Deletes a data generation job.",
+        "description": "Deletes a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4163,18 +4116,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4197,8 +4140,8 @@
     "/data_generation_jobs/{jobId}:cancel": {
       "post": {
         "operationId": "DataGenerationJobs_cancel",
-        "summary": "Cancel a data generation job",
-        "description": "Cancels the specified data generation job if it is still in progress.",
+        "summary": "Cancels a data generation job.",
+        "description": "Cancels a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4243,18 +4186,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4277,7 +4210,6 @@
     "/datasets": {
       "get": {
         "operationId": "Datasets_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each DatasetVersion",
         "parameters": [
           {
@@ -4295,27 +4227,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4342,7 +4255,6 @@
     "/datasets/{name}/versions": {
       "get": {
         "operationId": "Datasets_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given DatasetVersion",
         "parameters": [
           {
@@ -4369,27 +4281,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4416,7 +4309,6 @@
     "/datasets/{name}/versions/{version}": {
       "get": {
         "operationId": "Datasets_getVersion",
-        "summary": "Get a version",
         "description": "Get the specific version of the DatasetVersion. The service returns 404 Not Found error if the DatasetVersion does not exist.",
         "parameters": [
           {
@@ -4452,27 +4344,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4497,7 +4370,6 @@
       },
       "delete": {
         "operationId": "Datasets_deleteVersion",
-        "summary": "Delete a version",
         "description": "Delete the specific version of the DatasetVersion. The service returns 204 No Content if the DatasetVersion was deleted successfully or if the DatasetVersion does not exist.",
         "parameters": [
           {
@@ -4526,27 +4398,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4571,7 +4424,6 @@
       },
       "patch": {
         "operationId": "Datasets_createOrUpdateVersion",
-        "summary": "Create or update a version",
         "description": "Create a new or update an existing DatasetVersion with the given version id",
         "parameters": [
           {
@@ -4617,27 +4469,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4675,8 +4508,7 @@
     "/datasets/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Datasets_getCredentials",
-        "summary": "Get dataset credentials",
-        "description": "Gets the SAS credential to access the storage account associated with a Dataset version.",
+        "description": "Get the SAS credential to access the storage account associated with a Dataset version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4711,27 +4543,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4758,8 +4571,7 @@
     "/datasets/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Datasets_startPendingUploadVersion",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified dataset version.",
+        "description": "Start a new or get an existing pending upload of a dataset for a specific version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4794,27 +4606,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4852,8 +4645,7 @@
     "/deployments": {
       "get": {
         "operationId": "Deployments_list",
-        "summary": "List deployments",
-        "description": "Returns the deployed models available in the current project, optionally filtered by publisher, model name, or deployment type.",
+        "description": "List all deployed models in the project",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4912,27 +4704,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4959,8 +4732,7 @@
     "/deployments/{name}": {
       "get": {
         "operationId": "Deployments_get",
-        "summary": "Get a deployment",
-        "description": "Gets a deployed model.",
+        "description": "Get a deployed model.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4998,27 +4770,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5045,8 +4798,7 @@
     "/evaluationrules": {
       "get": {
         "operationId": "EvaluationRules_list",
-        "summary": "List evaluation rules",
-        "description": "Returns the evaluation rules configured for the project, optionally filtered by action type, agent name, or enabled state.",
+        "description": "List all evaluation rules.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5093,27 +4845,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5140,8 +4873,7 @@
     "/evaluationrules/{id}": {
       "get": {
         "operationId": "EvaluationRules_get",
-        "summary": "Get an evaluation rule",
-        "description": "Retrieves the specified evaluation rule and its configuration.",
+        "description": "Get an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5167,27 +4899,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5212,8 +4925,7 @@
       },
       "delete": {
         "operationId": "EvaluationRules_delete",
-        "summary": "Delete an evaluation rule",
-        "description": "Removes the specified evaluation rule from the project.",
+        "description": "Delete an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5232,27 +4944,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5277,8 +4970,7 @@
       },
       "put": {
         "operationId": "EvaluationRules_createOrUpdate",
-        "summary": "Create or update an evaluation rule",
-        "description": "Creates a new evaluation rule, or replaces the existing rule when the identifier matches.",
+        "description": "Create or update an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5326,27 +5018,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5384,8 +5057,7 @@
     "/evaluationtaxonomies": {
       "get": {
         "operationId": "EvaluationTaxonomies_list",
-        "summary": "List evaluation taxonomies",
-        "description": "Returns the evaluation taxonomies available in the project, optionally filtered by input name or input type.",
+        "description": "List evaluation taxonomies",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5434,27 +5106,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5481,8 +5134,7 @@
     "/evaluationtaxonomies/{name}": {
       "get": {
         "operationId": "EvaluationTaxonomies_get",
-        "summary": "Get an evaluation taxonomy",
-        "description": "Retrieves the specified evaluation taxonomy.",
+        "description": "Get an evaluation run by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5520,27 +5172,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5565,8 +5198,7 @@
       },
       "delete": {
         "operationId": "EvaluationTaxonomies_delete",
-        "summary": "Delete an evaluation taxonomy",
-        "description": "Removes the specified evaluation taxonomy from the project.",
+        "description": "Delete an evaluation taxonomy by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5597,27 +5229,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5642,8 +5255,7 @@
       },
       "put": {
         "operationId": "EvaluationTaxonomies_create",
-        "summary": "Create an evaluation taxonomy",
-        "description": "Creates or replaces the specified evaluation taxonomy with the provided definition.",
+        "description": "Create an evaluation taxonomy.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5691,27 +5303,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5747,7 +5340,6 @@
       },
       "patch": {
         "operationId": "EvaluationTaxonomies_update",
-        "summary": "Update an evaluation taxonomy",
         "description": "Update an evaluation taxonomy.",
         "parameters": [
           {
@@ -5786,27 +5378,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5844,7 +5417,7 @@
     "/evaluator_generation_jobs": {
       "post": {
         "operationId": "EvaluatorGenerationJobs_create",
-        "summary": "Create an evaluator generation job",
+        "summary": "Creates an evaluator generation job.",
         "description": "Creates an evaluator generation job. The service generates rubric-based evaluator\ndefinitions from the provided source materials asynchronously.",
         "parameters": [
           {
@@ -5906,18 +5479,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5949,8 +5512,8 @@
       },
       "get": {
         "operationId": "EvaluatorGenerationJobs_list",
-        "summary": "List evaluator generation jobs",
-        "description": "Returns a list of evaluator generation jobs. The List API has up to a few\nseconds of propagation delay, so a recently created job may not appear\nimmediately; use the Get evaluator generation job API with the job ID to\nretrieve a specific job without delay.",
+        "summary": "Returns a list of evaluator generation jobs.",
+        "description": "Returns a list of evaluator generation jobs.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -6054,18 +5617,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6088,7 +5641,7 @@
     "/evaluator_generation_jobs/{jobId}": {
       "get": {
         "operationId": "EvaluatorGenerationJobs_get",
-        "summary": "Get an evaluator generation job",
+        "summary": "Get info about an evaluator generation job.",
         "description": "Gets the details of an evaluator generation job by its ID.",
         "parameters": [
           {
@@ -6144,18 +5697,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6176,7 +5719,6 @@
       },
       "delete": {
         "operationId": "EvaluatorGenerationJobs_delete",
-        "summary": "Delete an evaluator generation job",
         "description": "Deletes an evaluator generation job by its ID. Deletes the job record only;\nthe generated evaluator (if any) is preserved.",
         "parameters": [
           {
@@ -6215,18 +5757,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6249,7 +5781,7 @@
     "/evaluator_generation_jobs/{jobId}:cancel": {
       "post": {
         "operationId": "EvaluatorGenerationJobs_cancel",
-        "summary": "Cancel an evaluator generation job",
+        "summary": "Cancels an evaluator generation job.",
         "description": "Cancels an evaluator generation job by its ID.",
         "parameters": [
           {
@@ -6295,18 +5827,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6329,8 +5851,7 @@
     "/evaluators": {
       "get": {
         "operationId": "Evaluators_listLatestVersions",
-        "summary": "List latest evaluator versions",
-        "description": "Lists the latest version of each evaluator",
+        "description": "List the latest version of each evaluator",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6391,27 +5912,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6438,8 +5940,7 @@
     "/evaluators/{name}/versions": {
       "get": {
         "operationId": "Evaluators_listVersions",
-        "summary": "List evaluator versions",
-        "description": "Returns the available versions for the specified evaluator.",
+        "description": "List all versions of the given evaluator",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6509,27 +6010,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6554,8 +6036,7 @@
       },
       "post": {
         "operationId": "Evaluators_createVersion",
-        "summary": "Create an evaluator version",
-        "description": "Creates a new evaluator version with an auto-incremented version identifier.",
+        "description": "Create a new EvaluatorVersion with auto incremented version id",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6593,27 +6074,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6650,8 +6112,7 @@
     "/evaluators/{name}/versions/{version}": {
       "get": {
         "operationId": "Evaluators_getVersion",
-        "summary": "Get an evaluator version",
-        "description": "Retrieves the specified evaluator version, returning 404 if it does not exist.",
+        "description": "Get the specific version of the EvaluatorVersion. The service returns 404 Not Found error if the EvaluatorVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6698,27 +6159,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6743,8 +6185,7 @@
       },
       "delete": {
         "operationId": "Evaluators_deleteVersion",
-        "summary": "Delete an evaluator version",
-        "description": "Removes the specified evaluator version. Returns 204 whether the version existed or not.",
+        "description": "Delete the specific version of the EvaluatorVersion. The service returns 204 No Content if the EvaluatorVersion was deleted successfully or if the EvaluatorVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6784,27 +6225,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6829,8 +6251,7 @@
       },
       "patch": {
         "operationId": "Evaluators_updateVersion",
-        "summary": "Update an evaluator version",
-        "description": "Updates the specified evaluator version in place.",
+        "description": "Update an existing EvaluatorVersion with the given version id",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6877,27 +6298,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6935,8 +6337,7 @@
     "/evaluators/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Evaluators_getCredentials",
-        "summary": "Get evaluator credentials",
-        "description": "Retrieves SAS credentials for accessing the storage account associated with the specified evaluator version.",
+        "description": "Get the SAS credential to access the storage account associated with an Evaluator version.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -6989,18 +6390,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7034,8 +6425,7 @@
     "/evaluators/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Evaluators_startPendingUpload",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified evaluator version.",
+        "description": "Start a new or get an existing pending upload of an evaluator for a specific version.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7088,18 +6478,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7133,7 +6513,6 @@
     "/indexes": {
       "get": {
         "operationId": "Indexes_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each Index",
         "parameters": [
           {
@@ -7151,27 +6530,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7198,7 +6558,6 @@
     "/indexes/{name}/versions": {
       "get": {
         "operationId": "Indexes_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given Index",
         "parameters": [
           {
@@ -7225,27 +6584,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7272,7 +6612,6 @@
     "/indexes/{name}/versions/{version}": {
       "get": {
         "operationId": "Indexes_getVersion",
-        "summary": "Get a version",
         "description": "Get the specific version of the Index. The service returns 404 Not Found error if the Index does not exist.",
         "parameters": [
           {
@@ -7308,27 +6647,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7353,7 +6673,6 @@
       },
       "delete": {
         "operationId": "Indexes_deleteVersion",
-        "summary": "Delete a version",
         "description": "Delete the specific version of the Index. The service returns 204 No Content if the Index was deleted successfully or if the Index does not exist.",
         "parameters": [
           {
@@ -7382,27 +6701,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7427,7 +6727,6 @@
       },
       "patch": {
         "operationId": "Indexes_createOrUpdateVersion",
-        "summary": "Create or update a version",
         "description": "Create a new or update an existing Index with the given version id",
         "parameters": [
           {
@@ -7473,27 +6772,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7531,8 +6811,7 @@
     "/insights": {
       "post": {
         "operationId": "Insights_generate",
-        "summary": "Generate insights",
-        "description": "Generates an insights report from the provided evaluation configuration.",
+        "description": "Generate Insights",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7587,18 +6866,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7625,8 +6894,7 @@
       },
       "get": {
         "operationId": "Insights_list",
-        "summary": "List insights",
-        "description": "Returns insights in reverse chronological order, with the most recent entries first.",
+        "description": "List all insights in reverse chronological order (newest first).",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7712,18 +6980,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7741,8 +6999,7 @@
     "/insights/{id}": {
       "get": {
         "operationId": "Insights_get",
-        "summary": "Get an insight",
-        "description": "Retrieves the specified insight report and its results.",
+        "description": "Get a specific insight by Id.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7797,18 +7054,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7826,8 +7073,7 @@
     "/memory_stores": {
       "post": {
         "operationId": "createMemoryStore",
-        "summary": "Create a memory store",
-        "description": "Creates a memory store resource with the provided configuration.",
+        "description": "Create a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7863,18 +7109,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7906,7 +7142,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -7936,8 +7172,7 @@
       },
       "get": {
         "operationId": "listMemoryStores",
-        "summary": "List memory stores",
-        "description": "Returns the memory stores available to the caller.",
+        "description": "List all memory stores.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8041,18 +7276,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8075,8 +7300,7 @@
     "/memory_stores/{name}": {
       "post": {
         "operationId": "updateMemoryStore",
-        "summary": "Update a memory store",
-        "description": "Updates the specified memory store with the supplied configuration changes.",
+        "description": "Update a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8121,18 +7345,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8159,7 +7373,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -8177,8 +7391,7 @@
       },
       "get": {
         "operationId": "getMemoryStore",
-        "summary": "Get a memory store",
-        "description": "Retrieves the specified memory store and its current configuration.",
+        "description": "Retrieve a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8223,18 +7436,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8255,8 +7458,7 @@
       },
       "delete": {
         "operationId": "deleteMemoryStore",
-        "summary": "Delete a memory store",
-        "description": "Deletes the specified memory store.",
+        "description": "Delete a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8301,18 +7503,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8335,8 +7527,7 @@
     "/memory_stores/{name}/items": {
       "post": {
         "operationId": "createMemory",
-        "summary": "Create a memory item",
-        "description": "Creates a memory item in the specified memory store.",
+        "description": "Create a memory item in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8381,18 +7572,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8448,8 +7629,7 @@
     "/memory_stores/{name}/items/{memory_id}": {
       "post": {
         "operationId": "updateMemory",
-        "summary": "Update a memory item",
-        "description": "Updates the specified memory item in the memory store.",
+        "description": "Update a memory item in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8503,18 +7683,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8554,8 +7724,7 @@
       },
       "get": {
         "operationId": "getMemory",
-        "summary": "Get a memory item",
-        "description": "Retrieves the specified memory item from the memory store.",
+        "description": "Retrieve a memory item from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8609,18 +7778,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8641,8 +7800,7 @@
       },
       "delete": {
         "operationId": "deleteMemory",
-        "summary": "Delete a memory item",
-        "description": "Deletes the specified memory item from the memory store.",
+        "description": "Delete a memory item from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8696,18 +7854,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8730,8 +7878,7 @@
     "/memory_stores/{name}/items:list": {
       "post": {
         "operationId": "listMemories",
-        "summary": "List memory items",
-        "description": "Returns memory items from the specified memory store.",
+        "description": "List all memory items in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8854,18 +8001,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8907,8 +8044,7 @@
     "/memory_stores/{name}/updates/{update_id}": {
       "get": {
         "operationId": "getUpdateResult",
-        "summary": "Get an update result",
-        "description": "Retrieves the status and result of a memory store update operation.",
+        "description": "Get memory store update result.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8962,18 +8098,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8996,8 +8122,7 @@
     "/memory_stores/{name}:delete_scope": {
       "post": {
         "operationId": "deleteScopeMemories",
-        "summary": "Delete memories by scope",
-        "description": "Deletes all memories in the specified memory store that are associated with the provided scope.",
+        "description": "Delete all memories associated with a specific scope from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9042,18 +8167,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9095,8 +8210,7 @@
     "/memory_stores/{name}:search_memories": {
       "post": {
         "operationId": "searchMemories",
-        "summary": "Search memories",
-        "description": "Searches the specified memory store for memories relevant to the provided conversation context.",
+        "description": "Search for relevant memories from a memory store based on conversation context.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9141,18 +8255,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9213,8 +8317,7 @@
     "/memory_stores/{name}:update_memories": {
       "post": {
         "operationId": "updateMemories",
-        "summary": "Update memories",
-        "description": "Starts an update that writes conversation memories into the specified memory store.\nThe operation returns a long-running status location for polling the update result.",
+        "description": "Update memory store with conversation memories.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9269,18 +8372,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9339,7 +8432,6 @@
     "/models": {
       "get": {
         "operationId": "Models_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each ModelVersion",
         "parameters": [
           {
@@ -9369,27 +8461,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9416,7 +8489,6 @@
     "/models/{name}/versions": {
       "get": {
         "operationId": "Models_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given ModelVersion",
         "parameters": [
           {
@@ -9455,27 +8527,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9502,8 +8555,7 @@
     "/models/{name}/versions/{version}": {
       "get": {
         "operationId": "Models_getVersion",
-        "summary": "Get a model version",
-        "description": "Retrieves the specified model version, returning 404 if it does not exist.",
+        "description": "Get the specific version of the ModelVersion. The service returns 404 Not Found error if the ModelVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9550,27 +8602,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9600,7 +8633,6 @@
       },
       "delete": {
         "operationId": "Models_deleteVersion",
-        "summary": "Delete a model version",
         "description": "Delete the specific version of the ModelVersion. The service returns 200 OK if the ModelVersion was deleted successfully or if the ModelVersion does not exist.",
         "parameters": [
           {
@@ -9641,27 +8673,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9691,7 +8704,6 @@
       },
       "patch": {
         "operationId": "Models_updateVersion",
-        "summary": "Update a model version",
         "description": "Update an existing ModelVersion with the given version id",
         "parameters": [
           {
@@ -9749,27 +8761,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9812,8 +8805,7 @@
     "/models/{name}/versions/{version}/createAsync": {
       "post": {
         "operationId": "Models_createAsync",
-        "summary": "Create a model version async",
-        "description": "Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a location header for polling the operation status.",
+        "description": "Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9873,15 +8865,9 @@
                       "description": "URL to poll for operation status."
                     },
                     "operationResult": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
                       "description": "URL to the operation result, or null if the operation is still in progress."
                     }
                   }
@@ -9889,27 +8875,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9952,8 +8919,7 @@
     "/models/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Models_getCredentials",
-        "summary": "Get model asset credentials",
-        "description": "Retrieves temporary credentials for accessing the storage backing the specified model version.",
+        "description": "Get credentials for a model version asset.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10000,27 +8966,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -10062,8 +9009,7 @@
     "/models/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Models_startPendingUpload",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified model version.",
+        "description": "Start or retrieve a pending upload for a model version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -10110,27 +9056,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -10172,8 +9099,7 @@
     "/openai/v1/conversations": {
       "post": {
         "operationId": "createConversation",
-        "summary": "Create a conversation",
-        "description": "Creates a new conversation resource.",
+        "description": "Create a conversation.",
         "parameters": [
           {
             "name": "x-ms-user-isolation-key",
@@ -10196,18 +9122,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10233,8 +9149,7 @@
       },
       "get": {
         "operationId": "listConversations",
-        "summary": "List conversations",
-        "description": "Returns the conversations available in the current project.",
+        "description": "Returns the list of all conversations.",
         "parameters": [
           {
             "name": "limit",
@@ -10345,18 +9260,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10374,8 +9279,7 @@
     "/openai/v1/conversations/{conversation_id}": {
       "post": {
         "operationId": "updateConversation",
-        "summary": "Update a conversation",
-        "description": "Modifies the specified conversation's properties.",
+        "description": "Update a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10407,18 +9311,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10444,8 +9338,7 @@
       },
       "get": {
         "operationId": "getConversation",
-        "summary": "Retrieve a conversation",
-        "description": "Retrieves the specified conversation and its metadata.",
+        "description": "Retrieves a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10477,18 +9370,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10504,8 +9387,7 @@
       },
       "delete": {
         "operationId": "deleteConversation",
-        "summary": "Delete a conversation",
-        "description": "Removes the specified conversation resource from the current project.",
+        "description": "Deletes a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10537,18 +9419,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10566,8 +9438,7 @@
     "/openai/v1/conversations/{conversation_id}/items": {
       "post": {
         "operationId": "createConversationItems",
-        "summary": "Create conversation items",
-        "description": "Adds one or more items to the specified conversation.",
+        "description": "Create items in a conversation with the given ID.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10612,18 +9483,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10662,8 +9523,7 @@
       },
       "get": {
         "operationId": "listConversationItems",
-        "summary": "List conversation items",
-        "description": "Returns the items belonging to the specified conversation.",
+        "description": "List all items for a conversation with the given ID.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10773,18 +9633,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10802,8 +9652,7 @@
     "/openai/v1/conversations/{conversation_id}/items/{item_id}": {
       "get": {
         "operationId": "getConversationItem",
-        "summary": "Get a conversation item",
-        "description": "Retrieves a specific item from the specified conversation.",
+        "description": "Get a single item from a conversation with the given IDs.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10844,18 +9693,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10871,8 +9710,7 @@
       },
       "delete": {
         "operationId": "deleteConversationItem",
-        "summary": "Delete a conversation item",
-        "description": "Removes the specified item from a conversation.",
+        "description": "Delete an item from a conversation with the given IDs.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -10913,18 +9751,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10942,8 +9770,8 @@
     "/openai/v1/evals": {
       "get": {
         "operationId": "Evals_listEvals",
-        "summary": "List evaluations",
-        "description": "Returns the evaluations configured in the current project.",
+        "summary": "List all evaluations",
+        "description": "List evaluations for a project.",
         "parameters": [
           {
             "name": "after",
@@ -10961,7 +9789,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -11033,18 +9865,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11060,8 +9882,8 @@
       },
       "post": {
         "operationId": "Evals_createEval",
-        "summary": "Create an evaluation",
-        "description": "Creates the structure of an evaluation that can be used to test a model's performance.\nAn evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.\nFor more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).",
+        "summary": "Create evaluation",
+        "description": "Create the structure of an evaluation that can be used to test a model's performance.\nAn evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.\nFor more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).",
         "parameters": [],
         "responses": {
           "200": {
@@ -11074,18 +9896,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11114,7 +9926,7 @@
       "delete": {
         "operationId": "Evals_deleteEval",
         "summary": "Delete an evaluation",
-        "description": "Removes the specified evaluation and its associated data.",
+        "description": "Delete an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11137,18 +9949,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11165,7 +9967,7 @@
       "get": {
         "operationId": "Evals_getEval",
         "summary": "Get an evaluation",
-        "description": "Retrieves the specified evaluation and its configuration.",
+        "description": "Get an evaluation by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11188,18 +9990,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11216,7 +10008,7 @@
       "post": {
         "operationId": "Evals_updateEval",
         "summary": "Update an evaluation",
-        "description": "Updates certain properties of an evaluation.",
+        "description": "Update certain properties of an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11239,18 +10031,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11278,8 +10060,8 @@
     "/openai/v1/evals/{eval_id}/runs": {
       "get": {
         "operationId": "Evals_listRuns",
-        "summary": "List evaluation runs",
-        "description": "Returns the runs associated with the specified evaluation.",
+        "summary": "Get a list of runs for an evaluation",
+        "description": "Get a list of runs for an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11306,7 +10088,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -11381,18 +10167,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11408,8 +10184,7 @@
       },
       "post": {
         "operationId": "Evals_createEvalRun",
-        "summary": "Create an evaluation run",
-        "description": "Creates an evaluation run for the specified evaluation.",
+        "summary": "Create evaluation run",
         "parameters": [
           {
             "name": "eval_id",
@@ -11432,18 +10207,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11471,8 +10236,8 @@
     "/openai/v1/evals/{eval_id}/runs/{run_id}": {
       "delete": {
         "operationId": "Evals_deleteEvalRun",
-        "summary": "Delete an evaluation run",
-        "description": "Removes the specified evaluation run.",
+        "summary": "Delete evaluation run",
+        "description": "Delete an eval run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11504,18 +10269,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11532,7 +10287,7 @@
       "get": {
         "operationId": "Evals_getEvalRun",
         "summary": "Get an evaluation run",
-        "description": "Retrieves the specified evaluation run and its current status.",
+        "description": "Get an evaluation run by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11564,18 +10319,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11591,8 +10336,8 @@
       },
       "post": {
         "operationId": "Evals_cancelEvalRun",
-        "summary": "Cancel an evaluation run",
-        "description": "Cancels an ongoing evaluation run.",
+        "summary": "Cancel evaluation run",
+        "description": "Cancel an ongoing evaluation run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11624,18 +10369,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11653,8 +10388,8 @@
     "/openai/v1/evals/{eval_id}/runs/{run_id}/output_items": {
       "get": {
         "operationId": "Evals_getEvalRunOutputItems",
-        "summary": "List evaluation run output items",
-        "description": "Returns the output items produced by the specified evaluation run.",
+        "summary": "Get evaluation run output items",
+        "description": "Get a list of output items for an evaluation run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11689,7 +10424,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -11760,18 +10499,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11790,7 +10519,7 @@
       "get": {
         "operationId": "Evals_getEvalRunOutputItem",
         "summary": "Get an output item of an evaluation run",
-        "description": "Retrieves a single output item from the specified evaluation run.",
+        "description": "Get an evaluation run output item by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -11831,18 +10560,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11860,7 +10579,6 @@
     "/openai/v1/fine_tuning/jobs": {
       "post": {
         "operationId": "createFineTuningJob",
-        "summary": "Create a fine-tuning job",
         "description": "Creates a fine-tuning job which begins the process of creating a new model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
         "parameters": [
           {
@@ -11885,18 +10603,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11922,8 +10630,7 @@
       },
       "get": {
         "operationId": "listPaginatedFineTuningJobs",
-        "summary": "List fine-tuning jobs",
-        "description": "Returns the fine-tuning jobs for the current organization.",
+        "description": "List your organization's fine-tuning jobs",
         "parameters": [
           {
             "name": "after",
@@ -11969,18 +10676,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11998,8 +10695,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}": {
       "get": {
         "operationId": "retrieveFineTuningJob",
-        "summary": "Get a fine-tuning job",
-        "description": "Gets info about a fine-tuning job.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
+        "description": "Get info about a fine-tuning job.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12032,18 +10728,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12061,8 +10747,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel": {
       "post": {
         "operationId": "cancelFineTuningJob",
-        "summary": "Cancel a fine-tuning job",
-        "description": "Immediately cancels the specified fine-tuning job.",
+        "description": "Immediately cancel a fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12095,18 +10780,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12124,8 +10799,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints": {
       "get": {
         "operationId": "listFineTuningJobCheckpoints",
-        "summary": "List fine-tuning job checkpoints",
-        "description": "Returns the checkpoints saved during the specified fine-tuning job.",
+        "description": "List checkpoints for a fine-tuning job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12180,18 +10854,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12209,8 +10873,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/events": {
       "get": {
         "operationId": "listFineTuningJobEvents",
-        "summary": "List fine-tuning job events",
-        "description": "Returns the status events emitted during the specified fine-tuning job.",
+        "description": "Get fine-grained status updates for a fine-tuning job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12265,18 +10928,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12294,8 +10947,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/pause": {
       "post": {
         "operationId": "pauseFineTuningJob",
-        "summary": "Pause a fine-tuning job",
-        "description": "Pauses the specified fine-tuning job while it is running.",
+        "description": "Pause a running fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12328,18 +10980,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12357,8 +10999,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/resume": {
       "post": {
         "operationId": "resumeFineTuningJob",
-        "summary": "Resume a fine-tuning job",
-        "description": "Resumes the specified fine-tuning job after it has been paused.",
+        "description": "Resume a paused fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -12391,18 +11032,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12419,9 +11050,7 @@
     },
     "/openai/v1/responses": {
       "post": {
-        "operationId": "createResponse",
-        "summary": "Create a model response",
-        "description": "Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.",
+        "operationId": "createResponse_createResponseStream",
         "parameters": [
           {
             "name": "x-ms-user-isolation-key",
@@ -12433,6 +11062,7 @@
             }
           }
         ],
+        "description": "Creates a model response. Creates a model response (streaming response).",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -12448,322 +11078,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "metadata": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Metadata"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "top_logprobs": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "temperature": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.numeric"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": 1
-                    },
-                    "top_p": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.numeric"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": 1
-                    },
-                    "user": {
-                      "type": "string",
-                      "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
-                      "deprecated": true
-                    },
-                    "safety_identifier": {
-                      "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
-                    },
-                    "prompt_cache_key": {
-                      "type": "string",
-                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
-                    },
-                    "prompt_cache_retention": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": [
-                            "in_memory",
-                            "24h"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "previous_response_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "model": {
-                      "type": "string",
-                      "description": "The model deployment to use for the creation of this response."
-                    },
-                    "reasoning": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Reasoning"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "background": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_tool_calls": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "text": {
-                      "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
-                    },
-                    "tools": {
-                      "$ref": "#/components/schemas/OpenAI.ToolsArray"
-                    },
-                    "tool_choice": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
-                        },
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-                        }
-                      ]
-                    },
-                    "prompt": {
-                      "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "truncation": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": [
-                            "auto",
-                            "disabled"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": "disabled"
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier for this Response."
-                    },
-                    "object": {
-                      "type": "string",
-                      "enum": [
-                        "response"
-                      ],
-                      "description": "The object type of this resource - always set to `response`.",
-                      "x-stainless-const": true
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "completed",
-                        "failed",
-                        "in_progress",
-                        "cancelled",
-                        "queued",
-                        "incomplete"
-                      ],
-                      "description": "The status of the response generation. One of `completed`, `failed`,\n  `in_progress`, `cancelled`, `queued`, or `incomplete`."
-                    },
-                    "created_at": {
-                      "type": "integer",
-                      "format": "unixtime",
-                      "description": "Unix timestamp (in seconds) of when this Response was created."
-                    },
-                    "completed_at": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "type": "integer",
-                      "format": "unixTimestamp"
-                    },
-                    "error": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ResponseError"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "incomplete_details": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ResponseIncompleteDetails"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "output": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/OpenAI.OutputItem"
-                      },
-                      "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
-                    },
-                    "instructions": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/components/schemas/OpenAI.InputItem"
-                          }
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "output_text": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "usage": {
-                      "$ref": "#/components/schemas/OpenAI.ResponseUsage"
-                    },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "parallel_tool_calls": {
-                      "type": "boolean",
-                      "description": "Whether to allow the model to run tool calls in parallel.",
-                      "default": true
-                    },
-                    "conversation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "agent_reference": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/AgentReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "The agent used for this response"
-                    },
-                    "content_filters": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ContentFilterResult"
-                      },
-                      "description": "The content filter evaluation results."
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "object",
-                    "created_at",
-                    "error",
-                    "incomplete_details",
-                    "output",
-                    "instructions",
-                    "parallel_tool_calls",
-                    "agent_reference"
-                  ]
+                  "$ref": "#/components/schemas/OpenAI.Response"
                 }
               },
               "text/event-stream": {
@@ -12773,18 +11088,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12802,285 +11107,408 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "metadata": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Metadata"
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "metadata": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Metadata"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "top_logprobs": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
+                      "top_logprobs": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "temperature": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.numeric"
+                      "temperature": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": 1
-                  },
-                  "top_p": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.numeric"
+                      "top_p": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": 1
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
-                    "deprecated": true
-                  },
-                  "safety_identifier": {
-                    "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
-                  },
-                  "prompt_cache_key": {
-                    "type": "string",
-                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
-                  },
-                  "prompt_cache_retention": {
-                    "anyOf": [
-                      {
+                      "user": {
+                        "type": "string",
+                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
+                        "deprecated": true
+                      },
+                      "safety_identifier": {
+                        "type": "string",
+                        "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      },
+                      "prompt_cache_key": {
+                        "type": "string",
+                        "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                      },
+                      "service_tier": {
+                        "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      },
+                      "prompt_cache_retention": {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
+                        ],
+                        "nullable": true
+                      },
+                      "previous_response_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "model": {
+                        "type": "string",
+                        "description": "The model deployment to use for the creation of this response."
+                      },
+                      "reasoning": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Reasoning"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "background": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "max_output_tokens": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "max_tool_calls": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "text": {
+                        "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
+                      },
+                      "tools": {
+                        "$ref": "#/components/schemas/OpenAI.ToolsArray"
+                      },
+                      "tool_choice": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+                          },
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+                          }
                         ]
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "previous_response_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                      "prompt": {
+                        "$ref": "#/components/schemas/OpenAI.Prompt"
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "model": {
-                    "type": "string",
-                    "description": "The model deployment to use for the creation of this response."
-                  },
-                  "reasoning": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Reasoning"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "background": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "max_tool_calls": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "text": {
-                    "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
-                  },
-                  "tools": {
-                    "$ref": "#/components/schemas/OpenAI.ToolsArray"
-                  },
-                  "tool_choice": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
-                      },
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-                      }
-                    ]
-                  },
-                  "prompt": {
-                    "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "truncation": {
-                    "anyOf": [
-                      {
+                      "truncation": {
                         "type": "string",
                         "enum": [
                           "auto",
                           "disabled"
-                        ]
+                        ],
+                        "nullable": true,
+                        "default": "disabled"
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": "disabled"
-                  },
-                  "input": {
-                    "$ref": "#/components/schemas/OpenAI.InputParam"
-                  },
-                  "include": {
-                    "anyOf": [
-                      {
+                      "input": {
+                        "$ref": "#/components/schemas/OpenAI.InputParam"
+                      },
+                      "include": {
                         "type": "array",
                         "items": {
                           "$ref": "#/components/schemas/OpenAI.IncludeEnum"
-                        }
+                        },
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "parallel_tool_calls": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "parallel_tool_calls": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": true
-                  },
-                  "store": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "store": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": true
-                  },
-                  "instructions": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                      "instructions": {
+                        "type": "string",
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
+                      "stream": {
+                        "type": "boolean",
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "stream": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "stream_options": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "stream_options": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                      "conversation": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ConversationParam"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "conversation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ConversationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "context_management": {
-                    "anyOf": [
-                      {
+                      "context_management": {
                         "type": "array",
                         "items": {
                           "$ref": "#/components/schemas/OpenAI.ContextManagementParam"
-                        }
+                        },
+                        "nullable": true,
+                        "description": "Context management configuration for this request."
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
+                      "agent_reference": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "The agent to use for generating the response."
                       },
-                      {
-                        "type": "null"
+                      "structured_inputs": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
                       }
-                    ]
+                    }
                   },
-                  "agent_reference": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/AgentReference"
-                      }
-                    ],
-                    "description": "The agent to use for generating the response."
-                  },
-                  "structured_inputs": {
+                  {
                     "type": "object",
-                    "unevaluatedProperties": {},
-                    "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                    "properties": {
+                      "metadata": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Metadata"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "top_logprobs": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
+                      },
+                      "user": {
+                        "type": "string",
+                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
+                        "deprecated": true
+                      },
+                      "safety_identifier": {
+                        "type": "string",
+                        "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      },
+                      "prompt_cache_key": {
+                        "type": "string",
+                        "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                      },
+                      "service_tier": {
+                        "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      },
+                      "prompt_cache_retention": {
+                        "type": "string",
+                        "enum": [
+                          "in-memory",
+                          "24h"
+                        ],
+                        "nullable": true
+                      },
+                      "previous_response_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "model": {
+                        "type": "string",
+                        "description": "The model deployment to use for the creation of this response."
+                      },
+                      "reasoning": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Reasoning"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "background": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "max_output_tokens": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "max_tool_calls": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "text": {
+                        "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
+                      },
+                      "tools": {
+                        "$ref": "#/components/schemas/OpenAI.ToolsArray"
+                      },
+                      "tool_choice": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+                          },
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+                          }
+                        ]
+                      },
+                      "prompt": {
+                        "$ref": "#/components/schemas/OpenAI.Prompt"
+                      },
+                      "truncation": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "disabled"
+                        ],
+                        "nullable": true,
+                        "default": "disabled"
+                      },
+                      "input": {
+                        "$ref": "#/components/schemas/OpenAI.InputParam"
+                      },
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/OpenAI.IncludeEnum"
+                        },
+                        "nullable": true
+                      },
+                      "parallel_tool_calls": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
+                      },
+                      "store": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
+                      },
+                      "instructions": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "stream": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "stream_options": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "conversation": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ConversationParam"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "context_management": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/OpenAI.ContextManagementParam"
+                        },
+                        "nullable": true,
+                        "description": "Context management configuration for this request."
+                      },
+                      "agent_reference": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "The agent to use for generating the response."
+                      },
+                      "structured_inputs": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                      }
+                    }
                   }
-                }
+                ]
               }
             }
           }
@@ -13088,8 +11516,7 @@
       },
       "get": {
         "operationId": "listResponses",
-        "summary": "List responses",
-        "description": "Returns a collection of all stored responses matching specified filter criteria.",
+        "description": "Returns the list of all responses.",
         "parameters": [
           {
             "name": "limit",
@@ -13210,18 +11637,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13239,8 +11656,7 @@
     "/openai/v1/responses/compact": {
       "post": {
         "operationId": "compactResponseConversation",
-        "summary": "Compact a conversation",
-        "description": "Compacts a conversation into a response object suitable for long-running and zero-data-retention scenarios.",
+        "description": "Produces a compaction of a responses conversation.",
         "parameters": [],
         "responses": {
           "200": {
@@ -13253,18 +11669,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13291,9 +11697,7 @@
     },
     "/openai/v1/responses/{response_id}": {
       "get": {
-        "operationId": "getResponse",
-        "summary": "Retrieve a model response",
-        "description": "Retrieves a model response with the given ID.",
+        "operationId": "getResponse_getResponseStream",
         "parameters": [
           {
             "name": "response_id",
@@ -13343,8 +11747,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "accept",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text/event-stream"
+              ]
+            }
           }
         ],
+        "description": "Retrieves a model response with the given ID. Retrieves a model response with the given ID (streaming response).",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -13370,18 +11786,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13397,7 +11803,6 @@
       },
       "delete": {
         "operationId": "deleteResponse",
-        "summary": "Delete a model response",
         "description": "Deletes a model response.",
         "parameters": [
           {
@@ -13439,18 +11844,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13468,8 +11863,7 @@
     "/openai/v1/responses/{response_id}/cancel": {
       "post": {
         "operationId": "cancelResponse",
-        "summary": "Cancel a model response",
-        "description": "Cancels a model response with the given ID. Only responses created with the background parameter set to true can be cancelled.",
+        "description": "Cancels a model response.",
         "parameters": [
           {
             "name": "response_id",
@@ -13510,18 +11904,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13539,8 +11923,7 @@
     "/openai/v1/responses/{response_id}/input_items": {
       "get": {
         "operationId": "listInputItems",
-        "summary": "List input items for a response",
-        "description": "Retrieves the input items associated with the specified response.",
+        "description": "Returns a list of input items for a given response.",
         "parameters": [
           {
             "name": "response_id",
@@ -13648,18 +12031,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13677,8 +12050,7 @@
     "/redTeams/runs": {
       "get": {
         "operationId": "RedTeams_list",
-        "summary": "List redteams",
-        "description": "Returns the redteams available in the current project.",
+        "description": "List a redteam by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -13707,27 +12079,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -13754,8 +12107,7 @@
     "/redTeams/runs/{name}": {
       "get": {
         "operationId": "RedTeams_get",
-        "summary": "Get a redteam",
-        "description": "Retrieves the specified redteam and its configuration.",
+        "description": "Get a redteam by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -13793,27 +12145,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -13840,8 +12173,7 @@
     "/redTeams/runs:run": {
       "post": {
         "operationId": "RedTeams_create",
-        "summary": "Create a redteam run",
-        "description": "Submits a new redteam run for execution with the provided configuration.",
+        "description": "Creates a redteam run.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -13877,18 +12209,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13917,8 +12239,7 @@
     "/routines": {
       "get": {
         "operationId": "listRoutines",
-        "summary": "List routines",
-        "description": "Returns the routines available in the current project.",
+        "description": "List routines.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -13933,16 +12254,46 @@
             }
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.after"
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.before"
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.order"
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -13992,18 +12343,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14026,8 +12367,7 @@
     "/routines/{routine_name}": {
       "put": {
         "operationId": "createOrUpdateRoutine",
-        "summary": "Create or update a routine",
-        "description": "Creates a new routine or replaces an existing routine with the supplied definition.",
+        "description": "Create or update a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14066,18 +12406,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14108,8 +12438,7 @@
       },
       "get": {
         "operationId": "getRoutine",
-        "summary": "Get a routine",
-        "description": "Retrieves the specified routine and its current configuration.",
+        "description": "Retrieve a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14148,18 +12477,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14180,8 +12499,7 @@
       },
       "delete": {
         "operationId": "deleteRoutine",
-        "summary": "Delete a routine",
-        "description": "Deletes the specified routine.",
+        "description": "Delete a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14213,18 +12531,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14247,8 +12555,7 @@
     "/routines/{routine_name}/runs": {
       "get": {
         "operationId": "listRoutineRuns",
-        "summary": "List prior runs for a routine",
-        "description": "Returns prior runs recorded for the specified routine.",
+        "description": "List prior runs for a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14269,16 +12576,46 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -14328,18 +12665,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14362,8 +12689,7 @@
     "/routines/{routine_name}:disable": {
       "post": {
         "operationId": "disableRoutine",
-        "summary": "Disable a routine",
-        "description": "Disables the specified routine so it no longer runs.",
+        "description": "Disable a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14402,18 +12728,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14436,8 +12752,7 @@
     "/routines/{routine_name}:dispatch_async": {
       "post": {
         "operationId": "dispatchRoutineAsync",
-        "summary": "Queue an asynchronous routine dispatch",
-        "description": "Queues an asynchronous dispatch for the specified routine.",
+        "description": "Queue an asynchronous routine dispatch.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14476,18 +12791,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14520,8 +12825,7 @@
     "/routines/{routine_name}:enable": {
       "post": {
         "operationId": "enableRoutine",
-        "summary": "Enable a routine",
-        "description": "Enables the specified routine so it can be dispatched.",
+        "description": "Enable a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -14560,18 +12864,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14594,8 +12888,7 @@
     "/schedules": {
       "get": {
         "operationId": "Schedules_list",
-        "summary": "List schedules",
-        "description": "Returns schedules that match the supplied type and enabled filters.",
+        "description": "List all schedules.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -14644,27 +12937,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -14691,8 +12965,7 @@
     "/schedules/{id}": {
       "delete": {
         "operationId": "Schedules_delete",
-        "summary": "Delete a schedule",
-        "description": "Deletes the specified schedule resource.",
+        "description": "Delete a schedule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -14723,27 +12996,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -14768,8 +13022,7 @@
       },
       "get": {
         "operationId": "Schedules_get",
-        "summary": "Get a schedule",
-        "description": "Retrieves the specified schedule resource.",
+        "description": "Get a schedule by id.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -14807,27 +13060,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -14852,8 +13086,7 @@
       },
       "put": {
         "operationId": "Schedules_createOrUpdate",
-        "summary": "Create or update a schedule",
-        "description": "Creates a new schedule or updates an existing schedule with the supplied definition.",
+        "description": "Create or update operation template.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -14901,27 +13134,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -14959,8 +13173,7 @@
     "/schedules/{id}/runs": {
       "get": {
         "operationId": "Schedules_listRuns",
-        "summary": "List schedule runs",
-        "description": "Returns schedule runs that match the supplied filters.",
+        "description": "List all schedule runs.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -15018,27 +13231,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -15065,8 +13259,7 @@
     "/schedules/{schedule_id}/runs/{run_id}": {
       "get": {
         "operationId": "Schedules_getRun",
-        "summary": "Get a schedule run",
-        "description": "Retrieves the specified run for a schedule.",
+        "description": "Get a schedule run by id.",
         "parameters": [
           {
             "name": "schedule_id",
@@ -15120,18 +13313,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15149,8 +13332,7 @@
     "/skills": {
       "get": {
         "operationId": "Skills_listSkills",
-        "summary": "List skills",
-        "description": "Returns the skills available in the current project.",
+        "description": "Returns the list of all skills.",
         "parameters": [
           {
             "name": "limit",
@@ -15254,18 +13436,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15288,8 +13460,7 @@
     "/skills/{name}": {
       "get": {
         "operationId": "Skills_getSkill",
-        "summary": "Retrieve a skill",
-        "description": "Retrieves the specified skill and its current configuration.",
+        "description": "Retrieves a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15334,18 +13505,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15366,8 +13527,7 @@
       },
       "post": {
         "operationId": "updateSkill",
-        "summary": "Update a skill",
-        "description": "Modifies the specified skill's configuration.",
+        "description": "Update a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15412,18 +13572,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15463,8 +13613,7 @@
       },
       "delete": {
         "operationId": "Skills_deleteSkill",
-        "summary": "Delete a skill",
-        "description": "Removes the specified skill and its associated versions.",
+        "description": "Deletes a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15509,18 +13658,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15543,8 +13682,7 @@
     "/skills/{name}/content": {
       "get": {
         "operationId": "getSkillContent",
-        "summary": "Download the zip content for the default version of a skill",
-        "description": "Downloads the zip content for the default version of a skill.",
+        "description": "Download the zip content for the default version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15584,23 +13722,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15657,7 +13786,6 @@
           }
         ],
         "description": "Creates a new version of a skill. If the skill does not exist, it will be created. Creates a new version of a skill from uploaded files via multipart form data.",
-        "summary": "Create a new version of a skill Create a skill version from uploaded files",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -15669,18 +13797,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15690,8 +13808,6 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new version of a skill. If the skill does not exist, it will be created.",
-        "x-ms-summary-override": "Create a new version of a skill",
         "x-ms-foundry-meta": {
           "required_previews": [
             "Skills=V1Preview"
@@ -15740,8 +13856,7 @@
       },
       "get": {
         "operationId": "listSkillVersions",
-        "summary": "List skill versions",
-        "description": "Returns the available versions for the specified skill.",
+        "description": "List all versions of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15854,18 +13969,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15888,8 +13993,7 @@
     "/skills/{name}/versions/{version}": {
       "get": {
         "operationId": "getSkillVersion",
-        "summary": "Retrieve a specific version of a skill",
-        "description": "Retrieves the specified version of a skill by name and version identifier.",
+        "description": "Retrieve a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -15943,18 +14047,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15975,8 +14069,7 @@
       },
       "delete": {
         "operationId": "deleteSkillVersion",
-        "summary": "Delete a specific version of a skill",
-        "description": "Removes the specified version of a skill.",
+        "description": "Delete a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -16030,18 +14123,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16064,8 +14147,7 @@
     "/skills/{name}/versions/{version}/content": {
       "get": {
         "operationId": "getSkillVersionContent",
-        "summary": "Download the zip content for a specific version of a skill",
-        "description": "Downloads the zip content for a specific version of a skill.",
+        "description": "Download the zip content for a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -16114,23 +14196,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16153,8 +14226,7 @@
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
-        "summary": "List toolboxes",
-        "description": "Returns the toolboxes available in the current project.",
+        "description": "List all toolboxes.",
         "parameters": [
           {
             "name": "limit",
@@ -16197,18 +14269,6 @@
               "type": "string"
             },
             "explode": false
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -16258,18 +14318,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16281,19 +14331,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}": {
       "get": {
         "operationId": "getToolbox",
-        "summary": "Retrieve a toolbox",
-        "description": "Retrieves the specified toolbox and its current configuration.",
+        "description": "Retrieve a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -16305,18 +14349,6 @@
             }
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -16338,18 +14370,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16361,32 +14383,14 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "patch": {
         "operationId": "updateToolbox",
-        "summary": "Update a toolbox to point to a specific version",
-        "description": "Updates the toolbox's default version pointer to the specified version.",
+        "description": "Update a toolbox to point to a specific version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/UpdateToolboxRequest.name"
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -16410,18 +14414,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16443,17 +14437,11 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "delete": {
         "operationId": "deleteToolbox",
-        "summary": "Delete a toolbox",
-        "description": "Removes the specified toolbox along with all of its versions.",
+        "description": "Delete a toolbox and all its versions.",
         "parameters": [
           {
             "name": "name",
@@ -16462,18 +14450,6 @@
             "description": "The name of the toolbox to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16491,18 +14467,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16514,19 +14480,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions": {
       "post": {
         "operationId": "createToolboxVersion",
-        "summary": "Create a new version of a toolbox",
-        "description": "Creates a new toolbox version, provisioning the toolbox itself if it does not already exist.",
+        "description": "Create a new version of a toolbox. If the toolbox does not exist, it will be created.",
         "parameters": [
           {
             "name": "name",
@@ -16536,18 +14496,6 @@
             "schema": {
               "type": "string",
               "maxLength": 256
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16572,18 +14520,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16610,7 +14548,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the toolbox."
@@ -16644,17 +14582,11 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "get": {
         "operationId": "listToolboxVersions",
-        "summary": "List toolbox versions",
-        "description": "Returns the available versions for the specified toolbox.",
+        "description": "List all versions of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -16708,18 +14640,6 @@
             "explode": false
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -16767,18 +14687,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16790,19 +14700,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions/{version}": {
       "get": {
         "operationId": "getToolboxVersion",
-        "summary": "Retrieve a specific version of a toolbox",
-        "description": "Retrieves the specified version of a toolbox by name and version identifier.",
+        "description": "Retrieve a specific version of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -16820,18 +14724,6 @@
             "description": "The version identifier to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -16856,18 +14748,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16879,17 +14761,11 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "deleteToolboxVersion",
-        "summary": "Delete a specific version of a toolbox",
-        "description": "Removes the specified version of a toolbox.",
+        "description": "Delete a specific version of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -16910,18 +14786,6 @@
             }
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -16936,18 +14800,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16959,12 +14813,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     }
   },
@@ -17057,52 +14906,11 @@
           "maxLength": 128
         }
       },
-      "ListRoutineRunsParameters.after": {
-        "name": "after",
-        "in": "query",
-        "required": false,
-        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.before": {
-        "name": "before",
-        "in": "query",
-        "required": false,
-        "description": "Unsupported. Reserved for future backward pagination support.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
         "required": false,
         "description": "An optional MLflow search-runs filter expression applied within the routine's experiment.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.limit": {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "description": "The maximum number of runs to return.",
-        "schema": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.order": {
-        "name": "order",
-        "in": "query",
-        "required": false,
-        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -17117,47 +14925,6 @@
           "type": "string",
           "maxLength": 128
         }
-      },
-      "ListRoutinesParameters.after": {
-        "name": "after",
-        "in": "query",
-        "required": false,
-        "description": "An opaque cursor returned as last_id by the previous list response.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.before": {
-        "name": "before",
-        "in": "query",
-        "required": false,
-        "description": "Unsupported. Reserved for future backward pagination support.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.limit": {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "description": "The maximum number of routines to return.",
-        "schema": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.order": {
-        "name": "order",
-        "in": "query",
-        "required": false,
-        "description": "The ordering direction. Supported values are asc and desc.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -17903,6 +15670,23 @@
         ],
         "description": "A trace source that selects traces by agent reference with time-based filtering."
       },
+      "AgentIdentifier": {
+        "type": "object",
+        "required": [
+          "agentName"
+        ],
+        "properties": {
+          "agentName": {
+            "type": "string",
+            "description": "Registered Foundry agent name (required)."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Pinned agent version. Defaults to latest if omitted."
+          }
+        },
+        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and systemPrompt are specified in options.optimizationConfig."
+      },
       "AgentIdentity": {
         "type": "object",
         "required": [
@@ -18057,7 +15841,6 @@
             "enum": [
               "activity_protocol",
               "responses",
-              "a2a",
               "mcp",
               "invocations",
               "invocations_ws"
@@ -18159,6 +15942,7 @@
               "idle",
               "updating",
               "failed",
+              "stopping",
               "deleting",
               "deleted",
               "expired"
@@ -18256,17 +16040,11 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
             "x-oaiTypeLabel": "map"
           },
@@ -19610,7 +17388,7 @@
               },
               "parameters": {
                 "type": "object",
-                "unevaluatedProperties": {},
+                "additionalProperties": {},
                 "description": "The parameters the functions accepts, described as a JSON Schema object."
               }
             },
@@ -20394,6 +18172,160 @@
         },
         "description": "Definition of input parameters for the Browser Automation Tool."
       },
+      "CandidateDeployConfig": {
+        "type": "object",
+        "properties": {
+          "instructions": {
+            "type": "string",
+            "description": "System prompt / instructions."
+          },
+          "model": {
+            "type": "string",
+            "description": "Foundry deployment name."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Optional sampling temperature."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Optional skill overrides."
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Optional tool overrides."
+          }
+        },
+        "description": "Deploy-config blob for a candidate. Suitable for setting OPTIMIZATION_CONFIG on a hosted-agent version."
+      },
+      "CandidateFileInfo": {
+        "type": "object",
+        "required": [
+          "path",
+          "type",
+          "sizeBytes"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Relative path of the file."
+          },
+          "type": {
+            "type": "string",
+            "description": "File type category (e.g. 'config', 'results')."
+          },
+          "sizeBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "File size in bytes."
+          }
+        },
+        "description": "File entry in a candidate's blob directory."
+      },
+      "CandidateMetadata": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "jobId",
+          "candidateName",
+          "status",
+          "hasResults",
+          "createdAt",
+          "updatedAt",
+          "files"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "Server-assigned candidate identifier."
+          },
+          "jobId": {
+            "type": "string",
+            "description": "Owning optimization job id."
+          },
+          "candidateName": {
+            "type": "string",
+            "description": "Display name of the candidate."
+          },
+          "status": {
+            "type": "string",
+            "description": "Candidate lifecycle status."
+          },
+          "score": {
+            "type": "number",
+            "format": "double",
+            "description": "Candidate's aggregate score."
+          },
+          "hasResults": {
+            "type": "boolean",
+            "description": "Whether detailed results are available for this candidate."
+          },
+          "createdAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when the candidate was created, represented in Unix time."
+          },
+          "updatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when the candidate was last updated, represented in Unix time."
+          },
+          "promotion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PromotionInfo"
+              }
+            ],
+            "description": "Promotion metadata. Null if not promoted."
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CandidateFileInfo"
+            },
+            "description": "Files in the candidate's blob directory."
+          }
+        },
+        "description": "Candidate metadata returned by GET /candidates/{id}."
+      },
+      "CandidateResults": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "results"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "Owning candidate id."
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationTaskResult"
+            },
+            "description": "Per-task evaluation rows."
+          }
+        },
+        "description": "Full per-task evaluation results for a candidate, returned by GET /candidates/{id}/results."
+      },
       "CaptureStructuredOutputsTool": {
         "type": "object",
         "required": [
@@ -20508,7 +18440,7 @@
           },
           "coordinates": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/ChartCoordinate"
             },
             "description": "  Optional mapping of IDs to 2D coordinates used by the UX for visualization.\n\n  The map keys are string identifiers (for example, a cluster id or a sample id)\n  and the values are the coordinates and visual size for rendering on a 2D chart.\n\n  This property is omitted unless the client requests coordinates (for example,\n  by passing `includeCoordinates=true` as a query parameter).\n\n  Example:\n  ```\n  {\n    \"cluster-1\": { \"x\": 12, \"y\": 34, \"size\": 8 },\n    \"sample-123\": { \"x\": 18, \"y\": 22, \"size\": 4 }\n  }\n  ```\n\n  Coordinates are intended only for client-side visualization and do not\n  modify the canonical insights results."
@@ -20762,7 +18694,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata of the connection",
@@ -20803,9 +18735,7 @@
           "image": {
             "type": "string",
             "description": "The container image for the hosted agent.",
-            "examples": [
-              "my-registry.azurecr.io/my-hosted-agent:latest"
-            ]
+            "example": "my-registry.azurecr.io/my-hosted-agent:latest"
           }
         },
         "description": "Container-based deployment configuration for a hosted agent.",
@@ -20867,14 +18797,6 @@
             "type": "integer",
             "format": "int32",
             "description": "Maximum number of evaluation runs allowed per hour."
-          },
-          "samplingRate": {
-            "type": "number",
-            "format": "double",
-            "maximum": 100,
-            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.",
-            "exclusiveMinimum": 0,
-            "default": 100
           }
         },
         "allOf": [
@@ -20916,7 +18838,7 @@
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Mapping from source fields to response_id field, which is required for retrieving chat history."
@@ -21020,6 +18942,8 @@
             "description": "JSON metadata including description and hosted definition."
           },
           "code": {
+            "type": "string",
+            "format": "binary",
             "description": "The code zip file (max 250 MB)."
           }
         },
@@ -21043,7 +18967,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -21060,7 +18984,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -21079,7 +19003,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -21193,6 +19117,8 @@
             "description": "JSON metadata including description and hosted definition."
           },
           "code": {
+            "type": "string",
+            "format": "binary",
             "description": "The code zip file (max 250 MB)."
           }
         },
@@ -21214,7 +19140,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -21245,7 +19171,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -21262,7 +19188,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -21275,7 +19201,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -21337,14 +19263,13 @@
             "description": "The name of the evaluation."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "data_source_config": {
             "oneOf": [
@@ -21394,7 +19319,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -21413,14 +19338,13 @@
             "description": "The name of the run."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "data_source": {
             "oneOf": [
@@ -21441,7 +19365,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -21463,7 +19387,10 @@
         "properties": {
           "files": {
             "type": "array",
-            "items": {},
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
             "description": "Skill files to upload. Upload a single zip file or multiple individual files with relative paths."
           },
           "default": {
@@ -21547,7 +19474,7 @@
             "readOnly": true
           }
         },
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "type": "string"
         },
         "allOf": [
@@ -21556,49 +19483,6 @@
           }
         ],
         "description": "Custom credential definition"
-      },
-      "CustomRoutineTrigger": {
-        "type": "object",
-        "required": [
-          "type",
-          "provider",
-          "parameters"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom"
-            ],
-            "description": "The trigger type."
-          },
-          "provider": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The external provider that emits the custom event."
-          },
-          "event_name": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "The provider-specific event name that fires the routine."
-          },
-          "parameters": {
-            "type": "object",
-            "unevaluatedProperties": {},
-            "description": "Provider-specific trigger parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RoutineTrigger"
-          }
-        ],
-        "description": "A custom event routine trigger.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
       },
       "DailyRecurrenceSchedule": {
         "type": "object",
@@ -21829,7 +19713,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tags to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs."
@@ -22015,15 +19899,13 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The overall object JSON schema for the run data source items."
           }
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -22062,7 +19944,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary of the output dataset.",
@@ -22109,6 +19991,50 @@
           }
         ],
         "description": "Dataset source for evaluator generation jobs — reference to a dataset."
+      },
+      "DatasetInfo": {
+        "type": "object",
+        "required": [
+          "taskCount",
+          "isInline"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Dataset name when using a registered dataset reference. Null for inline datasets."
+          },
+          "version": {
+            "type": "string",
+            "description": "Dataset version when using a registered dataset reference. Null for inline datasets."
+          },
+          "taskCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tasks/rows in the dataset."
+          },
+          "isInline": {
+            "type": "boolean",
+            "description": "True when the dataset was provided inline in the request body."
+          }
+        },
+        "description": "Metadata about the dataset used for optimization, surfaced in the response."
+      },
+      "DatasetRef": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Dataset name."
+          },
+          "version": {
+            "type": "string",
+            "description": "Dataset version. If not specified, the latest version is used."
+          }
+        },
+        "description": "Reference to a registered dataset in the Foundry Dataset Service."
       },
       "DatasetReference": {
         "type": "object",
@@ -22220,7 +20146,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -22575,7 +20501,7 @@
           },
           "always_applicable": {
             "type": "boolean",
-            "description": "When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. Defaults to `false`.",
             "default": false
           }
         },
@@ -22782,14 +20708,13 @@
             "description": "The Unix timestamp (in seconds) for when the eval was created."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "modified_at": {
             "allOf": [
@@ -22805,7 +20730,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -22997,14 +20922,13 @@
             "description": "Information about the run's data source."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "error": {
             "$ref": "#/components/schemas/OpenAI.EvalApiError"
@@ -23023,7 +20947,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -23127,7 +21051,7 @@
           },
           "datasource_item": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Details of the input data source item."
           },
           "results": {
@@ -23183,15 +21107,9 @@
             "description": "Whether the grader considered the output a pass."
           },
           "sample": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true,
             "description": "Optional sample or intermediate data produced by the grader."
           },
           "status": {
@@ -23221,13 +21139,13 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional details about the test criteria metric."
           }
         },
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "A single grader result for an evaluation run output item.",
         "title": "EvalRunOutputItemResult"
       },
@@ -23583,7 +21501,7 @@
           },
           "systemData": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "System metadata for the evaluation rule.",
@@ -23746,7 +21664,6 @@
           },
           "evalRun": {
             "type": "object",
-            "unevaluatedProperties": {},
             "description": "The evaluation run payload."
           }
         },
@@ -23797,7 +21714,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -23817,7 +21734,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -23839,7 +21756,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -23917,7 +21834,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -23939,7 +21856,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -23998,17 +21915,17 @@
           },
           "init_parameters": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema (Draft 2020-12) for the evaluator's input parameters. This includes parameters like type, properties, required."
           },
           "data_schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema (Draft 2020-12) for the evaluator's input data. This includes parameters like type, properties, required."
           },
           "metrics": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/EvaluatorMetric"
             },
             "description": "List of output metrics produced by this evaluator"
@@ -24373,7 +22290,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -24392,16 +22309,6 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
-          },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
           },
           "definition": {
             "allOf": [
@@ -24467,7 +22374,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -24487,16 +22394,6 @@
             },
             "description": "The categories of the evaluator"
           },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
-          },
           "definition": {
             "allOf": [
               {
@@ -24511,7 +22408,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -24528,7 +22425,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -24540,23 +22437,13 @@
             },
             "description": "The categories of the evaluator"
           },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
-          },
           "description": {
             "type": "string",
             "description": "The asset description text."
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -24718,13 +22605,17 @@
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
-                "type": "string"
-              },
-              {
-                "type": "null"
+                "type": "string",
+                "nullable": true
               }
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
@@ -24775,13 +22666,17 @@
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
-                "type": "string"
-              },
-              {
-                "type": "null"
+                "type": "string",
+                "nullable": true
               }
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
@@ -24925,14 +22820,12 @@
             "description": "Ranking options for search."
           },
           "filters": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Filters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "vector_store_ids": {
             "type": "array",
@@ -25158,40 +23051,19 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueEvent": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "opened",
-              "closed"
-            ]
-          }
-        ],
-        "description": "Known GitHub issue events that can fire a routine.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "GitHubIssueRoutineTrigger": {
+      "GitHubIssueOpenedRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "owner",
-          "repository",
-          "issue_event"
+          "assignee",
+          "repository"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue"
+              "github_issue_opened"
             ],
             "description": "The trigger type."
           },
@@ -25200,23 +23072,15 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "owner": {
+          "assignee": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
+            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
-          },
-          "issue_event": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/GitHubIssueEvent"
-              }
-            ],
-            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -25224,7 +23088,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue routine trigger.",
+        "description": "A GitHub issue-opened routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -25274,23 +23138,17 @@
           "header_name": {
             "type": "string",
             "description": "The name of the HTTP header to inject the secret value into.",
-            "examples": [
-              "X-Otlp-Api-Key"
-            ]
+            "example": "X-Otlp-Api-Key"
           },
           "secret_id": {
             "type": "string",
             "description": "The identifier of the secret store or connection.",
-            "examples": [
-              "my-secret-store"
-            ]
+            "example": "my-secret-store"
           },
           "secret_key": {
             "type": "string",
             "description": "The key within the secret to retrieve the authentication value.",
-            "examples": [
-              "OTLP_KEY"
-            ]
+            "example": "OTLP_KEY"
           }
         },
         "allOf": [
@@ -25329,29 +23187,23 @@
           "cpu": {
             "type": "string",
             "description": "The CPU configuration for the hosted agent.",
-            "examples": [
-              "0.25"
-            ]
+            "example": "0.25"
           },
           "memory": {
             "type": "string",
             "description": "The memory configuration for the hosted agent.",
-            "examples": [
-              "0.5Gi"
-            ]
+            "example": "0.5Gi"
           },
           "environment_variables": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Environment variables to set in the hosted agent container.",
-            "examples": [
-              {
-                "name": "LOG_LEVEL",
-                "value": "debug"
-              }
-            ]
+            "example": {
+              "name": "LOG_LEVEL",
+              "value": "debug"
+            }
           },
           "container_configuration": {
             "allOf": [
@@ -25372,17 +23224,15 @@
               "$ref": "#/components/schemas/ProtocolVersionRecord"
             },
             "description": "The protocols that the agent supports for ingress communication.",
-            "examples": [
-              [
-                {
-                  "protocol": "responses",
-                  "version": "v0.1.1"
-                },
-                {
-                  "protocol": "a2a",
-                  "version": "v0.3.0"
-                }
-              ]
+            "example": [
+              {
+                "protocol": "responses",
+                "version": "v0.1.1"
+              },
+              {
+                "protocol": "a2a",
+                "version": "v0.3.0"
+              }
             ],
             "x-ms-foundry-meta": {
               "required_previews": [
@@ -25550,7 +23400,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -25762,12 +23612,12 @@
           },
           "features": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Features to help with additional filtering of data in UX."
           },
           "correlationInfo": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Info about the correlation for the analysis sample."
           }
         },
@@ -25886,8 +23736,7 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type",
-          "input"
+          "type"
         ],
         "properties": {
           "type": {
@@ -25898,7 +23747,9 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
+            "type": "string",
+            "maxLength": 32768,
+            "description": "The raw input sent to the downstream invocations target."
           }
         },
         "allOf": [
@@ -25916,7 +23767,8 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "agent_endpoint_id"
         ],
         "properties": {
           "type": {
@@ -25926,18 +23778,10 @@
             ],
             "description": "The action type."
           },
-          "agent_name": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "The project-scoped agent name for routine dispatch."
-          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
-          },
-          "input": {
-            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
+            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
           },
           "session_id": {
             "type": "string",
@@ -25950,7 +23794,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
+        "description": "Dispatches a routine through the raw invocations API.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -25960,8 +23804,7 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type",
-          "input"
+          "type"
         ],
         "properties": {
           "type": {
@@ -25972,7 +23815,9 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
+            "type": "string",
+            "maxLength": 32768,
+            "description": "The user input sent to the downstream responses target."
           }
         },
         "allOf": [
@@ -26003,17 +23848,14 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for routine dispatch."
+            "description": "The project-scoped agent name for responses API dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+            "description": "The endpoint-scoped agent identifier for responses API dispatch."
           },
-          "input": {
-            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
-          },
-          "conversation": {
+          "conversation_id": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -26095,8 +23937,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -26211,17 +24052,11 @@
             "description": "Optional description of the MCP server, used to provide more context."
           },
           "headers": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "allowed_tools": {
             "anyOf": [
@@ -26229,37 +24064,41 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
-              },
-              {
-                "type": "null"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
+                  }
+                ],
+                "nullable": true
               }
             ]
           },
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
                 "type": "string",
                 "enum": [
                   "always",
                   "never"
-                ]
-              },
-              {
-                "type": "null"
+                ],
+                "nullable": true
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -26657,17 +24496,11 @@
             "description": "The status of the tool call."
           },
           "memories": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/MemoryItem"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemoryItem"
+            },
+            "nullable": true,
             "description": "The results returned from the memory search."
           }
         },
@@ -26745,7 +24578,7 @@
           },
           "procedural_memory_enabled": {
             "type": "boolean",
-            "description": "Whether to enable procedural memory extraction and storage. The service defaults to `true` if a value is not specified by the caller.",
+            "description": "Whether to enable procedural memory extraction and storage. Defaults to `true`.",
             "default": true
           },
           "default_ttl_seconds": {
@@ -26895,7 +24728,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -27202,7 +25035,7 @@
           },
           "capabilities": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Capabilities of deployed model",
@@ -27423,7 +25256,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -27630,7 +25463,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -27663,7 +25497,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -27697,7 +25532,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27725,7 +25561,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27825,7 +25662,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -27850,7 +25688,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27883,7 +25722,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27920,44 +25760,20 @@
             "default": "approximate"
           },
           "country": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "region": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -27985,14 +25801,12 @@
             "description": "An optional list of uploaded files to make available to your code."
           },
           "memory_limit": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ContainerMemoryLimit"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "network_policy": {
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
@@ -28026,12 +25840,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -28131,7 +25939,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -28156,19 +25965,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -28335,61 +26131,17 @@
                 "items": {
                   "$ref": "#/components/schemas/OpenAI.InputItem"
                 }
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "previous_response_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -28409,9 +26161,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -28513,14 +26263,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -28553,24 +26295,12 @@
             "description": "The ID of the pending safety check."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "A pending safety check for the computer call."
@@ -28590,8 +26320,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -28600,36 +26329,17 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -28667,29 +26377,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -28705,7 +26392,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -28752,7 +26440,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -28763,14 +26452,12 @@
             "description": "An optional list of uploaded files to make available to your code."
           },
           "memory_limit": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ContainerMemoryLimit"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "skills": {
             "type": "array",
@@ -28807,7 +26494,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -28868,7 +26556,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -28877,6 +26566,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -28897,7 +26594,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -28905,6 +26603,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -28952,7 +26676,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -29009,14 +26734,13 @@
             "description": "The context management entry type. Currently only 'compaction' is supported."
           },
           "compact_threshold": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         }
       },
@@ -29034,18 +26758,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -29057,56 +26777,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -29200,14 +26876,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -29262,34 +26932,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -29300,50 +26958,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -29366,9 +26987,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -29395,11 +27013,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -29415,8 +27032,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -29446,17 +27062,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -29488,18 +27143,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -29507,65 +27150,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -29607,17 +27193,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -29667,20 +27247,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -29726,7 +27305,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -29739,14 +27318,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -29761,67 +27339,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -29829,8 +27349,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -29872,9 +27391,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -29908,14 +27474,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -30045,19 +27605,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -30141,14 +27695,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -30192,7 +27740,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -30238,18 +27787,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -30260,14 +27803,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -30323,16 +27860,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -30364,14 +27891,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -30405,138 +27926,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -30553,11 +27942,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -30746,8 +28131,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -30817,27 +28201,20 @@
         "type": "object",
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "items": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.InputItem"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.InputItem"
+            },
+            "nullable": true
           }
         }
       },
@@ -31015,7 +28392,7 @@
           },
           "item_schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The json schema for each row in the data source."
           },
           "include_sample_schema": {
@@ -31084,7 +28461,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Metadata filters for the logs data source."
           }
         },
@@ -31279,7 +28656,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Metadata filters for the stored completions data source."
           }
         },
@@ -31331,52 +28708,33 @@
             "deprecated": true
           },
           "suffix": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "minLength": 1,
             "maxLength": 64,
             "description": "A string of up to 64 characters that will be added to your fine-tuned model name.\n  For example, a `suffix` of \"custom-model-name\" would produce a model name like `ft:gpt-4o-mini:openai:custom-model-name:7p4lURel`."
           },
           "validation_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "The ID of an uploaded file that contains validation data.\n  If you provide this file, the data is used to generate validation\n  metrics periodically during fine-tuning. These metrics can be viewed in\n  the fine-tuning results file.\n  The same data should not be present in both train and validation files.\n  Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.\n  See the [fine-tuning guide](/docs/guides/model-optimization) for more details."
           },
           "integrations": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations"
+            },
+            "nullable": true,
             "description": "A list of integrations to enable for your fine-tuning job."
           },
           "seed": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "minimum": 0,
             "maximum": 2147483647,
             "description": "The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.\n  If a seed is not specified, one will be generated for you."
@@ -31385,14 +28743,13 @@
             "$ref": "#/components/schemas/OpenAI.FineTuneMethod"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         }
       },
@@ -31472,24 +28829,12 @@
             "type": "string"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "entity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "tags": {
             "type": "array",
@@ -31676,7 +29021,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -31711,7 +29057,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -31735,7 +29082,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -31752,10 +29100,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -31828,8 +29172,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -31837,8 +29180,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -31847,7 +29189,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -31864,19 +29207,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31900,7 +29230,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -31908,19 +29239,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31960,16 +29278,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -31996,9 +29304,6 @@
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
       },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
-      },
       "OpenAI.Error": {
         "type": "object",
         "required": [
@@ -32007,27 +29312,15 @@
         ],
         "properties": {
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
             "type": "string"
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string"
@@ -32040,11 +29333,11 @@
           },
           "additionalInfo": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "debugInfo": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           }
         }
       },
@@ -32223,45 +29516,41 @@
         "type": "object",
         "properties": {
           "seed": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "top_p": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "top_p": {
+            "type": "number",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.numeric"
+              }
+            ],
+            "nullable": true,
             "default": 1
           },
           "temperature": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_completions_tokens": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "reasoning_effort": {
             "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
@@ -32602,11 +29891,11 @@
         "properties": {
           "item": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "sample": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           }
         }
       },
@@ -32647,111 +29936,75 @@
             "description": "The type of run data source. Always `responses`."
           },
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "instructions_search": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_after": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_before": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "reasoning_effort": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "temperature": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "top_p": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "users": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "tools": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           }
         },
         "description": "A EvalResponsesSource object describing a run data source configuration.",
@@ -32951,54 +30204,44 @@
             "default": "stored_completions"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_after": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_before": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "limit": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "A StoredCompletionsRunDataSource configuration describing a set of filters",
@@ -33024,7 +30267,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -33050,13 +30294,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -33108,7 +30345,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -33134,14 +30372,12 @@
             "description": "Ranking options for search."
           },
           "filters": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Filters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -33173,14 +30409,13 @@
             "type": "string"
           },
           "attributes": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.VectorStoreFileAttributes"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "score": {
             "type": "number",
@@ -33535,24 +30770,12 @@
             "type": "string"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "entity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "tags": {
             "type": "array",
@@ -33592,37 +30815,22 @@
             "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created."
           },
           "error": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FineTuningJobError"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "fine_tuned_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "fine_tuned_model": {
+            "type": "string",
+            "nullable": true
+          },
+          "finished_at": {
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "hyperparameters": {
             "allOf": [
@@ -33668,41 +30876,28 @@
             "description": "The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`."
           },
           "trained_tokens": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "training_file": {
             "type": "string",
             "description": "The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents)."
           },
           "validation_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "integrations": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FineTuningIntegration"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FineTuningIntegration"
+            },
+            "nullable": true
           },
           "seed": {
             "allOf": [
@@ -33713,30 +30908,21 @@
             "description": "The seed used for the fine-tuning job."
           },
           "estimated_finish": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "method": {
             "$ref": "#/components/schemas/OpenAI.FineTuneMethod"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.",
@@ -33848,14 +31034,8 @@
             "type": "string"
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -33934,13 +31114,17 @@
                 "type": "string",
                 "enum": [
                   "auto"
-                ]
+                ],
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
+                "type": "integer",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.integer"
+                  }
+                ],
+                "nullable": true
               }
             ],
             "default": "auto"
@@ -34010,35 +31194,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -34066,25 +31236,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -34092,7 +31250,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -34155,22 +31313,6 @@
           "incomplete"
         ]
       },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionObject": {
         "type": "object",
         "required": [
@@ -34189,20 +31331,14 @@
             "$ref": "#/components/schemas/OpenAI.FunctionParameters"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
       "OpenAI.FunctionParameters": {
         "type": "object",
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.\nOmitting `parameters` defines a function with an empty parameter list."
       },
       "OpenAI.FunctionShellAction": {
@@ -34220,24 +31356,22 @@
             }
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Execute a shell command.",
@@ -34257,24 +31391,22 @@
             "description": "Ordered shell commands for the execution environment to run."
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Commands and limits describing how to run the shell tool call.",
@@ -34488,7 +31620,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -34520,7 +31653,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -34607,14 +31741,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -34627,7 +31753,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -34650,7 +31777,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -34660,14 +31788,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -34681,17 +31801,17 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellToolParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -34816,46 +31936,25 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
             "description": "The name of the function to call."
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "parameters": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "defer_loading": {
             "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
+            "nullable": true
           }
         },
         "allOf": [
@@ -34866,62 +31965,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -35269,8 +32367,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -35293,7 +32390,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -35323,21 +32421,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -35381,14 +32472,12 @@
             "default": "auto"
           },
           "input_fidelity": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.InputFidelity"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "input_image_mask": {
             "allOf": [
@@ -35465,7 +32554,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -35482,7 +32571,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -35623,35 +32713,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -35679,25 +32755,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -35705,7 +32769,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -35784,35 +32848,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -35834,53 +32884,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "file_data": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "file_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           }
         },
         "description": "A file input to the model.",
@@ -35903,25 +32921,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -35929,7 +32935,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -35951,35 +32957,21 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.DetailEnum"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision)",
@@ -36007,9 +32999,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -36030,56 +33019,6 @@
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
       },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
         "required": [
@@ -36099,14 +33038,8 @@
             "default": "apply_patch_call"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36157,14 +33090,8 @@
             "default": "apply_patch_call_output"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36181,14 +33108,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -36239,34 +33160,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -36285,14 +33194,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string",
@@ -36326,14 +33229,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36354,27 +33251,19 @@
             "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
           },
           "acknowledged_safety_checks": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
+            },
+            "nullable": true
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -36391,6 +33280,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -36413,9 +33303,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -36466,10 +33353,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -36575,17 +33458,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -36605,14 +33482,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36654,14 +33525,12 @@
             "description": "Text, image, or file output of the function tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -36681,14 +33550,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36714,24 +33577,21 @@
             "description": "The shell commands and limits that describe how to run the tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -36751,14 +33611,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -36783,24 +33637,21 @@
             "description": "Captured chunks of stdout and stderr output, along with their associated outcomes."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -36814,7 +33665,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -36823,8 +33673,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -36837,10 +33686,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -36900,14 +33745,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -36990,19 +33829,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -37073,14 +33906,8 @@
             "x-stainless-const": true
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "approval_request_id": {
             "type": "string",
@@ -37091,14 +33918,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -37142,7 +33963,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -37188,18 +34010,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -37210,14 +34026,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -37265,16 +34075,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -37314,14 +34114,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -37355,143 +34149,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -37508,9 +34165,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -37586,6 +34240,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -37593,6 +34293,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -37670,7 +34419,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -37678,9 +34427,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -37701,56 +34447,6 @@
         },
         "description": "Content item used to generate a response."
       },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
         "required": [
@@ -37770,14 +34466,8 @@
             "default": "apply_patch_call"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -37828,14 +34518,8 @@
             "default": "apply_patch_call_output"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -37852,14 +34536,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -37910,34 +34588,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -37956,14 +34622,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string",
@@ -37997,14 +34657,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -38025,27 +34679,19 @@
             "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
           },
           "acknowledged_safety_checks": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
+            },
+            "nullable": true
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -38062,6 +34708,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -38084,9 +34731,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -38137,10 +34781,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -38219,17 +34859,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -38248,50 +34885,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -38385,14 +34978,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -38447,34 +35034,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -38529,6 +35104,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -38551,9 +35127,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -38580,11 +35153,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -38600,8 +35172,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -38631,9 +35202,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -38659,10 +35228,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -38768,17 +35333,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -38828,20 +35387,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -38887,7 +35445,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -38900,14 +35458,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -38925,7 +35482,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -38934,8 +35490,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -38948,10 +35503,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -38978,64 +35529,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -39069,14 +35562,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -39159,19 +35646,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -39255,14 +35736,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -39306,7 +35781,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -39352,18 +35828,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -39374,14 +35844,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -39437,16 +35901,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -39478,14 +35932,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -39519,138 +35967,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -39661,9 +35977,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -39783,17 +36096,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -39813,14 +36120,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -39862,14 +36163,12 @@
             "description": "Text, image, or file output of the function tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -39889,14 +36188,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -39922,24 +36215,21 @@
             "description": "The shell commands and limits that describe how to run the tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -39959,14 +36249,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -39991,24 +36275,21 @@
             "description": "Captured chunks of stdout and stderr output, along with their associated outcomes."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -40022,7 +36303,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -40031,8 +36311,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -40045,10 +36324,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -40108,14 +36383,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -40125,59 +36394,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -40251,19 +36467,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -40334,14 +36544,8 @@
             "x-stainless-const": true
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "approval_request_id": {
             "type": "string",
@@ -40352,14 +36556,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -40403,7 +36601,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -40449,18 +36648,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -40471,14 +36664,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -40526,16 +36713,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -40575,14 +36752,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -40629,7 +36800,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -40657,19 +36829,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -40681,56 +36848,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -40824,14 +36945,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -40886,34 +37001,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -40924,50 +37027,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -40990,9 +37056,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -41019,11 +37082,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -41039,8 +37101,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -41070,126 +37131,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -41231,17 +37173,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -41291,20 +37227,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -41350,7 +37285,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -41363,14 +37298,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -41385,67 +37319,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -41453,8 +37329,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -41496,9 +37371,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -41532,14 +37454,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41549,59 +37465,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -41675,19 +37538,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41771,14 +37628,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41822,7 +37673,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41868,18 +37720,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -41890,14 +37736,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41945,16 +37785,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -41973,200 +37803,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -42183,11 +37819,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -42200,8 +37831,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -42284,143 +37913,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -42437,9 +37929,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -42551,7 +38040,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -42592,24 +38082,12 @@
             "x-stainless-const": true
           },
           "first_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "last_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "x-ms-list-continuation-token": true
           },
           "has_more": {
@@ -42683,7 +38161,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -42693,6 +38172,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -42719,42 +38214,29 @@
             "description": "The command to run."
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "working_directory": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "env": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Environment variables to set for the command.",
             "x-oaiTypeLabel": "map"
           },
           "user": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "Execute a shell command on the server.",
@@ -42772,7 +38254,8 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local_shell"
           },
           "name": {
             "type": "string",
@@ -42856,14 +38339,8 @@
             "description": "The name of the tool."
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "input_schema": {
             "allOf": [
@@ -42874,14 +38351,13 @@
             "description": "The JSON schema describing the tool's input."
           },
           "annotations": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.MCPListToolsToolAnnotations"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "A tool available on an MCP server.",
@@ -42940,17 +38416,11 @@
             "description": "Optional description of the MCP server, used to provide more context."
           },
           "headers": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "allowed_tools": {
             "anyOf": [
@@ -42958,37 +38428,41 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
-              },
-              {
-                "type": "null"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
+                  }
+                ],
+                "nullable": true
               }
             ]
           },
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
                 "type": "string",
                 "enum": [
                   "always",
                   "never"
-                ]
-              },
-              {
-                "type": "null"
+                ],
+                "nullable": true
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -43063,8 +38537,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -43085,35 +38558,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -43141,25 +38600,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -43167,7 +38614,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -43330,14 +38777,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -43361,7 +38800,7 @@
       },
       "OpenAI.Metadata": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "type": "string"
         },
         "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -43370,13 +38809,18 @@
       "OpenAI.ModelIdsCompaction": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
+              }
+            ],
+            "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.",
+            "nullable": true
           },
           {
-            "type": "string"
-          },
-          {
-            "type": "null"
+            "type": "string",
+            "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.",
+            "nullable": true
           }
         ],
         "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models."
@@ -43417,182 +38861,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -43607,7 +38875,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -43624,19 +38893,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -43646,57 +38902,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -43886,19 +39091,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -43906,55 +39105,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -44048,14 +39201,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -44110,34 +39257,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -44192,6 +39327,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -44214,9 +39350,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -44243,128 +39376,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -44383,10 +39401,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -44394,18 +39408,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -44413,7 +39415,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -44455,17 +39458,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -44515,20 +39512,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -44574,7 +39570,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -44587,14 +39583,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -44612,7 +39607,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -44621,8 +39615,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -44635,10 +39628,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -44665,64 +39654,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -44756,14 +39687,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -44821,54 +39746,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -44912,54 +39789,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -44993,7 +39822,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -45039,18 +39869,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -45061,14 +39885,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -45116,16 +39934,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -45165,14 +39973,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -45206,138 +40008,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -45349,19 +40019,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -45369,9 +40033,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -45570,34 +40232,20 @@
             "description": "The unique identifier of the prompt template to use."
           },
           "version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "variables": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponsePromptVariables"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
-      },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
       },
       "OpenAI.RankerVersionType": {
         "type": "string",
@@ -45635,123 +40283,6 @@
           }
         }
       },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
-      },
       "OpenAI.Reasoning": {
         "type": "object",
         "properties": {
@@ -45759,57 +40290,39 @@
             "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
           },
           "summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "auto",
+              "concise",
+              "detailed"
+            ],
+            "nullable": true
           },
           "generate_summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "auto",
+              "concise",
+              "detailed"
+            ],
+            "nullable": true
           }
         },
         "description": "**gpt-5 and o-series models only**\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).",
         "title": "Reasoning"
       },
       "OpenAI.ReasoningEffort": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
-          },
-          {
-            "type": "null"
-          }
+        "type": "string",
+        "enum": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
         ],
-        "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`."
+        "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`.",
+        "nullable": true
       },
       "OpenAI.ReasoningTextContent": {
         "type": "object",
@@ -45850,45 +40363,41 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "top_logprobs": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "temperature": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "top_logprobs": {
+            "type": "integer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              }
+            ],
+            "nullable": true
+          },
+          "temperature": {
+            "type": "number",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.numeric"
+              }
+            ],
+            "nullable": true,
             "default": 1
           },
           "top_p": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "default": 1
           },
           "user": {
@@ -45898,8 +40407,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -45909,62 +40417,51 @@
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_memory",
-                  "24h"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in-memory",
+              "24h"
+            ],
+            "nullable": true
           },
           "previous_response_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "model": {
             "type": "string",
             "description": "The model deployment to use for the creation of this response."
           },
           "reasoning": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "background": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           },
-          "max_tool_calls": {
-            "anyOf": [
+          "max_output_tokens": {
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
+          },
+          "max_tool_calls": {
+            "type": "integer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              }
+            ],
+            "nullable": true
           },
           "text": {
             "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
@@ -45986,18 +40483,12 @@
             "$ref": "#/components/schemas/OpenAI.Prompt"
           },
           "truncation": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "disabled"
-                ]
-              },
-              {
-                "type": "null"
-              }
+            "type": "string",
+            "enum": [
+              "auto",
+              "disabled"
             ],
+            "nullable": true,
             "default": "disabled"
           },
           "id": {
@@ -46030,37 +40521,27 @@
             "description": "Unix timestamp (in seconds) of when this Response was created."
           },
           "completed_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "error": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponseError"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "incomplete_details": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponseIncompleteDetails"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "output": {
             "type": "array",
@@ -46079,34 +40560,16 @@
                 "items": {
                   "$ref": "#/components/schemas/OpenAI.InputItem"
                 }
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "output_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
-          },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "parallel_tool_calls": {
             "type": "boolean",
@@ -46114,34 +40577,22 @@
             "default": true
           },
           "conversation": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "agent_reference": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/AgentReference"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "agent_reference": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AgentReference"
+              }
+            ],
+            "nullable": true,
             "description": "The agent used for this response"
           },
           "content_filters": {
@@ -46180,15 +40631,10 @@
           },
           "delta": {
             "type": "string",
-            "contentEncoding": "base64",
+            "format": "base64",
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -46220,11 +40666,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -46261,11 +40702,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -46297,11 +40733,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -46352,11 +40783,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -46407,11 +40833,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -46457,11 +40878,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -46507,11 +40923,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -46557,11 +40968,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -46602,11 +41008,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -46670,11 +41071,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -46738,11 +41134,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -46783,11 +41174,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -46838,11 +41224,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -46894,11 +41275,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -46967,28 +41343,16 @@
             "x-stainless-const": true
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
             "type": "string",
             "description": "The error message."
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "sequence_number": {
             "allOf": [
@@ -46999,11 +41363,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -47044,11 +41403,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -47094,11 +41448,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -47144,11 +41493,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -47194,11 +41538,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -47273,20 +41612,14 @@
             "$ref": "#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
       "OpenAI.ResponseFormatJsonSchemaSchema": {
         "type": "object",
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "The schema for the response format, described as a JSON Schema object.\nLearn how to build JSON schemas [here](https://json-schema.org/).",
         "title": "JSON schema"
       },
@@ -47351,11 +41684,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -47410,11 +41738,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -47460,11 +41783,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -47511,11 +41829,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -47562,11 +41875,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -47627,11 +41935,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -47673,11 +41976,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -47730,11 +42028,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -47766,7 +42059,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -47825,11 +42118,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -47881,11 +42169,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -47932,11 +42215,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -47983,11 +42261,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -48034,11 +42307,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -48085,11 +42353,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -48136,11 +42399,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -48187,11 +42445,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -48242,11 +42495,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -48296,11 +42544,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -48373,11 +42616,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -48388,7 +42626,7 @@
       },
       "OpenAI.ResponsePromptVariables": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "anyOf": [
             {
               "type": "string"
@@ -48442,11 +42680,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -48511,11 +42744,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -48598,11 +42826,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -48681,11 +42904,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -48745,11 +42963,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -48809,11 +43022,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -48873,11 +43081,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -48937,11 +43140,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -49001,151 +43199,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -49217,11 +43276,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -49289,11 +43343,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -49426,11 +43475,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -49476,11 +43520,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -49526,11 +43565,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -49550,7 +43584,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -49577,7 +43612,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -49610,19 +43646,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -49633,13 +43656,6 @@
         "description": "A scroll action.",
         "title": "Scroll"
       },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
       "OpenAI.SearchContextSize": {
         "type": "string",
         "enum": [
@@ -49649,31 +43665,16 @@
         ]
       },
       "OpenAI.ServiceTier": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
           "flex",
+          "scale",
           "priority"
-        ]
+        ],
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.",
+        "nullable": true
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -49688,7 +43689,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -49719,7 +43721,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -49742,7 +43745,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -49766,7 +43770,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -49793,7 +43798,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -49916,14 +43922,8 @@
             "$ref": "#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         },
         "allOf": [
@@ -49971,10 +43971,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -50007,7 +44004,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "unevaluatedProperties": {}
+              "additionalProperties": {}
             },
             "description": "A list of tool definitions that the model should be allowed to call.\n  For the Responses API, the list of tool definitions might look like:\n  ```json\n  [\n    { \"type\": \"function\", \"name\": \"get_weather\" },\n    { \"type\": \"mcp\", \"server_label\": \"deepwiki\" },\n    { \"type\": \"image_generation\" }\n  ]\n  ```"
           }
@@ -50030,46 +44027,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -50216,14 +44173,8 @@
             "description": "The label of the MCP server to use."
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -50268,9 +44219,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -50294,9 +44243,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -50341,64 +44288,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -50409,7 +44298,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -50418,8 +44306,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -50483,7 +44369,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -50505,14 +44392,13 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be         useful for storing additional information about the object in a structured         format, and querying for objects via API or the dashboard.\n  Keys are strings with a maximum length of 64 characters. Values are strings         with a maximum length of 512 characters."
           }
         }
@@ -50533,7 +44419,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -50571,7 +44458,7 @@
       },
       "OpenAI.VectorStoreFileAttributes": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "anyOf": [
             {
               "type": "string"
@@ -50588,20 +44475,14 @@
         "x-oaiTypeLabel": "map"
       },
       "OpenAI.Verbosity": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
-          },
-          {
-            "type": "null"
-          }
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high"
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`.",
+        "nullable": true
       },
       "OpenAI.WaitParam": {
         "type": "object",
@@ -50615,7 +44496,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -50670,15 +44552,9 @@
             "x-stainless-const": true
           },
           "url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
             "description": "The URL opened by the model."
           }
         },
@@ -50688,7 +44564,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -50701,7 +44578,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -50739,8 +44616,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -50760,44 +44636,20 @@
             "default": "approximate"
           },
           "country": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "region": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "The approximate location of the user.",
@@ -50815,17 +44667,17 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "allOf": [
@@ -50834,12 +44686,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -50861,27 +44707,26 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchToolFilters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "type": "string",
@@ -50922,17 +44767,11 @@
         "type": "object",
         "properties": {
           "allowed_domains": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           }
         }
       },
@@ -51024,7 +44863,7 @@
           },
           "spec": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The openapi function shape, described as a JSON Schema object."
           },
           "auth": {
@@ -51057,7 +44896,7 @@
                 },
                 "parameters": {
                   "type": "object",
-                  "unevaluatedProperties": {},
+                  "additionalProperties": {},
                   "description": "The parameters the functions accepts, described as a JSON Schema object."
                 }
               },
@@ -51308,32 +45147,58 @@
         ],
         "description": "An OpenAPI tool stored in a toolbox."
       },
-      "OptimizationAgentIdentifier": {
+      "OptimizationAgentDefinition": {
         "type": "object",
-        "required": [
-          "agent_name"
-        ],
         "properties": {
-          "agent_name": {
+          "agentName": {
             "type": "string",
-            "description": "Registered Foundry agent name (required)."
+            "description": "Agent name."
           },
-          "agent_version": {
+          "agentVersion": {
             "type": "string",
-            "description": "Pinned agent version. Defaults to latest if omitted."
+            "description": "Agent version."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model deployment name."
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "System prompt / instructions."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Agent skills."
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Agent tools."
           }
         },
-        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config."
+        "description": "Agent definition returned in response payloads (includes resolved config)."
       },
       "OptimizationCandidate": {
         "type": "object",
         "required": [
           "name",
-          "avg_score",
-          "avg_tokens"
+          "config",
+          "mutations",
+          "avgScore",
+          "avgTokens",
+          "passRate",
+          "taskScores",
+          "isParetoOptimal"
         ],
         "properties": {
-          "candidate_id": {
+          "candidateId": {
             "type": "string",
             "description": "Server-assigned candidate identifier. Use with GET /candidates/{id} sub-endpoints."
           },
@@ -51341,26 +45206,50 @@
             "type": "string",
             "description": "Display name of the candidate (e.g., 'baseline', 'instruction-v2')."
           },
+          "config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationAgentDefinition"
+              }
+            ],
+            "description": "The agent configuration that produced this candidate."
+          },
           "mutations": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "What was mutated from the baseline (e.g., {system_prompt: 'new prompt'})."
+            "additionalProperties": {},
+            "description": "What was mutated from the baseline (e.g., {systemPrompt: 'new prompt'})."
           },
-          "avg_score": {
+          "avgScore": {
             "type": "number",
             "format": "double",
             "description": "Average composite score across all tasks."
           },
-          "avg_tokens": {
+          "avgTokens": {
             "type": "number",
             "format": "double",
             "description": "Average token usage across all tasks."
           },
-          "eval_id": {
+          "passRate": {
+            "type": "number",
+            "format": "double",
+            "description": "Fraction of tasks that met the pass threshold."
+          },
+          "taskScores": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationTaskResult"
+            },
+            "description": "Individual task-level scores."
+          },
+          "isParetoOptimal": {
+            "type": "boolean",
+            "description": "Whether this candidate is on the Pareto frontier (score vs cost)."
+          },
+          "evalId": {
             "type": "string",
             "description": "Foundry evaluation identifier used to score this candidate."
           },
-          "eval_run_id": {
+          "evalRunId": {
             "type": "string",
             "description": "Foundry evaluation run identifier for this candidate's scoring run."
           },
@@ -51375,166 +45264,17 @@
         },
         "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks."
       },
-      "OptimizationDatasetCriterion": {
-        "type": "object",
-        "required": [
-          "name",
-          "instruction"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Criterion name."
-          },
-          "instruction": {
-            "type": "string",
-            "description": "Criterion instruction / description."
-          }
-        },
-        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring."
-      },
-      "OptimizationDatasetInput": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationDatasetInputType"
-              }
-            ],
-            "description": "Dataset input type discriminator."
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "inline": "#/components/schemas/OptimizationInlineDatasetInput",
-            "reference": "#/components/schemas/OptimizationReferenceDatasetInput"
-          }
-        },
-        "description": "Base discriminated model for dataset input. Either inline items or a registered reference."
-      },
-      "OptimizationDatasetInputType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "inline",
-              "reference"
-            ]
-          }
-        ],
-        "description": "Discriminator values for the dataset input union."
-      },
-      "OptimizationDatasetItem": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string",
-            "description": "The user query / prompt."
-          },
-          "ground_truth": {
-            "type": "string",
-            "description": "Expected ground truth answer."
-          },
-          "desired_num_turns": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 20,
-            "description": "Desired number of conversation turns for simulation mode (1-20)."
-          },
-          "criteria": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OptimizationDatasetCriterion"
-            },
-            "description": "Per-item evaluation criteria."
-          }
-        },
-        "description": "A single item in an inline dataset."
-      },
-      "OptimizationEvaluatorRef": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Evaluator name."
-          },
-          "version": {
-            "type": "string",
-            "description": "Evaluator version. If not specified, the latest version is used."
-          }
-        },
-        "description": "Reference to a named evaluator, optionally pinned to a version."
-      },
-      "OptimizationInlineDatasetInput": {
-        "type": "object",
-        "required": [
-          "type",
-          "items"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "inline"
-            ],
-            "description": "Dataset input type discriminator."
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OptimizationDatasetItem"
-            },
-            "description": "Dataset items."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OptimizationDatasetInput"
-          }
-        ],
-        "description": "Inline dataset — items supplied directly in the request body."
-      },
       "OptimizationJob": {
         "type": "object",
         "required": [
           "id",
           "status",
-          "created_at",
-          "updated_at"
+          "createdAt"
         ],
         "properties": {
           "id": {
             "type": "string",
             "description": "Server-assigned unique identifier.",
-            "readOnly": true
-          },
-          "inputs": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobInputs"
-              }
-            ],
-            "description": "Caller-supplied inputs."
-          },
-          "result": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobResult"
-              }
-            ],
-            "description": "Result produced on success.",
             "readOnly": true
           },
           "status": {
@@ -51555,7 +45295,24 @@
             "description": "Error details — populated only on failure.",
             "readOnly": true
           },
-          "created_at": {
+          "result": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationJobResult"
+              }
+            ],
+            "description": "Result produced on success.",
+            "readOnly": true
+          },
+          "inputs": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationJobInputs"
+              }
+            ],
+            "description": "Caller-supplied inputs."
+          },
+          "createdAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -51564,7 +45321,7 @@
             "description": "The timestamp when the job was created, represented in Unix time.",
             "readOnly": true
           },
-          "updated_at": {
+          "updatedAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -51579,15 +45336,16 @@
                 "$ref": "#/components/schemas/OptimizationJobProgress"
               }
             ],
-            "description": "Progress snapshot. May be present in terminal states reflecting last-known progress.",
+            "description": "Progress while in flight. Absent in terminal states.",
             "readOnly": true
           },
-          "warnings": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Non-fatal warnings emitted at any point during optimization.",
+          "dataset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetInfo"
+              }
+            ],
+            "description": "Metadata about the dataset used for this optimization job.",
             "readOnly": true
           }
         },
@@ -51597,30 +45355,29 @@
         "type": "object",
         "required": [
           "agent",
-          "train_dataset",
-          "evaluators"
+          "trainDatasetReference"
         ],
         "properties": {
           "agent": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationAgentIdentifier"
+                "$ref": "#/components/schemas/AgentIdentifier"
               }
             ],
             "description": "The agent (and pinned version) being optimized."
           },
-          "train_dataset": {
+          "trainDatasetReference": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationDatasetInput"
+                "$ref": "#/components/schemas/DatasetRef"
               }
             ],
-            "description": "Training dataset — either inline items or a reference to a registered dataset. Required."
+            "description": "Reference to a registered training dataset (required)."
           },
-          "validation_dataset": {
+          "validationDatasetReference": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationDatasetInput"
+                "$ref": "#/components/schemas/DatasetRef"
               }
             ],
             "description": "Optional held-out validation dataset for measuring generalization of the final candidate."
@@ -51628,9 +45385,9 @@
           "evaluators": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/OptimizationEvaluatorRef"
+              "type": "string"
             },
-            "description": "Job-level evaluators referenced by name and optional version. Required; at least one must be provided."
+            "description": "Job-level evaluators (referenced by name). Per-task criteria may override. Default: ['task_adherence']."
           },
           "options": {
             "allOf": [
@@ -51643,96 +45400,25 @@
         },
         "description": "Caller-supplied inputs for an optimization job."
       },
-      "OptimizationJobListItem": {
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "created_at",
-          "updated_at"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Server-assigned unique identifier.",
-            "readOnly": true
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/JobStatus"
-              }
-            ],
-            "description": "Current lifecycle status.",
-            "readOnly": true
-          },
-          "error": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Error"
-              }
-            ],
-            "description": "Error details — populated only on failure.",
-            "readOnly": true
-          },
-          "created_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The timestamp when the job was created, represented in Unix time.",
-            "readOnly": true
-          },
-          "updated_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The timestamp when the job was last updated, represented in Unix time.",
-            "readOnly": true
-          },
-          "progress": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobProgress"
-              }
-            ],
-            "description": "Progress snapshot. May be present in terminal states reflecting last-known progress.",
-            "readOnly": true
-          },
-          "agent": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationAgentIdentifier"
-              }
-            ],
-            "description": "The agent targeted by this optimization job.",
-            "readOnly": true
-          }
-        },
-        "description": "Slim job representation returned by the LIST endpoint."
-      },
       "OptimizationJobProgress": {
         "type": "object",
         "required": [
-          "candidates_completed",
-          "best_score",
-          "elapsed_seconds"
+          "currentIteration",
+          "bestScore",
+          "elapsedSeconds"
         ],
         "properties": {
-          "candidates_completed": {
+          "currentIteration": {
             "type": "integer",
             "format": "int32",
-            "description": "Number of candidates whose evaluation has completed so far."
+            "description": "1-based current iteration index."
           },
-          "best_score": {
+          "bestScore": {
             "type": "number",
             "format": "double",
             "description": "Best score observed so far across all candidates."
           },
-          "elapsed_seconds": {
+          "elapsedSeconds": {
             "type": "number",
             "format": "double",
             "description": "Wall-clock time elapsed in seconds since the job began executing."
@@ -51744,12 +45430,20 @@
         "type": "object",
         "properties": {
           "baseline": {
-            "type": "string",
-            "description": "Candidate ID of the original (un-optimized) baseline evaluation."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationCandidate"
+              }
+            ],
+            "description": "Evaluation scores for the original (un-optimized) agent configuration."
           },
           "best": {
-            "type": "string",
-            "description": "Candidate ID of the highest-scoring candidate found during optimization."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationCandidate"
+              }
+            ],
+            "description": "The highest-scoring candidate found during optimization."
           },
           "candidates": {
             "type": "array",
@@ -51757,6 +45451,25 @@
               "$ref": "#/components/schemas/OptimizationCandidate"
             },
             "description": "All evaluated candidates including baseline."
+          },
+          "options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationOptions"
+              }
+            ],
+            "description": "The options used for this optimization run."
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Non-fatal warnings from the optimization run (e.g., target attribute failures that were skipped)."
+          },
+          "allTargetAttributesFailed": {
+            "type": "boolean",
+            "description": "True when all target attributes failed — only the baseline was evaluated."
           }
         },
         "description": "Terminal-state result body. Populated when status is succeeded or failed."
@@ -51764,27 +45477,26 @@
       "OptimizationOptions": {
         "type": "object",
         "properties": {
-          "max_candidates": {
+          "maxIterations": {
             "type": "integer",
             "format": "int32",
-            "minimum": 1,
-            "description": "Maximum number of optimization candidates to generate. Must be >= 1. Default: 5.",
+            "description": "Maximum optimization iterations per strategy. Must be >= 1. Default: 5.",
             "default": 5
           },
-          "optimization_config": {
+          "optimizationConfig": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "Per-target-attribute configuration overrides. Contains skills, tools, system_prompt for the agent, plus model space for model optimization."
+            "additionalProperties": {},
+            "description": "Per-target-attribute configuration overrides. Contains skills, tools, systemPrompt for the agent, plus model space for model optimization."
           },
-          "eval_model": {
+          "evalModel": {
             "type": "string",
             "description": "Model deployment used for evaluation. Defaults to server config (typically 'gpt-4o')."
           },
-          "optimization_model": {
+          "optimizationModel": {
             "type": "string",
             "description": "Model deployment for optimization reasoning (must be gpt-5 family). Falls back to the default eval model when not set."
           },
-          "evaluation_level": {
+          "evaluationLevel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/EvaluationLevel"
@@ -51795,35 +45507,73 @@
         },
         "description": "Tuning knobs and run-mode for an optimization job."
       },
-      "OptimizationReferenceDatasetInput": {
+      "OptimizationTaskResult": {
         "type": "object",
         "required": [
-          "type",
-          "name"
+          "taskName",
+          "scores",
+          "compositeScore",
+          "tokens",
+          "durationSeconds",
+          "passed"
         ],
         "properties": {
-          "type": {
+          "taskName": {
             "type": "string",
-            "enum": [
-              "reference"
-            ],
-            "description": "Dataset input type discriminator."
+            "description": "Task name (from the dataset)."
           },
-          "name": {
+          "query": {
             "type": "string",
-            "description": "Registered dataset name."
+            "description": "The user query / input for the task."
           },
-          "version": {
+          "scores": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            },
+            "description": "Per-evaluator scores keyed by evaluator name."
+          },
+          "compositeScore": {
+            "type": "number",
+            "format": "double",
+            "description": "Composite score combining all evaluator scores."
+          },
+          "tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total tokens consumed during the agent run for this task."
+          },
+          "durationSeconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Wall-clock seconds for this task's agent execution."
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the task met the pass threshold."
+          },
+          "errorMessage": {
             "type": "string",
-            "description": "Dataset version. If not specified, the latest version is used."
+            "description": "Error message if the task failed during execution."
+          },
+          "rationales": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Per-evaluator reasoning keyed by evaluator name."
+          },
+          "response": {
+            "type": "string",
+            "description": "Raw agent response text."
+          },
+          "runId": {
+            "type": "string",
+            "description": "Identifier of the agent run that produced this result."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OptimizationDatasetInput"
-          }
-        ],
-        "description": "Reference to a registered Foundry dataset."
+        "description": "Per-task evaluation result for a single candidate."
       },
       "OtlpTelemetryEndpoint": {
         "type": "object",
@@ -51843,9 +45593,7 @@
           "endpoint": {
             "type": "string",
             "description": "The OTLP collector endpoint URL.",
-            "examples": [
-              "https://my-collector.example.com/otlp"
-            ]
+            "example": "https://my-collector.example.com/otlp"
           },
           "protocol": {
             "allOf": [
@@ -51854,9 +45602,7 @@
               }
             ],
             "description": "The transport protocol for the OTLP endpoint.",
-            "examples": [
-              "Http"
-            ]
+            "example": "Http"
           }
         },
         "allOf": [
@@ -52240,15 +45986,43 @@
           ]
         }
       },
-      "PromotionInfo": {
+      "PromoteCandidateRequest": {
         "type": "object",
         "required": [
-          "promoted_at",
-          "agent_name",
-          "agent_version"
+          "agentName",
+          "agentVersion"
         ],
         "properties": {
-          "promoted_at": {
+          "agentName": {
+            "type": "string",
+            "description": "Name of the Foundry agent to promote to."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Version of the Foundry agent to promote to."
+          }
+        },
+        "description": "Request body for promoting a candidate to a Foundry agent version."
+      },
+      "PromoteCandidateResponse": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "status",
+          "promotedAt",
+          "agentName",
+          "agentVersion"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "The promoted candidate id."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status after promotion."
+          },
+          "promotedAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -52256,11 +46030,38 @@
             ],
             "description": "Timestamp when promotion occurred, represented in Unix time."
           },
-          "agent_name": {
+          "agentName": {
+            "type": "string",
+            "description": "Name of the Foundry agent promoted to."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Version of the Foundry agent promoted to."
+          }
+        },
+        "description": "Response after successfully promoting a candidate."
+      },
+      "PromotionInfo": {
+        "type": "object",
+        "required": [
+          "promotedAt",
+          "agentName",
+          "agentVersion"
+        ],
+        "properties": {
+          "promotedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when promotion occurred, represented in Unix time."
+          },
+          "agentName": {
             "type": "string",
             "description": "Name of the Foundry agent this candidate was promoted to."
           },
-          "agent_version": {
+          "agentVersion": {
             "type": "string",
             "description": "Version of the Foundry agent this candidate was promoted to."
           }
@@ -52285,55 +46086,36 @@
             "description": "The model deployment to use for this agent."
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "A system (or developer) message inserted into the model's context."
           },
           "temperature": {
-            "anyOf": [
-              {
-                "type": "number",
-                "format": "float"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "number",
+            "format": "float",
+            "nullable": true,
             "minimum": 0,
             "maximum": 2,
             "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\nWe generally recommend altering this or `top_p` but not both. Defaults to `1`.",
             "default": 1
           },
           "top_p": {
-            "anyOf": [
-              {
-                "type": "number",
-                "format": "float"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "number",
+            "format": "float",
+            "nullable": true,
             "minimum": 0,
             "maximum": 1,
             "description": "An alternative to sampling with temperature, called nucleus sampling,\nwhere the model considers the results of the tokens with top_p probability\nmass. So 0.1 means only the tokens comprising the top 10% probability mass\nare considered. We generally recommend altering this or `temperature` but not both.\nDefaults to `1`.",
             "default": 1
           },
           "reasoning": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "tools": {
             "type": "array",
@@ -52363,7 +46145,7 @@
           },
           "structured_inputs": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/StructuredInputDefinition"
             },
             "description": "Set of structured inputs that can participate in prompt template substitution or tool argument bindings."
@@ -52627,7 +46409,7 @@
           },
           "simulationOnly": {
             "type": "boolean",
-            "description": "Simulation-only or Simulation + Evaluation. If `true` the scan outputs conversation not evaluation result. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Simulation-only or Simulation + Evaluation. Default false, if true the scan outputs conversation not evaluation result.",
             "default": false
           },
           "riskCategories": {
@@ -52643,14 +46425,14 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Red team's tags. Unlike properties, tags are fully mutable."
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Red team's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed."
@@ -52878,7 +46660,7 @@
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Mapping from source fields to response_id field, required for retrieving chat history."
@@ -52928,7 +46710,10 @@
       "Routine": {
         "type": "object",
         "required": [
-          "enabled"
+          "name",
+          "enabled",
+          "triggers",
+          "action"
         ],
         "properties": {
           "name": {
@@ -52947,7 +46732,7 @@
           },
           "triggers": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/RoutineTrigger"
             },
             "description": "The triggers configured for the routine."
@@ -53058,6 +46843,10 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
+        "required": [
+          "triggers",
+          "action"
+        ],
         "properties": {
           "description": {
             "type": "string",
@@ -53070,7 +46859,7 @@
           },
           "triggers": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/RoutineTrigger"
             },
             "description": "The triggers configured for the routine. In v1, exactly one trigger entry is supported."
@@ -53143,21 +46932,19 @@
       "RoutineRun": {
         "type": "object",
         "required": [
-          "id"
+          "id",
+          "status",
+          "trigger_type",
+          "started_at"
         ],
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique run identifier for the routine attempt.",
-            "readOnly": true
+            "description": "The MLflow run identifier for the routine attempt."
           },
           "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunStatus"
-              }
-            ],
-            "description": "The run status."
+            "type": "string",
+            "description": "The underlying MLflow run status."
           },
           "phase": {
             "allOf": [
@@ -53175,10 +46962,6 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
-          "trigger_name": {
-            "type": "string",
-            "description": "The configured trigger name that produced the routine attempt."
-          },
           "attempt_source": {
             "allOf": [
               {
@@ -53195,22 +46978,6 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
-          "agent_id": {
-            "type": "string",
-            "description": "The project-scoped agent identifier recorded for the routine attempt."
-          },
-          "agent_endpoint_id": {
-            "type": "string",
-            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
-          },
-          "conversation_id": {
-            "type": "string",
-            "description": "The conversation identifier used by a responses API dispatch."
-          },
-          "session_id": {
-            "type": "string",
-            "description": "The hosted-agent session identifier used by an invocations API dispatch."
-          },
           "triggered_at": {
             "allOf": [
               {
@@ -53218,14 +46985,6 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
-          },
-          "scheduled_fire_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The scheduled fire time recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -53259,11 +47018,6 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
-          "error_status_code": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The downstream error status code captured for a failed attempt, when available."
-          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -53271,9 +47025,55 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
+          },
+          "diagnostics": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineRunDiagnostics"
+              }
+            ],
+            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "RoutineRunDiagnostics": {
+        "type": "object",
+        "required": [
+          "parameters",
+          "tags",
+          "metrics"
+        ],
+        "properties": {
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "MLflow parameters recorded on the run, keyed by parameter name."
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "MLflow tags recorded on the run, keyed by tag name."
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            },
+            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
+          }
+        },
+        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -53302,15 +47102,6 @@
           ]
         }
       },
-      "RoutineRunStatus": {
-        "type": "string",
-        "description": "The status of a routine run.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -53331,8 +47122,7 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
-            "custom": "#/components/schemas/CustomRoutineTrigger"
+            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -53350,8 +47140,7 @@
           {
             "type": "string",
             "enum": [
-              "custom",
-              "github_issue",
+              "github_issue_opened",
               "schedule",
               "timer"
             ]
@@ -53518,21 +47307,21 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Schedule's tags. Unlike properties, tags are fully mutable."
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Schedule's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed."
           },
           "systemData": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "System metadata for the resource.",
@@ -53629,7 +47418,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Properties of the schedule run.",
@@ -53654,7 +47443,7 @@
           },
           "configuration": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Configuration for the task."
@@ -53718,23 +47507,10 @@
       "SessionDirectoryListResponse": {
         "type": "object",
         "required": [
-          "has_more",
           "path",
           "entries"
         ],
         "properties": {
-          "first_id": {
-            "type": "string",
-            "description": "The first ID represented in this list."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "The last ID represented in this list."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "A value indicating whether there are additional values available not captured in this list."
-          },
           "path": {
             "type": "string",
             "description": "The path that was listed, relative to the session home directory."
@@ -53746,7 +47522,8 @@
             },
             "description": "The directory entries."
           }
-        }
+        },
+        "description": "Response from listing a directory in a session sandbox."
       },
       "SessionFileWriteResponse": {
         "type": "object",
@@ -53781,16 +47558,12 @@
               }
             ],
             "description": "The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.",
-            "examples": [
-              "log"
-            ]
+            "example": "log"
           },
           "data": {
             "type": "string",
             "description": "The event payload as plain text. Currently JSON-formatted but the schema is not contractual and may change.",
-            "examples": [
-              "{\"timestamp\":\"2026-03-10T09:33:17.121467567+00:00\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}"
-            ]
+            "example": "{\"timestamp\":\"2026-03-10T09:33:17.121467567+00:00\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}"
           }
         },
         "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```",
@@ -54069,7 +47842,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Arbitrary key-value metadata for additional properties."
@@ -54183,12 +47956,12 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema for the structured input (optional)."
           },
           "required": {
             "type": "boolean",
-            "description": "Whether the input property is required when the agent is invoked. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Whether the input property is required when the agent is invoked. Defaults to `false`.",
             "default": false
           }
         },
@@ -54213,18 +47986,12 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema for the structured output."
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
+            "nullable": true,
             "description": "Whether to enforce strict validation. Default `true`."
           }
         },
@@ -54519,7 +48286,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the taxonomy category."
@@ -54553,7 +48320,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the taxonomy sub-category."
@@ -54626,12 +48393,10 @@
               "$ref": "#/components/schemas/TelemetryDataKind"
             },
             "description": "Data types to export to this endpoint. Use an empty array to export no data.",
-            "examples": [
-              [
-                "ContainerStdoutStderr",
-                "ContainerOtel",
-                "Metrics"
-              ]
+            "example": [
+              "ContainerStdoutStderr",
+              "ContainerOtel",
+              "Metrics"
             ]
           },
           "auth": {
@@ -54771,12 +48536,11 @@
           },
           "initialization_parameters": {
             "type": "object",
-            "unevaluatedProperties": {},
             "description": "The initialization parameters for the evaluation. Must support structured outputs."
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "The model to use for the evaluation. Must support structured outputs."
@@ -54788,7 +48552,8 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "at"
         ],
         "properties": {
           "type": {
@@ -54799,12 +48564,12 @@
             "description": "The trigger type."
           },
           "at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The UTC date and time at which the timer fires."
+            "type": "string",
+            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "An optional IANA or Windows time zone identifier when the timer uses a local timestamp."
           }
         },
         "allOf": [
@@ -54823,7 +48588,7 @@
         "anyOf": [
           {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           {
             "type": "string"
@@ -55044,7 +48809,7 @@
           },
           "tool_configs": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
             "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
@@ -55095,17 +48860,11 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
             "x-oaiTypeLabel": "map"
           },
@@ -55493,7 +49252,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -55510,7 +49269,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -55523,7 +49282,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -55572,18 +49331,17 @@
             "type": "string"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -55599,7 +49357,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -55834,24 +49592,22 @@
             ]
           },
           "filters": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchToolFilters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "type": "string",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -1,117 +1,33 @@
-openapi: 3.2.0
+openapi: 3.0.0
 info:
   title: Microsoft Foundry
   version: v1
 tags:
-  - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
   - name: Agents
-    parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
-    parent: Agents Root
-  - name: Agent Invocations WebSocket
-    parent: Agents Root
-    description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
-    parent: Agents Root
   - name: Agent Session Files
-    parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
-  - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
+  - name: Agent Invocations
   - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
+  - name: Datasets
   - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
   - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
+  - name: Evaluation Rules
+  - name: Evaluators
+  - name: EvaluatorGenerationJobs
+  - name: Indexes
   - name: Insights
-    parent: Evaluations
+  - name: Models
+  - name: Memory Stores
+  - name: Conversations
+  - name: Evals
+  - name: Fine-Tuning
+  - name: Responses
+  - name: Redteams
+  - name: Routines
+  - name: Schedules
+  - name: Skills
+  - name: Toolboxes
+  - name: DataGenerationJobs
+  - name: AgentOptimizationJobs
 paths:
   /agent_optimization_jobs:
     post:
@@ -126,7 +42,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: Operation-Id
           in: header
           required: false
@@ -158,14 +74,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -177,15 +87,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OptimizationJob'
-        description: The job to create.
+              $ref: '#/components/schemas/OptimizationJobInputs'
+        description: The optimization job inputs.
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
     get:
       operationId: AgentOptimizationJobs_list
       summary: Returns a list of agent optimization jobs.
-      description: List optimization jobs. Supports cursor pagination and optional status / agent_name filters.
+      description: List optimization jobs. Supports cursor pagination and optional status / agentName filters.
       parameters:
         - name: Foundry-Features
           in: header
@@ -194,7 +104,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: limit
           in: query
           required: false
@@ -242,7 +152,7 @@ paths:
           schema:
             $ref: '#/components/schemas/JobStatus'
           explode: false
-        - name: agent_name
+        - name: agentName
           in: query
           required: false
           description: Filter to jobs targeting this agent name.
@@ -270,7 +180,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/OptimizationJobListItem'
+                      $ref: '#/components/schemas/OptimizationJob'
                     description: The requested list of items.
                   first_id:
                     type: string
@@ -282,14 +192,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -298,12 +202,12 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
   /agent_optimization_jobs/{jobId}:
     get:
       operationId: AgentOptimizationJobs_get
       summary: Get info about an agent optimization job.
-      description: Get an optimization job by id.
+      description: Get an optimization job by id. Returns 202 while in progress, 200 when terminal.
       parameters:
         - name: Foundry-Features
           in: header
@@ -312,7 +216,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
@@ -332,7 +236,6 @@ paths:
           headers:
             Retry-After:
               required: false
-              description: Recommended number of seconds to wait before polling again.
               schema:
                 type: integer
                 format: int32
@@ -340,14 +243,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
+        '202':
+          description: The request has been accepted for processing, but processing has not yet completed.
+          headers:
+            Retry-After:
+              required: false
+              schema:
+                type: integer
+                format: int32
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                $ref: '#/components/schemas/OptimizationJob'
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -356,7 +265,7 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
     delete:
       operationId: AgentOptimizationJobs_delete
       summary: Deletes an agent optimization job.
@@ -369,13 +278,20 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
           description: The ID of the job to delete.
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: When true, force-delete even if the job is in a non-terminal state.
+          schema:
+            type: boolean
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -386,14 +302,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -402,12 +312,12 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
-  /agent_optimization_jobs/{jobId}:cancel:
-    post:
-      operationId: AgentOptimizationJobs_cancel
-      summary: Cancels an agent optimization job.
-      description: Request cancellation of a running or queued job. Returns an error if the job is already in a terminal state.
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates:
+    get:
+      operationId: AgentOptimizationJobs_listCandidates
+      summary: Returns a list of candidates for an optimization job.
+      description: List candidates produced by a job.
       parameters:
         - name: Foundry-Features
           in: header
@@ -416,7 +326,381 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OptimizationCandidate'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}:
+    get:
+      operationId: AgentOptimizationJobs_getCandidate
+      summary: Get a candidate by id.
+      description: Get a single candidate's metadata, manifest, and promotion info.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateMetadata'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/config:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateConfig
+      summary: Get candidate deploy config.
+      description: Get the candidate's deploy config JSON. Used to compose `agents.create_version(...)` from a candidate.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateDeployConfig'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/files:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateFile
+      summary: Get a candidate file.
+      description: Stream a specific file from the candidate's blob directory.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Relative path of the file to download (e.g. 'files/examples.jsonl').
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/results:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateResults
+      summary: Get candidate evaluation results.
+      description: Get full per-task evaluation results for a candidate.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateResults'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}:promote:
+    post:
+      operationId: AgentOptimizationJobs_promoteCandidate
+      summary: Promote a candidate.
+      description: Promotes a candidate, recording the deployment timestamp and target agent version.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id to promote.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromoteCandidateResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromoteCandidateRequest'
+        description: Promotion details.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}:cancel:
+    post:
+      operationId: AgentOptimizationJobs_cancel
+      summary: Cancels an agent optimization job.
+      description: Request cancellation. Idempotent on terminal states.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
@@ -437,14 +721,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -453,7 +731,7 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
   /agents:
     post:
       operationId: Agents_createAgent_Agents_createAgentFromCode
@@ -485,12 +763,11 @@ paths:
           schema:
             type: string
       description: |-
-        Creates a new agent or a new version of an existing agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.
+        Creates the agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.
         The agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.
         The SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.
         The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
         Maximum upload size is 250 MB.
-      summary: Create an agent Create a new code-based agent
       responses:
         '200':
           description: The request has succeeded.
@@ -498,20 +775,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new agent or a new version of an existing agent.
-      x-ms-summary-override: Create an agent
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
@@ -531,8 +800,7 @@ paths:
                 contentType: application/json
     get:
       operationId: Agents_listAgents
-      summary: List agents
-      description: Returns a paged collection of agent resources.
+      description: Returns the list of all agents.
       parameters:
         - name: kind
           in: query
@@ -614,14 +882,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -631,8 +893,7 @@ paths:
   /agents/{agent_name}:
     get:
       operationId: Agents_getAgent
-      summary: Get an agent
-      description: Retrieves an agent definition by its unique name.
+      description: Retrieves the agent.
       parameters:
         - name: agent_name
           in: path
@@ -654,14 +915,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -702,7 +957,6 @@ paths:
         If the code and definition are unchanged (matched by x-ms-code-zip-sha256 header), returns the existing version.
         The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
         Maximum upload size is 250 MB.
-      summary: Update an agent Update a code-based agent
       responses:
         '200':
           description: The request has succeeded.
@@ -710,20 +964,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.
-      x-ms-summary-override: Update an agent
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
@@ -743,7 +989,6 @@ paths:
                 contentType: application/json
     delete:
       operationId: Agents_deleteAgent
-      summary: Delete an agent
       description: |-
         Deletes an agent. For hosted agents, if any version has active sessions, the request
         is rejected with HTTP 409 unless `force` is set to true. When force is true, all
@@ -758,7 +1003,7 @@ paths:
         - name: force
           in: query
           required: false
-          description: For Hosted Agents, if `true`, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.
+          description: For Hosted Agents, if true, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.
           schema:
             type: boolean
             default: false
@@ -777,14 +1022,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAgentResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -793,8 +1032,7 @@ paths:
         - Agents
     patch:
       operationId: Agents_patchAgentObject
-      summary: Update an agent endpoint
-      description: Applies a merge-patch update to the specified agent endpoint configuration.
+      description: Updates an agent endpoint.
       parameters:
         - name: Foundry-Features
           in: header
@@ -810,7 +1048,6 @@ paths:
           description: The name of the agent to retrieve.
           schema:
             type: string
-            title: The name of the agent to retrieve
         - name: api-version
           in: query
           required: true
@@ -825,14 +1062,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -851,9 +1082,8 @@ paths:
   /agents/{agent_name}/code:download:
     get:
       operationId: Agents_downloadAgentCode
-      summary: Download agent code
       description: |-
-        Downloads the code zip for a code-based hosted agent.
+        Download the code zip for a code-based hosted agent.
         Returns the previously-uploaded zip (`application/zip`).
 
         If `agent_version` is supplied, returns that version's code zip; otherwise
@@ -908,15 +1138,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -929,7 +1154,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations:
     post:
       operationId: AgentInvocations_createAgentInvocation
-      summary: Create an agent invocation
       description: Creates an invocation for the specified agent version.
       parameters:
         - name: agent_name
@@ -983,14 +1207,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1009,7 +1227,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationOpenApiSpec
-      summary: Get an agent invocation OpenAPI spec
       description: |-
         Retrieves the OpenAPI specification for an agent version's invocation contract.
         Returns 404 if the agent does not expose an OpenAPI specification.
@@ -1042,15 +1259,9 @@ paths:
             application/json:
               schema:
                 type: object
-                unevaluatedProperties: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                additionalProperties: {}
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1063,7 +1274,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}:
     get:
       operationId: AgentInvocations_getAgentInvocation
-      summary: Get an agent invocation
       description: |-
         Retrieves the invocation with the given ID.
         Returns 404 if the agent does not support this operation or if the invocation ID is not found.
@@ -1113,14 +1323,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1133,7 +1337,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel:
     post:
       operationId: AgentInvocations_cancelAgentInvocation
-      summary: Cancel an agent invocation
       description: |-
         Cancels an invocation.
         Returns 404 if the agent does not support this operation or if the invocation ID is not found.
@@ -1183,14 +1386,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1209,7 +1406,6 @@ paths:
   /agents/{agent_name}/endpoint/sessions:
     post:
       operationId: Agents_createSession
-      summary: Create a session
       description: |-
         Creates a new session for an agent endpoint.
         The endpoint resolves the backing agent version from `version_indicator` and
@@ -1249,20 +1445,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentSessionResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       requestBody:
         required: true
         content:
@@ -1274,8 +1464,7 @@ paths:
           - AgentEndpoints=V1Preview
     get:
       operationId: Agents_listSessions
-      summary: List sessions for an agent
-      description: Returns a paged collection of sessions associated with the specified agent endpoint.
+      description: Returns a list of sessions for the specified agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1370,30 +1559,23 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
-      summary: List session files
       description: |-
-        Returns files and directories at the specified path in the session sandbox.
-        The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
+        List files and directories at a given path in the session sandbox.
+        Returns only the immediate children of the specified directory (non-recursive).
       parameters:
         - name: Foundry-Features
           in: header
@@ -1417,8 +1599,8 @@ paths:
             type: string
         - name: path
           in: query
-          required: false
-          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+          required: true
+          description: The directory path to list, relative to the session home directory.
           schema:
             type: string
           explode: false
@@ -1428,46 +1610,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
         - name: api-version
           in: query
           required: true
@@ -1482,14 +1624,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SessionDirectoryListResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1501,10 +1637,9 @@ paths:
           - HostedAgents=V1Preview
     delete:
       operationId: AgentSessionFiles_deleteSessionFile
-      summary: Delete a session file
       description: |-
-        Deletes the specified file or directory from the session sandbox.
-        When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
+        Delete a file or directory from the session sandbox.
+        If `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1536,7 +1671,7 @@ paths:
         - name: recursive
           in: query
           required: false
-          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+          description: Whether to recursively delete directory contents. Defaults to false.
           schema:
             type: boolean
             default: false
@@ -1557,14 +1692,8 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1577,10 +1706,9 @@ paths:
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content:
     put:
       operationId: AgentSessionFiles_uploadSessionFile
-      summary: Upload a session file
       description: |-
-        Uploads binary file content to the specified path in the session sandbox.
-        The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
+        Upload a file to the session sandbox via binary stream.
+        Maximum file size is 50 MB. Uploads exceeding this limit return 413 Payload Too Large.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1629,14 +1757,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SessionFileWriteResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1648,16 +1770,14 @@ paths:
         content:
           application/octet-stream:
             schema:
-              contentMediaType: application/octet-stream
+              type: string
+              format: binary
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
     get:
       operationId: AgentSessionFiles_downloadSessionFile
-      summary: Download a session file
-      description: |-
-        Downloads the file at the specified sandbox path as a binary stream.
-        The path is resolved relative to the session home directory.
+      description: Download a file from the session sandbox as a binary stream.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1705,15 +1825,10 @@ paths:
           content:
             application/octet-stream:
               schema:
-                contentMediaType: application/octet-stream
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1726,8 +1841,7 @@ paths:
   /agents/{agent_name}/endpoint/sessions/{session_id}:
     get:
       operationId: Agents_getSession
-      summary: Get a session
-      description: Retrieves the details of a hosted agent session by agent name and session identifier.
+      description: Retrieves a session by ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1769,26 +1883,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentSessionResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
     delete:
       operationId: Agents_deleteSession
-      summary: Delete a session
       description: |-
         Deletes a session synchronously.
         Returns 204 No Content when the session is deleted or does not exist.
@@ -1829,28 +1936,23 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:stop:
     post:
       operationId: Agents_stopSession
-      summary: Stop a session
-      description: Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.
+      description: |-
+        Stops a session.
+        Returns 204 No Content when the stop succeeds.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1882,27 +1984,20 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/import:
     post:
       operationId: Agents_updateAgentFromManifest
-      summary: Update an agent from a manifest
       description: |-
         Updates the agent from a manifest by adding a new version if there are any changes to the agent definition.
         If no changes, returns the existing agent version.
@@ -1927,14 +2022,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1981,13 +2070,7 @@ paths:
           description: SHA-256 hex digest of the uploaded code zip. Used for change detection (dedup) and integrity verification.
           schema:
             type: string
-      description: |-
-        Creates a new version for the specified agent and returns the created version resource. Creates a new agent version from code. Uploads the code zip and creates a new version
-        for an existing agent. The SHA-256 hex digest of the zip is provided in the
-        `x-ms-code-zip-sha256` header for integrity and dedup.
-        The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
-        Maximum upload size is 250 MB.
-      summary: Create an agent version Create an agent version from code
+      description: Create a new agent version.
       responses:
         '200':
           description: The request has succeeded.
@@ -1995,25 +2078,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new version for the specified agent and returns the created version resource.
-      x-ms-summary-override: Create an agent version
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
       tags:
-        - Agent Versions
+        - Agents
       requestBody:
         required: true
         content:
@@ -2028,8 +2103,7 @@ paths:
                 contentType: application/json
     get:
       operationId: Agents_listAgentVersions
-      summary: List agent versions
-      description: Returns a paged collection of versions for the specified agent.
+      description: Returns the list of versions of an agent.
       parameters:
         - name: agent_name
           in: path
@@ -2110,25 +2184,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
-      summary: Get an agent version
-      description: Retrieves the specified version of an agent by its agent name and version identifier.
+      description: Retrieves a specific version of an agent.
       parameters:
         - name: agent_name
           in: path
@@ -2156,23 +2223,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
     delete:
       operationId: Agents_deleteAgentVersion
-      summary: Delete an agent version
       description: |-
         Deletes a specific version of an agent. For hosted agents, if the version has active
         sessions, the request is rejected with HTTP 409 unless `force` is set to true. When
@@ -2193,7 +2253,7 @@ paths:
         - name: force
           in: query
           required: false
-          description: For Hosted Agents, if `true`, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.
+          description: For Hosted Agents, if true, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.
           schema:
             type: boolean
             default: false
@@ -2212,24 +2272,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAgentVersionResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream
-      summary: Stream console logs for a hosted agent session
       description: |-
         Streams console logs (stdout / stderr) for a specific hosted agent session
         as a Server-Sent Events (SSE) stream.
@@ -2298,28 +2351,21 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/SessionLogEvent'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
   /agents/{agent_name}/versions:import:
     post:
       operationId: Agents_createAgentVersionFromManifest
-      summary: Create an agent version from manifest
-      description: Imports the provided manifest to create a new version for the specified agent.
+      description: Create a new agent version from a manifest.
       parameters:
         - name: agent_name
           in: path
@@ -2346,20 +2392,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
       requestBody:
         required: true
         content:
@@ -2369,8 +2409,7 @@ paths:
   /agents:import:
     post:
       operationId: Agents_createAgentFromManifest
-      summary: Create an agent from a manifest
-      description: Imports the provided manifest to create an agent and returns the created resource.
+      description: Creates an agent from a manifest.
       parameters:
         - name: api-version
           in: query
@@ -2386,14 +2425,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2409,21 +2442,20 @@ paths:
   /connections:
     get:
       operationId: Connections_list
-      summary: List connections
-      description: Returns the connections available in the current project, optionally filtered by type or default status.
+      description: List all connections in the project, without populating connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: connectionType
           in: query
           required: false
-          description: Lists connections of this specific type
+          description: List connections of this specific type
           schema:
             $ref: '#/components/schemas/ConnectionType'
           explode: false
         - name: defaultConnection
           in: query
           required: false
-          description: Lists connections that are default connections
+          description: List connections that are default connections
           schema:
             type: boolean
           explode: false
@@ -2441,20 +2473,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedConnection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -2470,8 +2490,7 @@ paths:
   /connections/{name}:
     get:
       operationId: Connections_get
-      summary: Get a connection
-      description: Retrieves the specified connection and its configuration details without including credential values.
+      description: Get a connection by name, without populating connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -2494,20 +2513,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Connection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -2523,8 +2530,7 @@ paths:
   /connections/{name}/getConnectionWithCredentials:
     post:
       operationId: Connections_getWithCredentials
-      summary: Get a connection with credentials
-      description: Retrieves the specified connection together with its credential values.
+      description: Get a connection by name, with its connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -2547,20 +2553,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Connection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -2576,7 +2570,7 @@ paths:
   /data_generation_jobs:
     get:
       operationId: DataGenerationJobs_list
-      summary: List data generation jobs
+      summary: Returns a list of data generation jobs
       description: Returns a list of data generation jobs.
       parameters:
         - name: Foundry-Features
@@ -2660,14 +2654,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2679,8 +2667,8 @@ paths:
           - DataGenerationJobs=V1Preview
     post:
       operationId: DataGenerationJobs_create
-      summary: Create a data generation job
-      description: Submits a new data generation job for asynchronous execution.
+      summary: Creates a data generation job.
+      description: Creates a data generation job.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2721,14 +2709,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2748,8 +2730,8 @@ paths:
   /data_generation_jobs/{jobId}:
     get:
       operationId: DataGenerationJobs_get
-      summary: Get a data generation job
-      description: Retrieves the specified data generation job and its current status.
+      summary: Get info about a data generation job.
+      description: Gets the details of a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2786,14 +2768,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2805,8 +2781,8 @@ paths:
           - DataGenerationJobs=V1Preview
     delete:
       operationId: DataGenerationJobs_delete
-      summary: Delete a data generation job
-      description: Removes the specified data generation job and its associated output.
+      summary: Deletes a data generation job.
+      description: Deletes a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2832,14 +2808,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2852,8 +2822,8 @@ paths:
   /data_generation_jobs/{jobId}:cancel:
     post:
       operationId: DataGenerationJobs_cancel
-      summary: Cancel a data generation job
-      description: Cancels the specified data generation job if it is still in progress.
+      summary: Cancels a data generation job.
+      description: Cancels a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2883,14 +2853,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2903,7 +2867,6 @@ paths:
   /datasets:
     get:
       operationId: Datasets_listLatest
-      summary: List latest versions
       description: List the latest version of each DatasetVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -2914,20 +2877,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -2943,7 +2894,6 @@ paths:
   /datasets/{name}/versions:
     get:
       operationId: Datasets_listVersions
-      summary: List versions
       description: List all versions of the given DatasetVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -2960,20 +2910,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -2989,7 +2927,6 @@ paths:
   /datasets/{name}/versions/{version}:
     get:
       operationId: Datasets_getVersion
-      summary: Get a version
       description: Get the specific version of the DatasetVersion. The service returns 404 Not Found error if the DatasetVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3012,20 +2949,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3040,7 +2965,6 @@ paths:
         - Datasets
     delete:
       operationId: Datasets_deleteVersion
-      summary: Delete a version
       description: Delete the specific version of the DatasetVersion. The service returns 204 No Content if the DatasetVersion was deleted successfully or if the DatasetVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3059,20 +2983,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3087,7 +2999,6 @@ paths:
         - Datasets
     patch:
       operationId: Datasets_createOrUpdateVersion
-      summary: Create or update a version
       description: Create a new or update an existing DatasetVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3116,20 +3027,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3152,8 +3051,7 @@ paths:
   /datasets/{name}/versions/{version}/credentials:
     post:
       operationId: Datasets_getCredentials
-      summary: Get dataset credentials
-      description: Gets the SAS credential to access the storage account associated with a Dataset version.
+      description: Get the SAS credential to access the storage account associated with a Dataset version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3175,20 +3073,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3204,8 +3090,7 @@ paths:
   /datasets/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Datasets_startPendingUploadVersion
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified dataset version.
+      description: Start a new or get an existing pending upload of a dataset for a specific version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3227,20 +3112,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PendingUploadResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3263,8 +3136,7 @@ paths:
   /deployments:
     get:
       operationId: Deployments_list
-      summary: List deployments
-      description: Returns the deployed models available in the current project, optionally filtered by publisher, model name, or deployment type.
+      description: List all deployed models in the project
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: modelPublisher
@@ -3302,20 +3174,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDeployment'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3331,8 +3191,7 @@ paths:
   /deployments/{name}:
     get:
       operationId: Deployments_get
-      summary: Get a deployment
-      description: Gets a deployed model.
+      description: Get a deployed model.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3355,20 +3214,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Deployment'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3384,8 +3231,7 @@ paths:
   /evaluationrules:
     get:
       operationId: EvaluationRules_list
-      summary: List evaluation rules
-      description: Returns the evaluation rules configured for the project, optionally filtered by action type, agent name, or enabled state.
+      description: List all evaluation rules.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: actionType
@@ -3416,20 +3262,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3445,8 +3279,7 @@ paths:
   /evaluationrules/{id}:
     get:
       operationId: EvaluationRules_get
-      summary: Get an evaluation rule
-      description: Retrieves the specified evaluation rule and its configuration.
+      description: Get an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -3462,20 +3295,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3490,8 +3311,7 @@ paths:
         - Evaluation Rules
     delete:
       operationId: EvaluationRules_delete
-      summary: Delete an evaluation rule
-      description: Removes the specified evaluation rule from the project.
+      description: Delete an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -3503,20 +3323,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3531,8 +3339,7 @@ paths:
         - Evaluation Rules
     put:
       operationId: EvaluationRules_createOrUpdate
-      summary: Create or update an evaluation rule
-      description: Creates a new evaluation rule, or replaces the existing rule when the identifier matches.
+      description: Create or update an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -3562,20 +3369,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3598,8 +3393,7 @@ paths:
   /evaluationtaxonomies:
     get:
       operationId: EvaluationTaxonomies_list
-      summary: List evaluation taxonomies
-      description: Returns the evaluation taxonomies available in the project, optionally filtered by input name or input type.
+      description: List evaluation taxonomies
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: inputName
@@ -3631,20 +3425,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3660,8 +3442,7 @@ paths:
   /evaluationtaxonomies/{name}:
     get:
       operationId: EvaluationTaxonomies_get
-      summary: Get an evaluation taxonomy
-      description: Retrieves the specified evaluation taxonomy.
+      description: Get an evaluation run by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3685,20 +3466,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3713,8 +3482,7 @@ paths:
         - Evaluation Taxonomies
     delete:
       operationId: EvaluationTaxonomies_delete
-      summary: Delete an evaluation taxonomy
-      description: Removes the specified evaluation taxonomy from the project.
+      description: Delete an evaluation taxonomy by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3734,20 +3502,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3762,8 +3518,7 @@ paths:
         - Evaluation Taxonomies
     put:
       operationId: EvaluationTaxonomies_create
-      summary: Create an evaluation taxonomy
-      description: Creates or replaces the specified evaluation taxonomy with the provided definition.
+      description: Create an evaluation taxonomy.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -3793,20 +3548,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3828,7 +3571,6 @@ paths:
         description: The evaluation taxonomy.
     patch:
       operationId: EvaluationTaxonomies_update
-      summary: Update an evaluation taxonomy
       description: Update an evaluation taxonomy.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3853,20 +3595,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3889,7 +3619,7 @@ paths:
   /evaluator_generation_jobs:
     post:
       operationId: EvaluatorGenerationJobs_create
-      summary: Create an evaluator generation job
+      summary: Creates an evaluator generation job.
       description: |-
         Creates an evaluator generation job. The service generates rubric-based evaluator
         definitions from the provided source materials asynchronously.
@@ -3933,14 +3663,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3959,12 +3683,8 @@ paths:
           - Evaluations=V1Preview
     get:
       operationId: EvaluatorGenerationJobs_list
-      summary: List evaluator generation jobs
-      description: |-
-        Returns a list of evaluator generation jobs. The List API has up to a few
-        seconds of propagation delay, so a recently created job may not appear
-        immediately; use the Get evaluator generation job API with the job ID to
-        retrieve a specific job without delay.
+      summary: Returns a list of evaluator generation jobs.
+      description: Returns a list of evaluator generation jobs.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4047,14 +3767,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4067,7 +3781,7 @@ paths:
   /evaluator_generation_jobs/{jobId}:
     get:
       operationId: EvaluatorGenerationJobs_get
-      summary: Get an evaluator generation job
+      summary: Get info about an evaluator generation job.
       description: Gets the details of an evaluator generation job by its ID.
       parameters:
         - name: Foundry-Features
@@ -4105,14 +3819,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4124,7 +3832,6 @@ paths:
           - Evaluations=V1Preview
     delete:
       operationId: EvaluatorGenerationJobs_delete
-      summary: Delete an evaluator generation job
       description: |-
         Deletes an evaluator generation job by its ID. Deletes the job record only;
         the generated evaluator (if any) is preserved.
@@ -4153,14 +3860,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4173,7 +3874,7 @@ paths:
   /evaluator_generation_jobs/{jobId}:cancel:
     post:
       operationId: EvaluatorGenerationJobs_cancel
-      summary: Cancel an evaluator generation job
+      summary: Cancels an evaluator generation job.
       description: Cancels an evaluator generation job by its ID.
       parameters:
         - name: Foundry-Features
@@ -4204,14 +3905,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4224,8 +3919,7 @@ paths:
   /evaluators:
     get:
       operationId: Evaluators_listLatestVersions
-      summary: List latest evaluator versions
-      description: Lists the latest version of each evaluator
+      description: List the latest version of each evaluator
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: type
@@ -4263,20 +3957,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4292,8 +3974,7 @@ paths:
   /evaluators/{name}/versions:
     get:
       operationId: Evaluators_listVersions
-      summary: List evaluator versions
-      description: Returns the available versions for the specified evaluator.
+      description: List all versions of the given evaluator
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4337,20 +4018,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4365,8 +4034,7 @@ paths:
         - Evaluators
     post:
       operationId: Evaluators_createVersion
-      summary: Create an evaluator version
-      description: Creates a new evaluator version with an auto-incremented version identifier.
+      description: Create a new EvaluatorVersion with auto incremented version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4390,20 +4058,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4425,8 +4081,7 @@ paths:
   /evaluators/{name}/versions/{version}:
     get:
       operationId: Evaluators_getVersion
-      summary: Get an evaluator version
-      description: Retrieves the specified evaluator version, returning 404 if it does not exist.
+      description: Get the specific version of the EvaluatorVersion. The service returns 404 Not Found error if the EvaluatorVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4456,20 +4111,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4484,8 +4127,7 @@ paths:
         - Evaluators
     delete:
       operationId: Evaluators_deleteVersion
-      summary: Delete an evaluator version
-      description: Removes the specified evaluator version. Returns 204 whether the version existed or not.
+      description: Delete the specific version of the EvaluatorVersion. The service returns 204 No Content if the EvaluatorVersion was deleted successfully or if the EvaluatorVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4511,20 +4153,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4539,8 +4169,7 @@ paths:
         - Evaluators
     patch:
       operationId: Evaluators_updateVersion
-      summary: Update an evaluator version
-      description: Updates the specified evaluator version in place.
+      description: Update an existing EvaluatorVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4570,20 +4199,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4606,8 +4223,7 @@ paths:
   /evaluators/{name}/versions/{version}/credentials:
     post:
       operationId: Evaluators_getCredentials
-      summary: Get evaluator credentials
-      description: Retrieves SAS credentials for accessing the storage account associated with the specified evaluator version.
+      description: Get the SAS credential to access the storage account associated with an Evaluator version.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4642,14 +4258,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4669,8 +4279,7 @@ paths:
   /evaluators/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Evaluators_startPendingUpload
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified evaluator version.
+      description: Start a new or get an existing pending upload of an evaluator for a specific version.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4705,14 +4314,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PendingUploadResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4732,7 +4335,6 @@ paths:
   /indexes:
     get:
       operationId: Indexes_listLatest
-      summary: List latest versions
       description: List the latest version of each Index
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4743,20 +4345,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedIndex'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4772,7 +4362,6 @@ paths:
   /indexes/{name}/versions:
     get:
       operationId: Indexes_listVersions
-      summary: List versions
       description: List all versions of the given Index
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4789,20 +4378,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedIndex'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4818,7 +4395,6 @@ paths:
   /indexes/{name}/versions/{version}:
     get:
       operationId: Indexes_getVersion
-      summary: Get a version
       description: Get the specific version of the Index. The service returns 404 Not Found error if the Index does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4841,20 +4417,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Index'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4869,7 +4433,6 @@ paths:
         - Indexes
     delete:
       operationId: Indexes_deleteVersion
-      summary: Delete a version
       description: Delete the specific version of the Index. The service returns 204 No Content if the Index was deleted successfully or if the Index does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4888,20 +4451,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4916,7 +4467,6 @@ paths:
         - Indexes
     patch:
       operationId: Indexes_createOrUpdateVersion
-      summary: Create or update a version
       description: Create a new or update an existing Index with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4945,20 +4495,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Index'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4981,8 +4519,7 @@ paths:
   /insights:
     post:
       operationId: Insights_generate
-      summary: Generate insights
-      description: Generates an insights report from the provided evaluation configuration.
+      description: Generate Insights
       parameters:
         - name: Foundry-Features
           in: header
@@ -5019,14 +4556,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Insight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5042,8 +4573,7 @@ paths:
         description: Complete evaluation configuration including data source, evaluators, and result settings
     get:
       operationId: Insights_list
-      summary: List insights
-      description: Returns insights in reverse chronological order, with the most recent entries first.
+      description: List all insights in reverse chronological order (newest first).
       parameters:
         - name: Foundry-Features
           in: header
@@ -5102,14 +4632,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedInsight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5119,8 +4643,7 @@ paths:
   /insights/{id}:
     get:
       operationId: Insights_get
-      summary: Get an insight
-      description: Retrieves the specified insight report and its results.
+      description: Get a specific insight by Id.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5157,14 +4680,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Insight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5174,8 +4691,7 @@ paths:
   /memory_stores:
     post:
       operationId: createMemoryStore
-      summary: Create a memory store
-      description: Creates a memory store resource with the provided configuration.
+      description: Create a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5199,14 +4715,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5230,7 +4740,7 @@ paths:
                   description: A human-readable description of the memory store.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the memory store.
                 definition:
@@ -5245,8 +4755,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: listMemoryStores
-      summary: List memory stores
-      description: Returns the memory stores available to the caller.
+      description: List all memory stores.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5329,14 +4838,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5349,8 +4852,7 @@ paths:
   /memory_stores/{name}:
     post:
       operationId: updateMemoryStore
-      summary: Update a memory store
-      description: Updates the specified memory store with the supplied configuration changes.
+      description: Update a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5380,14 +4882,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5407,7 +4903,7 @@ paths:
                   description: A human-readable description of the memory store.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the memory store.
       x-ms-foundry-meta:
@@ -5415,8 +4911,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: getMemoryStore
-      summary: Get a memory store
-      description: Retrieves the specified memory store and its current configuration.
+      description: Retrieve a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5446,14 +4941,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5465,8 +4954,7 @@ paths:
           - MemoryStores=V1Preview
     delete:
       operationId: deleteMemoryStore
-      summary: Delete a memory store
-      description: Deletes the specified memory store.
+      description: Delete a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5496,14 +4984,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteMemoryStoreResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5516,8 +4998,7 @@ paths:
   /memory_stores/{name}/items:
     post:
       operationId: createMemory
-      summary: Create a memory item
-      description: Creates a memory item in the specified memory store.
+      description: Create a memory item in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5547,14 +5028,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5588,8 +5063,7 @@ paths:
   /memory_stores/{name}/items/{memory_id}:
     post:
       operationId: updateMemory
-      summary: Update a memory item
-      description: Updates the specified memory item in the memory store.
+      description: Update a memory item in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5625,14 +5099,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5656,8 +5124,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: getMemory
-      summary: Get a memory item
-      description: Retrieves the specified memory item from the memory store.
+      description: Retrieve a memory item from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5693,14 +5160,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5712,8 +5173,7 @@ paths:
           - MemoryStores=V1Preview
     delete:
       operationId: deleteMemory
-      summary: Delete a memory item
-      description: Deletes the specified memory item from the memory store.
+      description: Delete a memory item from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5749,14 +5209,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteMemoryResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5769,8 +5223,7 @@ paths:
   /memory_stores/{name}/items:list:
     post:
       operationId: listMemories
-      summary: List memory items
-      description: Returns memory items from the specified memory store.
+      description: List all memory items in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5866,14 +5319,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5898,8 +5345,7 @@ paths:
   /memory_stores/{name}/updates/{update_id}:
     get:
       operationId: getUpdateResult
-      summary: Get an update result
-      description: Retrieves the status and result of a memory store update operation.
+      description: Get memory store update result.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5935,14 +5381,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreUpdateResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5955,8 +5395,7 @@ paths:
   /memory_stores/{name}:delete_scope:
     post:
       operationId: deleteScopeMemories
-      summary: Delete memories by scope
-      description: Deletes all memories in the specified memory store that are associated with the provided scope.
+      description: Delete all memories associated with a specific scope from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5986,14 +5425,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreDeleteScopeResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6018,8 +5451,7 @@ paths:
   /memory_stores/{name}:search_memories:
     post:
       operationId: searchMemories
-      summary: Search memories
-      description: Searches the specified memory store for memories relevant to the provided conversation context.
+      description: Search for relevant memories from a memory store based on conversation context.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6049,14 +5481,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreSearchResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6093,10 +5519,7 @@ paths:
   /memory_stores/{name}:update_memories:
     post:
       operationId: updateMemories
-      summary: Update memories
-      description: |-
-        Starts an update that writes conversation memories into the specified memory store.
-        The operation returns a long-running status location for polling the update result.
+      description: Update memory store with conversation memories.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6133,14 +5556,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreUpdateResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6182,7 +5599,6 @@ paths:
   /models:
     get:
       operationId: Models_listLatest
-      summary: List latest versions
       description: List the latest version of each ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6201,20 +5617,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6230,7 +5634,6 @@ paths:
   /models/{name}/versions:
     get:
       operationId: Models_listVersions
-      summary: List versions
       description: List all versions of the given ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6255,20 +5658,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6284,8 +5675,7 @@ paths:
   /models/{name}/versions/{version}:
     get:
       operationId: Models_getVersion
-      summary: Get a model version
-      description: Retrieves the specified model version, returning 404 if it does not exist.
+      description: Get the specific version of the ModelVersion. The service returns 404 Not Found error if the ModelVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6315,20 +5705,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6346,7 +5724,6 @@ paths:
           - Models=V1Preview
     delete:
       operationId: Models_deleteVersion
-      summary: Delete a model version
       description: Delete the specific version of the ModelVersion. The service returns 200 OK if the ModelVersion was deleted successfully or if the ModelVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6373,20 +5750,8 @@ paths:
       responses:
         '200':
           description: The request has succeeded.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6404,7 +5769,6 @@ paths:
           - Models=V1Preview
     patch:
       operationId: Models_updateVersion
-      summary: Update a model version
       description: Update an existing ModelVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6441,20 +5805,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6480,8 +5832,7 @@ paths:
   /models/{name}/versions/{version}/createAsync:
     post:
       operationId: Models_createAsync
-      summary: Create a model version async
-      description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a location header for polling the operation status.
+      description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -6524,25 +5875,12 @@ paths:
                     format: uri
                     description: URL to poll for operation status.
                   operationResult:
-                    anyOf:
-                      - type: string
-                        format: uri
-                      - type: 'null'
+                    type: string
+                    format: uri
+                    nullable: true
                     description: URL to the operation result, or null if the operation is still in progress.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6568,8 +5906,7 @@ paths:
   /models/{name}/versions/{version}/credentials:
     post:
       operationId: Models_getCredentials
-      summary: Get model asset credentials
-      description: Retrieves temporary credentials for accessing the storage backing the specified model version.
+      description: Get credentials for a model version asset.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -6599,20 +5936,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6637,8 +5962,7 @@ paths:
   /models/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Models_startPendingUpload
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified model version.
+      description: Start or retrieve a pending upload for a model version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -6668,20 +5992,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelPendingUploadResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6706,8 +6018,7 @@ paths:
   /openai/v1/conversations:
     post:
       operationId: createConversation
-      summary: Create a conversation
-      description: Creates a new conversation resource.
+      description: Create a conversation.
       parameters:
         - name: x-ms-user-isolation-key
           in: header
@@ -6722,14 +6033,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6744,8 +6049,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CreateConversationBody'
     get:
       operationId: listConversations
-      summary: List conversations
-      description: Returns the conversations available in the current project.
+      description: Returns the list of all conversations.
       parameters:
         - name: limit
           in: query
@@ -6833,14 +6137,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6850,8 +6148,7 @@ paths:
   /openai/v1/conversations/{conversation_id}:
     post:
       operationId: updateConversation
-      summary: Update a conversation
-      description: Modifies the specified conversation's properties.
+      description: Update a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -6872,14 +6169,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6894,8 +6185,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.UpdateConversationBody'
     get:
       operationId: getConversation
-      summary: Retrieve a conversation
-      description: Retrieves the specified conversation and its metadata.
+      description: Retrieves a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -6916,14 +6206,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6932,8 +6216,7 @@ paths:
         - Conversations
     delete:
       operationId: deleteConversation
-      summary: Delete a conversation
-      description: Removes the specified conversation resource from the current project.
+      description: Deletes a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -6954,14 +6237,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.DeletedConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6971,8 +6248,7 @@ paths:
   /openai/v1/conversations/{conversation_id}/items:
     post:
       operationId: createConversationItems
-      summary: Create conversation items
-      description: Adds one or more items to the specified conversation.
+      description: Create items in a conversation with the given ID.
       parameters:
         - name: conversation_id
           in: path
@@ -7004,14 +6280,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationItemList'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7035,8 +6305,7 @@ paths:
                 - items
     get:
       operationId: listConversationItems
-      summary: List conversation items
-      description: Returns the items belonging to the specified conversation.
+      description: List all items for a conversation with the given ID.
       parameters:
         - name: conversation_id
           in: path
@@ -7123,14 +6392,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7140,8 +6403,7 @@ paths:
   /openai/v1/conversations/{conversation_id}/items/{item_id}:
     get:
       operationId: getConversationItem
-      summary: Get a conversation item
-      description: Retrieves a specific item from the specified conversation.
+      description: Get a single item from a conversation with the given IDs.
       parameters:
         - name: conversation_id
           in: path
@@ -7168,14 +6430,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.OutputItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7184,8 +6440,7 @@ paths:
         - Conversations
     delete:
       operationId: deleteConversationItem
-      summary: Delete a conversation item
-      description: Removes the specified item from a conversation.
+      description: Delete an item from a conversation with the given IDs.
       parameters:
         - name: conversation_id
           in: path
@@ -7212,14 +6467,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7229,8 +6478,8 @@ paths:
   /openai/v1/evals:
     get:
       operationId: Evals_listEvals
-      summary: List evaluations
-      description: Returns the evaluations configured in the current project.
+      summary: List all evaluations
+      description: List evaluations for a project.
       parameters:
         - name: after
           in: query
@@ -7244,7 +6493,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -7296,14 +6546,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7312,9 +6556,9 @@ paths:
         - Evals
     post:
       operationId: Evals_createEval
-      summary: Create an evaluation
+      summary: Create evaluation
       description: |-
-        Creates the structure of an evaluation that can be used to test a model's performance.
+        Create the structure of an evaluation that can be used to test a model's performance.
         An evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.
         For more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).
       parameters: []
@@ -7325,14 +6569,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7349,7 +6587,7 @@ paths:
     delete:
       operationId: Evals_deleteEval
       summary: Delete an evaluation
-      description: Removes the specified evaluation and its associated data.
+      description: Delete an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -7364,14 +6602,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteEvalResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7381,7 +6613,7 @@ paths:
     get:
       operationId: Evals_getEval
       summary: Get an evaluation
-      description: Retrieves the specified evaluation and its configuration.
+      description: Get an evaluation by ID.
       parameters:
         - name: eval_id
           in: path
@@ -7396,14 +6628,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7413,7 +6639,7 @@ paths:
     post:
       operationId: Evals_updateEval
       summary: Update an evaluation
-      description: Updates certain properties of an evaluation.
+      description: Update certain properties of an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -7428,14 +6654,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7451,8 +6671,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs:
     get:
       operationId: Evals_listRuns
-      summary: List evaluation runs
-      description: Returns the runs associated with the specified evaluation.
+      summary: Get a list of runs for an evaluation
+      description: Get a list of runs for an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -7472,7 +6692,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -7525,14 +6746,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7541,8 +6756,7 @@ paths:
         - Evals
     post:
       operationId: Evals_createEvalRun
-      summary: Create an evaluation run
-      description: Creates an evaluation run for the specified evaluation.
+      summary: Create evaluation run
       parameters:
         - name: eval_id
           in: path
@@ -7557,14 +6771,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7580,8 +6788,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs/{run_id}:
     delete:
       operationId: Evals_deleteEvalRun
-      summary: Delete an evaluation run
-      description: Removes the specified evaluation run.
+      summary: Delete evaluation run
+      description: Delete an eval run.
       parameters:
         - name: eval_id
           in: path
@@ -7602,14 +6810,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteEvalRunResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7619,7 +6821,7 @@ paths:
     get:
       operationId: Evals_getEvalRun
       summary: Get an evaluation run
-      description: Retrieves the specified evaluation run and its current status.
+      description: Get an evaluation run by ID.
       parameters:
         - name: eval_id
           in: path
@@ -7640,14 +6842,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7656,8 +6852,8 @@ paths:
         - Evals
     post:
       operationId: Evals_cancelEvalRun
-      summary: Cancel an evaluation run
-      description: Cancels an ongoing evaluation run.
+      summary: Cancel evaluation run
+      description: Cancel an ongoing evaluation run.
       parameters:
         - name: eval_id
           in: path
@@ -7678,14 +6874,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7695,8 +6885,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs/{run_id}/output_items:
     get:
       operationId: Evals_getEvalRunOutputItems
-      summary: List evaluation run output items
-      description: Returns the output items produced by the specified evaluation run.
+      summary: Get evaluation run output items
+      description: Get a list of output items for an evaluation run.
       parameters:
         - name: eval_id
           in: path
@@ -7721,7 +6911,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -7772,14 +6963,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7790,7 +6975,7 @@ paths:
     get:
       operationId: Evals_getEvalRunOutputItem
       summary: Get an output item of an evaluation run
-      description: Retrieves a single output item from the specified evaluation run.
+      description: Get an evaluation run output item by ID.
       parameters:
         - name: eval_id
           in: path
@@ -7817,14 +7002,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRunOutputItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7834,7 +7013,6 @@ paths:
   /openai/v1/fine_tuning/jobs:
     post:
       operationId: createFineTuningJob
-      summary: Create a fine-tuning job
       description: |-
         Creates a fine-tuning job which begins the process of creating a new model from a given dataset.
 
@@ -7856,14 +7034,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7878,8 +7050,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequest'
     get:
       operationId: listPaginatedFineTuningJobs
-      summary: List fine-tuning jobs
-      description: Returns the fine-tuning jobs for the current organization.
+      description: List your organization's fine-tuning jobs
       parameters:
         - name: after
           in: query
@@ -7911,14 +7082,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListPaginatedFineTuningJobsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7928,9 +7093,8 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}:
     get:
       operationId: retrieveFineTuningJob
-      summary: Get a fine-tuning job
       description: |-
-        Gets info about a fine-tuning job.
+        Get info about a fine-tuning job.
 
         [Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
       parameters:
@@ -7954,14 +7118,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7971,8 +7129,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel:
     post:
       operationId: cancelFineTuningJob
-      summary: Cancel a fine-tuning job
-      description: Immediately cancels the specified fine-tuning job.
+      description: Immediately cancel a fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -7994,14 +7151,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8011,8 +7162,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
     get:
       operationId: listFineTuningJobCheckpoints
-      summary: List fine-tuning job checkpoints
-      description: Returns the checkpoints saved during the specified fine-tuning job.
+      description: List checkpoints for a fine-tuning job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -8050,14 +7200,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListFineTuningJobCheckpointsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8067,8 +7211,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/events:
     get:
       operationId: listFineTuningJobEvents
-      summary: List fine-tuning job events
-      description: Returns the status events emitted during the specified fine-tuning job.
+      description: Get fine-grained status updates for a fine-tuning job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -8106,14 +7249,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListFineTuningJobEventsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8123,8 +7260,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/pause:
     post:
       operationId: pauseFineTuningJob
-      summary: Pause a fine-tuning job
-      description: Pauses the specified fine-tuning job while it is running.
+      description: Pause a running fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -8146,14 +7282,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8163,8 +7293,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/resume:
     post:
       operationId: resumeFineTuningJob
-      summary: Resume a fine-tuning job
-      description: Resumes the specified fine-tuning job after it has been paused.
+      description: Resume a paused fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -8186,14 +7315,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8202,9 +7325,7 @@ paths:
         - Fine-Tuning
   /openai/v1/responses:
     post:
-      operationId: createResponse
-      summary: Create a model response
-      description: Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.
+      operationId: createResponse_createResponseStream
       parameters:
         - name: x-ms-user-isolation-key
           in: header
@@ -8212,6 +7333,7 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
+      description: Creates a model response. Creates a model response (streaming response).
       responses:
         '200':
           description: The request has succeeded.
@@ -8224,200 +7346,12 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Metadata'
-                      - type: 'null'
-                  top_logprobs:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  temperature:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.numeric'
-                      - type: 'null'
-                    default: 1
-                  top_p:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.numeric'
-                      - type: 'null'
-                    default: 1
-                  user:
-                    type: string
-                    description: |-
-                      This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
-                        A stable identifier for your end-users.
-                        Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                    deprecated: true
-                  safety_identifier:
-                    type: string
-                    maxLength: 64
-                    description: |-
-                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                  prompt_cache_key:
-                    type: string
-                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTier'
-                  prompt_cache_retention:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - in_memory
-                          - 24h
-                      - type: 'null'
-                  previous_response_id:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
-                  model:
-                    type: string
-                    description: The model deployment to use for the creation of this response.
-                  reasoning:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Reasoning'
-                      - type: 'null'
-                  background:
-                    anyOf:
-                      - type: boolean
-                      - type: 'null'
-                  max_tool_calls:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  text:
-                    $ref: '#/components/schemas/OpenAI.ResponseTextParam'
-                  tools:
-                    $ref: '#/components/schemas/OpenAI.ToolsArray'
-                  tool_choice:
-                    oneOf:
-                      - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
-                      - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-                  prompt:
-                    $ref: '#/components/schemas/OpenAI.Prompt'
-                  truncation:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - auto
-                          - disabled
-                      - type: 'null'
-                    default: disabled
-                  id:
-                    type: string
-                    description: Unique identifier for this Response.
-                  object:
-                    type: string
-                    enum:
-                      - response
-                    description: The object type of this resource - always set to `response`.
-                    x-stainless-const: true
-                  status:
-                    type: string
-                    enum:
-                      - completed
-                      - failed
-                      - in_progress
-                      - cancelled
-                      - queued
-                      - incomplete
-                    description: |-
-                      The status of the response generation. One of `completed`, `failed`,
-                        `in_progress`, `cancelled`, `queued`, or `incomplete`.
-                  created_at:
-                    type: integer
-                    format: unixtime
-                    description: Unix timestamp (in seconds) of when this Response was created.
-                  completed_at:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                      - type: 'null'
-                    type: integer
-                    format: unixTimestamp
-                  error:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseError'
-                      - type: 'null'
-                  incomplete_details:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseIncompleteDetails'
-                      - type: 'null'
-                  output:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/OpenAI.OutputItem'
-                    description: |-
-                      An array of content items generated by the model.
-                        - The length and order of items in the `output` array is dependent
-                        on the model's response.
-                        - Rather than accessing the first item in the `output` array and
-                        assuming it's an `assistant` message with the content generated by
-                        the model, you might consider using the `output_text` property where
-                        supported in SDKs.
-                  instructions:
-                    anyOf:
-                      - type: string
-                      - type: array
-                        items:
-                          $ref: '#/components/schemas/OpenAI.InputItem'
-                      - type: 'null'
-                  output_text:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
-                  usage:
-                    $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
-                  parallel_tool_calls:
-                    type: boolean
-                    description: Whether to allow the model to run tool calls in parallel.
-                    default: true
-                  conversation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  agent_reference:
-                    anyOf:
-                      - $ref: '#/components/schemas/AgentReference'
-                      - type: 'null'
-                    description: The agent used for this response
-                  content_filters:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ContentFilterResult'
-                    description: The content filter evaluation results.
-                required:
-                  - id
-                  - object
-                  - created_at
-                  - error
-                  - incomplete_details
-                  - output
-                  - instructions
-                  - parallel_tool_calls
-                  - agent_reference
+                $ref: '#/components/schemas/OpenAI.Response'
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/OpenAI.CreateResponseStreamingResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8429,149 +7363,274 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                metadata:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Metadata'
-                    - type: 'null'
-                top_logprobs:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                temperature:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.numeric'
-                    - type: 'null'
-                  default: 1
-                top_p:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.numeric'
-                    - type: 'null'
-                  default: 1
-                user:
-                  type: string
-                  description: |-
-                    This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
-                      A stable identifier for your end-users.
-                      Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                  deprecated: true
-                safety_identifier:
-                  type: string
-                  maxLength: 64
-                  description: |-
-                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                prompt_cache_key:
-                  type: string
-                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTier'
-                prompt_cache_retention:
-                  anyOf:
-                    - type: string
+              anyOf:
+                - type: object
+                  properties:
+                    metadata:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Metadata'
+                      nullable: true
+                    top_logprobs:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    temperature:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    top_p:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    user:
+                      type: string
+                      description: |-
+                        This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
+                          A stable identifier for your end-users.
+                          Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      deprecated: true
+                    safety_identifier:
+                      type: string
+                      description: |-
+                        A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                          The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    prompt_cache_key:
+                      type: string
+                      description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                    service_tier:
+                      $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    prompt_cache_retention:
+                      type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
-                    - type: 'null'
-                previous_response_id:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                model:
-                  type: string
-                  description: The model deployment to use for the creation of this response.
-                reasoning:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Reasoning'
-                    - type: 'null'
-                background:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                max_tool_calls:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                text:
-                  $ref: '#/components/schemas/OpenAI.ResponseTextParam'
-                tools:
-                  $ref: '#/components/schemas/OpenAI.ToolsArray'
-                tool_choice:
-                  oneOf:
-                    - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
-                    - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-                prompt:
-                  $ref: '#/components/schemas/OpenAI.Prompt'
-                truncation:
-                  anyOf:
-                    - type: string
+                      nullable: true
+                    previous_response_id:
+                      type: string
+                      nullable: true
+                    model:
+                      type: string
+                      description: The model deployment to use for the creation of this response.
+                    reasoning:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      nullable: true
+                    background:
+                      type: boolean
+                      nullable: true
+                    max_output_tokens:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    max_tool_calls:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    text:
+                      $ref: '#/components/schemas/OpenAI.ResponseTextParam'
+                    tools:
+                      $ref: '#/components/schemas/OpenAI.ToolsArray'
+                    tool_choice:
+                      oneOf:
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
+                    prompt:
+                      $ref: '#/components/schemas/OpenAI.Prompt'
+                    truncation:
+                      type: string
                       enum:
                         - auto
                         - disabled
-                    - type: 'null'
-                  default: disabled
-                input:
-                  $ref: '#/components/schemas/OpenAI.InputParam'
-                include:
-                  anyOf:
-                    - type: array
+                      nullable: true
+                      default: disabled
+                    input:
+                      $ref: '#/components/schemas/OpenAI.InputParam'
+                    include:
+                      type: array
                       items:
                         $ref: '#/components/schemas/OpenAI.IncludeEnum'
-                    - type: 'null'
-                parallel_tool_calls:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                  default: true
-                store:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                  default: true
-                instructions:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
-                stream:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                stream_options:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
-                    - type: 'null'
-                conversation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ConversationParam'
-                    - type: 'null'
-                context_management:
-                  anyOf:
-                    - type: array
+                      nullable: true
+                    parallel_tool_calls:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    store:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    instructions:
+                      type: string
+                      nullable: true
+                    stream:
+                      type: boolean
+                      nullable: true
+                    stream_options:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
+                      nullable: true
+                    conversation:
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ConversationParam'
+                      nullable: true
+                    context_management:
+                      type: array
                       items:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
-                    - type: 'null'
-                  description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                agent_reference:
-                  allOf:
-                    - $ref: '#/components/schemas/AgentReference'
-                  description: The agent to use for generating the response.
-                structured_inputs:
-                  type: object
-                  unevaluatedProperties: {}
-                  description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                      nullable: true
+                      description: Context management configuration for this request.
+                    agent_reference:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: The agent to use for generating the response.
+                    structured_inputs:
+                      type: object
+                      additionalProperties: {}
+                      description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                - type: object
+                  properties:
+                    metadata:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Metadata'
+                      nullable: true
+                    top_logprobs:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    temperature:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    top_p:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    user:
+                      type: string
+                      description: |-
+                        This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
+                          A stable identifier for your end-users.
+                          Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      deprecated: true
+                    safety_identifier:
+                      type: string
+                      description: |-
+                        A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                          The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    prompt_cache_key:
+                      type: string
+                      description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                    service_tier:
+                      $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    prompt_cache_retention:
+                      type: string
+                      enum:
+                        - in-memory
+                        - 24h
+                      nullable: true
+                    previous_response_id:
+                      type: string
+                      nullable: true
+                    model:
+                      type: string
+                      description: The model deployment to use for the creation of this response.
+                    reasoning:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      nullable: true
+                    background:
+                      type: boolean
+                      nullable: true
+                    max_output_tokens:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    max_tool_calls:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    text:
+                      $ref: '#/components/schemas/OpenAI.ResponseTextParam'
+                    tools:
+                      $ref: '#/components/schemas/OpenAI.ToolsArray'
+                    tool_choice:
+                      oneOf:
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
+                    prompt:
+                      $ref: '#/components/schemas/OpenAI.Prompt'
+                    truncation:
+                      type: string
+                      enum:
+                        - auto
+                        - disabled
+                      nullable: true
+                      default: disabled
+                    input:
+                      $ref: '#/components/schemas/OpenAI.InputParam'
+                    include:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/OpenAI.IncludeEnum'
+                      nullable: true
+                    parallel_tool_calls:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    store:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    instructions:
+                      type: string
+                      nullable: true
+                    stream:
+                      type: boolean
+                      nullable: true
+                    stream_options:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
+                      nullable: true
+                    conversation:
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ConversationParam'
+                      nullable: true
+                    context_management:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/OpenAI.ContextManagementParam'
+                      nullable: true
+                      description: Context management configuration for this request.
+                    agent_reference:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: The agent to use for generating the response.
+                    structured_inputs:
+                      type: object
+                      additionalProperties: {}
+                      description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
     get:
       operationId: listResponses
-      summary: List responses
-      description: Returns a collection of all stored responses matching specified filter criteria.
+      description: Returns the list of all responses.
       parameters:
         - name: limit
           in: query
@@ -8666,14 +7725,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8683,8 +7736,7 @@ paths:
   /openai/v1/responses/compact:
     post:
       operationId: compactResponseConversation
-      summary: Compact a conversation
-      description: Compacts a conversation into a response object suitable for long-running and zero-data-retention scenarios.
+      description: Produces a compaction of a responses conversation.
       parameters: []
       responses:
         '200':
@@ -8693,14 +7745,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.CompactResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8715,9 +7761,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CompactResponseMethodPublicBody'
   /openai/v1/responses/{response_id}:
     get:
-      operationId: getResponse
-      summary: Retrieve a model response
-      description: Retrieves a model response with the given ID.
+      operationId: getResponse_getResponseStream
       parameters:
         - name: response_id
           in: path
@@ -8752,6 +7796,14 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
+        - name: accept
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - text/event-stream
+      description: Retrieves a model response with the given ID. Retrieves a model response with the given ID (streaming response).
       responses:
         '200':
           description: The request has succeeded.
@@ -8768,14 +7820,8 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/OpenAI.CreateResponseStreamingResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8784,7 +7830,6 @@ paths:
         - Responses
     delete:
       operationId: deleteResponse
-      summary: Delete a model response
       description: Deletes a model response.
       parameters:
         - name: response_id
@@ -8812,14 +7857,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteResponseResult'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8829,8 +7868,7 @@ paths:
   /openai/v1/responses/{response_id}/cancel:
     post:
       operationId: cancelResponse
-      summary: Cancel a model response
-      description: Cancels a model response with the given ID. Only responses created with the background parameter set to true can be cancelled.
+      description: Cancels a model response.
       parameters:
         - name: response_id
           in: path
@@ -8857,14 +7895,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.Response'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8874,8 +7906,7 @@ paths:
   /openai/v1/responses/{response_id}/input_items:
     get:
       operationId: listInputItems
-      summary: List input items for a response
-      description: Retrieves the input items associated with the specified response.
+      description: Returns a list of input items for a given response.
       parameters:
         - name: response_id
           in: path
@@ -8960,14 +7991,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8977,8 +8002,7 @@ paths:
   /redTeams/runs:
     get:
       operationId: RedTeams_list
-      summary: List redteams
-      description: Returns the redteams available in the current project.
+      description: List a redteam by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -8996,20 +8020,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedRedTeam'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9025,8 +8037,7 @@ paths:
   /redTeams/runs/{name}:
     get:
       operationId: RedTeams_get
-      summary: Get a redteam
-      description: Retrieves the specified redteam and its configuration.
+      description: Get a redteam by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -9050,20 +8061,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedTeam'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9079,8 +8078,7 @@ paths:
   /redTeams/runs:run:
     post:
       operationId: RedTeams_create
-      summary: Create a redteam run
-      description: Submits a new redteam run for execution with the provided configuration.
+      description: Creates a redteam run.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9104,14 +8102,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedTeam'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9128,8 +8120,7 @@ paths:
   /routines:
     get:
       operationId: listRoutines
-      summary: List routines
-      description: Returns the routines available in the current project.
+      description: List routines.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9139,10 +8130,46 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
-        - $ref: '#/components/parameters/ListRoutinesParameters.after'
-        - $ref: '#/components/parameters/ListRoutinesParameters.before'
-        - $ref: '#/components/parameters/ListRoutinesParameters.order'
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -9176,14 +8203,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9196,8 +8217,7 @@ paths:
   /routines/{routine_name}:
     put:
       operationId: createOrUpdateRoutine
-      summary: Create or update a routine
-      description: Creates a new routine or replaces an existing routine with the supplied definition.
+      description: Create or update a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9222,14 +8242,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9247,8 +8261,7 @@ paths:
           - Routines=V1Preview
     get:
       operationId: getRoutine
-      summary: Get a routine
-      description: Retrieves the specified routine and its current configuration.
+      description: Retrieve a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9273,14 +8286,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9292,8 +8299,7 @@ paths:
           - Routines=V1Preview
     delete:
       operationId: deleteRoutine
-      summary: Delete a routine
-      description: Deletes the specified routine.
+      description: Delete a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9314,14 +8320,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9334,8 +8334,7 @@ paths:
   /routines/{routine_name}/runs:
     get:
       operationId: listRoutineRuns
-      summary: List prior runs for a routine
-      description: Returns prior runs recorded for the specified routine.
+      description: List prior runs for a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9347,10 +8346,46 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -9384,14 +8419,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9404,8 +8433,7 @@ paths:
   /routines/{routine_name}:disable:
     post:
       operationId: disableRoutine
-      summary: Disable a routine
-      description: Disables the specified routine so it no longer runs.
+      description: Disable a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9430,14 +8458,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9450,8 +8472,7 @@ paths:
   /routines/{routine_name}:dispatch_async:
     post:
       operationId: dispatchRoutineAsync
-      summary: Queue an asynchronous routine dispatch
-      description: Queues an asynchronous dispatch for the specified routine.
+      description: Queue an asynchronous routine dispatch.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9476,14 +8497,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DispatchRoutineResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9502,8 +8517,7 @@ paths:
   /routines/{routine_name}:enable:
     post:
       operationId: enableRoutine
-      summary: Enable a routine
-      description: Enables the specified routine so it can be dispatched.
+      description: Enable a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -9528,14 +8542,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9548,8 +8556,7 @@ paths:
   /schedules:
     get:
       operationId: Schedules_list
-      summary: List schedules
-      description: Returns schedules that match the supplied type and enabled filters.
+      description: List all schedules.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: type
@@ -9581,20 +8588,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedSchedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9610,8 +8605,7 @@ paths:
   /schedules/{id}:
     delete:
       operationId: Schedules_delete
-      summary: Delete a schedule
-      description: Deletes the specified schedule resource.
+      description: Delete a schedule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -9631,20 +8625,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9659,8 +8641,7 @@ paths:
         - Schedules
     get:
       operationId: Schedules_get
-      summary: Get a schedule
-      description: Retrieves the specified schedule resource.
+      description: Get a schedule by id.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -9684,20 +8665,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9712,8 +8681,7 @@ paths:
         - Schedules
     put:
       operationId: Schedules_createOrUpdate
-      summary: Create or update a schedule
-      description: Creates a new schedule or updates an existing schedule with the supplied definition.
+      description: Create or update operation template.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -9743,20 +8711,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9779,8 +8735,7 @@ paths:
   /schedules/{id}/runs:
     get:
       operationId: Schedules_listRuns
-      summary: List schedule runs
-      description: Returns schedule runs that match the supplied filters.
+      description: List all schedule runs.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -9818,20 +8773,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedScheduleRun'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -9847,8 +8790,7 @@ paths:
   /schedules/{schedule_id}/runs/{run_id}:
     get:
       operationId: Schedules_getRun
-      summary: Get a schedule run
-      description: Retrieves the specified run for a schedule.
+      description: Get a schedule run by id.
       parameters:
         - name: schedule_id
           in: path
@@ -9884,14 +8826,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScheduleRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9901,8 +8837,7 @@ paths:
   /skills:
     get:
       operationId: Skills_listSkills
-      summary: List skills
-      description: Returns the skills available in the current project.
+      description: Returns the list of all skills.
       parameters:
         - name: limit
           in: query
@@ -9985,14 +8920,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10005,8 +8934,7 @@ paths:
   /skills/{name}:
     get:
       operationId: Skills_getSkill
-      summary: Retrieve a skill
-      description: Retrieves the specified skill and its current configuration.
+      description: Retrieves a skill.
       parameters:
         - name: name
           in: path
@@ -10036,14 +8964,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Skill'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10055,8 +8977,7 @@ paths:
           - Skills=V1Preview
     post:
       operationId: updateSkill
-      summary: Update a skill
-      description: Modifies the specified skill's configuration.
+      description: Update a skill.
       parameters:
         - name: name
           in: path
@@ -10086,14 +9007,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Skill'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10117,8 +9032,7 @@ paths:
           - Skills=V1Preview
     delete:
       operationId: Skills_deleteSkill
-      summary: Delete a skill
-      description: Removes the specified skill and its associated versions.
+      description: Deletes a skill.
       parameters:
         - name: name
           in: path
@@ -10148,14 +9062,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteSkillResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10168,8 +9076,7 @@ paths:
   /skills/{name}/content:
     get:
       operationId: getSkillContent
-      summary: Download the zip content for the default version of a skill
-      description: Downloads the zip content for the default version of a skill.
+      description: Download the zip content for the default version of a skill.
       parameters:
         - name: name
           in: path
@@ -10198,15 +9105,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10242,7 +9144,6 @@ paths:
             type: string
           explode: false
       description: Creates a new version of a skill. If the skill does not exist, it will be created. Creates a new version of a skill from uploaded files via multipart form data.
-      summary: Create a new version of a skill Create a skill version from uploaded files
       responses:
         '200':
           description: The request has succeeded.
@@ -10250,20 +9151,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SkillVersion'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new version of a skill. If the skill does not exist, it will be created.
-      x-ms-summary-override: Create a new version of a skill
       x-ms-foundry-meta:
         required_previews:
           - Skills=V1Preview
@@ -10293,8 +9186,7 @@ paths:
                 contentType: text/plain
     get:
       operationId: listSkillVersions
-      summary: List skill versions
-      description: Returns the available versions for the specified skill.
+      description: List all versions of a skill.
       parameters:
         - name: name
           in: path
@@ -10383,14 +9275,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10403,8 +9289,7 @@ paths:
   /skills/{name}/versions/{version}:
     get:
       operationId: getSkillVersion
-      summary: Retrieve a specific version of a skill
-      description: Retrieves the specified version of a skill by name and version identifier.
+      description: Retrieve a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -10440,14 +9325,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SkillVersion'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10459,8 +9338,7 @@ paths:
           - Skills=V1Preview
     delete:
       operationId: deleteSkillVersion
-      summary: Delete a specific version of a skill
-      description: Removes the specified version of a skill.
+      description: Delete a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -10496,14 +9374,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteSkillVersionResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10516,8 +9388,7 @@ paths:
   /skills/{name}/versions/{version}/content:
     get:
       operationId: getSkillVersionContent
-      summary: Download the zip content for a specific version of a skill
-      description: Downloads the zip content for a specific version of a skill.
+      description: Download the zip content for a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -10552,15 +9423,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10573,8 +9439,7 @@ paths:
   /toolboxes:
     get:
       operationId: listToolboxes
-      summary: List toolboxes
-      description: Returns the toolboxes available in the current project.
+      description: List all toolboxes.
       parameters:
         - name: limit
           in: query
@@ -10616,14 +9481,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10657,28 +9514,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}:
     get:
       operationId: getToolbox
-      summary: Retrieve a toolbox
-      description: Retrieves the specified toolbox and its current configuration.
+      description: Retrieve a toolbox.
       parameters:
         - name: name
           in: path
@@ -10686,14 +9533,6 @@ paths:
           description: The name of the toolbox to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10708,37 +9547,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     patch:
       operationId: updateToolbox
-      summary: Update a toolbox to point to a specific version
-      description: Updates the toolbox's default version pointer to the specified version.
+      description: Update a toolbox to point to a specific version.
       parameters:
         - $ref: '#/components/parameters/UpdateToolboxRequest.name'
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10753,14 +9574,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10773,13 +9588,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateToolboxRequest'
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolbox
-      summary: Delete a toolbox
-      description: Removes the specified toolbox along with all of its versions.
+      description: Delete a toolbox and all its versions.
       parameters:
         - name: name
           in: path
@@ -10787,14 +9598,6 @@ paths:
           description: The name of the toolbox to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10805,28 +9608,18 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions:
     post:
       operationId: createToolboxVersion
-      summary: Create a new version of a toolbox
-      description: Creates a new toolbox version, provisioning the toolbox itself if it does not already exist.
+      description: Create a new version of a toolbox. If the toolbox does not exist, it will be created.
       parameters:
         - name: name
           in: path
@@ -10835,14 +9628,6 @@ paths:
           schema:
             type: string
             maxLength: 256
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10857,14 +9642,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10884,7 +9663,7 @@ paths:
                   description: A human-readable description of the toolbox.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the toolbox.
                 tools:
@@ -10903,13 +9682,9 @@ paths:
                   description: Policy configuration for this toolbox version.
               required:
                 - tools
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     get:
       operationId: listToolboxVersions
-      summary: List toolbox versions
-      description: Returns the available versions for the specified toolbox.
+      description: List all versions of a toolbox.
       parameters:
         - name: name
           in: path
@@ -10957,14 +9732,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -10998,28 +9765,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions/{version}:
     get:
       operationId: getToolboxVersion
-      summary: Retrieve a specific version of a toolbox
-      description: Retrieves the specified version of a toolbox by name and version identifier.
+      description: Retrieve a specific version of a toolbox.
       parameters:
         - name: name
           in: path
@@ -11033,14 +9790,6 @@ paths:
           description: The version identifier to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -11055,27 +9804,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolboxVersion
-      summary: Delete a specific version of a toolbox
-      description: Removes the specified version of a toolbox.
+      description: Delete a specific version of a toolbox.
       parameters:
         - name: name
           in: path
@@ -11089,14 +9828,6 @@ paths:
           description: The version identifier to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -11107,23 +9838,14 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
 security:
   - OAuth2Auth:
       - https://ai.azure.com/.default
@@ -11193,44 +9915,11 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutineRunsParameters.after:
-      name: after
-      in: query
-      required: false
-      description: An opaque cursor returned as last_id by the previous list-runs response.
-      schema:
-        type: string
-      explode: false
-    ListRoutineRunsParameters.before:
-      name: before
-      in: query
-      required: false
-      description: Unsupported. Reserved for future backward pagination support.
-      schema:
-        type: string
-      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
       required: false
       description: An optional MLflow search-runs filter expression applied within the routine's experiment.
-      schema:
-        type: string
-      explode: false
-    ListRoutineRunsParameters.limit:
-      name: limit
-      in: query
-      required: false
-      description: The maximum number of runs to return.
-      schema:
-        type: integer
-        format: int32
-      explode: false
-    ListRoutineRunsParameters.order:
-      name: order
-      in: query
-      required: false
-      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -11242,39 +9931,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutinesParameters.after:
-      name: after
-      in: query
-      required: false
-      description: An opaque cursor returned as last_id by the previous list response.
-      schema:
-        type: string
-      explode: false
-    ListRoutinesParameters.before:
-      name: before
-      in: query
-      required: false
-      description: Unsupported. Reserved for future backward pagination support.
-      schema:
-        type: string
-      explode: false
-    ListRoutinesParameters.limit:
-      name: limit
-      in: query
-      required: false
-      description: The maximum number of routines to return.
-      schema:
-        type: integer
-        format: int32
-      explode: false
-    ListRoutinesParameters.order:
-      name: order
-      in: query
-      required: false
-      description: The ordering direction. Supported values are asc and desc.
-      schema:
-        type: string
-      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -11774,6 +10430,18 @@ components:
       allOf:
         - $ref: '#/components/schemas/TraceSource'
       description: A trace source that selects traces by agent reference with time-based filtering.
+    AgentIdentifier:
+      type: object
+      required:
+        - agentName
+      properties:
+        agentName:
+          type: string
+          description: Registered Foundry agent name (required).
+        agentVersion:
+          type: string
+          description: Pinned agent version. Defaults to latest if omitted.
+      description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and systemPrompt are specified in options.optimizationConfig.
     AgentIdentity:
       type: object
       required:
@@ -11870,7 +10538,6 @@ components:
           enum:
             - activity_protocol
             - responses
-            - a2a
             - mcp
             - invocations
             - invocations_ws
@@ -11941,6 +10608,7 @@ components:
             - idle
             - updating
             - failed
+            - stopping
             - deleting
             - deleted
             - expired
@@ -12004,11 +10672,10 @@ components:
         - definition
       properties:
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
             useful for storing additional information about the object in a structured
@@ -12889,7 +11556,7 @@ components:
               description: A description of what the function does, used by the model to choose when and how to call the function.
             parameters:
               type: object
-              unevaluatedProperties: {}
+              additionalProperties: {}
               description: The parameters the functions accepts, described as a JSON Schema object.
           required:
             - name
@@ -13393,6 +12060,116 @@ components:
             - $ref: '#/components/schemas/BrowserAutomationToolConnectionParameters'
           description: The project connection parameters associated with the Browser Automation Tool.
       description: Definition of input parameters for the Browser Automation Tool.
+    CandidateDeployConfig:
+      type: object
+      properties:
+        instructions:
+          type: string
+          description: System prompt / instructions.
+        model:
+          type: string
+          description: Foundry deployment name.
+        temperature:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 2
+          description: Optional sampling temperature.
+        skills:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Optional skill overrides.
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Optional tool overrides.
+      description: Deploy-config blob for a candidate. Suitable for setting OPTIMIZATION_CONFIG on a hosted-agent version.
+    CandidateFileInfo:
+      type: object
+      required:
+        - path
+        - type
+        - sizeBytes
+      properties:
+        path:
+          type: string
+          description: Relative path of the file.
+        type:
+          type: string
+          description: File type category (e.g. 'config', 'results').
+        sizeBytes:
+          type: integer
+          format: int64
+          description: File size in bytes.
+      description: File entry in a candidate's blob directory.
+    CandidateMetadata:
+      type: object
+      required:
+        - candidateId
+        - jobId
+        - candidateName
+        - status
+        - hasResults
+        - createdAt
+        - updatedAt
+        - files
+      properties:
+        candidateId:
+          type: string
+          description: Server-assigned candidate identifier.
+        jobId:
+          type: string
+          description: Owning optimization job id.
+        candidateName:
+          type: string
+          description: Display name of the candidate.
+        status:
+          type: string
+          description: Candidate lifecycle status.
+        score:
+          type: number
+          format: double
+          description: Candidate's aggregate score.
+        hasResults:
+          type: boolean
+          description: Whether detailed results are available for this candidate.
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when the candidate was created, represented in Unix time.
+        updatedAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when the candidate was last updated, represented in Unix time.
+        promotion:
+          allOf:
+            - $ref: '#/components/schemas/PromotionInfo'
+          description: Promotion metadata. Null if not promoted.
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/CandidateFileInfo'
+          description: Files in the candidate's blob directory.
+      description: Candidate metadata returned by GET /candidates/{id}.
+    CandidateResults:
+      type: object
+      required:
+        - candidateId
+        - results
+      properties:
+        candidateId:
+          type: string
+          description: Owning candidate id.
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptimizationTaskResult'
+          description: Per-task evaluation rows.
+      description: Full per-task evaluation results for a candidate, returned by GET /candidates/{id}/results.
     CaptureStructuredOutputsTool:
       type: object
       required:
@@ -13470,7 +12247,7 @@ components:
           description: List of clusters identified in the insights.
         coordinates:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/ChartCoordinate'
           description: |2-
               Optional mapping of IDs to 2D coordinates used by the UX for visualization.
@@ -13665,7 +12442,7 @@ components:
           readOnly: true
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata of the connection
           readOnly: true
@@ -13694,8 +12471,7 @@ components:
         image:
           type: string
           description: The container image for the hosted agent.
-          examples:
-            - my-registry.azurecr.io/my-hosted-agent:latest
+          example: my-registry.azurecr.io/my-hosted-agent:latest
       description: Container-based deployment configuration for a hosted agent.
       x-ms-foundry-meta:
         required_previews:
@@ -13738,13 +12514,6 @@ components:
           type: integer
           format: int32
           description: Maximum number of evaluation runs allowed per hour.
-        samplingRate:
-          type: number
-          format: double
-          maximum: 100
-          description: Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.
-          exclusiveMinimum: 0
-          default: 100
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.
@@ -13774,7 +12543,7 @@ components:
           default: 5
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Mapping from source fields to response_id field, which is required for retrieving chat history.
         sampling_params:
@@ -13837,6 +12606,8 @@ components:
             - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
+          type: string
+          format: binary
           description: The code zip file (max 250 MB).
       required:
         - metadata
@@ -13858,7 +12629,7 @@ components:
             - Must not exceed 63 characters.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -13877,7 +12648,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     CreateAgentRequest:
       type: object
@@ -13895,7 +12666,7 @@ components:
             - Must not exceed 63 characters.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -13970,6 +12741,8 @@ components:
             - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
+          type: string
+          format: binary
           description: The code zip file (max 250 MB).
       required:
         - metadata
@@ -13985,7 +12758,7 @@ components:
           description: A human-readable description of the agent.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -14015,7 +12788,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -14034,7 +12807,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     CreateAgentVersionRequest:
       type: object
@@ -14043,7 +12816,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -14090,9 +12863,10 @@ components:
           type: string
           description: The name of the evaluation.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         data_source_config:
           oneOf:
             - $ref: '#/components/schemas/OpenAI.CreateEvalCustomDataSourceConfig'
@@ -14114,7 +12888,7 @@ components:
           description: A list of graders for all eval runs in this group. Graders can reference variables in the data source using double curly braces notation, like `{{item.variable_name}}`. To reference the model's output, use the `sample` namespace (ie, `{{sample.output_text}}`).
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -14129,9 +12903,10 @@ components:
           type: string
           description: The name of the run.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         data_source:
           oneOf:
             - $ref: '#/components/schemas/OpenAI.CreateEvalJsonlRunDataSource'
@@ -14141,7 +12916,7 @@ components:
           description: Details about the run's data source.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -14157,7 +12932,9 @@ components:
       properties:
         files:
           type: array
-          items: {}
+          items:
+            type: string
+            format: binary
           description: Skill files to upload. Upload a single zip file or multiple individual files with relative paths.
         default:
           type: boolean
@@ -14213,41 +12990,11 @@ components:
             - CustomKeys
           description: The credential type
           readOnly: true
-      unevaluatedProperties:
+      additionalProperties:
         type: string
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
-    CustomRoutineTrigger:
-      type: object
-      required:
-        - type
-        - provider
-        - parameters
-      properties:
-        type:
-          type: string
-          enum:
-            - custom
-          description: The trigger type.
-        provider:
-          type: string
-          maxLength: 128
-          description: The external provider that emits the custom event.
-        event_name:
-          type: string
-          maxLength: 256
-          description: The provider-specific event name that fires the routine.
-        parameters:
-          type: object
-          unevaluatedProperties: {}
-          description: Provider-specific trigger parameters.
-      allOf:
-        - $ref: '#/components/schemas/RoutineTrigger'
-      description: A custom event routine trigger.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -14395,7 +13142,7 @@ components:
           description: Description to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tags to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs.
       description: Output options for data generation job.
@@ -14517,12 +13264,11 @@ components:
           description: The data source type discriminator.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -14552,7 +13298,7 @@ components:
           readOnly: true
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary of the output dataset.
           readOnly: true
@@ -14582,6 +13328,38 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvaluatorGenerationJobSource'
       description: Dataset source for evaluator generation jobs — reference to a dataset.
+    DatasetInfo:
+      type: object
+      required:
+        - taskCount
+        - isInline
+      properties:
+        name:
+          type: string
+          description: Dataset name when using a registered dataset reference. Null for inline datasets.
+        version:
+          type: string
+          description: Dataset version when using a registered dataset reference. Null for inline datasets.
+        taskCount:
+          type: integer
+          format: int32
+          description: Number of tasks/rows in the dataset.
+        isInline:
+          type: boolean
+          description: True when the dataset was provided inline in the request body.
+      description: Metadata about the dataset used for optimization, surfaced in the response.
+    DatasetRef:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Dataset name.
+        version:
+          type: string
+          description: Dataset version. If not specified, the latest version is used.
+      description: Reference to a registered dataset in the Foundry Dataset Service.
     DatasetReference:
       type: object
       required:
@@ -14659,7 +13437,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       discriminator:
@@ -14907,7 +13685,7 @@ components:
           description: Relative weight of this dimension (1-10). The generation pipeline assigns exactly one dimension weight 8-10; all others use 1-6. User edits are not constrained by this heuristic.
         always_applicable:
           type: boolean
-          description: When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. The service defaults to `false` if a value is not specified by the caller.
+          description: When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. Defaults to `false`.
           default: false
       description: A single dimension — one independent, measurable quality dimension within a rubric evaluator's scoring blueprint.
     DispatchRoutineRequest:
@@ -15031,9 +13809,10 @@ components:
           format: unixtime
           description: The Unix timestamp (in seconds) for when the eval was created.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         modified_at:
           allOf:
             - $ref: '#/components/schemas/integer'
@@ -15043,7 +13822,7 @@ components:
           description: the name of the person who created the run.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -15214,9 +13993,10 @@ components:
             - $ref: '#/components/schemas/EvalRunDataSource'
           description: Information about the run's data source.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         error:
           $ref: '#/components/schemas/OpenAI.EvalApiError'
         modified_at:
@@ -15228,7 +14008,7 @@ components:
           description: the name of the person who created the run.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -15487,7 +14267,7 @@ components:
           description: The identifier for the data source item.
         datasource_item:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Details of the input data source item.
         results:
           type: array
@@ -15577,10 +14357,9 @@ components:
           type: boolean
           description: Whether the grader considered the output a pass.
         sample:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
           description: Optional sample or intermediate data produced by the grader.
         status:
           allOf:
@@ -15601,10 +14380,10 @@ components:
           description: The reason for the test criteria metric.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional details about the test criteria metric.
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: A single grader result for an evaluation run output item.
       title: EvalRunOutputItemResult
     EvalRunOutputItemResultStatus:
@@ -15844,7 +14623,7 @@ components:
           description: Indicates whether the evaluation rule is enabled. Default is true.
         systemData:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: System metadata for the evaluation rule.
           readOnly: true
@@ -15948,7 +14727,6 @@ components:
           description: Identifier of the evaluation group.
         evalRun:
           type: object
-          unevaluatedProperties: {}
           description: The evaluation run payload.
       allOf:
         - $ref: '#/components/schemas/ScheduleTask'
@@ -15983,7 +14761,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -15997,7 +14775,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
         taxonomyInput:
@@ -16011,7 +14789,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -16059,7 +14837,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
         taxonomyInput:
@@ -16073,7 +14851,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -16110,15 +14888,15 @@ components:
           description: The type of evaluator definition
         init_parameters:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema (Draft 2020-12) for the evaluator's input parameters. This includes parameters like type, properties, required.
         data_schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema (Draft 2020-12) for the evaluator's input data. This includes parameters like type, properties, required.
         metrics:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/EvaluatorMetric'
           description: List of output metrics produced by this evaluator
       discriminator:
@@ -16355,7 +15133,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         evaluator_type:
@@ -16367,13 +15145,6 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16420,7 +15191,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         evaluator_type:
@@ -16432,13 +15203,6 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -16448,7 +15212,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Evaluator Definition
@@ -16460,7 +15224,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         categories:
@@ -16468,19 +15232,12 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         description:
           type: string
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Evaluator Definition
@@ -16595,9 +15352,12 @@ components:
           description: (Optional) The URL of the FabricIQ MCP server. If not provided, the URL from the project connection will be used.
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
-            - type: 'null'
+              nullable: true
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
         name:
@@ -16631,9 +15391,12 @@ components:
           description: (Optional) The URL of the FabricIQ MCP server. If not provided, the URL from the project connection will be used.
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
-            - type: 'null'
+              nullable: true
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
       allOf:
@@ -16723,9 +15486,9 @@ components:
             - $ref: '#/components/schemas/OpenAI.RankingOptions'
           description: Ranking options for search.
         filters:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
-            - type: 'null'
+          nullable: true
         vector_store_ids:
           type: array
           items:
@@ -16861,50 +15624,34 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueEvent:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - opened
-            - closed
-      description: Known GitHub issue events that can fire a routine.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    GitHubIssueRoutineTrigger:
+    GitHubIssueOpenedRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - owner
+        - assignee
         - repository
-        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue
+            - github_issue_opened
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        owner:
+        assignee:
           type: string
           maxLength: 128
-          description: The GitHub owner or organization that scopes which issues can fire the trigger.
+          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
-        issue_event:
-          allOf:
-            - $ref: '#/components/schemas/GitHubIssueEvent'
-          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue routine trigger.
+      description: A GitHub issue-opened routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -16938,18 +15685,15 @@ components:
         header_name:
           type: string
           description: The name of the HTTP header to inject the secret value into.
-          examples:
-            - X-Otlp-Api-Key
+          example: X-Otlp-Api-Key
         secret_id:
           type: string
           description: The identifier of the secret store or connection.
-          examples:
-            - my-secret-store
+          example: my-secret-store
         secret_key:
           type: string
           description: The key within the secret to retrieve the authentication value.
-          examples:
-            - OTLP_KEY
+          example: OTLP_KEY
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpointAuth'
       description: Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.
@@ -16977,21 +15721,19 @@ components:
         cpu:
           type: string
           description: The CPU configuration for the hosted agent.
-          examples:
-            - '0.25'
+          example: '0.25'
         memory:
           type: string
           description: The memory configuration for the hosted agent.
-          examples:
-            - 0.5Gi
+          example: 0.5Gi
         environment_variables:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Environment variables to set in the hosted agent container.
-          examples:
-            - name: LOG_LEVEL
-              value: debug
+          example:
+            name: LOG_LEVEL
+            value: debug
         container_configuration:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'
@@ -17004,11 +15746,11 @@ components:
           items:
             $ref: '#/components/schemas/ProtocolVersionRecord'
           description: The protocols that the agent supports for ingress communication.
-          examples:
-            - - protocol: responses
-                version: v0.1.1
-              - protocol: a2a
-                version: v0.3.0
+          example:
+            - protocol: responses
+              version: v0.1.1
+            - protocol: a2a
+              version: v0.3.0
           x-ms-foundry-meta:
             required_previews:
               - CodeAgents=V1Preview
@@ -17110,7 +15852,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       discriminator:
@@ -17254,11 +15996,11 @@ components:
           description: Sample type
         features:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Features to help with additional filtering of data in UX.
         correlationInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Info about the correlation for the analysis sample.
       discriminator:
         propertyName: type
@@ -17338,7 +16080,6 @@ components:
       type: object
       required:
         - type
-        - input
       properties:
         type:
           type: string
@@ -17346,7 +16087,9 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
+          type: string
+          maxLength: 32768
+          description: The raw input sent to the downstream invocations target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -17357,29 +16100,24 @@ components:
       type: object
       required:
         - type
+        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
-        agent_name:
-          type: string
-          maxLength: 256
-          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: Legacy endpoint-scoped agent identifier for routine dispatch.
-        input:
-          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
+          description: The endpoint-scoped agent identifier for invocations API dispatch.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
+      description: Dispatches a routine through the raw invocations API.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -17387,7 +16125,6 @@ components:
       type: object
       required:
         - type
-        - input
       properties:
         type:
           type: string
@@ -17395,7 +16132,9 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
+          type: string
+          maxLength: 32768
+          description: The user input sent to the downstream responses target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -17415,14 +16154,12 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for routine dispatch.
+          description: The project-scoped agent name for responses API dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: Legacy endpoint-scoped agent identifier for routine dispatch.
-        input:
-          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
-        conversation:
+          description: The endpoint-scoped agent identifier for responses API dispatch.
+        conversation_id:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -17474,7 +16211,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -17573,30 +16309,32 @@ components:
           type: string
           description: Optional description of the MCP server, used to provide more context.
         headers:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         allowed_tools:
           anyOf:
             - type: array
               items:
                 type: string
-            - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
-            - type: 'null'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
+              nullable: true
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
               enum:
                 - always
                 - never
-            - type: 'null'
+              nullable: true
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -17849,11 +16587,10 @@ components:
             - $ref: '#/components/schemas/ToolCallStatus'
           description: The status of the tool call.
         memories:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/MemoryItem'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoryItem'
+          nullable: true
           description: The results returned from the memory search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
@@ -17905,7 +16642,7 @@ components:
           default: true
         procedural_memory_enabled:
           type: boolean
-          description: Whether to enable procedural memory extraction and storage. The service defaults to `true` if a value is not specified by the caller.
+          description: Whether to enable procedural memory extraction and storage. Defaults to `true`.
           default: true
         default_ttl_seconds:
           type: integer
@@ -18005,7 +16742,7 @@ components:
           description: A human-readable description of the memory store.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Arbitrary key-value metadata to associate with the memory store.
         definition:
@@ -18201,7 +16938,7 @@ components:
           readOnly: true
         capabilities:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Capabilities of deployed model
           readOnly: true
@@ -18350,7 +17087,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Model Version Definition
@@ -18492,6 +17229,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -18515,6 +17253,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -18539,6 +17278,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -18558,6 +17298,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -18623,6 +17364,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -18640,6 +17382,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -18663,6 +17406,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -18688,21 +17432,17 @@ components:
           x-stainless-const: true
           default: approximate
         country:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         region:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         city:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         timezone:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.AutoCodeInterpreterToolParam:
       type: object
       required:
@@ -18722,9 +17462,9 @@ components:
           maxItems: 50
           description: An optional list of uploaded files to make available to your code.
         memory_limit:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ContainerMemoryLimit'
-            - type: 'null'
+          nullable: true
         network_policy:
           $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
       description: Configuration for a code interpreter container. Optionally specify the IDs of the files to run the code on.
@@ -18748,12 +17488,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -18848,6 +17582,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -18860,12 +17595,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -18983,27 +17712,13 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          nullable: true
         previous_response_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         instructions:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -19020,8 +17735,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -19093,14 +17806,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -19124,13 +17829,11 @@ components:
           type: string
           description: The ID of the pending safety check.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: A pending safety check for the computer call.
     OpenAI.ComputerEnvironment:
       type: string
@@ -19146,7 +17849,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -19154,19 +17856,14 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -19193,21 +17890,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -19222,6 +17904,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -19249,6 +17932,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -19256,9 +17940,9 @@ components:
           maxItems: 50
           description: An optional list of uploaded files to make available to your code.
         memory_limit:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ContainerMemoryLimit'
-            - type: 'null'
+          nullable: true
         skills:
           type: array
           items:
@@ -19285,6 +17969,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -19325,12 +18010,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -19344,8 +18036,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -19378,6 +18091,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -19412,9 +18126,10 @@ components:
           type: string
           description: The context management entry type. Currently only 'compaction' is supported.
         compact_threshold:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
     OpenAI.ConversationItem:
       type: object
       required:
@@ -19426,18 +18141,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -19449,39 +18160,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -19546,9 +18228,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -19589,54 +18270,26 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -19654,8 +18307,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -19676,11 +18327,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -19694,7 +18344,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -19718,15 +18367,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -19749,60 +18425,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -19837,11 +18463,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: |-
@@ -19877,12 +18502,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -19915,7 +18541,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -19923,9 +18549,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -19933,56 +18560,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -19992,7 +18572,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -20022,8 +18601,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -20050,9 +18664,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: An image generation request made by the model.
@@ -20147,13 +18760,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a local shell tool call.
@@ -20213,9 +18825,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A response to an MCP approval request.
@@ -20246,7 +18857,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -20279,20 +18891,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: An invocation of a tool on an MCP server.
@@ -20329,10 +18939,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -20354,9 +18960,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -20384,87 +18989,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -20478,11 +19002,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -20618,7 +19138,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -20674,15 +19193,15 @@ components:
       type: object
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         items:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.InputItem'
+          nullable: true
     OpenAI.CreateEvalCompletionsRunDataSource:
       type: object
       required:
@@ -20803,7 +19322,7 @@ components:
           default: custom
         item_schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The json schema for each row in the data source.
         include_sample_schema:
           type: boolean
@@ -20875,7 +19394,7 @@ components:
           default: logs
         metadata:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Metadata filters for the logs data source.
       description: |-
         A data source config which specifies the metadata property of your logs query.
@@ -21020,7 +19539,7 @@ components:
           default: stored_completions
         metadata:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Metadata filters for the stored completions data source.
       description: Deprecated in favor of LogsDataSourceConfig.
       title: StoredCompletionsDataSourceConfig
@@ -21070,18 +19589,16 @@ components:
               This value is now deprecated in favor of `method`, and should be passed in under the `method` parameter.
           deprecated: true
         suffix:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           minLength: 1
           maxLength: 64
           description: |-
             A string of up to 64 characters that will be added to your fine-tuned model name.
               For example, a `suffix` of "custom-model-name" would produce a model name like `ft:gpt-4o-mini:openai:custom-model-name:7p4lURel`.
         validation_file:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           description: |-
             The ID of an uploaded file that contains validation data.
               If you provide this file, the data is used to generate validation
@@ -21091,16 +19608,16 @@ components:
               Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.
               See the [fine-tuning guide](/docs/guides/model-optimization) for more details.
         integrations:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations'
+          nullable: true
           description: A list of integrations to enable for your fine-tuning job.
         seed:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
           minimum: 0
           maximum: 2147483647
           description: |-
@@ -21109,9 +19626,10 @@ components:
         method:
           $ref: '#/components/schemas/OpenAI.FineTuneMethod'
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
     OpenAI.CreateFineTuningJobRequestHyperparameters:
       type: object
       properties:
@@ -21157,13 +19675,11 @@ components:
         project:
           type: string
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         entity:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         tags:
           type: array
           items:
@@ -21236,6 +19752,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -21258,6 +19775,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -21274,6 +19792,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -21284,9 +19803,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -21334,14 +19850,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -21349,6 +19863,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -21357,12 +19872,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -21379,6 +19888,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -21391,12 +19901,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -21425,10 +19929,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -21453,8 +19953,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -21462,15 +19960,13 @@ components:
         - message
       properties:
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
           type: string
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
         details:
@@ -21479,10 +19975,10 @@ components:
             $ref: '#/components/schemas/OpenAI.Error'
         additionalInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         debugInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
     OpenAI.EvalApiError:
       type: object
       required:
@@ -21612,22 +20108,26 @@ components:
       type: object
       properties:
         seed:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         max_completions_tokens:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         reasoning_effort:
           $ref: '#/components/schemas/OpenAI.ReasoningEffort'
     OpenAI.EvalGraderStringCheck:
@@ -21880,10 +20380,10 @@ components:
       properties:
         item:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         sample:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
     OpenAI.EvalJsonlFileIdSource:
       type: object
       required:
@@ -21912,50 +20412,49 @@ components:
             - responses
           description: The type of run data source. Always `responses`.
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
         model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         instructions_search:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_after:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_before:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         reasoning_effort:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ReasoningEffort'
-            - type: 'null'
+          nullable: true
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         users:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
         tools:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
       description: A EvalResponsesSource object describing a run data source configuration.
       title: EvalResponsesSource
       x-oaiMeta:
@@ -22101,25 +20600,28 @@ components:
           x-stainless-const: true
           default: stored_completions
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_after:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_before:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         limit:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: A StoredCompletionsRunDataSource configuration describing a set of filters
       title: StoredCompletionsRunDataSource
       x-oaiMeta:
@@ -22148,6 +20650,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -22162,11 +20665,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -22203,6 +20701,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -22217,9 +20716,9 @@ components:
             - $ref: '#/components/schemas/OpenAI.RankingOptions'
           description: Ranking options for search.
         filters:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
-            - type: 'null'
+          nullable: true
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -22240,9 +20739,10 @@ components:
         filename:
           type: string
         attributes:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.VectorStoreFileAttributes'
-            - type: 'null'
+          nullable: true
         score:
           type: number
           format: float
@@ -22450,13 +20950,11 @@ components:
         project:
           type: string
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         entity:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         tags:
           type: array
           items:
@@ -22488,20 +20986,17 @@ components:
           format: unixtime
           description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
         error:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FineTuningJobError'
-            - type: 'null'
+          nullable: true
         fine_tuned_model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         finished_at:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         hyperparameters:
           allOf:
             - $ref: '#/components/schemas/OpenAI.FineTuningJobHyperparameters'
@@ -22534,39 +21029,36 @@ components:
             - cancelled
           description: The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.
         trained_tokens:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         training_file:
           type: string
           description: The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).
         validation_file:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         integrations:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FineTuningIntegration'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FineTuningIntegration'
+          nullable: true
         seed:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The seed used for the fine-tuning job.
         estimated_finish:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         method:
           $ref: '#/components/schemas/OpenAI.FineTuneMethod'
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
       description: The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.
       title: FineTuningJob
       x-oaiMeta:
@@ -22698,9 +21190,8 @@ components:
         message:
           type: string
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.FineTuningJobEvent:
       type: object
       required:
@@ -22766,8 +21257,11 @@ components:
             - type: string
               enum:
                 - auto
-            - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+              nullable: true
+            - type: integer
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.integer'
+              nullable: true
           default: auto
         learning_rate_multiplier:
           oneOf:
@@ -22809,23 +21303,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -22844,18 +21333,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -22894,18 +21381,6 @@ components:
         - in_progress
         - completed
         - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionObject:
       type: object
       required:
@@ -22920,12 +21395,11 @@ components:
         parameters:
           $ref: '#/components/schemas/OpenAI.FunctionParameters'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
     OpenAI.FunctionParameters:
       type: object
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: |-
         The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.
         Omitting `parameters` defines a function with an empty parameter list.
@@ -22941,13 +21415,15 @@ components:
           items:
             type: string
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: Execute a shell command.
       title: Shell exec action
     OpenAI.FunctionShellActionParam:
@@ -22961,13 +21437,15 @@ components:
             type: string
           description: Ordered shell commands for the execution environment to run.
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: Commands and limits describing how to run the shell tool call.
       title: Shell action
     OpenAI.FunctionShellCallEnvironment:
@@ -23111,6 +21589,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -23131,6 +21610,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -23181,12 +21661,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -23198,6 +21672,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -23213,16 +21688,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -23234,10 +21704,12 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
-            - type: 'null'
+          nullable: true
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -23321,61 +21793,67 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
         description:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         parameters:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-        defer_loading:
           type: boolean
-          description: Whether this function is deferred and loaded via tool search.
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -23752,7 +22230,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -23770,6 +22247,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -23791,15 +22269,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -23836,9 +22314,9 @@ components:
               `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.InputFidelity'
-            - type: 'null'
+          nullable: true
         input_image_mask:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenToolInputImageMask'
@@ -23889,7 +22367,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -23911,6 +22388,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -24007,23 +22485,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -24042,18 +22515,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -24105,23 +22576,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -24137,26 +22603,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         file_data:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         file_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+          type: string
+          format: uri
+          nullable: true
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -24173,18 +22631,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -24200,18 +22656,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.DetailEnum'
-            - type: 'null'
+          nullable: true
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision)
       title: Input image
     OpenAI.InputItem:
@@ -24233,9 +22687,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -24256,38 +22707,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -24304,9 +22723,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24339,9 +22757,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call_output
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24352,9 +22769,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatusParam'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The streamed output emitted by an apply patch tool call.
@@ -24392,17 +22808,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A tool call to run code.
@@ -24414,9 +22828,8 @@ components:
         - encrypted_content
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
           enum:
@@ -24440,9 +22853,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24458,15 +22870,14 @@ components:
         output:
           $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
         acknowledged_safety_checks:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
+          nullable: true
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a computer tool call.
@@ -24477,6 +22888,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -24494,8 +22906,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -24536,9 +22946,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -24615,11 +23022,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: |-
@@ -24634,9 +23040,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24660,9 +23065,9 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a function tool call.
@@ -24675,9 +23080,8 @@ components:
         - action
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24695,13 +23099,14 @@ components:
             - $ref: '#/components/schemas/OpenAI.FunctionShellActionParam'
           description: The shell commands and limits that describe how to run the tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A tool representing a request to execute one or more shell commands.
@@ -24714,9 +23119,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -24735,13 +23139,14 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContentParam'
           description: Captured chunks of stdout and stderr output, along with their associated outcomes.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The streamed output items emitted by a shell tool call.
@@ -24749,7 +23154,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -24758,7 +23162,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -24768,9 +23171,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -24818,9 +23218,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: An image generation request made by the model.
@@ -24879,13 +23278,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a local shell tool call.
@@ -24935,9 +23333,8 @@ components:
           description: The type of the item. Always `mcp_approval_response`.
           x-stainless-const: true
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         approval_request_id:
           type: string
           description: The ID of the approval request being answered.
@@ -24945,9 +23342,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A response to an MCP approval request.
@@ -24978,7 +23374,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -25011,20 +23408,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: An invocation of a tool on an MCP server.
@@ -25058,10 +23453,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -25092,9 +23483,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -25122,77 +23512,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -25206,9 +23525,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -25265,6 +23581,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -25273,6 +23627,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -25334,7 +23725,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -25342,9 +23733,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -25362,38 +23750,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -25410,9 +23766,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -25445,9 +23800,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call_output
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -25458,9 +23812,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatusParam'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The streamed output emitted by an apply patch tool call.
@@ -25498,17 +23851,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A tool call to run code.
@@ -25520,9 +23871,8 @@ components:
         - encrypted_content
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
           enum:
@@ -25546,9 +23896,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -25564,15 +23913,14 @@ components:
         output:
           $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
         acknowledged_safety_checks:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
+          nullable: true
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a computer tool call.
@@ -25583,6 +23931,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25600,8 +23949,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25642,9 +23989,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -25697,17 +24041,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -25724,35 +24065,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -25817,9 +24129,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -25860,17 +24171,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A tool call to run code.
@@ -25908,6 +24217,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25925,8 +24235,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25947,11 +24255,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -25965,7 +24272,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -25989,8 +24295,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -26011,9 +24315,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -26090,11 +24391,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: |-
@@ -26130,12 +24430,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -26168,7 +24469,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -26176,9 +24477,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -26189,7 +24491,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -26198,7 +24499,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -26208,9 +24508,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -26232,51 +24529,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -26303,9 +24555,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: An image generation request made by the model.
@@ -26364,13 +24615,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: The output of a local shell tool call.
@@ -26430,9 +24680,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A response to an MCP approval request.
@@ -26463,7 +24712,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -26496,20 +24746,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: An invocation of a tool on an MCP server.
@@ -26546,10 +24794,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -26571,9 +24815,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -26601,87 +24844,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -26689,9 +24851,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -26786,11 +24945,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: |-
@@ -26805,9 +24963,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -26831,9 +24988,9 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a function tool call.
@@ -26846,9 +25003,8 @@ components:
         - action
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -26866,13 +25022,14 @@ components:
             - $ref: '#/components/schemas/OpenAI.FunctionShellActionParam'
           description: The shell commands and limits that describe how to run the tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A tool representing a request to execute one or more shell commands.
@@ -26885,9 +25042,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -26906,13 +25062,14 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContentParam'
           description: Captured chunks of stdout and stderr output, along with their associated outcomes.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The streamed output items emitted by a shell tool call.
@@ -26920,7 +25077,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -26929,7 +25085,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -26939,9 +25094,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -26989,57 +25141,12 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -27094,13 +25201,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a local shell tool call.
@@ -27150,9 +25256,8 @@ components:
           description: The type of the item. Always `mcp_approval_response`.
           x-stainless-const: true
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         approval_request_id:
           type: string
           description: The ID of the approval request being answered.
@@ -27160,9 +25265,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A response to an MCP approval request.
@@ -27193,7 +25297,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -27226,20 +25331,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An invocation of a tool on an MCP server.
@@ -27273,10 +25376,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27307,9 +25406,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -27349,6 +25447,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -27366,19 +25465,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -27391,38 +25485,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -27487,9 +25550,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -27530,54 +25592,26 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27595,8 +25629,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27617,11 +25649,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -27635,7 +25666,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -27659,91 +25689,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -27778,11 +25723,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: |-
@@ -27818,12 +25762,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -27856,7 +25801,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -27864,9 +25809,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -27874,56 +25820,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -27933,7 +25832,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27963,8 +25861,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -27991,57 +25924,12 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -28096,13 +25984,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a local shell tool call.
@@ -28162,9 +26049,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A response to an MCP approval request.
@@ -28195,7 +26081,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -28228,20 +26115,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An invocation of a tool on an MCP server.
@@ -28275,10 +26160,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -28292,134 +26173,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -28433,11 +26186,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -28450,8 +26198,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -28515,77 +26261,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -28599,9 +26274,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -28693,6 +26365,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -28720,13 +26393,11 @@ components:
             - list
           x-stainless-const: true
         first_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         last_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           x-ms-list-continuation-token: true
         has_more:
           type: boolean
@@ -28779,10 +26450,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -28803,23 +26487,22 @@ components:
             type: string
           description: The command to run.
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         working_directory:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         env:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Environment variables to set for the command.
           x-oaiTypeLabel: map
         user:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: Execute a shell command on the server.
       title: Local shell exec action
     OpenAI.LocalShellToolParam:
@@ -28833,6 +26516,7 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+          default: local_shell
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -28891,17 +26575,17 @@ components:
           type: string
           description: The name of the tool.
         description:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         input_schema:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPListToolsToolInputSchema'
           description: The JSON schema describing the tool's input.
         annotations:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.MCPListToolsToolAnnotations'
-            - type: 'null'
+          nullable: true
       description: A tool available on an MCP server.
       title: MCP list tools tool
     OpenAI.MCPListToolsToolAnnotations:
@@ -28963,30 +26647,32 @@ components:
           type: string
           description: Optional description of the MCP server, used to provide more context.
         headers:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         allowed_tools:
           anyOf:
             - type: array
               items:
                 type: string
-            - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
-            - type: 'null'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
+              nullable: true
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
               enum:
                 - always
                 - never
-            - type: 'null'
+              nullable: true
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -29046,7 +26732,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -29061,23 +26746,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -29096,18 +26776,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -29217,15 +26895,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -29245,7 +26914,7 @@ components:
         - incomplete
     OpenAI.Metadata:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         type: string
       description: |-
         Set of 16 key-value pairs that can be attached to an object. This can be
@@ -29256,9 +26925,13 @@ components:
       x-oaiTypeLabel: map
     OpenAI.ModelIdsCompaction:
       anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
+        - allOf:
+            - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
+          description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
+          nullable: true
         - type: string
-        - type: 'null'
+          description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
+          nullable: true
       description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
     OpenAI.ModelIdsResponses:
       anyOf:
@@ -29283,125 +26956,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -29415,6 +26969,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -29423,50 +26978,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -29603,19 +27118,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -29623,38 +27132,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -29719,9 +27197,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -29762,17 +27239,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run code.
@@ -29810,6 +27285,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -29827,8 +27303,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -29849,99 +27323,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -29955,27 +27343,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -30010,11 +27387,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: |-
@@ -30050,12 +27426,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -30088,7 +27465,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -30096,9 +27473,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -30109,7 +27487,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -30118,7 +27495,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -30128,9 +27504,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -30152,51 +27525,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -30223,9 +27551,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An image generation request made by the model.
@@ -30264,37 +27591,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -30326,37 +27622,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -30383,7 +27648,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -30416,20 +27682,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An invocation of a tool on an MCP server.
@@ -30463,10 +27727,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30497,9 +27757,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -30527,87 +27786,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -30616,19 +27794,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -30636,9 +27808,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -30781,21 +27951,16 @@ components:
           type: string
           description: The unique identifier of the prompt template to use.
         version:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         variables:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponsePromptVariables'
-            - type: 'null'
+          nullable: true
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -30816,118 +27981,39 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
         effort:
           $ref: '#/components/schemas/OpenAI.ReasoningEffort'
         summary:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - concise
-                - detailed
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - concise
+            - detailed
+          nullable: true
         generate_summary:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - concise
-                - detailed
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - concise
+            - detailed
+          nullable: true
       description: |-
         **gpt-5 and o-series models only**
         Configuration options for
         [reasoning models](https://platform.openai.com/docs/guides/reasoning).
       title: Reasoning
     OpenAI.ReasoningEffort:
-      anyOf:
-        - type: string
-          enum:
-            - none
-            - minimal
-            - low
-            - medium
-            - high
-            - xhigh
-        - type: 'null'
+      type: string
+      enum:
+        - none
+        - minimal
+        - low
+        - medium
+        - high
+        - xhigh
       description: |-
         Constrains effort on reasoning for
         [reasoning models](https://platform.openai.com/docs/guides/reasoning).
@@ -30938,6 +28024,7 @@ components:
         - All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.
         - The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.
         - `xhigh` is supported for all models after `gpt-5.1-codex-max`.
+      nullable: true
     OpenAI.ReasoningTextContent:
       type: object
       required:
@@ -30970,22 +28057,26 @@ components:
         - agent_reference
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         top_logprobs:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         user:
           type: string
@@ -30996,41 +28087,44 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
-          anyOf:
-            - type: string
-              enum:
-                - in_memory
-                - 24h
-            - type: 'null'
+          type: string
+          enum:
+            - in-memory
+            - 24h
+          nullable: true
         previous_response_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         model:
           type: string
           description: The model deployment to use for the creation of this response.
         reasoning:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
+          nullable: true
         background:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-        max_tool_calls:
-          anyOf:
+          type: boolean
+          nullable: true
+        max_output_tokens:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
+        max_tool_calls:
+          type: integer
+          allOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
+          nullable: true
         text:
           $ref: '#/components/schemas/OpenAI.ResponseTextParam'
         tools:
@@ -31042,12 +28136,11 @@ components:
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
         truncation:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - disabled
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - disabled
+          nullable: true
           default: disabled
         id:
           type: string
@@ -31075,20 +28168,19 @@ components:
           format: unixtime
           description: Unix timestamp (in seconds) of when this Response was created.
         completed_at:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         error:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseError'
-            - type: 'null'
+          nullable: true
         incomplete_details:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseIncompleteDetails'
-            - type: 'null'
+          nullable: true
         output:
           type: array
           items:
@@ -31107,33 +28199,26 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          nullable: true
         output_text:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
           default: true
         conversation:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         agent_reference:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/AgentReference'
-            - type: 'null'
+          nullable: true
           description: The agent used for this response
         content_filters:
           type: array
@@ -31160,10 +28245,8 @@ components:
           description: A sequence number for this chunk of the stream response.
         delta:
           type: string
-          contentEncoding: base64
+          format: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -31191,8 +28274,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -31223,8 +28304,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -31252,8 +28331,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -31293,8 +28370,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -31336,8 +28411,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -31375,8 +28448,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -31413,8 +28484,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -31451,8 +28520,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -31485,8 +28552,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -31581,8 +28646,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -31635,8 +28698,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -31675,8 +28736,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -31748,8 +28807,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -31791,8 +28848,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -31855,22 +28910,18 @@ components:
           description: The type of the event. Always `error`.
           x-stainless-const: true
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
           type: string
           description: The error message.
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         sequence_number:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -31904,8 +28955,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -31971,8 +29020,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -32009,8 +29056,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -32047,8 +29092,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -32112,12 +29155,11 @@ components:
         schema:
           $ref: '#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
     OpenAI.ResponseFormatJsonSchemaSchema:
       type: object
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: |-
         The schema for the response format, described as a JSON Schema object.
         Learn how to build JSON schemas [here](https://json-schema.org/).
@@ -32164,8 +29206,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -32210,8 +29250,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -32250,8 +29288,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -32289,8 +29325,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -32328,8 +29362,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -32376,8 +29408,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -32413,8 +29443,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -32486,8 +29514,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -32545,7 +29571,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -32586,8 +29612,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -32630,8 +29654,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -32670,8 +29692,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -32709,8 +29729,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -32748,8 +29766,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -32787,8 +29803,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -32826,8 +29840,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -32865,8 +29877,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -32905,8 +29915,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -32950,8 +29958,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -33015,8 +30021,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -33039,7 +30043,7 @@ components:
           }
     OpenAI.ResponsePromptVariables:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         anyOf:
           - type: string
           - $ref: '#/components/schemas/OpenAI.InputTextContent'
@@ -33073,8 +30077,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -33126,8 +30128,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -33192,8 +30192,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -33259,8 +30257,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -33310,8 +30306,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -33361,8 +30355,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -33410,8 +30402,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -33459,8 +30449,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -33508,8 +30496,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -33523,127 +30509,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -33698,8 +30563,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -33753,8 +30616,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -33851,8 +30712,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -33889,8 +30748,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -33927,8 +30784,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -33951,6 +30806,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -33970,6 +30826,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -33986,21 +30843,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -34008,15 +30854,13 @@ components:
         - medium
         - high
     OpenAI.ServiceTier:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-        - type: 'null'
+      type: string
+      enum:
+        - auto
+        - default
+        - flex
+        - scale
+        - priority
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
@@ -34024,13 +30868,7 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
+      nullable: true
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -34043,6 +30881,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -34064,6 +30903,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -34079,6 +30919,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -34095,6 +30936,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -34113,6 +30955,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -34210,9 +31053,8 @@ components:
         schema:
           $ref: '#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.TextResponseFormatConfiguration'
       description: |-
@@ -34254,9 +31096,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -34285,7 +31124,7 @@ components:
           type: array
           items:
             type: object
-            unevaluatedProperties: {}
+            additionalProperties: {}
           description: |-
             A list of tool definitions that the model should be allowed to call.
               For the Responses API, the list of tool definitions might look like:
@@ -34309,34 +31148,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -34438,9 +31249,8 @@ components:
           type: string
           description: The label of the MCP server to use.
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Use this option to force the model to call a specific tool on a remote MCP server.
@@ -34480,8 +31290,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -34503,8 +31311,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -34533,38 +31339,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -34572,7 +31346,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -34581,8 +31354,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -34647,6 +31418,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -34660,9 +31432,10 @@ components:
         - metadata
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be         useful for storing additional information about the object in a structured         format, and querying for objects via API or the dashboard.
               Keys are strings with a maximum length of 64 characters. Values are strings         with a maximum length of 512 characters.
@@ -34681,6 +31454,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -34702,7 +31476,7 @@ components:
       title: URL citation
     OpenAI.VectorStoreFileAttributes:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         anyOf:
           - type: string
           - $ref: '#/components/schemas/OpenAI.numeric'
@@ -34715,17 +31489,16 @@ components:
         length of 512 characters, booleans, or numbers.
       x-oaiTypeLabel: map
     OpenAI.Verbosity:
-      anyOf:
-        - type: string
-          enum:
-            - low
-            - medium
-            - high
-        - type: 'null'
+      type: string
+      enum:
+        - low
+        - medium
+        - high
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
         Currently supported values are `low`, `medium`, and `high`.
+      nullable: true
     OpenAI.WaitParam:
       type: object
       required:
@@ -34737,6 +31510,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -34775,10 +31549,9 @@ components:
           description: The action type.
           x-stainless-const: true
         url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
           description: The URL opened by the model.
       description: Action type "open_page" - Opens a specific URL from search results.
       title: Open page action
@@ -34786,6 +31559,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -34795,7 +31569,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -34824,7 +31598,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -34838,21 +31611,17 @@ components:
           x-stainless-const: true
           default: approximate
         country:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         region:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         city:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         timezone:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: The approximate location of the user.
       title: Web search approximate location
     OpenAI.WebSearchPreviewTool:
@@ -34866,18 +31635,16 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -34892,14 +31659,17 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
-            - type: 'null'
+          nullable: true
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           type: string
           enum:
@@ -34930,11 +31700,10 @@ components:
       type: object
       properties:
         allowed_domains:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
     OpenAI.integer:
       type: integer
       format: int64
@@ -34998,7 +31767,7 @@ components:
           description: A description of what the function does, used by the model to choose when and how to call the function.
         spec:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The openapi function shape, described as a JSON Schema object.
         auth:
           allOf:
@@ -35022,7 +31791,7 @@ components:
                 description: A description of what the function does, used by the model to choose when and how to call the function.
               parameters:
                 type: object
-                unevaluatedProperties: {}
+                additionalProperties: {}
                 description: The parameters the functions accepts, described as a JSON Schema object.
             required:
               - name
@@ -35177,47 +31946,84 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An OpenAPI tool stored in a toolbox.
-    OptimizationAgentIdentifier:
+    OptimizationAgentDefinition:
       type: object
-      required:
-        - agent_name
       properties:
-        agent_name:
+        agentName:
           type: string
-          description: Registered Foundry agent name (required).
-        agent_version:
+          description: Agent name.
+        agentVersion:
           type: string
-          description: Pinned agent version. Defaults to latest if omitted.
-      description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.
+          description: Agent version.
+        model:
+          type: string
+          description: Model deployment name.
+        systemPrompt:
+          type: string
+          description: System prompt / instructions.
+        skills:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Agent skills.
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Agent tools.
+      description: Agent definition returned in response payloads (includes resolved config).
     OptimizationCandidate:
       type: object
       required:
         - name
-        - avg_score
-        - avg_tokens
+        - config
+        - mutations
+        - avgScore
+        - avgTokens
+        - passRate
+        - taskScores
+        - isParetoOptimal
       properties:
-        candidate_id:
+        candidateId:
           type: string
           description: Server-assigned candidate identifier. Use with GET /candidates/{id} sub-endpoints.
         name:
           type: string
           description: Display name of the candidate (e.g., 'baseline', 'instruction-v2').
+        config:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationAgentDefinition'
+          description: The agent configuration that produced this candidate.
         mutations:
           type: object
-          unevaluatedProperties: {}
-          description: "What was mutated from the baseline (e.g., {system_prompt: 'new prompt'})."
-        avg_score:
+          additionalProperties: {}
+          description: "What was mutated from the baseline (e.g., {systemPrompt: 'new prompt'})."
+        avgScore:
           type: number
           format: double
           description: Average composite score across all tasks.
-        avg_tokens:
+        avgTokens:
           type: number
           format: double
           description: Average token usage across all tasks.
-        eval_id:
+        passRate:
+          type: number
+          format: double
+          description: Fraction of tasks that met the pass threshold.
+        taskScores:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptimizationTaskResult'
+          description: Individual task-level scores.
+        isParetoOptimal:
+          type: boolean
+          description: Whether this candidate is on the Pareto frontier (score vs cost).
+        evalId:
           type: string
           description: Foundry evaluation identifier used to score this candidate.
-        eval_run_id:
+        evalRunId:
           type: string
           description: Foundry evaluation run identifier for this candidate's scoring run.
         promotion:
@@ -35225,114 +32031,16 @@ components:
             - $ref: '#/components/schemas/PromotionInfo'
           description: Promotion metadata. Null if the candidate has not been promoted.
       description: Aggregated evaluation result for a single candidate agent configuration across all tasks.
-    OptimizationDatasetCriterion:
-      type: object
-      required:
-        - name
-        - instruction
-      properties:
-        name:
-          type: string
-          description: Criterion name.
-        instruction:
-          type: string
-          description: Criterion instruction / description.
-      description: 'Evaluation criterion: a name + instruction pair used for per-item scoring.'
-    OptimizationDatasetInput:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInputType'
-          description: Dataset input type discriminator.
-      discriminator:
-        propertyName: type
-        mapping:
-          inline: '#/components/schemas/OptimizationInlineDatasetInput'
-          reference: '#/components/schemas/OptimizationReferenceDatasetInput'
-      description: Base discriminated model for dataset input. Either inline items or a registered reference.
-    OptimizationDatasetInputType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - inline
-            - reference
-      description: Discriminator values for the dataset input union.
-    OptimizationDatasetItem:
-      type: object
-      properties:
-        query:
-          type: string
-          description: The user query / prompt.
-        ground_truth:
-          type: string
-          description: Expected ground truth answer.
-        desired_num_turns:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 20
-          description: Desired number of conversation turns for simulation mode (1-20).
-        criteria:
-          type: array
-          items:
-            $ref: '#/components/schemas/OptimizationDatasetCriterion'
-          description: Per-item evaluation criteria.
-      description: A single item in an inline dataset.
-    OptimizationEvaluatorRef:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Evaluator name.
-        version:
-          type: string
-          description: Evaluator version. If not specified, the latest version is used.
-      description: Reference to a named evaluator, optionally pinned to a version.
-    OptimizationInlineDatasetInput:
-      type: object
-      required:
-        - type
-        - items
-      properties:
-        type:
-          type: string
-          enum:
-            - inline
-          description: Dataset input type discriminator.
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/OptimizationDatasetItem'
-          description: Dataset items.
-      allOf:
-        - $ref: '#/components/schemas/OptimizationDatasetInput'
-      description: Inline dataset — items supplied directly in the request body.
     OptimizationJob:
       type: object
       required:
         - id
         - status
-        - created_at
-        - updated_at
+        - createdAt
       properties:
         id:
           type: string
           description: Server-assigned unique identifier.
-          readOnly: true
-        inputs:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobInputs'
-          description: Caller-supplied inputs.
-        result:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobResult'
-          description: Result produced on success.
           readOnly: true
         status:
           allOf:
@@ -35344,12 +32052,21 @@ components:
             - $ref: '#/components/schemas/OpenAI.Error'
           description: Error details — populated only on failure.
           readOnly: true
-        created_at:
+        result:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationJobResult'
+          description: Result produced on success.
+          readOnly: true
+        inputs:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationJobInputs'
+          description: Caller-supplied inputs.
+        createdAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The timestamp when the job was created, represented in Unix time.
           readOnly: true
-        updated_at:
+        updatedAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The timestamp when the job was last updated, represented in Unix time.
@@ -35357,103 +32074,58 @@ components:
         progress:
           allOf:
             - $ref: '#/components/schemas/OptimizationJobProgress'
-          description: Progress snapshot. May be present in terminal states reflecting last-known progress.
+          description: Progress while in flight. Absent in terminal states.
           readOnly: true
-        warnings:
-          type: array
-          items:
-            type: string
-          description: Non-fatal warnings emitted at any point during optimization.
+        dataset:
+          allOf:
+            - $ref: '#/components/schemas/DatasetInfo'
+          description: Metadata about the dataset used for this optimization job.
           readOnly: true
       description: Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.
     OptimizationJobInputs:
       type: object
       required:
         - agent
-        - train_dataset
-        - evaluators
+        - trainDatasetReference
       properties:
         agent:
           allOf:
-            - $ref: '#/components/schemas/OptimizationAgentIdentifier'
+            - $ref: '#/components/schemas/AgentIdentifier'
           description: The agent (and pinned version) being optimized.
-        train_dataset:
+        trainDatasetReference:
           allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInput'
-          description: Training dataset — either inline items or a reference to a registered dataset. Required.
-        validation_dataset:
+            - $ref: '#/components/schemas/DatasetRef'
+          description: Reference to a registered training dataset (required).
+        validationDatasetReference:
           allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInput'
+            - $ref: '#/components/schemas/DatasetRef'
           description: Optional held-out validation dataset for measuring generalization of the final candidate.
         evaluators:
           type: array
           items:
-            $ref: '#/components/schemas/OptimizationEvaluatorRef'
-          description: Job-level evaluators referenced by name and optional version. Required; at least one must be provided.
+            type: string
+          description: "Job-level evaluators (referenced by name). Per-task criteria may override. Default: ['task_adherence']."
         options:
           allOf:
             - $ref: '#/components/schemas/OptimizationOptions'
           description: Tuning knobs and run-mode.
       description: Caller-supplied inputs for an optimization job.
-    OptimizationJobListItem:
-      type: object
-      required:
-        - id
-        - status
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          description: Server-assigned unique identifier.
-          readOnly: true
-        status:
-          allOf:
-            - $ref: '#/components/schemas/JobStatus'
-          description: Current lifecycle status.
-          readOnly: true
-        error:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.Error'
-          description: Error details — populated only on failure.
-          readOnly: true
-        created_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The timestamp when the job was created, represented in Unix time.
-          readOnly: true
-        updated_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The timestamp when the job was last updated, represented in Unix time.
-          readOnly: true
-        progress:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobProgress'
-          description: Progress snapshot. May be present in terminal states reflecting last-known progress.
-          readOnly: true
-        agent:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationAgentIdentifier'
-          description: The agent targeted by this optimization job.
-          readOnly: true
-      description: Slim job representation returned by the LIST endpoint.
     OptimizationJobProgress:
       type: object
       required:
-        - candidates_completed
-        - best_score
-        - elapsed_seconds
+        - currentIteration
+        - bestScore
+        - elapsedSeconds
       properties:
-        candidates_completed:
+        currentIteration:
           type: integer
           format: int32
-          description: Number of candidates whose evaluation has completed so far.
-        best_score:
+          description: 1-based current iteration index.
+        bestScore:
           type: number
           format: double
           description: Best score observed so far across all candidates.
-        elapsed_seconds:
+        elapsedSeconds:
           type: number
           format: double
           description: Wall-clock time elapsed in seconds since the job began executing.
@@ -35462,61 +32134,106 @@ components:
       type: object
       properties:
         baseline:
-          type: string
-          description: Candidate ID of the original (un-optimized) baseline evaluation.
+          allOf:
+            - $ref: '#/components/schemas/OptimizationCandidate'
+          description: Evaluation scores for the original (un-optimized) agent configuration.
         best:
-          type: string
-          description: Candidate ID of the highest-scoring candidate found during optimization.
+          allOf:
+            - $ref: '#/components/schemas/OptimizationCandidate'
+          description: The highest-scoring candidate found during optimization.
         candidates:
           type: array
           items:
             $ref: '#/components/schemas/OptimizationCandidate'
           description: All evaluated candidates including baseline.
+        options:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationOptions'
+          description: The options used for this optimization run.
+        warnings:
+          type: array
+          items:
+            type: string
+          description: Non-fatal warnings from the optimization run (e.g., target attribute failures that were skipped).
+        allTargetAttributesFailed:
+          type: boolean
+          description: True when all target attributes failed — only the baseline was evaluated.
       description: Terminal-state result body. Populated when status is succeeded or failed.
     OptimizationOptions:
       type: object
       properties:
-        max_candidates:
+        maxIterations:
           type: integer
           format: int32
-          minimum: 1
-          description: 'Maximum number of optimization candidates to generate. Must be >= 1. Default: 5.'
+          description: 'Maximum optimization iterations per strategy. Must be >= 1. Default: 5.'
           default: 5
-        optimization_config:
+        optimizationConfig:
           type: object
-          unevaluatedProperties: {}
-          description: Per-target-attribute configuration overrides. Contains skills, tools, system_prompt for the agent, plus model space for model optimization.
-        eval_model:
+          additionalProperties: {}
+          description: Per-target-attribute configuration overrides. Contains skills, tools, systemPrompt for the agent, plus model space for model optimization.
+        evalModel:
           type: string
           description: Model deployment used for evaluation. Defaults to server config (typically 'gpt-4o').
-        optimization_model:
+        optimizationModel:
           type: string
           description: Model deployment for optimization reasoning (must be gpt-5 family). Falls back to the default eval model when not set.
-        evaluation_level:
+        evaluationLevel:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
       description: Tuning knobs and run-mode for an optimization job.
-    OptimizationReferenceDatasetInput:
+    OptimizationTaskResult:
       type: object
       required:
-        - type
-        - name
+        - taskName
+        - scores
+        - compositeScore
+        - tokens
+        - durationSeconds
+        - passed
       properties:
-        type:
+        taskName:
           type: string
-          enum:
-            - reference
-          description: Dataset input type discriminator.
-        name:
+          description: Task name (from the dataset).
+        query:
           type: string
-          description: Registered dataset name.
-        version:
+          description: The user query / input for the task.
+        scores:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          description: Per-evaluator scores keyed by evaluator name.
+        compositeScore:
+          type: number
+          format: double
+          description: Composite score combining all evaluator scores.
+        tokens:
+          type: integer
+          format: int32
+          description: Total tokens consumed during the agent run for this task.
+        durationSeconds:
+          type: number
+          format: double
+          description: Wall-clock seconds for this task's agent execution.
+        passed:
+          type: boolean
+          description: Whether the task met the pass threshold.
+        errorMessage:
           type: string
-          description: Dataset version. If not specified, the latest version is used.
-      allOf:
-        - $ref: '#/components/schemas/OptimizationDatasetInput'
-      description: Reference to a registered Foundry dataset.
+          description: Error message if the task failed during execution.
+        rationales:
+          type: object
+          additionalProperties:
+            type: string
+          description: Per-evaluator reasoning keyed by evaluator name.
+        response:
+          type: string
+          description: Raw agent response text.
+        runId:
+          type: string
+          description: Identifier of the agent run that produced this result.
+      description: Per-task evaluation result for a single candidate.
     OtlpTelemetryEndpoint:
       type: object
       required:
@@ -35532,14 +32249,12 @@ components:
         endpoint:
           type: string
           description: The OTLP collector endpoint URL.
-          examples:
-            - https://my-collector.example.com/otlp
+          example: https://my-collector.example.com/otlp
         protocol:
           allOf:
             - $ref: '#/components/schemas/TelemetryTransportProtocol'
           description: The transport protocol for the OTLP endpoint.
-          examples:
-            - Http
+          example: Http
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
@@ -35801,21 +32516,60 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - MemoryStores=V1Preview
-    PromotionInfo:
+    PromoteCandidateRequest:
       type: object
       required:
-        - promoted_at
-        - agent_name
-        - agent_version
+        - agentName
+        - agentVersion
       properties:
-        promoted_at:
+        agentName:
+          type: string
+          description: Name of the Foundry agent to promote to.
+        agentVersion:
+          type: string
+          description: Version of the Foundry agent to promote to.
+      description: Request body for promoting a candidate to a Foundry agent version.
+    PromoteCandidateResponse:
+      type: object
+      required:
+        - candidateId
+        - status
+        - promotedAt
+        - agentName
+        - agentVersion
+      properties:
+        candidateId:
+          type: string
+          description: The promoted candidate id.
+        status:
+          type: string
+          description: Status after promotion.
+        promotedAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: Timestamp when promotion occurred, represented in Unix time.
-        agent_name:
+        agentName:
+          type: string
+          description: Name of the Foundry agent promoted to.
+        agentVersion:
+          type: string
+          description: Version of the Foundry agent promoted to.
+      description: Response after successfully promoting a candidate.
+    PromotionInfo:
+      type: object
+      required:
+        - promotedAt
+        - agentName
+        - agentVersion
+      properties:
+        promotedAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when promotion occurred, represented in Unix time.
+        agentName:
           type: string
           description: Name of the Foundry agent this candidate was promoted to.
-        agent_version:
+        agentVersion:
           type: string
           description: Version of the Foundry agent this candidate was promoted to.
       description: Promotion metadata recorded when a candidate is deployed to a Foundry agent.
@@ -35833,15 +32587,13 @@ components:
           type: string
           description: The model deployment to use for this agent.
         instructions:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           description: A system (or developer) message inserted into the model's context.
         temperature:
-          anyOf:
-            - type: number
-              format: float
-            - type: 'null'
+          type: number
+          format: float
+          nullable: true
           minimum: 0
           maximum: 2
           description: |-
@@ -35849,10 +32601,9 @@ components:
             We generally recommend altering this or `top_p` but not both. Defaults to `1`.
           default: 1
         top_p:
-          anyOf:
-            - type: number
-              format: float
-            - type: 'null'
+          type: number
+          format: float
+          nullable: true
           minimum: 0
           maximum: 1
           description: |-
@@ -35863,9 +32614,10 @@ components:
             Defaults to `1`.
           default: 1
         reasoning:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
+          nullable: true
         tools:
           type: array
           items:
@@ -35886,7 +32638,7 @@ components:
           description: Configuration options for a text response from the model. Can be plain text or structured JSON data.
         structured_inputs:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that can participate in prompt template substitution or tool argument bindings.
       allOf:
@@ -36061,7 +32813,7 @@ components:
           description: List of attack strategies or nested lists of attack strategies.
         simulationOnly:
           type: boolean
-          description: Simulation-only or Simulation + Evaluation. If `true` the scan outputs conversation not evaluation result. The service defaults to `false` if a value is not specified by the caller.
+          description: Simulation-only or Simulation + Evaluation. Default false, if true the scan outputs conversation not evaluation result.
           default: false
         riskCategories:
           type: array
@@ -36073,12 +32825,12 @@ components:
           description: Application scenario for the red team operation, to generate scenario specific attacks.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Red team's tags. Unlike properties, tags are fully mutable.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Red team's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.
         status:
@@ -36230,7 +32982,7 @@ components:
           description: The maximum number of turns of chat history to evaluate.
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Mapping from source fields to response_id field, required for retrieving chat history.
         source:
@@ -36260,7 +33012,10 @@ components:
     Routine:
       type: object
       required:
+        - name
         - enabled
+        - triggers
+        - action
       properties:
         name:
           type: string
@@ -36275,7 +33030,7 @@ components:
           description: Whether the routine is enabled.
         triggers:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/RoutineTrigger'
           description: The triggers configured for the routine.
         action:
@@ -36339,6 +33094,9 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
+      required:
+        - triggers
+        - action
       properties:
         description:
           type: string
@@ -36349,7 +33107,7 @@ components:
           description: Whether the routine is enabled.
         triggers:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/RoutineTrigger'
           description: The triggers configured for the routine. In v1, exactly one trigger entry is supported.
         action:
@@ -36393,15 +33151,16 @@ components:
       type: object
       required:
         - id
+        - status
+        - trigger_type
+        - started_at
       properties:
         id:
           type: string
-          description: The unique run identifier for the routine attempt.
-          readOnly: true
+          description: The MLflow run identifier for the routine attempt.
         status:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunStatus'
-          description: The run status.
+          type: string
+          description: The underlying MLflow run status.
         phase:
           allOf:
             - $ref: '#/components/schemas/RoutineRunPhase'
@@ -36410,9 +33169,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
-        trigger_name:
-          type: string
-          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -36421,26 +33177,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
-        agent_id:
-          type: string
-          description: The project-scoped agent identifier recorded for the routine attempt.
-        agent_endpoint_id:
-          type: string
-          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
-        conversation_id:
-          type: string
-          description: The conversation identifier used by a responses API dispatch.
-        session_id:
-          type: string
-          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
-        scheduled_fire_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The scheduled fire time recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -36461,17 +33201,44 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
-        error_status_code:
-          type: integer
-          format: int32
-          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
+        diagnostics:
+          allOf:
+            - $ref: '#/components/schemas/RoutineRunDiagnostics'
+          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunDiagnostics:
+      type: object
+      required:
+        - parameters
+        - tags
+        - metrics
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+          description: MLflow parameters recorded on the run, keyed by parameter name.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: MLflow tags recorded on the run, keyed by tag name.
+        metrics:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          description: Latest MLflow metric values recorded on the run, keyed by metric name.
+      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36485,12 +33252,6 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunStatus:
-      type: string
-      description: The status of a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -36508,8 +33269,7 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
-          custom: '#/components/schemas/CustomRoutineTrigger'
+          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -36519,8 +33279,7 @@ components:
         - type: string
         - type: string
           enum:
-            - custom
-            - github_issue
+            - github_issue_opened
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
@@ -36631,17 +33390,17 @@ components:
           description: Task for the schedule.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Schedule's tags. Unlike properties, tags are fully mutable.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Schedule's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.
         systemData:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: System metadata for the resource.
           readOnly: true
@@ -36709,7 +33468,7 @@ components:
           readOnly: true
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Properties of the schedule run.
           readOnly: true
@@ -36725,7 +33484,7 @@ components:
           description: Type of the task.
         configuration:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Configuration for the task.
       discriminator:
@@ -36769,19 +33528,9 @@ components:
     SessionDirectoryListResponse:
       type: object
       required:
-        - has_more
         - path
         - entries
       properties:
-        first_id:
-          type: string
-          description: The first ID represented in this list.
-        last_id:
-          type: string
-          description: The last ID represented in this list.
-        has_more:
-          type: boolean
-          description: A value indicating whether there are additional values available not captured in this list.
         path:
           type: string
           description: The path that was listed, relative to the session home directory.
@@ -36790,6 +33539,7 @@ components:
           items:
             $ref: '#/components/schemas/SessionDirectoryEntry'
           description: The directory entries.
+      description: Response from listing a directory in a session sandbox.
     SessionFileWriteResponse:
       type: object
       required:
@@ -36814,13 +33564,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/SessionLogEventType'
           description: The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.
-          examples:
-            - log
+          example: log
         data:
           type: string
           description: The event payload as plain text. Currently JSON-formatted but the schema is not contractual and may change.
-          examples:
-            - '{"timestamp":"2026-03-10T09:33:17.121467567+00:00","stream":"stdout","message":"Starting server on port 18080"}'
+          example: '{"timestamp":"2026-03-10T09:33:17.121467567+00:00","stream":"stdout","message":"Starting server on port 18080"}'
       description: |-
         A single Server-Sent Event frame emitted by the hosted agent session log stream.
 
@@ -37022,7 +33770,7 @@ components:
           description: Environment requirements or compatibility notes for the skill.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Arbitrary key-value metadata for additional properties.
         allowed_tools:
@@ -37104,11 +33852,11 @@ components:
           description: The default value for the input if no run-time value is provided.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema for the structured input (optional).
         required:
           type: boolean
-          description: Whether the input property is required when the agent is invoked. The service defaults to `false` if a value is not specified by the caller.
+          description: Whether the input property is required when the agent is invoked. Defaults to `false`.
           default: false
       description: An structured input that can participate in prompt template substitutions and tool argument binding.
     StructuredOutputDefinition:
@@ -37127,12 +33875,11 @@ components:
           description: A description of the output to emit. Used by the model to determine when to emit the output.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema for the structured output.
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
           description: Whether to enforce strict validation. Default `true`.
       description: A structured output that can be produced by the agent.
     StructuredOutputsOutputItem:
@@ -37320,7 +34067,7 @@ components:
           description: List of taxonomy sub categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the taxonomy category.
       description: Taxonomy category definition.
@@ -37345,7 +34092,7 @@ components:
           description: List of taxonomy items under this sub-category.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the taxonomy sub-category.
       description: Taxonomy sub-category definition.
@@ -37392,10 +34139,10 @@ components:
           items:
             $ref: '#/components/schemas/TelemetryDataKind'
           description: Data types to export to this endpoint. Use an empty array to export no data.
-          examples:
-            - - ContainerStdoutStderr
-              - ContainerOtel
-              - Metrics
+          example:
+            - ContainerStdoutStderr
+            - ContainerOtel
+            - Metrics
         auth:
           allOf:
             - $ref: '#/components/schemas/TelemetryEndpointAuth'
@@ -37479,11 +34226,10 @@ components:
           description: The version of the evaluator. Latest version if not specified.
         initialization_parameters:
           type: object
-          unevaluatedProperties: {}
           description: The initialization parameters for the evaluation. Must support structured outputs.
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: The model to use for the evaluation. Must support structured outputs.
       description: An Azure AI Evaluator grader used as testing criterion in evaluations.
@@ -37492,6 +34238,7 @@ components:
       type: object
       required:
         - type
+        - at
       properties:
         type:
           type: string
@@ -37499,9 +34246,11 @@ components:
             - timer
           description: The trigger type.
         at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The UTC date and time at which the timer fires.
+          type: string
+          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+        time_zone:
+          type: string
+          description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
       description: A one-shot timer routine trigger.
@@ -37511,7 +34260,7 @@ components:
     ToolCallOutputContent:
       anyOf:
         - type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         - type: string
         - type: array
           items: {}
@@ -37661,7 +34410,7 @@ components:
           description: Optional user-defined description for this tool or configuration.
         tool_configs:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
             Per-tool configuration map. Keys are tool names or `*` (catch-all default).
@@ -37706,11 +34455,10 @@ components:
         - tools
       properties:
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
             useful for storing additional information about the object in a structured
@@ -37971,7 +34719,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -37990,7 +34738,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     UpdateAgentRequest:
       type: object
@@ -37999,7 +34747,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -38036,12 +34784,13 @@ components:
         name:
           type: string
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -38054,7 +34803,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Request body for updating a model version. Only description and tags can be modified.
@@ -38201,13 +34950,15 @@ components:
           enum:
             - web_search
         filters:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
-            - type: 'null'
+          nullable: true
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           type: string
           enum:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -1,223 +1,93 @@
 {
-  "openapi": "3.2.0",
+  "openapi": "3.0.0",
   "info": {
     "title": "Microsoft Foundry",
     "version": "virtual-public-preview"
   },
   "tags": [
     {
+      "name": "Agents"
+    },
+    {
+      "name": "Agent Containers"
+    },
+    {
+      "name": "Agent Session Files"
+    },
+    {
+      "name": "Agent Invocations"
+    },
+    {
+      "name": "Agent Invocations WebSocket"
+    },
+    {
+      "name": "Connections"
+    },
+    {
+      "name": "Datasets"
+    },
+    {
+      "name": "Deployments"
+    },
+    {
+      "name": "Evaluation Taxonomies"
+    },
+    {
+      "name": "Evaluation Rules"
+    },
+    {
       "name": "EvaluationSuiteGenerationJobs"
+    },
+    {
+      "name": "Evaluators"
+    },
+    {
+      "name": "EvaluatorGenerationJobs"
+    },
+    {
+      "name": "Indexes"
+    },
+    {
+      "name": "Insights"
+    },
+    {
+      "name": "Models"
+    },
+    {
+      "name": "Memory Stores"
+    },
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Evals"
     },
     {
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Responses"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Redteams"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Routines"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Schedules"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Skills"
     },
     {
-      "name": "Agent Invocations",
-      "parent": "Agents Root"
+      "name": "Toolboxes"
     },
     {
-      "name": "Agent Invocations WebSocket",
-      "parent": "Agents Root",
-      "description": "Agent Invocations (WebSocket)"
+      "name": "DataGenerationJobs"
     },
     {
-      "name": "Agent Sessions",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
-    },
-    {
-      "name": "Platform APIs"
-    },
-    {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "AgentOptimizationJobs"
     }
   ],
   "paths": {
@@ -235,7 +105,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -286,18 +156,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -315,22 +175,22 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/OptimizationJob"
+                "$ref": "#/components/schemas/OptimizationJobInputs"
               }
             }
           },
-          "description": "The job to create."
+          "description": "The optimization job inputs."
         },
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       },
       "get": {
         "operationId": "AgentOptimizationJobs_list",
         "summary": "Returns a list of agent optimization jobs.",
-        "description": "List optimization jobs. Supports cursor pagination and optional status / agent_name filters.",
+        "description": "List optimization jobs. Supports cursor pagination and optional status / agentName filters.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -340,7 +200,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -397,7 +257,7 @@
             "explode": false
           },
           {
-            "name": "agent_name",
+            "name": "agentName",
             "in": "query",
             "required": false,
             "description": "Filter to jobs targeting this agent name.",
@@ -432,7 +292,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/OptimizationJobListItem"
+                        "$ref": "#/components/schemas/OptimizationJob"
                       },
                       "description": "The requested list of items."
                     },
@@ -454,18 +314,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -480,7 +330,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
@@ -489,7 +339,7 @@
       "get": {
         "operationId": "AgentOptimizationJobs_get",
         "summary": "Get info about an agent optimization job.",
-        "description": "Get an optimization job by id.",
+        "description": "Get an optimization job by id. Returns 202 while in progress, 200 when terminal.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -499,7 +349,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -529,7 +379,6 @@
             "headers": {
               "Retry-After": {
                 "required": false,
-                "description": "Recommended number of seconds to wait before polling again.",
                 "schema": {
                   "type": "integer",
                   "format": "int32"
@@ -544,18 +393,27 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "headers": {
+              "Retry-After": {
+                "required": false,
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
+                  "$ref": "#/components/schemas/OptimizationJob"
                 }
               }
             }
           },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -570,7 +428,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       },
@@ -587,7 +445,7 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -599,6 +457,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "description": "When true, force-delete even if the job is in a non-terminal state.",
+            "schema": {
+              "type": "boolean"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -615,18 +483,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -641,16 +499,16 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
     },
-    "/agent_optimization_jobs/{jobId}:cancel": {
-      "post": {
-        "operationId": "AgentOptimizationJobs_cancel",
-        "summary": "Cancels an agent optimization job.",
-        "description": "Request cancellation of a running or queued job. Returns an error if the job is already in a terminal state.",
+    "/agent_optimization_jobs/{jobId}/candidates": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_listCandidates",
+        "summary": "Returns a list of candidates for an optimization job.",
+        "description": "List candidates produced by a job.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -660,7 +518,562 @@
             "schema": {
               "type": "string",
               "enum": [
-                "AgentsOptimization=V2Preview"
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "has_more"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/OptimizationCandidate"
+                      },
+                      "description": "The requested list of items."
+                    },
+                    "first_id": {
+                      "type": "string",
+                      "description": "The first ID represented in this list."
+                    },
+                    "last_id": {
+                      "type": "string",
+                      "description": "The last ID represented in this list."
+                    },
+                    "has_more": {
+                      "type": "boolean",
+                      "description": "A value indicating whether there are additional values available not captured in this list."
+                    }
+                  },
+                  "description": "The response data for a requested list of items."
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidate",
+        "summary": "Get a candidate by id.",
+        "description": "Get a single candidate's metadata, manifest, and promotion info.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateMetadata"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/config": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateConfig",
+        "summary": "Get candidate deploy config.",
+        "description": "Get the candidate's deploy config JSON. Used to compose `agents.create_version(...)` from a candidate.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateDeployConfig"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/files": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateFile",
+        "summary": "Get a candidate file.",
+        "description": "Stream a specific file from the candidate's blob directory.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "Relative path of the file to download (e.g. 'files/examples.jsonl').",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}/results": {
+      "get": {
+        "operationId": "AgentOptimizationJobs_getCandidateResults",
+        "summary": "Get candidate evaluation results.",
+        "description": "Get full per-task evaluation results for a candidate.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CandidateResults"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}/candidates/{candidateId}:promote": {
+      "post": {
+        "operationId": "AgentOptimizationJobs_promoteCandidate",
+        "summary": "Promote a candidate.",
+        "description": "Promotes a candidate, recording the deployment timestamp and target agent version.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
+              ]
+            }
+          },
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "The optimization job id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "path",
+            "required": true,
+            "description": "The candidate id to promote.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "description": "The API version to use for this operation.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromoteCandidateResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "AgentOptimizationJobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromoteCandidateRequest"
+              }
+            }
+          },
+          "description": "Promotion details."
+        },
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "AgentsOptimization=V1Preview"
+          ]
+        }
+      }
+    },
+    "/agent_optimization_jobs/{jobId}:cancel": {
+      "post": {
+        "operationId": "AgentOptimizationJobs_cancel",
+        "summary": "Cancels an agent optimization job.",
+        "description": "Request cancellation. Idempotent on terminal states.",
+        "parameters": [
+          {
+            "name": "Foundry-Features",
+            "in": "header",
+            "required": false,
+            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AgentsOptimization=V1Preview"
               ]
             }
           },
@@ -695,18 +1108,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -721,7 +1124,7 @@
         ],
         "x-ms-foundry-meta": {
           "conditional_previews": [
-            "AgentsOptimization=V2Preview"
+            "AgentsOptimization=V1Preview"
           ]
         }
       }
@@ -769,8 +1172,7 @@
             }
           }
         ],
-        "description": "Creates a new agent or a new version of an existing agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.\nThe agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.\nThe SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Create an agent Create a new code-based agent",
+        "description": "Creates the agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.\nThe agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.\nThe SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -782,18 +1184,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -803,8 +1195,6 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new agent or a new version of an existing agent.",
-        "x-ms-summary-override": "Create an agent",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
@@ -836,8 +1226,7 @@
       },
       "get": {
         "operationId": "Agents_listAgents",
-        "summary": "List agents",
-        "description": "Returns a paged collection of agent resources.",
+        "description": "Returns the list of all agents.",
         "parameters": [
           {
             "name": "kind",
@@ -939,18 +1328,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -968,7 +1347,6 @@
     "/agents/endpoint/protocols/invocations_ws": {
       "get": {
         "operationId": "AgentWebsocket_connectEndpointWebsocket",
-        "summary": "Establish a WebSocket connection to a hosted agent",
         "description": "Establishes a WebSocket connection to a hosted agent. The target project and\nagent are passed as query parameters. The service resolves (or creates) a\nsession, resolves the agent version, then relays text and binary frames\nbidirectionally between the client and the agent (1 MB maximum frame size).\n\nThe client must send an HTTP GET with `Upgrade: websocket` headers.",
         "parameters": [
           {
@@ -1067,18 +1445,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1101,8 +1469,7 @@
     "/agents/{agent_name}": {
       "get": {
         "operationId": "Agents_getAgent",
-        "summary": "Get an agent",
-        "description": "Retrieves an agent definition by its unique name.",
+        "description": "Retrieves the agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -1135,18 +1502,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1202,7 +1559,6 @@
           }
         ],
         "description": "Updates the agent by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version. Updates a code-based agent by uploading new code and creating a new version.\nIf the code and definition are unchanged (matched by x-ms-code-zip-sha256 header), returns the existing version.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Update an agent Update a code-based agent",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -1214,18 +1570,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1235,8 +1581,6 @@
             }
           }
         },
-        "x-ms-description-override": "Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.",
-        "x-ms-summary-override": "Update an agent",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
@@ -1268,7 +1612,6 @@
       },
       "delete": {
         "operationId": "Agents_deleteAgent",
-        "summary": "Delete an agent",
         "description": "Deletes an agent. For hosted agents, if any version has active sessions, the request\nis rejected with HTTP 409 unless `force` is set to true. When force is true, all\nassociated sessions are cascade-deleted along with the agent and its versions.",
         "parameters": [
           {
@@ -1284,7 +1627,7 @@
             "name": "force",
             "in": "query",
             "required": false,
-            "description": "For Hosted Agents, if `true`, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.",
+            "description": "For Hosted Agents, if true, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -1313,18 +1656,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1340,8 +1673,7 @@
       },
       "patch": {
         "operationId": "Agents_patchAgentObject",
-        "summary": "Update an agent endpoint",
-        "description": "Applies a merge-patch update to the specified agent endpoint configuration.",
+        "description": "Updates an agent endpoint.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -1361,8 +1693,7 @@
             "required": true,
             "description": "The name of the agent to retrieve.",
             "schema": {
-              "type": "string",
-              "title": "The name of the agent to retrieve"
+              "type": "string"
             }
           },
           {
@@ -1387,18 +1718,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1431,8 +1752,7 @@
     "/agents/{agent_name}/code:download": {
       "get": {
         "operationId": "Agents_downloadAgentCode",
-        "summary": "Download agent code",
-        "description": "Downloads the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
+        "description": "Download the code zip for a code-based hosted agent.\nReturns the previously-uploaded zip (`application/zip`).\n\nIf `agent_version` is supplied, returns that version's code zip; otherwise\nreturns the latest version's code zip.\n\nThe SHA-256 digest of the returned bytes matches the `content_hash` on the\nresolved version's `code_configuration`.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -1491,23 +1811,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1530,7 +1841,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations": {
       "post": {
         "operationId": "AgentInvocations_createAgentInvocation",
-        "summary": "Create an agent invocation",
         "description": "Creates an invocation for the specified agent version.",
         "parameters": [
           {
@@ -1609,18 +1919,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1652,7 +1952,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocationOpenApiSpec",
-        "summary": "Get an agent invocation OpenAPI spec",
         "description": "Retrieves the OpenAPI specification for an agent version's invocation contract.\nReturns 404 if the agent does not expose an OpenAPI specification.",
         "parameters": [
           {
@@ -1694,23 +1993,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "unevaluatedProperties": {}
+                  "additionalProperties": {}
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1733,7 +2022,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}": {
       "get": {
         "operationId": "AgentInvocations_getAgentInvocation",
-        "summary": "Get an agent invocation",
         "description": "Retrieves the invocation with the given ID.\nReturns 404 if the agent does not support this operation or if the invocation ID is not found.",
         "parameters": [
           {
@@ -1804,18 +2092,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1838,7 +2116,6 @@
     "/agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel": {
       "post": {
         "operationId": "AgentInvocations_cancelAgentInvocation",
-        "summary": "Cancel an agent invocation",
         "description": "Cancels an invocation.\nReturns 404 if the agent does not support this operation or if the invocation ID is not found.",
         "parameters": [
           {
@@ -1909,18 +2186,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1952,7 +2219,6 @@
     "/agents/{agent_name}/endpoint/sessions": {
       "post": {
         "operationId": "Agents_createSession",
-        "summary": "Create a session",
         "description": "Creates a new session for an agent endpoint.\nThe endpoint resolves the backing agent version from `version_indicator` and\nenforces session ownership using the provided isolation key for session-mutating operations.",
         "parameters": [
           {
@@ -2007,18 +2273,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2029,7 +2285,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -2049,8 +2305,7 @@
       },
       "get": {
         "operationId": "Agents_listSessions",
-        "summary": "List sessions for an agent",
-        "description": "Returns a paged collection of sessions associated with the specified agent endpoint.",
+        "description": "Returns a list of sessions for the specified agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2172,18 +2427,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2194,7 +2439,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2206,8 +2451,7 @@
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files": {
       "get": {
         "operationId": "AgentSessionFiles_listSessionFiles",
-        "summary": "List session files",
-        "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
+        "description": "List files and directories at a given path in the session sandbox.\nReturns only the immediate children of the specified directory (non-recursive).",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2242,8 +2486,8 @@
           {
             "name": "path",
             "in": "query",
-            "required": false,
-            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+            "required": true,
+            "description": "The directory path to list, relative to the session home directory.",
             "schema": {
               "type": "string"
             },
@@ -2257,48 +2501,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
-            },
-            "explode": false
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "required": false,
-            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
-            "schema": {
-              "$ref": "#/components/schemas/PageOrder"
-            },
-            "explode": false
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
           },
           {
             "name": "api-version",
@@ -2322,18 +2524,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2354,8 +2546,7 @@
       },
       "delete": {
         "operationId": "AgentSessionFiles_deleteSessionFile",
-        "summary": "Delete a session file",
-        "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
+        "description": "Delete a file or directory from the session sandbox.\nIf `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2401,7 +2592,7 @@
             "name": "recursive",
             "in": "query",
             "required": false,
-            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Whether to recursively delete directory contents. Defaults to false.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -2432,18 +2623,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2466,8 +2647,7 @@
     "/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content": {
       "put": {
         "operationId": "AgentSessionFiles_uploadSessionFile",
-        "summary": "Upload a session file",
-        "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
+        "description": "Upload a file to the session sandbox via binary stream.\nMaximum file size is 50 MB. Uploads exceeding this limit return 413 Payload Too Large.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2540,18 +2720,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2569,7 +2739,8 @@
           "content": {
             "application/octet-stream": {
               "schema": {
-                "contentMediaType": "application/octet-stream"
+                "type": "string",
+                "format": "binary"
               }
             }
           }
@@ -2582,8 +2753,7 @@
       },
       "get": {
         "operationId": "AgentSessionFiles_downloadSessionFile",
-        "summary": "Download a session file",
-        "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
+        "description": "Download a file from the session sandbox as a binary stream.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2651,23 +2821,14 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "contentMediaType": "application/octet-stream"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2690,8 +2851,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}": {
       "get": {
         "operationId": "Agents_getSession",
-        "summary": "Get a session",
-        "description": "Retrieves the details of a hosted agent session by agent name and session identifier.",
+        "description": "Retrieves a session by ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2754,18 +2914,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2776,7 +2926,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2786,7 +2936,6 @@
       },
       "delete": {
         "operationId": "Agents_deleteSession",
-        "summary": "Delete a session",
         "description": "Deletes a session synchronously.\nReturns 204 No Content when the session is deleted or does not exist.",
         "parameters": [
           {
@@ -2843,18 +2992,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2865,7 +3004,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2877,8 +3016,7 @@
     "/agents/{agent_name}/endpoint/sessions/{session_id}:stop": {
       "post": {
         "operationId": "Agents_stopSession",
-        "summary": "Stop a session",
-        "description": "Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.",
+        "description": "Stops a session.\nReturns 204 No Content when the stop succeeds.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -2925,18 +3063,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -2947,7 +3075,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -2959,7 +3087,6 @@
     "/agents/{agent_name}/import": {
       "post": {
         "operationId": "Agents_updateAgentFromManifest",
-        "summary": "Update an agent from a manifest",
         "description": "Updates the agent from a manifest by adding a new version if there are any changes to the agent definition.\nIf no changes, returns the existing agent version.",
         "parameters": [
           {
@@ -2993,18 +3120,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3032,8 +3149,7 @@
     "/agents/{agent_name}/operations": {
       "get": {
         "operationId": "AgentContainers_listAgentContainerOperations",
-        "summary": "List agent container operations",
-        "description": "Returns container operations recorded for the specified agent across its container lifecycle.",
+        "description": "List container operations for an agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3146,18 +3262,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3180,8 +3286,7 @@
     "/agents/{agent_name}/operations/{operation_id}": {
       "get": {
         "operationId": "AgentContainers_getAgentContainerOperation",
-        "summary": "Get an agent container operation",
-        "description": "Retrieves the status and details of the specified container operation for an agent.",
+        "description": "Get the status of a container operation for an agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3235,18 +3340,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3309,8 +3404,7 @@
             }
           }
         ],
-        "description": "Creates a new version for the specified agent and returns the created version resource. Creates a new agent version from code. Uploads the code zip and creates a new version\nfor an existing agent. The SHA-256 hex digest of the zip is provided in the\n`x-ms-code-zip-sha256` header for integrity and dedup.\nThe request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).\nMaximum upload size is 250 MB.",
-        "summary": "Create an agent version Create an agent version from code",
+        "description": "Create a new agent version.",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -3322,18 +3416,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3343,15 +3427,13 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new version for the specified agent and returns the created version resource.",
-        "x-ms-summary-override": "Create an agent version",
         "x-ms-foundry-meta": {
           "required_previews": [
             "CodeAgents=V1Preview"
           ]
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -3376,8 +3458,7 @@
       },
       "get": {
         "operationId": "Agents_listAgentVersions",
-        "summary": "List agent versions",
-        "description": "Returns a paged collection of versions for the specified agent.",
+        "description": "Returns the list of versions of an agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -3478,18 +3559,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3500,15 +3571,14 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       }
     },
     "/agents/{agent_name}/versions/{agent_version}": {
       "get": {
         "operationId": "Agents_getAgentVersion",
-        "summary": "Get an agent version",
-        "description": "Retrieves the specified version of an agent by its agent name and version identifier.",
+        "description": "Retrieves a specific version of an agent.",
         "parameters": [
           {
             "name": "agent_name",
@@ -3550,18 +3620,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3572,12 +3632,11 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       },
       "delete": {
         "operationId": "Agents_deleteAgentVersion",
-        "summary": "Delete an agent version",
         "description": "Deletes a specific version of an agent. For hosted agents, if the version has active\nsessions, the request is rejected with HTTP 409 unless `force` is set to true. When\nforce is true, all sessions associated with this version are cascade-deleted.",
         "parameters": [
           {
@@ -3602,7 +3661,7 @@
             "name": "force",
             "in": "query",
             "required": false,
-            "description": "For Hosted Agents, if `true`, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.",
+            "description": "For Hosted Agents, if true, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -3631,18 +3690,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3653,15 +3702,14 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ]
       }
     },
     "/agents/{agent_name}/versions/{agent_version}/containers/default": {
       "get": {
         "operationId": "AgentContainers_getAgentContainer",
-        "summary": "Get an agent container",
-        "description": "Retrieves the default container resource for the specified agent version.\nThe response includes the current container state and configuration.",
+        "description": "Get a container for a specific version of an agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3715,18 +3763,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3749,8 +3787,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default/operations": {
       "get": {
         "operationId": "AgentContainers_listAgentVersionContainerOperations",
-        "summary": "List agent version container operations",
-        "description": "Returns container operations for the default container of the specified agent version.",
+        "description": "List container operations for a specific version of an agent.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3872,18 +3909,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3906,8 +3933,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default:delete": {
       "post": {
         "operationId": "AgentContainers_deleteAgentContainer",
-        "summary": "Delete an agent container",
-        "description": "Deletes the default container for the specified agent version.\nThe long-running operation returns an operation resource that can be polled to completion.",
+        "description": "Delete a container for a specific version of an agent. If the container doesn't exist, the operation will be no-op.\nThe operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.\nhttps://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -3970,18 +3996,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4004,8 +4020,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default:logstream": {
       "post": {
         "operationId": "AgentContainers_streamAgentContainerLogs",
-        "summary": "Stream agent container logs",
-        "description": "Streams console or system logs from the default container for the specified agent version.\nClients can target a specific replica and request trailing log lines before the chunked text stream begins.",
+        "description": "Container log entry streamed from the container as text chunks.\nEach chunk is a UTF-8 string that may be either a plain text log line\nor a JSON-formatted log entry, depending on the type of container log being streamed.\nClients should treat each chunk as opaque text and, if needed, attempt\nto parse it as JSON based on their logging requirements.\n\nFor system logs, the format is JSON with the following structure:\n{\"TimeStamp\":\"2025-12-15T16:51:33Z\",\"Type\":\"Normal\",\"ContainerAppName\":null,\"RevisionName\":null,\"ReplicaName\":null,\"Msg\":\"Connecting to the events collector...\",\"Reason\":\"StartingGettingEvents\",\"EventSource\":\"ContainerAppController\",\"Count\":1}\n{\"TimeStamp\":\"2025-12-15T16:51:34Z\",\"Type\":\"Normal\",\"ContainerAppName\":null,\"RevisionName\":null,\"ReplicaName\":null,\"Msg\":\"Successfully connected to events server\",\"Reason\":\"ConnectedToEventsServer\",\"EventSource\":\"ContainerAppController\",\"Count\":1}\n\nFor console logs, the format is plain text as emitted by the container's stdout/stderr.\n2025-12-15T08:43:48.72656  Connecting to the container 'agent-container'...\n2025-12-15T08:43:48.75451  Successfully Connected to container: 'agent-container' [Revision: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b', Replica: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b-6898b9c89f-mpkjc']\n2025-12-15T08:33:59.0671054Z stdout F INFO:     127.0.0.1:42588 - \"GET /readiness HTTP/1.1\" 200 OK\n2025-12-15T08:34:29.0649033Z stdout F INFO:     127.0.0.1:60246 - \"GET /readiness HTTP/1.1\" 200 OK\n2025-12-15T08:34:59.0644467Z stdout F INFO:     127.0.0.1:43994 - \"GET /readiness HTTP/1.1\" 200 OK",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4083,18 +4098,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4117,8 +4122,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default:start": {
       "post": {
         "operationId": "AgentContainers_startAgentContainer",
-        "summary": "Start an agent container",
-        "description": "Starts the default container for the specified agent version.\nThe long-running operation provisions replicas when a container is not already running.",
+        "description": "Start a container for a specific version of an agent. If the container is already running, the operation will be no-op.\nThe operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.\nhttps://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4181,18 +4185,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4239,8 +4233,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default:stop": {
       "post": {
         "operationId": "AgentContainers_stopAgentContainer",
-        "summary": "Stop an agent container",
-        "description": "Stops the default container for the specified agent version.\nThe long-running operation completes even when the container is already stopped.",
+        "description": "Stop a container for a specific version of an agent. If the container is not running, or already stopped, the operation will be no-op.\nThe operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.\nhttps://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4303,18 +4296,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4337,8 +4320,7 @@
     "/agents/{agent_name}/versions/{agent_version}/containers/default:update": {
       "post": {
         "operationId": "AgentContainers_updateAgentContainer",
-        "summary": "Update an agent container",
-        "description": "Updates the replica settings for the default container of the specified agent version.\nThe long-running operation applies changes only when a container is already running.",
+        "description": "Update a container for a specific version of an agent. If the container is not running, the operation will be no-op.\nThe operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.\nhttps://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -4401,18 +4383,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4457,7 +4429,6 @@
     "/agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream": {
       "get": {
         "operationId": "Agents_getSessionLogStream",
-        "summary": "Stream console logs for a hosted agent session",
         "description": "Streams console logs (stdout / stderr) for a specific hosted agent session\nas a Server-Sent Events (SSE) stream.\n\nEach SSE frame contains:\n- `event`: always `\"log\"`\n- `data`: a plain-text log line (currently JSON-formatted, but the schema\nis not contractual and may include additional keys or change format\nover time — clients should treat it as an opaque string)\n\nExample SSE frames:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting FoundryCBAgent server on port 8088\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.130Z\",\"stream\":\"stderr\",\"message\":\"INFO: Application startup complete.\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:35:52.714Z\",\"stream\":\"status\",\"message\":\"No logs since last 60 seconds\"}\n```\n\nThe stream remains open until the client disconnects or the server\nterminates the connection. Clients should handle reconnection as needed.",
         "parameters": [
           {
@@ -4521,18 +4492,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4543,7 +4504,7 @@
           }
         },
         "tags": [
-          "Agent Sessions"
+          "Agents"
         ],
         "x-ms-foundry-meta": {
           "required_previews": [
@@ -4555,8 +4516,7 @@
     "/agents/{agent_name}/versions:import": {
       "post": {
         "operationId": "Agents_createAgentVersionFromManifest",
-        "summary": "Create an agent version from manifest",
-        "description": "Imports the provided manifest to create a new version for the specified agent.",
+        "description": "Create a new agent version from a manifest.",
         "parameters": [
           {
             "name": "agent_name",
@@ -4590,18 +4550,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4612,7 +4562,7 @@
           }
         },
         "tags": [
-          "Agent Versions"
+          "Agents"
         ],
         "requestBody": {
           "required": true,
@@ -4629,8 +4579,7 @@
     "/agents:import": {
       "post": {
         "operationId": "Agents_createAgentFromManifest",
-        "summary": "Create an agent from a manifest",
-        "description": "Imports the provided manifest to create an agent and returns the created resource.",
+        "description": "Creates an agent from a manifest.",
         "parameters": [
           {
             "name": "api-version",
@@ -4654,18 +4603,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4693,8 +4632,7 @@
     "/connections": {
       "get": {
         "operationId": "Connections_list",
-        "summary": "List connections",
-        "description": "Returns the connections available in the current project, optionally filtered by type or default status.",
+        "description": "List all connections in the project, without populating connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4703,7 +4641,7 @@
             "name": "connectionType",
             "in": "query",
             "required": false,
-            "description": "Lists connections of this specific type",
+            "description": "List connections of this specific type",
             "schema": {
               "$ref": "#/components/schemas/ConnectionType"
             },
@@ -4713,7 +4651,7 @@
             "name": "defaultConnection",
             "in": "query",
             "required": false,
-            "description": "Lists connections that are default connections",
+            "description": "List connections that are default connections",
             "schema": {
               "type": "boolean"
             },
@@ -4743,27 +4681,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4790,8 +4709,7 @@
     "/connections/{name}": {
       "get": {
         "operationId": "Connections_get",
-        "summary": "Get a connection",
-        "description": "Retrieves the specified connection and its configuration details without including credential values.",
+        "description": "Get a connection by name, without populating connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4829,27 +4747,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4876,8 +4775,7 @@
     "/connections/{name}/getConnectionWithCredentials": {
       "post": {
         "operationId": "Connections_getWithCredentials",
-        "summary": "Get a connection with credentials",
-        "description": "Retrieves the specified connection together with its credential values.",
+        "description": "Get a connection by name, with its connection credentials",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -4915,27 +4813,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -4962,7 +4841,7 @@
     "/data_generation_jobs": {
       "get": {
         "operationId": "DataGenerationJobs_list",
-        "summary": "List data generation jobs",
+        "summary": "Returns a list of data generation jobs",
         "description": "Returns a list of data generation jobs.",
         "parameters": [
           {
@@ -5067,18 +4946,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5099,8 +4968,8 @@
       },
       "post": {
         "operationId": "DataGenerationJobs_create",
-        "summary": "Create a data generation job",
-        "description": "Submits a new data generation job for asynchronous execution.",
+        "summary": "Creates a data generation job.",
+        "description": "Creates a data generation job.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -5161,18 +5030,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5206,8 +5065,8 @@
     "/data_generation_jobs/{jobId}": {
       "get": {
         "operationId": "DataGenerationJobs_get",
-        "summary": "Get a data generation job",
-        "description": "Retrieves the specified data generation job and its current status.",
+        "summary": "Get info about a data generation job.",
+        "description": "Gets the details of a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -5262,18 +5121,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5294,8 +5143,8 @@
       },
       "delete": {
         "operationId": "DataGenerationJobs_delete",
-        "summary": "Delete a data generation job",
-        "description": "Removes the specified data generation job and its associated output.",
+        "summary": "Deletes a data generation job.",
+        "description": "Deletes a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -5333,18 +5182,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5367,8 +5206,8 @@
     "/data_generation_jobs/{jobId}:cancel": {
       "post": {
         "operationId": "DataGenerationJobs_cancel",
-        "summary": "Cancel a data generation job",
-        "description": "Cancels the specified data generation job if it is still in progress.",
+        "summary": "Cancels a data generation job.",
+        "description": "Cancels a data generation job by its ID.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -5413,18 +5252,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5447,7 +5276,6 @@
     "/datasets": {
       "get": {
         "operationId": "Datasets_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each DatasetVersion",
         "parameters": [
           {
@@ -5465,27 +5293,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5512,7 +5321,6 @@
     "/datasets/{name}/versions": {
       "get": {
         "operationId": "Datasets_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given DatasetVersion",
         "parameters": [
           {
@@ -5539,27 +5347,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5586,7 +5375,6 @@
     "/datasets/{name}/versions/{version}": {
       "get": {
         "operationId": "Datasets_getVersion",
-        "summary": "Get a version",
         "description": "Get the specific version of the DatasetVersion. The service returns 404 Not Found error if the DatasetVersion does not exist.",
         "parameters": [
           {
@@ -5622,27 +5410,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5667,7 +5436,6 @@
       },
       "delete": {
         "operationId": "Datasets_deleteVersion",
-        "summary": "Delete a version",
         "description": "Delete the specific version of the DatasetVersion. The service returns 204 No Content if the DatasetVersion was deleted successfully or if the DatasetVersion does not exist.",
         "parameters": [
           {
@@ -5696,27 +5464,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5741,7 +5490,6 @@
       },
       "patch": {
         "operationId": "Datasets_createOrUpdateVersion",
-        "summary": "Create or update a version",
         "description": "Create a new or update an existing DatasetVersion with the given version id",
         "parameters": [
           {
@@ -5787,27 +5535,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5845,8 +5574,7 @@
     "/datasets/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Datasets_getCredentials",
-        "summary": "Get dataset credentials",
-        "description": "Gets the SAS credential to access the storage account associated with a Dataset version.",
+        "description": "Get the SAS credential to access the storage account associated with a Dataset version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5881,27 +5609,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -5928,8 +5637,7 @@
     "/datasets/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Datasets_startPendingUploadVersion",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified dataset version.",
+        "description": "Start a new or get an existing pending upload of a dataset for a specific version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -5964,27 +5672,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6022,8 +5711,7 @@
     "/deployments": {
       "get": {
         "operationId": "Deployments_list",
-        "summary": "List deployments",
-        "description": "Returns the deployed models available in the current project, optionally filtered by publisher, model name, or deployment type.",
+        "description": "List all deployed models in the project",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6082,27 +5770,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6129,8 +5798,7 @@
     "/deployments/{name}": {
       "get": {
         "operationId": "Deployments_get",
-        "summary": "Get a deployment",
-        "description": "Gets a deployed model.",
+        "description": "Get a deployed model.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -6168,27 +5836,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6215,7 +5864,7 @@
     "/evaluation_suite_generation_jobs": {
       "post": {
         "operationId": "EvaluationSuiteGenerationJobs_create",
-        "summary": "Create an evaluation suite generation job",
+        "summary": "Creates an evaluation suite generation job.",
         "description": "Create a new job (preview). Includes optional Foundry-Features header and Operation-Id for idempotent retries.",
         "parameters": [
           {
@@ -6277,18 +5926,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6320,7 +5959,7 @@
       },
       "get": {
         "operationId": "EvaluationSuiteGenerationJobs_list",
-        "summary": "List evaluation suite generation jobs",
+        "summary": "Returns a list of evaluation suite generation jobs.",
         "description": "List jobs with cursor-based pagination (preview). Includes optional Foundry-Features header.",
         "parameters": [
           {
@@ -6425,18 +6064,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6459,7 +6088,7 @@
     "/evaluation_suite_generation_jobs/{jobId}": {
       "get": {
         "operationId": "EvaluationSuiteGenerationJobs_get",
-        "summary": "Get an evaluation suite generation job",
+        "summary": "Get info about an evaluation suite generation job.",
         "description": "Get a job by ID (preview). Includes optional Foundry-Features header.",
         "parameters": [
           {
@@ -6515,18 +6144,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6547,7 +6166,7 @@
       },
       "delete": {
         "operationId": "EvaluationSuiteGenerationJobs_delete",
-        "summary": "Delete an evaluation suite generation job",
+        "summary": "Deletes an evaluation suite generation job.",
         "description": "Delete a job (preview). Returns 204 No Content.",
         "parameters": [
           {
@@ -6586,18 +6205,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6620,7 +6229,7 @@
     "/evaluation_suite_generation_jobs/{jobId}:cancel": {
       "post": {
         "operationId": "EvaluationSuiteGenerationJobs_cancel",
-        "summary": "Cancel an evaluation suite generation job",
+        "summary": "Cancels an evaluation suite generation job.",
         "description": "Cancel a running job (preview). Returns 200 with the updated job.",
         "parameters": [
           {
@@ -6666,18 +6275,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6700,7 +6299,6 @@
     "/evaluation_suites": {
       "get": {
         "operationId": "EvaluationSuites_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each EvaluationSuiteVersion",
         "parameters": [
           {
@@ -6728,27 +6326,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6772,7 +6351,6 @@
     "/evaluation_suites/{name}/versions": {
       "get": {
         "operationId": "EvaluationSuites_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given EvaluationSuiteVersion",
         "parameters": [
           {
@@ -6799,27 +6377,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -6841,7 +6400,6 @@
       },
       "post": {
         "operationId": "EvaluationSuites_createEvaluationSuiteVersion",
-        "summary": "Create an evaluation suite version",
         "description": "Create a new EvaluationSuiteVersion with auto incremented version id",
         "parameters": [
           {
@@ -6887,18 +6445,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6929,7 +6477,6 @@
     "/evaluation_suites/{name}/versions/{version}": {
       "get": {
         "operationId": "EvaluationSuites_getVersion",
-        "summary": "Get a version",
         "description": "Get the specific version of the EvaluationSuiteVersion. The service returns 404 Not Found error if the EvaluationSuiteVersion does not exist.",
         "parameters": [
           {
@@ -6965,27 +6512,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7007,7 +6535,6 @@
       },
       "delete": {
         "operationId": "EvaluationSuites_deleteVersion",
-        "summary": "Delete a version",
         "description": "Delete the specific version of the EvaluationSuiteVersion. The service returns 204 No Content if the EvaluationSuiteVersion was deleted successfully or if the EvaluationSuiteVersion does not exist.",
         "parameters": [
           {
@@ -7036,27 +6563,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7078,7 +6586,6 @@
       },
       "patch": {
         "operationId": "EvaluationSuites_createOrUpdateVersion",
-        "summary": "Create or update a version",
         "description": "Create a new or update an existing EvaluationSuiteVersion with the given version id",
         "parameters": [
           {
@@ -7124,27 +6631,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7179,8 +6667,7 @@
     "/evaluation_suites/{name}:run": {
       "post": {
         "operationId": "EvaluationSuites_run",
-        "summary": "Run an evaluation suite",
-        "description": "Runs an evaluation using the suite's testing criteria and dataset.",
+        "description": "Run an evaluation using the suite's testing criteria and dataset.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -7225,18 +6712,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7267,8 +6744,7 @@
     "/evaluationrules": {
       "get": {
         "operationId": "EvaluationRules_list",
-        "summary": "List evaluation rules",
-        "description": "Returns the evaluation rules configured for the project, optionally filtered by action type, agent name, or enabled state.",
+        "description": "List all evaluation rules.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7315,27 +6791,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7362,8 +6819,7 @@
     "/evaluationrules/{id}": {
       "get": {
         "operationId": "EvaluationRules_get",
-        "summary": "Get an evaluation rule",
-        "description": "Retrieves the specified evaluation rule and its configuration.",
+        "description": "Get an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7389,27 +6845,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7434,8 +6871,7 @@
       },
       "delete": {
         "operationId": "EvaluationRules_delete",
-        "summary": "Delete an evaluation rule",
-        "description": "Removes the specified evaluation rule from the project.",
+        "description": "Delete an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7454,27 +6890,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7499,8 +6916,7 @@
       },
       "put": {
         "operationId": "EvaluationRules_createOrUpdate",
-        "summary": "Create or update an evaluation rule",
-        "description": "Creates a new evaluation rule, or replaces the existing rule when the identifier matches.",
+        "description": "Create or update an evaluation rule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7548,27 +6964,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7606,8 +7003,7 @@
     "/evaluations/runs": {
       "get": {
         "operationId": "Evaluations_list",
-        "summary": "List evaluation runs",
-        "description": "Returns the evaluation runs available in the current project.",
+        "description": "List evaluation runs",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7636,27 +7032,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7680,8 +7057,7 @@
     "/evaluations/runs/{name}": {
       "get": {
         "operationId": "Evaluations_get",
-        "summary": "Get an evaluation run",
-        "description": "Retrieves the specified evaluation run and its current status.",
+        "description": "Get an evaluation run by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7719,27 +7095,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7761,8 +7118,7 @@
       },
       "delete": {
         "operationId": "Evaluations_delete",
-        "summary": "Delete an evaluation run",
-        "description": "Removes the specified evaluation run from the project.",
+        "description": "Delete an evaluation run by name",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7793,27 +7149,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7837,8 +7174,7 @@
     "/evaluations/runs/{name}:cancel": {
       "post": {
         "operationId": "Evaluations_cancel",
-        "summary": "Cancel an evaluation run",
-        "description": "Cancels the specified evaluation run before it completes.",
+        "description": "Cancel an evaluation run by name",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7869,27 +7205,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7913,8 +7230,7 @@
     "/evaluations/runs:run": {
       "post": {
         "operationId": "Evaluations_create",
-        "summary": "Create an evaluation run",
-        "description": "Submits a new evaluation run with the provided configuration.",
+        "description": "Creates an evaluation run.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -7931,27 +7247,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -7986,8 +7283,7 @@
     "/evaluations/runs:runAgent": {
       "post": {
         "operationId": "Evaluations_createAgentEvaluation",
-        "summary": "Create an agent evaluation run",
-        "description": "Submits a new agent evaluation run with the provided request.",
+        "description": "Creates an agent evaluation run.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8004,27 +7300,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8059,8 +7336,7 @@
     "/evaluationtaxonomies": {
       "get": {
         "operationId": "EvaluationTaxonomies_list",
-        "summary": "List evaluation taxonomies",
-        "description": "Returns the evaluation taxonomies available in the project, optionally filtered by input name or input type.",
+        "description": "List evaluation taxonomies",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8109,27 +7385,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8156,8 +7413,7 @@
     "/evaluationtaxonomies/{name}": {
       "get": {
         "operationId": "EvaluationTaxonomies_get",
-        "summary": "Get an evaluation taxonomy",
-        "description": "Retrieves the specified evaluation taxonomy.",
+        "description": "Get an evaluation run by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8195,27 +7451,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8240,8 +7477,7 @@
       },
       "delete": {
         "operationId": "EvaluationTaxonomies_delete",
-        "summary": "Delete an evaluation taxonomy",
-        "description": "Removes the specified evaluation taxonomy from the project.",
+        "description": "Delete an evaluation taxonomy by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8272,27 +7508,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8317,8 +7534,7 @@
       },
       "put": {
         "operationId": "EvaluationTaxonomies_create",
-        "summary": "Create an evaluation taxonomy",
-        "description": "Creates or replaces the specified evaluation taxonomy with the provided definition.",
+        "description": "Create an evaluation taxonomy.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -8366,27 +7582,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8422,7 +7619,6 @@
       },
       "patch": {
         "operationId": "EvaluationTaxonomies_update",
-        "summary": "Update an evaluation taxonomy",
         "description": "Update an evaluation taxonomy.",
         "parameters": [
           {
@@ -8461,27 +7657,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -8519,7 +7696,7 @@
     "/evaluator_generation_jobs": {
       "post": {
         "operationId": "EvaluatorGenerationJobs_create",
-        "summary": "Create an evaluator generation job",
+        "summary": "Creates an evaluator generation job.",
         "description": "Creates an evaluator generation job. The service generates rubric-based evaluator\ndefinitions from the provided source materials asynchronously.",
         "parameters": [
           {
@@ -8581,18 +7758,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8624,8 +7791,8 @@
       },
       "get": {
         "operationId": "EvaluatorGenerationJobs_list",
-        "summary": "List evaluator generation jobs",
-        "description": "Returns a list of evaluator generation jobs. The List API has up to a few\nseconds of propagation delay, so a recently created job may not appear\nimmediately; use the Get evaluator generation job API with the job ID to\nretrieve a specific job without delay.",
+        "summary": "Returns a list of evaluator generation jobs.",
+        "description": "Returns a list of evaluator generation jobs.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -8729,18 +7896,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8763,7 +7920,7 @@
     "/evaluator_generation_jobs/{jobId}": {
       "get": {
         "operationId": "EvaluatorGenerationJobs_get",
-        "summary": "Get an evaluator generation job",
+        "summary": "Get info about an evaluator generation job.",
         "description": "Gets the details of an evaluator generation job by its ID.",
         "parameters": [
           {
@@ -8819,18 +7976,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8851,7 +7998,6 @@
       },
       "delete": {
         "operationId": "EvaluatorGenerationJobs_delete",
-        "summary": "Delete an evaluator generation job",
         "description": "Deletes an evaluator generation job by its ID. Deletes the job record only;\nthe generated evaluator (if any) is preserved.",
         "parameters": [
           {
@@ -8890,18 +8036,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8924,7 +8060,7 @@
     "/evaluator_generation_jobs/{jobId}:cancel": {
       "post": {
         "operationId": "EvaluatorGenerationJobs_cancel",
-        "summary": "Cancel an evaluator generation job",
+        "summary": "Cancels an evaluator generation job.",
         "description": "Cancels an evaluator generation job by its ID.",
         "parameters": [
           {
@@ -8970,18 +8106,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9004,8 +8130,7 @@
     "/evaluators": {
       "get": {
         "operationId": "Evaluators_listLatestVersions",
-        "summary": "List latest evaluator versions",
-        "description": "Lists the latest version of each evaluator",
+        "description": "List the latest version of each evaluator",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9066,27 +8191,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9113,8 +8219,7 @@
     "/evaluators/{name}/versions": {
       "get": {
         "operationId": "Evaluators_listVersions",
-        "summary": "List evaluator versions",
-        "description": "Returns the available versions for the specified evaluator.",
+        "description": "List all versions of the given evaluator",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9184,27 +8289,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9229,8 +8315,7 @@
       },
       "post": {
         "operationId": "Evaluators_createVersion",
-        "summary": "Create an evaluator version",
-        "description": "Creates a new evaluator version with an auto-incremented version identifier.",
+        "description": "Create a new EvaluatorVersion with auto incremented version id",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9268,27 +8353,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9325,8 +8391,7 @@
     "/evaluators/{name}/versions/{version}": {
       "get": {
         "operationId": "Evaluators_getVersion",
-        "summary": "Get an evaluator version",
-        "description": "Retrieves the specified evaluator version, returning 404 if it does not exist.",
+        "description": "Get the specific version of the EvaluatorVersion. The service returns 404 Not Found error if the EvaluatorVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9373,27 +8438,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9418,8 +8464,7 @@
       },
       "delete": {
         "operationId": "Evaluators_deleteVersion",
-        "summary": "Delete an evaluator version",
-        "description": "Removes the specified evaluator version. Returns 204 whether the version existed or not.",
+        "description": "Delete the specific version of the EvaluatorVersion. The service returns 204 No Content if the EvaluatorVersion was deleted successfully or if the EvaluatorVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9459,27 +8504,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9504,8 +8530,7 @@
       },
       "patch": {
         "operationId": "Evaluators_updateVersion",
-        "summary": "Update an evaluator version",
-        "description": "Updates the specified evaluator version in place.",
+        "description": "Update an existing EvaluatorVersion with the given version id",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -9552,27 +8577,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9610,8 +8616,7 @@
     "/evaluators/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Evaluators_getCredentials",
-        "summary": "Get evaluator credentials",
-        "description": "Retrieves SAS credentials for accessing the storage account associated with the specified evaluator version.",
+        "description": "Get the SAS credential to access the storage account associated with an Evaluator version.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9664,18 +8669,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9709,8 +8704,7 @@
     "/evaluators/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Evaluators_startPendingUpload",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified evaluator version.",
+        "description": "Start a new or get an existing pending upload of an evaluator for a specific version.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -9763,18 +8757,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -9808,7 +8792,6 @@
     "/indexes": {
       "get": {
         "operationId": "Indexes_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each Index",
         "parameters": [
           {
@@ -9826,27 +8809,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9873,7 +8837,6 @@
     "/indexes/{name}/versions": {
       "get": {
         "operationId": "Indexes_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given Index",
         "parameters": [
           {
@@ -9900,27 +8863,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -9947,7 +8891,6 @@
     "/indexes/{name}/versions/{version}": {
       "get": {
         "operationId": "Indexes_getVersion",
-        "summary": "Get a version",
         "description": "Get the specific version of the Index. The service returns 404 Not Found error if the Index does not exist.",
         "parameters": [
           {
@@ -9983,27 +8926,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -10028,7 +8952,6 @@
       },
       "delete": {
         "operationId": "Indexes_deleteVersion",
-        "summary": "Delete a version",
         "description": "Delete the specific version of the Index. The service returns 204 No Content if the Index was deleted successfully or if the Index does not exist.",
         "parameters": [
           {
@@ -10057,27 +8980,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -10102,7 +9006,6 @@
       },
       "patch": {
         "operationId": "Indexes_createOrUpdateVersion",
-        "summary": "Create or update a version",
         "description": "Create a new or update an existing Index with the given version id",
         "parameters": [
           {
@@ -10148,27 +9051,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -10206,8 +9090,7 @@
     "/insights": {
       "post": {
         "operationId": "Insights_generate",
-        "summary": "Generate insights",
-        "description": "Generates an insights report from the provided evaluation configuration.",
+        "description": "Generate Insights",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10262,18 +9145,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10300,8 +9173,7 @@
       },
       "get": {
         "operationId": "Insights_list",
-        "summary": "List insights",
-        "description": "Returns insights in reverse chronological order, with the most recent entries first.",
+        "description": "List all insights in reverse chronological order (newest first).",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10387,18 +9259,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10416,8 +9278,7 @@
     "/insights/{id}": {
       "get": {
         "operationId": "Insights_get",
-        "summary": "Get an insight",
-        "description": "Retrieves the specified insight report and its results.",
+        "description": "Get a specific insight by Id.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10472,18 +9333,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10501,8 +9352,6 @@
     "/managedAgentIdentityBlueprints": {
       "get": {
         "operationId": "ManagedAgentIdentityBlueprints_listManagedAgentIdentityBlueprints",
-        "summary": "List blueprints",
-        "description": "Lists all managed agent identity blueprints.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10560,18 +9409,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10591,8 +9430,6 @@
     "/managedAgentIdentityBlueprints/{blueprint_name}": {
       "put": {
         "operationId": "ManagedAgentIdentityBlueprints_createOrUpdateManagedAgentIdentityBlueprint",
-        "summary": "Create or update a blueprint",
-        "description": "Creates or updates a managed agent identity blueprint.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10637,18 +9474,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10676,7 +9503,6 @@
       },
       "get": {
         "operationId": "ManagedAgentIdentityBlueprints_getManagedAgentIdentityBlueprint",
-        "summary": "Get a blueprint",
         "description": "Retrieves a managed agent identity blueprint by name.",
         "parameters": [
           {
@@ -10722,18 +9548,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10751,7 +9567,6 @@
       },
       "delete": {
         "operationId": "ManagedAgentIdentityBlueprints_deleteManagedAgentIdentityBlueprint",
-        "summary": "Delete a blueprint",
         "description": "Deletes a managed agent identity blueprint by name.",
         "parameters": [
           {
@@ -10790,18 +9605,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10821,8 +9626,7 @@
     "/memory_stores": {
       "post": {
         "operationId": "createMemoryStore",
-        "summary": "Create a memory store",
-        "description": "Creates a memory store resource with the provided configuration.",
+        "description": "Create a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -10858,18 +9662,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -10901,7 +9695,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -10931,8 +9725,7 @@
       },
       "get": {
         "operationId": "listMemoryStores",
-        "summary": "List memory stores",
-        "description": "Returns the memory stores available to the caller.",
+        "description": "List all memory stores.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11036,18 +9829,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11070,8 +9853,7 @@
     "/memory_stores/{name}": {
       "post": {
         "operationId": "updateMemoryStore",
-        "summary": "Update a memory store",
-        "description": "Updates the specified memory store with the supplied configuration changes.",
+        "description": "Update a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11116,18 +9898,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11154,7 +9926,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -11172,8 +9944,7 @@
       },
       "get": {
         "operationId": "getMemoryStore",
-        "summary": "Get a memory store",
-        "description": "Retrieves the specified memory store and its current configuration.",
+        "description": "Retrieve a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11218,18 +9989,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11250,8 +10011,7 @@
       },
       "delete": {
         "operationId": "deleteMemoryStore",
-        "summary": "Delete a memory store",
-        "description": "Deletes the specified memory store.",
+        "description": "Delete a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11296,18 +10056,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11330,8 +10080,7 @@
     "/memory_stores/{name}/items": {
       "post": {
         "operationId": "createMemory",
-        "summary": "Create a memory item",
-        "description": "Creates a memory item in the specified memory store.",
+        "description": "Create a memory item in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11376,18 +10125,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11443,8 +10182,7 @@
     "/memory_stores/{name}/items/{memory_id}": {
       "post": {
         "operationId": "updateMemory",
-        "summary": "Update a memory item",
-        "description": "Updates the specified memory item in the memory store.",
+        "description": "Update a memory item in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11498,18 +10236,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11549,8 +10277,7 @@
       },
       "get": {
         "operationId": "getMemory",
-        "summary": "Get a memory item",
-        "description": "Retrieves the specified memory item from the memory store.",
+        "description": "Retrieve a memory item from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11604,18 +10331,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11636,8 +10353,7 @@
       },
       "delete": {
         "operationId": "deleteMemory",
-        "summary": "Delete a memory item",
-        "description": "Deletes the specified memory item from the memory store.",
+        "description": "Delete a memory item from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11691,18 +10407,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11725,8 +10431,7 @@
     "/memory_stores/{name}/items:list": {
       "post": {
         "operationId": "listMemories",
-        "summary": "List memory items",
-        "description": "Returns memory items from the specified memory store.",
+        "description": "List all memory items in a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11849,18 +10554,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11902,8 +10597,7 @@
     "/memory_stores/{name}/updates/{update_id}": {
       "get": {
         "operationId": "getUpdateResult",
-        "summary": "Get an update result",
-        "description": "Retrieves the status and result of a memory store update operation.",
+        "description": "Get memory store update result.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -11957,18 +10651,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11991,8 +10675,7 @@
     "/memory_stores/{name}:delete_scope": {
       "post": {
         "operationId": "deleteScopeMemories",
-        "summary": "Delete memories by scope",
-        "description": "Deletes all memories in the specified memory store that are associated with the provided scope.",
+        "description": "Delete all memories associated with a specific scope from a memory store.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -12037,18 +10720,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12090,8 +10763,7 @@
     "/memory_stores/{name}:search_memories": {
       "post": {
         "operationId": "searchMemories",
-        "summary": "Search memories",
-        "description": "Searches the specified memory store for memories relevant to the provided conversation context.",
+        "description": "Search for relevant memories from a memory store based on conversation context.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -12136,18 +10808,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12208,8 +10870,7 @@
     "/memory_stores/{name}:update_memories": {
       "post": {
         "operationId": "updateMemories",
-        "summary": "Update memories",
-        "description": "Starts an update that writes conversation memories into the specified memory store.\nThe operation returns a long-running status location for polling the update result.",
+        "description": "Update memory store with conversation memories.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -12264,18 +10925,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -12334,7 +10985,6 @@
     "/models": {
       "get": {
         "operationId": "Models_listLatest",
-        "summary": "List latest versions",
         "description": "List the latest version of each ModelVersion",
         "parameters": [
           {
@@ -12364,27 +11014,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12411,7 +11042,6 @@
     "/models/{name}/versions": {
       "get": {
         "operationId": "Models_listVersions",
-        "summary": "List versions",
         "description": "List all versions of the given ModelVersion",
         "parameters": [
           {
@@ -12450,27 +11080,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12497,8 +11108,7 @@
     "/models/{name}/versions/{version}": {
       "get": {
         "operationId": "Models_getVersion",
-        "summary": "Get a model version",
-        "description": "Retrieves the specified model version, returning 404 if it does not exist.",
+        "description": "Get the specific version of the ModelVersion. The service returns 404 Not Found error if the ModelVersion does not exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -12545,27 +11155,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12595,7 +11186,6 @@
       },
       "delete": {
         "operationId": "Models_deleteVersion",
-        "summary": "Delete a model version",
         "description": "Delete the specific version of the ModelVersion. The service returns 200 OK if the ModelVersion was deleted successfully or if the ModelVersion does not exist.",
         "parameters": [
           {
@@ -12636,27 +11226,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12686,7 +11257,6 @@
       },
       "patch": {
         "operationId": "Models_updateVersion",
-        "summary": "Update a model version",
         "description": "Update an existing ModelVersion with the given version id",
         "parameters": [
           {
@@ -12744,27 +11314,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12807,8 +11358,7 @@
     "/models/{name}/versions/{version}/createAsync": {
       "post": {
         "operationId": "Models_createAsync",
-        "summary": "Create a model version async",
-        "description": "Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a location header for polling the operation status.",
+        "description": "Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -12868,15 +11418,9 @@
                       "description": "URL to poll for operation status."
                     },
                     "operationResult": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
+                      "type": "string",
+                      "format": "uri",
+                      "nullable": true,
                       "description": "URL to the operation result, or null if the operation is still in progress."
                     }
                   }
@@ -12884,27 +11428,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -12947,8 +11472,7 @@
     "/models/{name}/versions/{version}/credentials": {
       "post": {
         "operationId": "Models_getCredentials",
-        "summary": "Get model asset credentials",
-        "description": "Retrieves temporary credentials for accessing the storage backing the specified model version.",
+        "description": "Get credentials for a model version asset.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -12995,27 +11519,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -13057,8 +11562,7 @@
     "/models/{name}/versions/{version}/startPendingUpload": {
       "post": {
         "operationId": "Models_startPendingUpload",
-        "summary": "Start a pending upload",
-        "description": "Initiates a new pending upload or retrieves an existing one for the specified model version.",
+        "description": "Start or retrieve a pending upload for a model version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -13105,27 +11609,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -13167,8 +11652,7 @@
     "/openai/v1/conversations": {
       "post": {
         "operationId": "createConversation",
-        "summary": "Create a conversation",
-        "description": "Creates a new conversation resource.",
+        "description": "Create a conversation.",
         "parameters": [
           {
             "name": "x-ms-user-isolation-key",
@@ -13191,18 +11675,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13228,8 +11702,7 @@
       },
       "get": {
         "operationId": "listConversations",
-        "summary": "List conversations",
-        "description": "Returns the conversations available in the current project.",
+        "description": "Returns the list of all conversations.",
         "parameters": [
           {
             "name": "limit",
@@ -13340,18 +11813,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13369,8 +11832,7 @@
     "/openai/v1/conversations/{conversation_id}": {
       "post": {
         "operationId": "updateConversation",
-        "summary": "Update a conversation",
-        "description": "Modifies the specified conversation's properties.",
+        "description": "Update a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13402,18 +11864,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13439,8 +11891,7 @@
       },
       "get": {
         "operationId": "getConversation",
-        "summary": "Retrieve a conversation",
-        "description": "Retrieves the specified conversation and its metadata.",
+        "description": "Retrieves a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13472,18 +11923,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13499,8 +11940,7 @@
       },
       "delete": {
         "operationId": "deleteConversation",
-        "summary": "Delete a conversation",
-        "description": "Removes the specified conversation resource from the current project.",
+        "description": "Deletes a conversation.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13532,18 +11972,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13561,8 +11991,7 @@
     "/openai/v1/conversations/{conversation_id}/items": {
       "post": {
         "operationId": "createConversationItems",
-        "summary": "Create conversation items",
-        "description": "Adds one or more items to the specified conversation.",
+        "description": "Create items in a conversation with the given ID.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13607,18 +12036,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13657,8 +12076,7 @@
       },
       "get": {
         "operationId": "listConversationItems",
-        "summary": "List conversation items",
-        "description": "Returns the items belonging to the specified conversation.",
+        "description": "List all items for a conversation with the given ID.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13768,18 +12186,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13797,8 +12205,7 @@
     "/openai/v1/conversations/{conversation_id}/items/{item_id}": {
       "get": {
         "operationId": "getConversationItem",
-        "summary": "Get a conversation item",
-        "description": "Retrieves a specific item from the specified conversation.",
+        "description": "Get a single item from a conversation with the given IDs.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13839,18 +12246,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13866,8 +12263,7 @@
       },
       "delete": {
         "operationId": "deleteConversationItem",
-        "summary": "Delete a conversation item",
-        "description": "Removes the specified item from a conversation.",
+        "description": "Delete an item from a conversation with the given IDs.",
         "parameters": [
           {
             "name": "conversation_id",
@@ -13908,18 +12304,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -13937,8 +12323,8 @@
     "/openai/v1/evals": {
       "get": {
         "operationId": "Evals_listEvals",
-        "summary": "List evaluations",
-        "description": "Returns the evaluations configured in the current project.",
+        "summary": "List all evaluations",
+        "description": "List evaluations for a project.",
         "parameters": [
           {
             "name": "after",
@@ -13956,7 +12342,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -14028,18 +12418,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14055,8 +12435,8 @@
       },
       "post": {
         "operationId": "Evals_createEval",
-        "summary": "Create an evaluation",
-        "description": "Creates the structure of an evaluation that can be used to test a model's performance.\nAn evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.\nFor more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).",
+        "summary": "Create evaluation",
+        "description": "Create the structure of an evaluation that can be used to test a model's performance.\nAn evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.\nFor more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).",
         "parameters": [],
         "responses": {
           "200": {
@@ -14069,18 +12449,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14109,7 +12479,7 @@
       "delete": {
         "operationId": "Evals_deleteEval",
         "summary": "Delete an evaluation",
-        "description": "Removes the specified evaluation and its associated data.",
+        "description": "Delete an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14132,18 +12502,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14160,7 +12520,7 @@
       "get": {
         "operationId": "Evals_getEval",
         "summary": "Get an evaluation",
-        "description": "Retrieves the specified evaluation and its configuration.",
+        "description": "Get an evaluation by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14183,18 +12543,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14211,7 +12561,7 @@
       "post": {
         "operationId": "Evals_updateEval",
         "summary": "Update an evaluation",
-        "description": "Updates certain properties of an evaluation.",
+        "description": "Update certain properties of an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14234,18 +12584,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14273,8 +12613,8 @@
     "/openai/v1/evals/{eval_id}/runs": {
       "get": {
         "operationId": "Evals_listRuns",
-        "summary": "List evaluation runs",
-        "description": "Returns the runs associated with the specified evaluation.",
+        "summary": "Get a list of runs for an evaluation",
+        "description": "Get a list of runs for an evaluation.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14301,7 +12641,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -14376,18 +12720,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14403,8 +12737,7 @@
       },
       "post": {
         "operationId": "Evals_createEvalRun",
-        "summary": "Create an evaluation run",
-        "description": "Creates an evaluation run for the specified evaluation.",
+        "summary": "Create evaluation run",
         "parameters": [
           {
             "name": "eval_id",
@@ -14427,18 +12760,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14466,8 +12789,8 @@
     "/openai/v1/evals/{eval_id}/runs/{run_id}": {
       "delete": {
         "operationId": "Evals_deleteEvalRun",
-        "summary": "Delete an evaluation run",
-        "description": "Removes the specified evaluation run.",
+        "summary": "Delete evaluation run",
+        "description": "Delete an eval run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14499,18 +12822,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14527,7 +12840,7 @@
       "get": {
         "operationId": "Evals_getEvalRun",
         "summary": "Get an evaluation run",
-        "description": "Retrieves the specified evaluation run and its current status.",
+        "description": "Get an evaluation run by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14559,18 +12872,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14586,8 +12889,8 @@
       },
       "post": {
         "operationId": "Evals_cancelEvalRun",
-        "summary": "Cancel an evaluation run",
-        "description": "Cancels an ongoing evaluation run.",
+        "summary": "Cancel evaluation run",
+        "description": "Cancel an ongoing evaluation run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14619,18 +12922,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14648,8 +12941,8 @@
     "/openai/v1/evals/{eval_id}/runs/{run_id}/output_items": {
       "get": {
         "operationId": "Evals_getEvalRunOutputItems",
-        "summary": "List evaluation run output items",
-        "description": "Returns the output items produced by the specified evaluation run.",
+        "summary": "Get evaluation run output items",
+        "description": "Get a list of output items for an evaluation run.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14684,7 +12977,11 @@
             "required": false,
             "description": "Number of runs to retrieve.",
             "schema": {
-              "$ref": "#/components/schemas/integer",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/integer"
+                }
+              ],
               "default": 20
             },
             "explode": false
@@ -14755,18 +13052,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14785,7 +13072,7 @@
       "get": {
         "operationId": "Evals_getEvalRunOutputItem",
         "summary": "Get an output item of an evaluation run",
-        "description": "Retrieves a single output item from the specified evaluation run.",
+        "description": "Get an evaluation run output item by ID.",
         "parameters": [
           {
             "name": "eval_id",
@@ -14826,18 +13113,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14855,7 +13132,6 @@
     "/openai/v1/fine_tuning/jobs": {
       "post": {
         "operationId": "createFineTuningJob",
-        "summary": "Create a fine-tuning job",
         "description": "Creates a fine-tuning job which begins the process of creating a new model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
         "parameters": [
           {
@@ -14880,18 +13156,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14917,8 +13183,7 @@
       },
       "get": {
         "operationId": "listPaginatedFineTuningJobs",
-        "summary": "List fine-tuning jobs",
-        "description": "Returns the fine-tuning jobs for the current organization.",
+        "description": "List your organization's fine-tuning jobs",
         "parameters": [
           {
             "name": "after",
@@ -14964,18 +13229,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -14993,8 +13248,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}": {
       "get": {
         "operationId": "retrieveFineTuningJob",
-        "summary": "Get a fine-tuning job",
-        "description": "Gets info about a fine-tuning job.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
+        "description": "Get info about a fine-tuning job.\n\n[Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15027,18 +13281,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15056,8 +13300,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel": {
       "post": {
         "operationId": "cancelFineTuningJob",
-        "summary": "Cancel a fine-tuning job",
-        "description": "Immediately cancels the specified fine-tuning job.",
+        "description": "Immediately cancel a fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15090,18 +13333,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15119,8 +13352,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints": {
       "get": {
         "operationId": "listFineTuningJobCheckpoints",
-        "summary": "List fine-tuning job checkpoints",
-        "description": "Returns the checkpoints saved during the specified fine-tuning job.",
+        "description": "List checkpoints for a fine-tuning job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15175,18 +13407,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15204,8 +13426,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/events": {
       "get": {
         "operationId": "listFineTuningJobEvents",
-        "summary": "List fine-tuning job events",
-        "description": "Returns the status events emitted during the specified fine-tuning job.",
+        "description": "Get fine-grained status updates for a fine-tuning job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15260,18 +13481,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15289,8 +13500,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/pause": {
       "post": {
         "operationId": "pauseFineTuningJob",
-        "summary": "Pause a fine-tuning job",
-        "description": "Pauses the specified fine-tuning job while it is running.",
+        "description": "Pause a running fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15323,18 +13533,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15352,8 +13552,7 @@
     "/openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/resume": {
       "post": {
         "operationId": "resumeFineTuningJob",
-        "summary": "Resume a fine-tuning job",
-        "description": "Resumes the specified fine-tuning job after it has been paused.",
+        "description": "Resume a paused fine-tune job.",
         "parameters": [
           {
             "name": "fine_tuning_job_id",
@@ -15386,18 +13585,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15414,9 +13603,7 @@
     },
     "/openai/v1/responses": {
       "post": {
-        "operationId": "createResponse",
-        "summary": "Create a model response",
-        "description": "Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.",
+        "operationId": "createResponse_createResponseStream",
         "parameters": [
           {
             "name": "x-ms-user-isolation-key",
@@ -15428,6 +13615,7 @@
             }
           }
         ],
+        "description": "Creates a model response. Creates a model response (streaming response).",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -15443,334 +13631,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "metadata": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Metadata"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "top_logprobs": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "temperature": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.numeric"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": 1
-                    },
-                    "top_p": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.numeric"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": 1
-                    },
-                    "user": {
-                      "type": "string",
-                      "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
-                      "deprecated": true
-                    },
-                    "safety_identifier": {
-                      "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
-                    },
-                    "prompt_cache_key": {
-                      "type": "string",
-                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
-                    },
-                    "prompt_cache_retention": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": [
-                            "in_memory",
-                            "24h"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "previous_response_id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "model": {
-                      "type": "string",
-                      "description": "The model deployment to use for the creation of this response."
-                    },
-                    "reasoning": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Reasoning"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "background": {
-                      "anyOf": [
-                        {
-                          "type": "boolean"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_tool_calls": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "text": {
-                      "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
-                    },
-                    "tools": {
-                      "$ref": "#/components/schemas/OpenAI.ToolsArray"
-                    },
-                    "tool_choice": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
-                        },
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-                        }
-                      ]
-                    },
-                    "prompt": {
-                      "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "truncation": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": [
-                            "auto",
-                            "disabled"
-                          ]
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": "disabled"
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier for this Response."
-                    },
-                    "object": {
-                      "type": "string",
-                      "enum": [
-                        "response"
-                      ],
-                      "description": "The object type of this resource - always set to `response`.",
-                      "x-stainless-const": true
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "completed",
-                        "failed",
-                        "in_progress",
-                        "cancelled",
-                        "queued",
-                        "incomplete"
-                      ],
-                      "description": "The status of the response generation. One of `completed`, `failed`,\n  `in_progress`, `cancelled`, `queued`, or `incomplete`."
-                    },
-                    "created_at": {
-                      "type": "integer",
-                      "format": "unixtime",
-                      "description": "Unix timestamp (in seconds) of when this Response was created."
-                    },
-                    "completed_at": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "type": "integer",
-                      "format": "unixTimestamp"
-                    },
-                    "error": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ResponseError"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "incomplete_details": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ResponseIncompleteDetails"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "output": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/OpenAI.OutputItem"
-                      },
-                      "description": "An array of content items generated by the model.\n  - The length and order of items in the `output` array is dependent\n  on the model's response.\n  - Rather than accessing the first item in the `output` array and\n  assuming it's an `assistant` message with the content generated by\n  the model, you might consider using the `output_text` property where\n  supported in SDKs."
-                    },
-                    "instructions": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/components/schemas/OpenAI.InputItem"
-                          }
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "output_text": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "usage": {
-                      "$ref": "#/components/schemas/OpenAI.ResponseUsage"
-                    },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "parallel_tool_calls": {
-                      "type": "boolean",
-                      "description": "Whether to allow the model to run tool calls in parallel.",
-                      "default": true
-                    },
-                    "conversation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "agent": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/AgentId"
-                        }
-                      ],
-                      "description": "(Deprecated) Use agent_reference instead.\nThe agent used for this response"
-                    },
-                    "agent_session_id": {
-                      "type": "string",
-                      "description": "The session identifier for this response. Currently only relevant for hosted agents.\nAlways returned for hosted agents — either the caller-provided value, the auto-derived value,\nor an auto-generated UUID. Use for session-scoped operations and to maintain sandbox\naffinity in follow-up calls."
-                    },
-                    "agent_reference": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/AgentReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "The agent used for this response"
-                    },
-                    "content_filters": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ContentFilterResult"
-                      },
-                      "description": "The content filter evaluation results."
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "object",
-                    "created_at",
-                    "error",
-                    "incomplete_details",
-                    "output",
-                    "instructions",
-                    "parallel_tool_calls",
-                    "agent_reference"
-                  ]
+                  "$ref": "#/components/schemas/OpenAI.Response"
                 }
               },
               "text/event-stream": {
@@ -15780,18 +13641,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -15809,297 +13660,432 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "metadata": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Metadata"
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "metadata": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Metadata"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "top_logprobs": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
+                      "top_logprobs": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "temperature": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.numeric"
+                      "temperature": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": 1
-                  },
-                  "top_p": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.numeric"
+                      "top_p": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": 1
-                  },
-                  "user": {
-                    "type": "string",
-                    "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
-                    "deprecated": true
-                  },
-                  "safety_identifier": {
-                    "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
-                  },
-                  "prompt_cache_key": {
-                    "type": "string",
-                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
-                  },
-                  "prompt_cache_retention": {
-                    "anyOf": [
-                      {
+                      "user": {
+                        "type": "string",
+                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
+                        "deprecated": true
+                      },
+                      "safety_identifier": {
+                        "type": "string",
+                        "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      },
+                      "prompt_cache_key": {
+                        "type": "string",
+                        "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                      },
+                      "service_tier": {
+                        "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      },
+                      "prompt_cache_retention": {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
+                        ],
+                        "nullable": true
+                      },
+                      "previous_response_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "model": {
+                        "type": "string",
+                        "description": "The model deployment to use for the creation of this response."
+                      },
+                      "reasoning": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Reasoning"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "background": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "max_output_tokens": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "max_tool_calls": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "text": {
+                        "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
+                      },
+                      "tools": {
+                        "$ref": "#/components/schemas/OpenAI.ToolsArray"
+                      },
+                      "tool_choice": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+                          },
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+                          }
                         ]
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "previous_response_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                      "prompt": {
+                        "$ref": "#/components/schemas/OpenAI.Prompt"
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "model": {
-                    "type": "string",
-                    "description": "The model deployment to use for the creation of this response."
-                  },
-                  "reasoning": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.Reasoning"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "background": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "max_tool_calls": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "text": {
-                    "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
-                  },
-                  "tools": {
-                    "$ref": "#/components/schemas/OpenAI.ToolsArray"
-                  },
-                  "tool_choice": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
-                      },
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-                      }
-                    ]
-                  },
-                  "prompt": {
-                    "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "truncation": {
-                    "anyOf": [
-                      {
+                      "truncation": {
                         "type": "string",
                         "enum": [
                           "auto",
                           "disabled"
-                        ]
+                        ],
+                        "nullable": true,
+                        "default": "disabled"
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": "disabled"
-                  },
-                  "input": {
-                    "$ref": "#/components/schemas/OpenAI.InputParam"
-                  },
-                  "include": {
-                    "anyOf": [
-                      {
+                      "input": {
+                        "$ref": "#/components/schemas/OpenAI.InputParam"
+                      },
+                      "include": {
                         "type": "array",
                         "items": {
                           "$ref": "#/components/schemas/OpenAI.IncludeEnum"
-                        }
+                        },
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "parallel_tool_calls": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "parallel_tool_calls": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": true
-                  },
-                  "store": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "store": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": true
-                  },
-                  "instructions": {
-                    "anyOf": [
-                      {
-                        "type": "string"
+                      "instructions": {
+                        "type": "string",
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
+                      "stream": {
+                        "type": "boolean",
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "stream": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
+                      "stream_options": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "stream_options": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                      "conversation": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ConversationParam"
+                          }
+                        ],
+                        "nullable": true
                       },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "conversation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ConversationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "context_management": {
-                    "anyOf": [
-                      {
+                      "context_management": {
                         "type": "array",
                         "items": {
                           "$ref": "#/components/schemas/OpenAI.ContextManagementParam"
-                        }
+                        },
+                        "nullable": true,
+                        "description": "Context management configuration for this request."
                       },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
+                      "agent": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "(Deprecated) Use agent_reference instead.\nThe agent to use for generating the response."
                       },
-                      {
-                        "type": "null"
+                      "agent_session_id": {
+                        "type": "string",
+                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
+                      },
+                      "agent_reference": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "The agent to use for generating the response."
+                      },
+                      "structured_inputs": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
                       }
-                    ]
+                    }
                   },
-                  "agent": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/AgentReference"
-                      }
-                    ],
-                    "description": "(Deprecated) Use agent_reference instead.\nThe agent to use for generating the response."
-                  },
-                  "agent_session_id": {
-                    "type": "string",
-                    "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
-                  },
-                  "agent_reference": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/AgentReference"
-                      }
-                    ],
-                    "description": "The agent to use for generating the response."
-                  },
-                  "structured_inputs": {
+                  {
                     "type": "object",
-                    "unevaluatedProperties": {},
-                    "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                    "properties": {
+                      "metadata": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Metadata"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "top_logprobs": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
+                      },
+                      "top_p": {
+                        "type": "number",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.numeric"
+                          }
+                        ],
+                        "nullable": true,
+                        "default": 1
+                      },
+                      "user": {
+                        "type": "string",
+                        "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\n  A stable identifier for your end-users.\n  Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).",
+                        "deprecated": true
+                      },
+                      "safety_identifier": {
+                        "type": "string",
+                        "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      },
+                      "prompt_cache_key": {
+                        "type": "string",
+                        "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                      },
+                      "service_tier": {
+                        "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      },
+                      "prompt_cache_retention": {
+                        "type": "string",
+                        "enum": [
+                          "in-memory",
+                          "24h"
+                        ],
+                        "nullable": true
+                      },
+                      "previous_response_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "model": {
+                        "type": "string",
+                        "description": "The model deployment to use for the creation of this response."
+                      },
+                      "reasoning": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.Reasoning"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "background": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "max_output_tokens": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "max_tool_calls": {
+                        "type": "integer",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.integer"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "text": {
+                        "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
+                      },
+                      "tools": {
+                        "$ref": "#/components/schemas/OpenAI.ToolsArray"
+                      },
+                      "tool_choice": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceOptions"
+                          },
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+                          }
+                        ]
+                      },
+                      "prompt": {
+                        "$ref": "#/components/schemas/OpenAI.Prompt"
+                      },
+                      "truncation": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "disabled"
+                        ],
+                        "nullable": true,
+                        "default": "disabled"
+                      },
+                      "input": {
+                        "$ref": "#/components/schemas/OpenAI.InputParam"
+                      },
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/OpenAI.IncludeEnum"
+                        },
+                        "nullable": true
+                      },
+                      "parallel_tool_calls": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
+                      },
+                      "store": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "default": true
+                      },
+                      "instructions": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "stream": {
+                        "type": "boolean",
+                        "nullable": true
+                      },
+                      "stream_options": {
+                        "type": "object",
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ResponseStreamOptions"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "conversation": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/OpenAI.ConversationParam"
+                          }
+                        ],
+                        "nullable": true
+                      },
+                      "context_management": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/OpenAI.ContextManagementParam"
+                        },
+                        "nullable": true,
+                        "description": "Context management configuration for this request."
+                      },
+                      "agent": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "(Deprecated) Use agent_reference instead.\nThe agent to use for generating the response."
+                      },
+                      "agent_session_id": {
+                        "type": "string",
+                        "description": "Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.\nWhen provided, the request is routed to the same sandbox. When omitted, auto-derived from\nconversation_id/prev_response_id or a new UUID is generated."
+                      },
+                      "agent_reference": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/AgentReference"
+                          }
+                        ],
+                        "description": "The agent to use for generating the response."
+                      },
+                      "structured_inputs": {
+                        "type": "object",
+                        "additionalProperties": {},
+                        "description": "The structured inputs to the response that can participate in prompt template substitution or tool argument bindings."
+                      }
+                    }
                   }
-                }
+                ]
               }
             }
           }
@@ -16107,8 +14093,7 @@
       },
       "get": {
         "operationId": "listResponses",
-        "summary": "List responses",
-        "description": "Returns a collection of all stored responses matching specified filter criteria.",
+        "description": "Returns the list of all responses.",
         "parameters": [
           {
             "name": "limit",
@@ -16229,18 +14214,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16258,8 +14233,7 @@
     "/openai/v1/responses/compact": {
       "post": {
         "operationId": "compactResponseConversation",
-        "summary": "Compact a conversation",
-        "description": "Compacts a conversation into a response object suitable for long-running and zero-data-retention scenarios.",
+        "description": "Produces a compaction of a responses conversation.",
         "parameters": [],
         "responses": {
           "200": {
@@ -16272,18 +14246,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16310,9 +14274,7 @@
     },
     "/openai/v1/responses/{response_id}": {
       "get": {
-        "operationId": "getResponse",
-        "summary": "Retrieve a model response",
-        "description": "Retrieves a model response with the given ID.",
+        "operationId": "getResponse_getResponseStream",
         "parameters": [
           {
             "name": "response_id",
@@ -16362,8 +14324,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "accept",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "text/event-stream"
+              ]
+            }
           }
         ],
+        "description": "Retrieves a model response with the given ID. Retrieves a model response with the given ID (streaming response).",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -16389,18 +14363,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16416,7 +14380,6 @@
       },
       "delete": {
         "operationId": "deleteResponse",
-        "summary": "Delete a model response",
         "description": "Deletes a model response.",
         "parameters": [
           {
@@ -16458,18 +14421,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16487,8 +14440,7 @@
     "/openai/v1/responses/{response_id}/cancel": {
       "post": {
         "operationId": "cancelResponse",
-        "summary": "Cancel a model response",
-        "description": "Cancels a model response with the given ID. Only responses created with the background parameter set to true can be cancelled.",
+        "description": "Cancels a model response.",
         "parameters": [
           {
             "name": "response_id",
@@ -16529,18 +14481,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16558,8 +14500,7 @@
     "/openai/v1/responses/{response_id}/input_items": {
       "get": {
         "operationId": "listInputItems",
-        "summary": "List input items for a response",
-        "description": "Retrieves the input items associated with the specified response.",
+        "description": "Returns a list of input items for a given response.",
         "parameters": [
           {
             "name": "response_id",
@@ -16667,18 +14608,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16696,8 +14627,7 @@
     "/redTeams/runs": {
       "get": {
         "operationId": "RedTeams_list",
-        "summary": "List redteams",
-        "description": "Returns the redteams available in the current project.",
+        "description": "List a redteam by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -16726,27 +14656,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -16773,8 +14684,7 @@
     "/redTeams/runs/{name}": {
       "get": {
         "operationId": "RedTeams_get",
-        "summary": "Get a redteam",
-        "description": "Retrieves the specified redteam and its configuration.",
+        "description": "Get a redteam by name.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -16812,27 +14722,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -16859,8 +14750,7 @@
     "/redTeams/runs:run": {
       "post": {
         "operationId": "RedTeams_create",
-        "summary": "Create a redteam run",
-        "description": "Submits a new redteam run for execution with the provided configuration.",
+        "description": "Creates a redteam run.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -16896,18 +14786,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -16936,8 +14816,7 @@
     "/routines": {
       "get": {
         "operationId": "listRoutines",
-        "summary": "List routines",
-        "description": "Returns the routines available in the current project.",
+        "description": "List routines.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -16952,16 +14831,46 @@
             }
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.limit"
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.after"
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.before"
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutinesParameters.order"
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -17011,18 +14920,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17045,8 +14944,7 @@
     "/routines/{routine_name}": {
       "put": {
         "operationId": "createOrUpdateRoutine",
-        "summary": "Create or update a routine",
-        "description": "Creates a new routine or replaces an existing routine with the supplied definition.",
+        "description": "Create or update a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17085,18 +14983,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17127,8 +15015,7 @@
       },
       "get": {
         "operationId": "getRoutine",
-        "summary": "Get a routine",
-        "description": "Retrieves the specified routine and its current configuration.",
+        "description": "Retrieve a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17167,18 +15054,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17199,8 +15076,7 @@
       },
       "delete": {
         "operationId": "deleteRoutine",
-        "summary": "Delete a routine",
-        "description": "Deletes the specified routine.",
+        "description": "Delete a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17232,18 +15108,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17266,8 +15132,7 @@
     "/routines/{routine_name}/runs": {
       "get": {
         "operationId": "listRoutineRuns",
-        "summary": "List prior runs for a routine",
-        "description": "Returns prior runs recorded for the specified routine.",
+        "description": "List prior runs for a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17288,16 +15153,46 @@
             "$ref": "#/components/parameters/ListRoutineRunsParameters.filter"
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.limit"
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the\ndefault is 20.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 20
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.after"
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`\nfor descending order.",
+            "schema": {
+              "$ref": "#/components/schemas/PageOrder"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.before"
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include after=obj_foo in order to fetch the next page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/ListRoutineRunsParameters.order"
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list.\nFor instance, if you make a list request and receive 100 objects, ending with obj_foo, your\nsubsequent call can include before=obj_foo in order to fetch the previous page of the list.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -17347,18 +15242,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17381,8 +15266,7 @@
     "/routines/{routine_name}:disable": {
       "post": {
         "operationId": "disableRoutine",
-        "summary": "Disable a routine",
-        "description": "Disables the specified routine so it no longer runs.",
+        "description": "Disable a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17421,18 +15305,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17455,8 +15329,7 @@
     "/routines/{routine_name}:dispatch_async": {
       "post": {
         "operationId": "dispatchRoutineAsync",
-        "summary": "Queue an asynchronous routine dispatch",
-        "description": "Queues an asynchronous dispatch for the specified routine.",
+        "description": "Queue an asynchronous routine dispatch.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17495,18 +15368,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17539,8 +15402,7 @@
     "/routines/{routine_name}:enable": {
       "post": {
         "operationId": "enableRoutine",
-        "summary": "Enable a routine",
-        "description": "Enables the specified routine so it can be dispatched.",
+        "description": "Enable a routine.",
         "parameters": [
           {
             "name": "Foundry-Features",
@@ -17579,18 +15441,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -17613,8 +15465,7 @@
     "/schedules": {
       "get": {
         "operationId": "Schedules_list",
-        "summary": "List schedules",
-        "description": "Returns schedules that match the supplied type and enabled filters.",
+        "description": "List all schedules.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -17663,27 +15514,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -17710,8 +15542,7 @@
     "/schedules/{id}": {
       "delete": {
         "operationId": "Schedules_delete",
-        "summary": "Delete a schedule",
-        "description": "Deletes the specified schedule resource.",
+        "description": "Delete a schedule.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -17742,27 +15573,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful."
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -17787,8 +15599,7 @@
       },
       "get": {
         "operationId": "Schedules_get",
-        "summary": "Get a schedule",
-        "description": "Retrieves the specified schedule resource.",
+        "description": "Get a schedule by id.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -17826,27 +15637,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -17871,8 +15663,7 @@
       },
       "put": {
         "operationId": "Schedules_createOrUpdate",
-        "summary": "Create or update a schedule",
-        "description": "Creates a new schedule or updates an existing schedule with the supplied definition.",
+        "description": "Create or update operation template.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -17920,27 +15711,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -17978,8 +15750,7 @@
     "/schedules/{id}/runs": {
       "get": {
         "operationId": "Schedules_listRuns",
-        "summary": "List schedule runs",
-        "description": "Returns schedule runs that match the supplied filters.",
+        "description": "List all schedule runs.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Azure.Core.Foundations.ApiVersionParameter"
@@ -18037,27 +15808,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "headers": {
-              "x-ms-error-code": {
-                "required": false,
-                "description": "String error code indicating what went wrong.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Azure.Core.Foundations.ErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "headers": {
               "x-ms-error-code": {
                 "required": false,
@@ -18084,8 +15836,7 @@
     "/schedules/{schedule_id}/runs/{run_id}": {
       "get": {
         "operationId": "Schedules_getRun",
-        "summary": "Get a schedule run",
-        "description": "Retrieves the specified run for a schedule.",
+        "description": "Get a schedule run by id.",
         "parameters": [
           {
             "name": "schedule_id",
@@ -18139,18 +15890,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18168,8 +15909,7 @@
     "/skills": {
       "get": {
         "operationId": "Skills_listSkills",
-        "summary": "List skills",
-        "description": "Returns the skills available in the current project.",
+        "description": "Returns the list of all skills.",
         "parameters": [
           {
             "name": "limit",
@@ -18273,18 +16013,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18307,8 +16037,7 @@
     "/skills/{name}": {
       "get": {
         "operationId": "Skills_getSkill",
-        "summary": "Retrieve a skill",
-        "description": "Retrieves the specified skill and its current configuration.",
+        "description": "Retrieves a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18353,18 +16082,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18385,8 +16104,7 @@
       },
       "post": {
         "operationId": "updateSkill",
-        "summary": "Update a skill",
-        "description": "Modifies the specified skill's configuration.",
+        "description": "Update a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18431,18 +16149,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18482,8 +16190,7 @@
       },
       "delete": {
         "operationId": "Skills_deleteSkill",
-        "summary": "Delete a skill",
-        "description": "Removes the specified skill and its associated versions.",
+        "description": "Deletes a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18528,18 +16235,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18562,8 +16259,7 @@
     "/skills/{name}/content": {
       "get": {
         "operationId": "getSkillContent",
-        "summary": "Download the zip content for the default version of a skill",
-        "description": "Downloads the zip content for the default version of a skill.",
+        "description": "Download the zip content for the default version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18603,23 +16299,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18676,7 +16363,6 @@
           }
         ],
         "description": "Creates a new version of a skill. If the skill does not exist, it will be created. Creates a new version of a skill from uploaded files via multipart form data.",
-        "summary": "Create a new version of a skill Create a skill version from uploaded files",
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -18688,18 +16374,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18709,8 +16385,6 @@
             }
           }
         },
-        "x-ms-description-override": "Creates a new version of a skill. If the skill does not exist, it will be created.",
-        "x-ms-summary-override": "Create a new version of a skill",
         "x-ms-foundry-meta": {
           "required_previews": [
             "Skills=V1Preview"
@@ -18759,8 +16433,7 @@
       },
       "get": {
         "operationId": "listSkillVersions",
-        "summary": "List skill versions",
-        "description": "Returns the available versions for the specified skill.",
+        "description": "List all versions of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18873,18 +16546,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18907,8 +16570,7 @@
     "/skills/{name}/versions/{version}": {
       "get": {
         "operationId": "getSkillVersion",
-        "summary": "Retrieve a specific version of a skill",
-        "description": "Retrieves the specified version of a skill by name and version identifier.",
+        "description": "Retrieve a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -18962,18 +16624,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -18994,8 +16646,7 @@
       },
       "delete": {
         "operationId": "deleteSkillVersion",
-        "summary": "Delete a specific version of a skill",
-        "description": "Removes the specified version of a skill.",
+        "description": "Delete a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -19049,18 +16700,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19083,8 +16724,7 @@
     "/skills/{name}/versions/{version}/content": {
       "get": {
         "operationId": "getSkillVersionContent",
-        "summary": "Download the zip content for a specific version of a skill",
-        "description": "Downloads the zip content for a specific version of a skill.",
+        "description": "Download the zip content for a specific version of a skill.",
         "parameters": [
           {
             "name": "name",
@@ -19133,23 +16773,14 @@
             "content": {
               "application/zip": {
                 "schema": {
-                  "contentMediaType": "application/zip"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19172,8 +16803,7 @@
     "/toolboxes": {
       "get": {
         "operationId": "listToolboxes",
-        "summary": "List toolboxes",
-        "description": "Returns the toolboxes available in the current project.",
+        "description": "List all toolboxes.",
         "parameters": [
           {
             "name": "limit",
@@ -19216,18 +16846,6 @@
               "type": "string"
             },
             "explode": false
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -19277,18 +16895,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19300,19 +16908,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}": {
       "get": {
         "operationId": "getToolbox",
-        "summary": "Retrieve a toolbox",
-        "description": "Retrieves the specified toolbox and its current configuration.",
+        "description": "Retrieve a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -19324,18 +16926,6 @@
             }
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -19357,18 +16947,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19380,32 +16960,14 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "patch": {
         "operationId": "updateToolbox",
-        "summary": "Update a toolbox to point to a specific version",
-        "description": "Updates the toolbox's default version pointer to the specified version.",
+        "description": "Update a toolbox to point to a specific version.",
         "parameters": [
           {
             "$ref": "#/components/parameters/UpdateToolboxRequest.name"
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
           },
           {
             "name": "api-version",
@@ -19429,18 +16991,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19462,17 +17014,11 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "delete": {
         "operationId": "deleteToolbox",
-        "summary": "Delete a toolbox",
-        "description": "Removes the specified toolbox along with all of its versions.",
+        "description": "Delete a toolbox and all its versions.",
         "parameters": [
           {
             "name": "name",
@@ -19481,18 +17027,6 @@
             "description": "The name of the toolbox to delete.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19510,18 +17044,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19533,19 +17057,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions": {
       "post": {
         "operationId": "createToolboxVersion",
-        "summary": "Create a new version of a toolbox",
-        "description": "Creates a new toolbox version, provisioning the toolbox itself if it does not already exist.",
+        "description": "Create a new version of a toolbox. If the toolbox does not exist, it will be created.",
         "parameters": [
           {
             "name": "name",
@@ -19555,18 +17073,6 @@
             "schema": {
               "type": "string",
               "maxLength": 256
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19591,18 +17097,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19629,7 +17125,7 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "unevaluatedProperties": {
+                    "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Arbitrary key-value metadata to associate with the toolbox."
@@ -19663,17 +17159,11 @@
               }
             }
           }
-        },
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
         }
       },
       "get": {
         "operationId": "listToolboxVersions",
-        "summary": "List toolbox versions",
-        "description": "Returns the available versions for the specified toolbox.",
+        "description": "List all versions of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -19727,18 +17217,6 @@
             "explode": false
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -19786,18 +17264,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19809,19 +17277,13 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     },
     "/toolboxes/{name}/versions/{version}": {
       "get": {
         "operationId": "getToolboxVersion",
-        "summary": "Retrieve a specific version of a toolbox",
-        "description": "Retrieves the specified version of a toolbox by name and version identifier.",
+        "description": "Retrieve a specific version of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -19839,18 +17301,6 @@
             "description": "The version identifier to retrieve.",
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
             }
           },
           {
@@ -19875,18 +17325,8 @@
               }
             }
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19898,17 +17338,11 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       },
       "delete": {
         "operationId": "deleteToolboxVersion",
-        "summary": "Delete a specific version of a toolbox",
-        "description": "Removes the specified version of a toolbox.",
+        "description": "Delete a specific version of a toolbox.",
         "parameters": [
           {
             "name": "name",
@@ -19929,18 +17363,6 @@
             }
           },
           {
-            "name": "Foundry-Features",
-            "in": "header",
-            "required": true,
-            "description": "A feature flag opt-in required when using preview operations or modifying persisted preview resources.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Toolboxes=V1Preview"
-              ]
-            }
-          },
-          {
             "name": "api-version",
             "in": "query",
             "required": true,
@@ -19955,18 +17377,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "4XX": {
-            "description": "Client error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
+          "default": {
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19978,12 +17390,7 @@
         },
         "tags": [
           "Toolboxes"
-        ],
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Toolboxes=V1Preview"
-          ]
-        }
+        ]
       }
     }
   },
@@ -20076,52 +17483,11 @@
           "maxLength": 128
         }
       },
-      "ListRoutineRunsParameters.after": {
-        "name": "after",
-        "in": "query",
-        "required": false,
-        "description": "An opaque cursor returned as last_id by the previous list-runs response.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.before": {
-        "name": "before",
-        "in": "query",
-        "required": false,
-        "description": "Unsupported. Reserved for future backward pagination support.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
       "ListRoutineRunsParameters.filter": {
         "name": "filter",
         "in": "query",
         "required": false,
         "description": "An optional MLflow search-runs filter expression applied within the routine's experiment.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.limit": {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "description": "The maximum number of runs to return.",
-        "schema": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "explode": false
-      },
-      "ListRoutineRunsParameters.order": {
-        "name": "order",
-        "in": "query",
-        "required": false,
-        "description": "The ordering direction. Supported values are asc and desc.",
         "schema": {
           "type": "string"
         },
@@ -20136,47 +17502,6 @@
           "type": "string",
           "maxLength": 128
         }
-      },
-      "ListRoutinesParameters.after": {
-        "name": "after",
-        "in": "query",
-        "required": false,
-        "description": "An opaque cursor returned as last_id by the previous list response.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.before": {
-        "name": "before",
-        "in": "query",
-        "required": false,
-        "description": "Unsupported. Reserved for future backward pagination support.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.limit": {
-        "name": "limit",
-        "in": "query",
-        "required": false,
-        "description": "The maximum number of routines to return.",
-        "schema": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "explode": false
-      },
-      "ListRoutinesParameters.order": {
-        "name": "order",
-        "in": "query",
-        "required": false,
-        "description": "The ordering direction. Supported values are asc and desc.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       },
       "UpdateToolboxRequest.name": {
         "name": "name",
@@ -20654,17 +17979,13 @@
             "type": "integer",
             "format": "int32",
             "description": "The maximum number of replicas for the container. Default is 1.",
-            "examples": [
-              10
-            ]
+            "example": 10
           },
           "min_replicas": {
             "type": "integer",
             "format": "int32",
             "description": "The minimum number of replicas for the container. Default is 1.",
-            "examples": [
-              1
-            ]
+            "example": 1
           },
           "error_message": {
             "type": "string",
@@ -21088,7 +18409,7 @@
           },
           "evaluators": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/EvaluatorConfiguration"
             },
             "description": "Evaluators to be used for the evaluation."
@@ -21165,7 +18486,7 @@
           },
           "additionalDetails": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties relevant to the evaluator. These will differ between evaluators."
@@ -21353,6 +18674,23 @@
           }
         }
       },
+      "AgentIdentifier": {
+        "type": "object",
+        "required": [
+          "agentName"
+        ],
+        "properties": {
+          "agentName": {
+            "type": "string",
+            "description": "Registered Foundry agent name (required)."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Pinned agent version. Defaults to latest if omitted."
+          }
+        },
+        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and systemPrompt are specified in options.optimizationConfig."
+      },
       "AgentIdentity": {
         "type": "object",
         "required": [
@@ -21508,7 +18846,6 @@
             "enum": [
               "activity_protocol",
               "responses",
-              "a2a",
               "mcp",
               "invocations",
               "invocations_ws"
@@ -21610,6 +18947,7 @@
               "idle",
               "updating",
               "failed",
+              "stopping",
               "deleting",
               "deleted",
               "expired"
@@ -21707,17 +19045,11 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
             "x-oaiTypeLabel": "map"
           },
@@ -23095,7 +20427,7 @@
               },
               "parameters": {
                 "type": "object",
-                "unevaluatedProperties": {},
+                "additionalProperties": {},
                 "description": "The parameters the functions accepts, described as a JSON Schema object."
               }
             },
@@ -23879,6 +21211,160 @@
         },
         "description": "Definition of input parameters for the Browser Automation Tool."
       },
+      "CandidateDeployConfig": {
+        "type": "object",
+        "properties": {
+          "instructions": {
+            "type": "string",
+            "description": "System prompt / instructions."
+          },
+          "model": {
+            "type": "string",
+            "description": "Foundry deployment name."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Optional sampling temperature."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Optional skill overrides."
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Optional tool overrides."
+          }
+        },
+        "description": "Deploy-config blob for a candidate. Suitable for setting OPTIMIZATION_CONFIG on a hosted-agent version."
+      },
+      "CandidateFileInfo": {
+        "type": "object",
+        "required": [
+          "path",
+          "type",
+          "sizeBytes"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Relative path of the file."
+          },
+          "type": {
+            "type": "string",
+            "description": "File type category (e.g. 'config', 'results')."
+          },
+          "sizeBytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "File size in bytes."
+          }
+        },
+        "description": "File entry in a candidate's blob directory."
+      },
+      "CandidateMetadata": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "jobId",
+          "candidateName",
+          "status",
+          "hasResults",
+          "createdAt",
+          "updatedAt",
+          "files"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "Server-assigned candidate identifier."
+          },
+          "jobId": {
+            "type": "string",
+            "description": "Owning optimization job id."
+          },
+          "candidateName": {
+            "type": "string",
+            "description": "Display name of the candidate."
+          },
+          "status": {
+            "type": "string",
+            "description": "Candidate lifecycle status."
+          },
+          "score": {
+            "type": "number",
+            "format": "double",
+            "description": "Candidate's aggregate score."
+          },
+          "hasResults": {
+            "type": "boolean",
+            "description": "Whether detailed results are available for this candidate."
+          },
+          "createdAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when the candidate was created, represented in Unix time."
+          },
+          "updatedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when the candidate was last updated, represented in Unix time."
+          },
+          "promotion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PromotionInfo"
+              }
+            ],
+            "description": "Promotion metadata. Null if not promoted."
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CandidateFileInfo"
+            },
+            "description": "Files in the candidate's blob directory."
+          }
+        },
+        "description": "Candidate metadata returned by GET /candidates/{id}."
+      },
+      "CandidateResults": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "results"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "Owning candidate id."
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationTaskResult"
+            },
+            "description": "Per-task evaluation rows."
+          }
+        },
+        "description": "Full per-task evaluation results for a candidate, returned by GET /candidates/{id}/results."
+      },
       "CaptureStructuredOutputsTool": {
         "type": "object",
         "required": [
@@ -23993,7 +21479,7 @@
           },
           "coordinates": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/ChartCoordinate"
             },
             "description": "  Optional mapping of IDs to 2D coordinates used by the UX for visualization.\n\n  The map keys are string identifiers (for example, a cluster id or a sample id)\n  and the values are the coordinates and visual size for rendering on a 2D chart.\n\n  This property is omitted unless the client requests coordinates (for example,\n  by passing `includeCoordinates=true` as a query parameter).\n\n  Example:\n  ```\n  {\n    \"cluster-1\": { \"x\": 12, \"y\": 34, \"size\": 8 },\n    \"sample-123\": { \"x\": 18, \"y\": 22, \"size\": 4 }\n  }\n  ```\n\n  Coordinates are intended only for client-side visualization and do not\n  modify the canonical insights results."
@@ -24247,7 +21733,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata of the connection",
@@ -24300,17 +21786,15 @@
               "$ref": "#/components/schemas/ProtocolVersionRecord"
             },
             "description": "The protocols that the agent supports for ingress communication of the containers.",
-            "examples": [
-              [
-                {
-                  "protocol": "responses",
-                  "version": "v0.1.1"
-                },
-                {
-                  "protocol": "a2a",
-                  "version": "v0.3.0"
-                }
-              ]
+            "example": [
+              {
+                "protocol": "responses",
+                "version": "v0.1.1"
+              },
+              {
+                "protocol": "a2a",
+                "version": "v0.3.0"
+              }
             ]
           },
           "container_app_resource_id": {
@@ -24320,11 +21804,7 @@
           "ingress_subdomain_suffix": {
             "type": "string",
             "description": "The suffix to apply to the app subdomain when sending ingress to the agent. This can be a label (e.g., '---current'), a specific revision (e.g., '--0000001'), or empty to use the default endpoint for the container app.",
-            "examples": [
-              "--0000001",
-              "---current",
-              ""
-            ]
+            "example": "--0000001"
           }
         },
         "allOf": [
@@ -24348,9 +21828,7 @@
           "image": {
             "type": "string",
             "description": "The container image for the hosted agent.",
-            "examples": [
-              "my-registry.azurecr.io/my-hosted-agent:latest"
-            ]
+            "example": "my-registry.azurecr.io/my-hosted-agent:latest"
           }
         },
         "description": "Container-based deployment configuration for a hosted agent.",
@@ -24499,14 +21977,6 @@
             "type": "integer",
             "format": "int32",
             "description": "Maximum number of evaluation runs allowed per hour."
-          },
-          "samplingRate": {
-            "type": "number",
-            "format": "double",
-            "maximum": 100,
-            "description": "Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.",
-            "exclusiveMinimum": 0,
-            "default": 100
           }
         },
         "allOf": [
@@ -24548,7 +22018,7 @@
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Mapping from source fields to response_id field, which is required for retrieving chat history."
@@ -24652,6 +22122,8 @@
             "description": "JSON metadata including description and hosted definition."
           },
           "code": {
+            "type": "string",
+            "format": "binary",
             "description": "The code zip file (max 250 MB)."
           }
         },
@@ -24675,7 +22147,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -24692,7 +22164,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -24711,7 +22183,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -24825,6 +22297,8 @@
             "description": "JSON metadata including description and hosted definition."
           },
           "code": {
+            "type": "string",
+            "format": "binary",
             "description": "The code zip file (max 250 MB)."
           }
         },
@@ -24846,7 +22320,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -24877,7 +22351,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -24894,7 +22368,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -24907,7 +22381,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -24969,14 +22443,13 @@
             "description": "The name of the evaluation."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "data_source_config": {
             "oneOf": [
@@ -25026,7 +22499,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -25045,14 +22518,13 @@
             "description": "The name of the run."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "data_source": {
             "oneOf": [
@@ -25073,7 +22545,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -25113,7 +22585,10 @@
         "properties": {
           "files": {
             "type": "array",
-            "items": {},
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
             "description": "Skill files to upload. Upload a single zip file or multiple individual files with relative paths."
           },
           "default": {
@@ -25214,7 +22689,7 @@
             "readOnly": true
           }
         },
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "type": "string"
         },
         "allOf": [
@@ -25223,49 +22698,6 @@
           }
         ],
         "description": "Custom credential definition"
-      },
-      "CustomRoutineTrigger": {
-        "type": "object",
-        "required": [
-          "type",
-          "provider",
-          "parameters"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom"
-            ],
-            "description": "The trigger type."
-          },
-          "provider": {
-            "type": "string",
-            "maxLength": 128,
-            "description": "The external provider that emits the custom event."
-          },
-          "event_name": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "The provider-specific event name that fires the routine."
-          },
-          "parameters": {
-            "type": "object",
-            "unevaluatedProperties": {},
-            "description": "Provider-specific trigger parameters."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/RoutineTrigger"
-          }
-        ],
-        "description": "A custom event routine trigger.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
       },
       "DailyRecurrenceSchedule": {
         "type": "object",
@@ -25496,7 +22928,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tags to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs."
@@ -25682,15 +23114,13 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The overall object JSON schema for the run data source items."
           }
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -25729,7 +23159,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary of the output dataset.",
@@ -25810,6 +23240,50 @@
           }
         ],
         "description": "Dataset source for evaluator generation jobs — reference to a dataset."
+      },
+      "DatasetInfo": {
+        "type": "object",
+        "required": [
+          "taskCount",
+          "isInline"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Dataset name when using a registered dataset reference. Null for inline datasets."
+          },
+          "version": {
+            "type": "string",
+            "description": "Dataset version when using a registered dataset reference. Null for inline datasets."
+          },
+          "taskCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tasks/rows in the dataset."
+          },
+          "isInline": {
+            "type": "boolean",
+            "description": "True when the dataset was provided inline in the request body."
+          }
+        },
+        "description": "Metadata about the dataset used for optimization, surfaced in the response."
+      },
+      "DatasetRef": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Dataset name."
+          },
+          "version": {
+            "type": "string",
+            "description": "Dataset version. If not specified, the latest version is used."
+          }
+        },
+        "description": "Reference to a registered dataset in the Foundry Dataset Service."
       },
       "DatasetReference": {
         "type": "object",
@@ -25921,7 +23395,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -26302,7 +23776,7 @@
           },
           "always_applicable": {
             "type": "boolean",
-            "description": "When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. Defaults to `false`.",
             "default": false
           }
         },
@@ -26509,14 +23983,13 @@
             "description": "The Unix timestamp (in seconds) for when the eval was created."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "modified_at": {
             "allOf": [
@@ -26532,7 +24005,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -26724,14 +24197,13 @@
             "description": "Information about the run's data source."
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "error": {
             "$ref": "#/components/schemas/OpenAI.EvalApiError"
@@ -26750,7 +24222,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -26854,7 +24326,7 @@
           },
           "datasource_item": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Details of the input data source item."
           },
           "results": {
@@ -26910,15 +24382,9 @@
             "description": "Whether the grader considered the output a pass."
           },
           "sample": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true,
             "description": "Optional sample or intermediate data produced by the grader."
           },
           "status": {
@@ -26948,13 +24414,13 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional details about the test criteria metric."
           }
         },
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "A single grader result for an evaluation run output item.",
         "title": "EvalRunOutputItemResult"
       },
@@ -27170,21 +24636,21 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Evaluation's tags. Unlike properties, tags are fully mutable."
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Evaluation's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed."
           },
           "evaluators": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/EvaluatorConfiguration"
             },
             "description": "Evaluators to be used for the evaluation."
@@ -27414,7 +24880,7 @@
           },
           "systemData": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "System metadata for the evaluation rule.",
@@ -27579,7 +25045,6 @@
           },
           "evalRun": {
             "type": "object",
-            "unevaluatedProperties": {},
             "description": "The evaluation run payload."
           }
         },
@@ -27752,7 +25217,7 @@
           },
           "initialization_parameters": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Optional initialization parameters applied to all generated evaluators.\nFor example, deployment_name for LLM judge model, default threshold."
           },
           "data_generation_options": {
@@ -28141,7 +25606,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -28235,7 +25700,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -28320,7 +25785,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -28340,7 +25805,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -28362,7 +25827,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -28440,7 +25905,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -28462,7 +25927,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the evaluation taxonomy."
@@ -28498,12 +25963,12 @@
           },
           "initParams": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Initialization parameters of the evaluator."
           },
           "dataMapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Data parameters of the evaluator."
@@ -28546,17 +26011,17 @@
           },
           "init_parameters": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema (Draft 2020-12) for the evaluator's input parameters. This includes parameters like type, properties, required."
           },
           "data_schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema (Draft 2020-12) for the evaluator's input data. This includes parameters like type, properties, required."
           },
           "metrics": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/EvaluatorMetric"
             },
             "description": "List of output metrics produced by this evaluator"
@@ -28921,7 +26386,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -28940,16 +26405,6 @@
               "$ref": "#/components/schemas/EvaluatorCategory"
             },
             "description": "The categories of the evaluator"
-          },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
           },
           "definition": {
             "allOf": [
@@ -29015,7 +26470,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -29035,16 +26490,6 @@
             },
             "description": "The categories of the evaluator"
           },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
-          },
           "definition": {
             "allOf": [
               {
@@ -29059,7 +26504,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -29076,7 +26521,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Metadata about the evaluator"
@@ -29088,23 +26533,13 @@
             },
             "description": "The categories of the evaluator"
           },
-          "supported_evaluation_levels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EvaluationLevel"
-            },
-            "description": "Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `[\"turn\"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).",
-            "default": [
-              "turn"
-            ]
-          },
           "description": {
             "type": "string",
             "description": "The asset description text."
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -29266,13 +26701,17 @@
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
-                "type": "string"
-              },
-              {
-                "type": "null"
+                "type": "string",
+                "nullable": true
               }
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
@@ -29323,13 +26762,17 @@
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
-                "type": "string"
-              },
-              {
-                "type": "null"
+                "type": "string",
+                "nullable": true
               }
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
@@ -29473,14 +26916,12 @@
             "description": "Ranking options for search."
           },
           "filters": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Filters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "vector_store_ids": {
             "type": "array",
@@ -29706,40 +27147,19 @@
         },
         "description": "Details of a function tool call."
       },
-      "GitHubIssueEvent": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "opened",
-              "closed"
-            ]
-          }
-        ],
-        "description": "Known GitHub issue events that can fire a routine.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
-      "GitHubIssueRoutineTrigger": {
+      "GitHubIssueOpenedRoutineTrigger": {
         "type": "object",
         "required": [
           "type",
           "connection_id",
-          "owner",
-          "repository",
-          "issue_event"
+          "assignee",
+          "repository"
         ],
         "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "github_issue"
+              "github_issue_opened"
             ],
             "description": "The trigger type."
           },
@@ -29748,23 +27168,15 @@
             "maxLength": 256,
             "description": "The workspace connection identifier that resolves the GitHub configuration for the trigger."
           },
-          "owner": {
+          "assignee": {
             "type": "string",
             "maxLength": 128,
-            "description": "The GitHub owner or organization that scopes which issues can fire the trigger."
+            "description": "The GitHub assignee or organization filter that scopes which issues can fire the trigger."
           },
           "repository": {
             "type": "string",
             "maxLength": 128,
             "description": "The GitHub repository filter that scopes which issues can fire the trigger."
-          },
-          "issue_event": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/GitHubIssueEvent"
-              }
-            ],
-            "description": "The GitHub issue event that fires the routine."
           }
         },
         "allOf": [
@@ -29772,7 +27184,7 @@
             "$ref": "#/components/schemas/RoutineTrigger"
           }
         ],
-        "description": "A GitHub issue routine trigger.",
+        "description": "A GitHub issue-opened routine trigger.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -29822,23 +27234,17 @@
           "header_name": {
             "type": "string",
             "description": "The name of the HTTP header to inject the secret value into.",
-            "examples": [
-              "X-Otlp-Api-Key"
-            ]
+            "example": "X-Otlp-Api-Key"
           },
           "secret_id": {
             "type": "string",
             "description": "The identifier of the secret store or connection.",
-            "examples": [
-              "my-secret-store"
-            ]
+            "example": "my-secret-store"
           },
           "secret_key": {
             "type": "string",
             "description": "The key within the secret to retrieve the authentication value.",
-            "examples": [
-              "OTLP_KEY"
-            ]
+            "example": "OTLP_KEY"
           }
         },
         "allOf": [
@@ -29877,29 +27283,23 @@
           "cpu": {
             "type": "string",
             "description": "The CPU configuration for the hosted agent.",
-            "examples": [
-              "0.25"
-            ]
+            "example": "0.25"
           },
           "memory": {
             "type": "string",
             "description": "The memory configuration for the hosted agent.",
-            "examples": [
-              "0.5Gi"
-            ]
+            "example": "0.5Gi"
           },
           "environment_variables": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Environment variables to set in the hosted agent container.",
-            "examples": [
-              {
-                "name": "LOG_LEVEL",
-                "value": "debug"
-              }
-            ]
+            "example": {
+              "name": "LOG_LEVEL",
+              "value": "debug"
+            }
           },
           "container_configuration": {
             "allOf": [
@@ -29920,17 +27320,15 @@
               "$ref": "#/components/schemas/ProtocolVersionRecord"
             },
             "description": "The protocols that the agent supports for ingress communication.",
-            "examples": [
-              [
-                {
-                  "protocol": "responses",
-                  "version": "v0.1.1"
-                },
-                {
-                  "protocol": "a2a",
-                  "version": "v0.3.0"
-                }
-              ]
+            "example": [
+              {
+                "protocol": "responses",
+                "version": "v0.1.1"
+              },
+              {
+                "protocol": "a2a",
+                "version": "v0.3.0"
+              }
             ],
             "x-ms-foundry-meta": {
               "required_previews": [
@@ -30127,7 +27525,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -30383,12 +27781,12 @@
           },
           "features": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Features to help with additional filtering of data in UX."
           },
           "correlationInfo": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Info about the correlation for the analysis sample."
           }
         },
@@ -30507,8 +27905,7 @@
       "InvokeAgentInvocationsApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type",
-          "input"
+          "type"
         ],
         "properties": {
           "type": {
@@ -30519,7 +27916,9 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
+            "type": "string",
+            "maxLength": 32768,
+            "description": "The raw input sent to the downstream invocations target."
           }
         },
         "allOf": [
@@ -30537,7 +27936,8 @@
       "InvokeAgentInvocationsApiRoutineAction": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "agent_endpoint_id"
         ],
         "properties": {
           "type": {
@@ -30547,18 +27947,10 @@
             ],
             "description": "The action type."
           },
-          "agent_name": {
-            "type": "string",
-            "maxLength": 256,
-            "description": "The project-scoped agent name for routine dispatch."
-          },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
-          },
-          "input": {
-            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
+            "description": "The endpoint-scoped agent identifier for invocations API dispatch."
           },
           "session_id": {
             "type": "string",
@@ -30571,7 +27963,7 @@
             "$ref": "#/components/schemas/RoutineAction"
           }
         ],
-        "description": "Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.",
+        "description": "Dispatches a routine through the raw invocations API.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -30581,8 +27973,7 @@
       "InvokeAgentResponsesApiDispatchPayload": {
         "type": "object",
         "required": [
-          "type",
-          "input"
+          "type"
         ],
         "properties": {
           "type": {
@@ -30593,7 +27984,9 @@
             "description": "The manual dispatch payload type."
           },
           "input": {
-            "description": "The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null."
+            "type": "string",
+            "maxLength": 32768,
+            "description": "The user input sent to the downstream responses target."
           }
         },
         "allOf": [
@@ -30624,17 +28017,14 @@
           "agent_name": {
             "type": "string",
             "maxLength": 256,
-            "description": "The project-scoped agent name for routine dispatch."
+            "description": "The project-scoped agent name for responses API dispatch."
           },
           "agent_endpoint_id": {
             "type": "string",
             "maxLength": 256,
-            "description": "Legacy endpoint-scoped agent identifier for routine dispatch."
+            "description": "The endpoint-scoped agent identifier for responses API dispatch."
           },
-          "input": {
-            "description": "Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied."
-          },
-          "conversation": {
+          "conversation_id": {
             "type": "string",
             "maxLength": 256,
             "description": "An optional existing conversation identifier to continue during the downstream dispatch."
@@ -30716,8 +28106,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -30832,17 +28221,11 @@
             "description": "Optional description of the MCP server, used to provide more context."
           },
           "headers": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "allowed_tools": {
             "anyOf": [
@@ -30850,37 +28233,41 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
-              },
-              {
-                "type": "null"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
+                  }
+                ],
+                "nullable": true
               }
             ]
           },
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
                 "type": "string",
                 "enum": [
                   "always",
                   "never"
-                ]
-              },
-              {
-                "type": "null"
+                ],
+                "nullable": true
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -31343,17 +28730,11 @@
             "description": "The status of the tool call."
           },
           "memories": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/MemoryItem"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemoryItem"
+            },
+            "nullable": true,
             "description": "The results returned from the memory search."
           }
         },
@@ -31431,7 +28812,7 @@
           },
           "procedural_memory_enabled": {
             "type": "boolean",
-            "description": "Whether to enable procedural memory extraction and storage. The service defaults to `true` if a value is not specified by the caller.",
+            "description": "Whether to enable procedural memory extraction and storage. Defaults to `true`.",
             "default": true
           },
           "default_ttl_seconds": {
@@ -31581,7 +28962,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Arbitrary key-value metadata to associate with the memory store."
@@ -31923,7 +29304,7 @@
           },
           "capabilities": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Capabilities of deployed model",
@@ -32144,7 +29525,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -32351,7 +29732,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -32384,7 +29766,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -32418,7 +29801,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -32446,7 +29830,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -32546,7 +29931,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -32571,7 +29957,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -32604,7 +29991,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -32641,44 +30029,20 @@
             "default": "approximate"
           },
           "country": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "region": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -32706,14 +30070,12 @@
             "description": "An optional list of uploaded files to make available to your code."
           },
           "memory_limit": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ContainerMemoryLimit"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "network_policy": {
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
@@ -32747,12 +30109,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -32852,7 +30208,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -32877,19 +30234,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -33056,61 +30400,17 @@
                 "items": {
                   "$ref": "#/components/schemas/OpenAI.InputItem"
                 }
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "previous_response_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -33130,9 +30430,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -33234,14 +30532,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -33274,24 +30564,12 @@
             "description": "The ID of the pending safety check."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "A pending safety check for the computer call."
@@ -33311,8 +30589,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -33321,36 +30598,17 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -33388,29 +30646,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -33426,7 +30661,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -33473,7 +30709,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -33484,14 +30721,12 @@
             "description": "An optional list of uploaded files to make available to your code."
           },
           "memory_limit": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ContainerMemoryLimit"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "skills": {
             "type": "array",
@@ -33528,7 +30763,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -33589,7 +30825,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -33598,6 +30835,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -33618,7 +30863,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -33626,6 +30872,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -33673,7 +30945,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -33730,14 +31003,13 @@
             "description": "The context management entry type. Currently only 'compaction' is supported."
           },
           "compact_threshold": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         }
       },
@@ -33755,18 +31027,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -33778,56 +31046,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -33921,14 +31145,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -33983,34 +31201,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -34021,50 +31227,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -34087,9 +31256,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -34116,11 +31282,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -34136,8 +31301,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -34167,17 +31331,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -34209,18 +31412,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -34228,65 +31419,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -34328,17 +31462,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -34388,20 +31516,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -34447,7 +31574,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -34460,14 +31587,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -34482,67 +31608,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -34550,8 +31618,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -34593,9 +31660,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -34629,14 +31743,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -34766,19 +31874,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -34862,14 +31964,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -34913,7 +32009,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -34959,18 +32056,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -34981,14 +32072,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -35044,16 +32129,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -35085,14 +32160,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -35126,138 +32195,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -35274,11 +32211,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -35467,8 +32400,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -35538,27 +32470,20 @@
         "type": "object",
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "items": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.InputItem"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.InputItem"
+            },
+            "nullable": true
           }
         }
       },
@@ -35736,7 +32661,7 @@
           },
           "item_schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The json schema for each row in the data source."
           },
           "include_sample_schema": {
@@ -35805,7 +32730,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Metadata filters for the logs data source."
           }
         },
@@ -36000,7 +32925,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Metadata filters for the stored completions data source."
           }
         },
@@ -36052,52 +32977,33 @@
             "deprecated": true
           },
           "suffix": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "minLength": 1,
             "maxLength": 64,
             "description": "A string of up to 64 characters that will be added to your fine-tuned model name.\n  For example, a `suffix` of \"custom-model-name\" would produce a model name like `ft:gpt-4o-mini:openai:custom-model-name:7p4lURel`."
           },
           "validation_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "The ID of an uploaded file that contains validation data.\n  If you provide this file, the data is used to generate validation\n  metrics periodically during fine-tuning. These metrics can be viewed in\n  the fine-tuning results file.\n  The same data should not be present in both train and validation files.\n  Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.\n  See the [fine-tuning guide](/docs/guides/model-optimization) for more details."
           },
           "integrations": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations"
+            },
+            "nullable": true,
             "description": "A list of integrations to enable for your fine-tuning job."
           },
           "seed": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "minimum": 0,
             "maximum": 2147483647,
             "description": "The seed controls the reproducibility of the job. Passing in the same seed and job parameters should produce the same results, but may differ in rare cases.\n  If a seed is not specified, one will be generated for you."
@@ -36106,14 +33012,13 @@
             "$ref": "#/components/schemas/OpenAI.FineTuneMethod"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         }
       },
@@ -36193,24 +33098,12 @@
             "type": "string"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "entity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "tags": {
             "type": "array",
@@ -36397,7 +33290,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -36432,7 +33326,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -36456,7 +33351,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -36473,10 +33369,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -36549,8 +33441,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -36558,8 +33449,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -36568,7 +33458,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -36585,19 +33476,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -36621,7 +33499,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -36629,19 +33508,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -36681,16 +33547,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -36717,9 +33573,6 @@
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
       },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
-      },
       "OpenAI.Error": {
         "type": "object",
         "required": [
@@ -36728,27 +33581,15 @@
         ],
         "properties": {
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
             "type": "string"
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string"
@@ -36761,11 +33602,11 @@
           },
           "additionalInfo": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "debugInfo": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           }
         }
       },
@@ -36944,45 +33785,41 @@
         "type": "object",
         "properties": {
           "seed": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "top_p": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "top_p": {
+            "type": "number",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.numeric"
+              }
+            ],
+            "nullable": true,
             "default": 1
           },
           "temperature": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_completions_tokens": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "reasoning_effort": {
             "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
@@ -37323,11 +34160,11 @@
         "properties": {
           "item": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "sample": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           }
         }
       },
@@ -37368,111 +34205,75 @@
             "description": "The type of run data source. Always `responses`."
           },
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "instructions_search": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_after": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_before": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "reasoning_effort": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "temperature": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "top_p": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "users": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "tools": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           }
         },
         "description": "A EvalResponsesSource object describing a run data source configuration.",
@@ -37672,54 +34473,44 @@
             "default": "stored_completions"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_after": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_before": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "limit": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "A StoredCompletionsRunDataSource configuration describing a set of filters",
@@ -37745,7 +34536,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -37771,13 +34563,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -37829,7 +34614,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -37855,14 +34641,12 @@
             "description": "Ranking options for search."
           },
           "filters": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Filters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -37894,14 +34678,13 @@
             "type": "string"
           },
           "attributes": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.VectorStoreFileAttributes"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "score": {
             "type": "number",
@@ -38256,24 +35039,12 @@
             "type": "string"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "entity": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "tags": {
             "type": "array",
@@ -38313,37 +35084,22 @@
             "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created."
           },
           "error": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FineTuningJobError"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "fine_tuned_model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "fine_tuned_model": {
+            "type": "string",
+            "nullable": true
+          },
+          "finished_at": {
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "hyperparameters": {
             "allOf": [
@@ -38389,41 +35145,28 @@
             "description": "The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`."
           },
           "trained_tokens": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "training_file": {
             "type": "string",
             "description": "The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents)."
           },
           "validation_file": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "integrations": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FineTuningIntegration"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FineTuningIntegration"
+            },
+            "nullable": true
           },
           "seed": {
             "allOf": [
@@ -38434,30 +35177,21 @@
             "description": "The seed used for the fine-tuning job."
           },
           "estimated_finish": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "method": {
             "$ref": "#/components/schemas/OpenAI.FineTuneMethod"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.",
@@ -38569,14 +35303,8 @@
             "type": "string"
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -38655,13 +35383,17 @@
                 "type": "string",
                 "enum": [
                   "auto"
-                ]
+                ],
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
+                "type": "integer",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.integer"
+                  }
+                ],
+                "nullable": true
               }
             ],
             "default": "auto"
@@ -38731,35 +35463,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -38787,25 +35505,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -38813,7 +35519,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -38876,22 +35582,6 @@
           "incomplete"
         ]
       },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionObject": {
         "type": "object",
         "required": [
@@ -38910,20 +35600,14 @@
             "$ref": "#/components/schemas/OpenAI.FunctionParameters"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
       "OpenAI.FunctionParameters": {
         "type": "object",
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.\nOmitting `parameters` defines a function with an empty parameter list."
       },
       "OpenAI.FunctionShellAction": {
@@ -38941,24 +35625,22 @@
             }
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Execute a shell command.",
@@ -38978,24 +35660,22 @@
             "description": "Ordered shell commands for the execution environment to run."
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Commands and limits describing how to run the shell tool call.",
@@ -39209,7 +35889,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -39241,7 +35922,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -39328,14 +36010,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -39348,7 +36022,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -39371,7 +36046,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -39381,14 +36057,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -39402,17 +36070,17 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellToolParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "name": {
             "type": "string",
@@ -39537,46 +36205,25 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
             "description": "The name of the function to call."
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "parameters": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {}
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {},
+            "nullable": true
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "defer_loading": {
             "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
+            "nullable": true
           }
         },
         "allOf": [
@@ -39587,62 +36234,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -39990,8 +36636,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -40014,7 +36659,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -40044,21 +36690,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -40102,14 +36741,12 @@
             "default": "auto"
           },
           "input_fidelity": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.InputFidelity"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "input_image_mask": {
             "allOf": [
@@ -40186,7 +36823,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -40203,7 +36840,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -40344,35 +36982,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -40400,25 +37024,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -40426,7 +37038,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -40505,35 +37117,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -40555,53 +37153,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "file_data": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "file_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           }
         },
         "description": "A file input to the model.",
@@ -40624,25 +37190,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -40650,7 +37204,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -40672,35 +37226,21 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.DetailEnum"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision)",
@@ -40728,9 +37268,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -40751,56 +37288,6 @@
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
       },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
         "required": [
@@ -40820,14 +37307,8 @@
             "default": "apply_patch_call"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -40878,14 +37359,8 @@
             "default": "apply_patch_call_output"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -40902,14 +37377,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -40960,34 +37429,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -41006,14 +37463,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string",
@@ -41047,14 +37498,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -41075,27 +37520,19 @@
             "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
           },
           "acknowledged_safety_checks": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
+            },
+            "nullable": true
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41112,6 +37549,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -41134,9 +37572,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -41187,10 +37622,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -41296,17 +37727,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -41326,14 +37751,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -41375,14 +37794,12 @@
             "description": "Text, image, or file output of the function tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41402,14 +37819,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -41435,24 +37846,21 @@
             "description": "The shell commands and limits that describe how to run the tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41472,14 +37880,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -41504,24 +37906,21 @@
             "description": "Captured chunks of stdout and stderr output, along with their associated outcomes."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41535,7 +37934,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -41544,8 +37942,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -41558,10 +37955,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -41621,14 +38014,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41711,19 +38098,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -41794,14 +38175,8 @@
             "x-stainless-const": true
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "approval_request_id": {
             "type": "string",
@@ -41812,14 +38187,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41863,7 +38232,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41909,18 +38279,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -41931,14 +38295,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -41986,16 +38344,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -42035,14 +38383,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -42076,143 +38418,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -42229,9 +38434,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -42307,6 +38509,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -42314,6 +38562,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -42391,7 +38688,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -42399,9 +38696,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -42422,56 +38716,6 @@
         },
         "description": "Content item used to generate a response."
       },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
         "required": [
@@ -42491,14 +38735,8 @@
             "default": "apply_patch_call"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -42549,14 +38787,8 @@
             "default": "apply_patch_call_output"
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -42573,14 +38805,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -42631,34 +38857,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -42677,14 +38891,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "type": {
             "type": "string",
@@ -42718,14 +38926,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -42746,27 +38948,19 @@
             "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
           },
           "acknowledged_safety_checks": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
+            },
+            "nullable": true
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -42783,6 +38977,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -42805,9 +39000,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -42858,10 +39050,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -42940,17 +39128,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -42969,50 +39154,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -43106,14 +39247,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -43168,34 +39303,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -43250,6 +39373,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -43272,9 +39396,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -43301,11 +39422,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -43321,8 +39441,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -43352,9 +39471,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -43380,10 +39497,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -43489,17 +39602,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -43549,20 +39656,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -43608,7 +39714,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -43621,14 +39727,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -43646,7 +39751,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -43655,8 +39759,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -43669,10 +39772,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -43699,64 +39798,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -43790,14 +39831,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -43880,19 +39915,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -43976,14 +40005,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -44027,7 +40050,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -44073,18 +40097,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -44095,14 +40113,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -44158,16 +40170,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -44199,14 +40201,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -44240,138 +40236,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -44382,9 +40246,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -44504,17 +40365,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -44534,14 +40389,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -44583,14 +40432,12 @@
             "description": "Text, image, or file output of the function tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -44610,14 +40457,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -44643,24 +40484,21 @@
             "description": "The shell commands and limits that describe how to run the tool call."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -44680,14 +40518,8 @@
         ],
         "properties": {
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "call_id": {
             "type": "string",
@@ -44712,24 +40544,21 @@
             "description": "Captured chunks of stdout and stderr output, along with their associated outcomes."
           },
           "status": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallItemStatus"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -44743,7 +40572,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -44752,8 +40580,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -44766,10 +40593,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -44829,14 +40652,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -44846,59 +40663,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -44972,19 +40736,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -45055,14 +40813,8 @@
             "x-stainless-const": true
           },
           "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "approval_request_id": {
             "type": "string",
@@ -45073,14 +40825,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -45124,7 +40870,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -45170,18 +40917,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -45192,14 +40933,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -45247,16 +40982,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -45296,14 +41021,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -45350,7 +41069,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -45378,19 +41098,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -45402,56 +41117,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -45545,14 +41214,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -45607,34 +41270,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -45645,50 +41296,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -45711,9 +41325,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -45740,11 +41351,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -45760,8 +41370,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -45791,126 +41400,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -45952,17 +41442,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -46012,20 +41496,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -46071,7 +41554,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -46084,14 +41567,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -46106,67 +41588,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -46174,8 +41598,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -46217,9 +41640,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -46253,14 +41723,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -46270,59 +41734,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -46396,19 +41807,13 @@
             "description": "A JSON string of the output of the local shell tool call."
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "nullable": true
           }
         },
         "allOf": [
@@ -46492,14 +41897,8 @@
             "description": "Whether the request was approved."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -46543,7 +41942,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -46589,18 +41989,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -46611,14 +42005,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -46666,16 +42054,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -46694,200 +42072,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -46904,11 +42088,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -46921,8 +42100,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -47005,143 +42182,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -47158,9 +42198,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -47272,7 +42309,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -47313,24 +42351,12 @@
             "x-stainless-const": true
           },
           "first_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "last_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "x-ms-list-continuation-token": true
           },
           "has_more": {
@@ -47404,7 +42430,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -47414,6 +42441,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -47440,42 +42483,29 @@
             "description": "The command to run."
           },
           "timeout_ms": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "working_directory": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "env": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Environment variables to set for the command.",
             "x-oaiTypeLabel": "map"
           },
           "user": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "Execute a shell command on the server.",
@@ -47493,7 +42523,8 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local_shell"
           },
           "name": {
             "type": "string",
@@ -47577,14 +42608,8 @@
             "description": "The name of the tool."
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "input_schema": {
             "allOf": [
@@ -47595,14 +42620,13 @@
             "description": "The JSON schema describing the tool's input."
           },
           "annotations": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.MCPListToolsToolAnnotations"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "A tool available on an MCP server.",
@@ -47661,17 +42685,11 @@
             "description": "Optional description of the MCP server, used to provide more context."
           },
           "headers": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
           },
           "allowed_tools": {
             "anyOf": [
@@ -47679,37 +42697,41 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "nullable": true
               },
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
-              },
-              {
-                "type": "null"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolFilter"
+                  }
+                ],
+                "nullable": true
               }
             ]
           },
           "require_approval": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/OpenAI.MCPToolRequireApproval"
+                  }
+                ],
+                "nullable": true
               },
               {
                 "type": "string",
                 "enum": [
                   "always",
                   "never"
-                ]
-              },
-              {
-                "type": "null"
+                ],
+                "nullable": true
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -47784,8 +42806,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -47806,35 +42827,21 @@
             "default": "input_file"
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "filename": {
             "type": "string",
             "description": "The name of the file to be sent to the model."
-          },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
           },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -47862,25 +42869,13 @@
             "default": "input_image"
           },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "format": "uri",
+            "nullable": true
           },
           "file_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "detail": {
             "allOf": [
@@ -47888,7 +42883,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -48051,14 +43046,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -48082,7 +43069,7 @@
       },
       "OpenAI.Metadata": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "type": "string"
         },
         "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -48091,13 +43078,18 @@
       "OpenAI.ModelIdsCompaction": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.ModelIdsResponses"
+              }
+            ],
+            "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.",
+            "nullable": true
           },
           {
-            "type": "string"
-          },
-          {
-            "type": "null"
+            "type": "string",
+            "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.",
+            "nullable": true
           }
         ],
         "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models."
@@ -48138,182 +43130,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -48328,7 +43144,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -48345,19 +43162,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -48367,57 +43171,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -48618,19 +43371,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -48638,55 +43385,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -48780,14 +43481,8 @@
             "description": "The status of the apply patch tool call output. One of `completed` or `failed`."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -48842,34 +43537,22 @@
             "description": "The ID of the container used to run the code."
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "outputs": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
-                    },
-                    {
-                      "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
-                    }
-                  ]
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputLogs"
+                },
+                {
+                  "$ref": "#/components/schemas/OpenAI.CodeInterpreterOutputImage"
                 }
-              },
-              {
-                "type": "null"
-              }
-            ]
+              ]
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -48924,6 +43607,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -48946,9 +43630,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -48975,128 +43656,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -49115,10 +43681,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -49126,18 +43688,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -49145,7 +43695,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -49187,17 +43738,11 @@
             "description": "The queries used to search for files."
           },
           "results": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FileSearchToolCallResults"
+            },
+            "nullable": true
           }
         },
         "allOf": [
@@ -49247,20 +43792,19 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "environment": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.FunctionShellCallEnvironment"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -49306,7 +43850,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -49319,14 +43863,13 @@
             "description": "An array of shell call output contents"
           },
           "max_output_length": {
-            "anyOf": [
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "created_by": {
             "type": "string",
@@ -49344,7 +43887,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -49353,8 +43895,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -49367,10 +43908,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -49397,64 +43934,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -49488,14 +43967,8 @@
             "description": "The status of the image generation call."
           },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -49553,54 +44026,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -49644,54 +44069,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -49725,7 +44102,8 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -49771,18 +44149,12 @@
             "description": "A JSON string of the arguments passed to the tool."
           },
           "output": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           "status": {
             "allOf": [
@@ -49793,14 +44165,8 @@
             "description": "The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`."
           },
           "approval_request_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -49848,16 +44214,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -49897,14 +44253,8 @@
             "description": "The unique identifier of the reasoning content."
           },
           "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "summary": {
             "type": "array",
@@ -49938,138 +44288,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -50081,19 +44299,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -50101,9 +44313,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -50302,34 +44512,20 @@
             "description": "The unique identifier of the prompt template to use."
           },
           "version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "variables": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponsePromptVariables"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
-      },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
       },
       "OpenAI.RankerVersionType": {
         "type": "string",
@@ -50367,123 +44563,6 @@
           }
         }
       },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
-      },
       "OpenAI.Reasoning": {
         "type": "object",
         "properties": {
@@ -50491,57 +44570,39 @@
             "$ref": "#/components/schemas/OpenAI.ReasoningEffort"
           },
           "summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "auto",
+              "concise",
+              "detailed"
+            ],
+            "nullable": true
           },
           "generate_summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "auto",
+              "concise",
+              "detailed"
+            ],
+            "nullable": true
           }
         },
         "description": "**gpt-5 and o-series models only**\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).",
         "title": "Reasoning"
       },
       "OpenAI.ReasoningEffort": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ]
-          },
-          {
-            "type": "null"
-          }
+        "type": "string",
+        "enum": [
+          "none",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
         ],
-        "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`."
+        "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`.",
+        "nullable": true
       },
       "OpenAI.ReasoningTextContent": {
         "type": "object",
@@ -50582,45 +44643,41 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "top_logprobs": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "temperature": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true
+          },
+          "top_logprobs": {
+            "type": "integer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              }
+            ],
+            "nullable": true
+          },
+          "temperature": {
+            "type": "number",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.numeric"
+              }
+            ],
+            "nullable": true,
             "default": 1
           },
           "top_p": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.numeric"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "default": 1
           },
           "user": {
@@ -50630,8 +44687,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -50641,62 +44697,51 @@
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_memory",
-                  "24h"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "in-memory",
+              "24h"
+            ],
+            "nullable": true
           },
           "previous_response_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "model": {
             "type": "string",
             "description": "The model deployment to use for the creation of this response."
           },
           "reasoning": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "background": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           },
-          "max_tool_calls": {
-            "anyOf": [
+          "max_output_tokens": {
+            "type": "integer",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
+          },
+          "max_tool_calls": {
+            "type": "integer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
+              }
+            ],
+            "nullable": true
           },
           "text": {
             "$ref": "#/components/schemas/OpenAI.ResponseTextParam"
@@ -50718,18 +44763,12 @@
             "$ref": "#/components/schemas/OpenAI.Prompt"
           },
           "truncation": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "auto",
-                  "disabled"
-                ]
-              },
-              {
-                "type": "null"
-              }
+            "type": "string",
+            "enum": [
+              "auto",
+              "disabled"
             ],
+            "nullable": true,
             "default": "disabled"
           },
           "id": {
@@ -50762,37 +44801,27 @@
             "description": "Unix timestamp (in seconds) of when this Response was created."
           },
           "completed_at": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "type": "integer",
-            "format": "unixTimestamp"
+            "format": "unixtime",
+            "nullable": true
           },
           "error": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponseError"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "incomplete_details": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ResponseIncompleteDetails"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "output": {
             "type": "array",
@@ -50811,34 +44840,16 @@
                 "items": {
                   "$ref": "#/components/schemas/OpenAI.InputItem"
                 }
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "output_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
-          },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "parallel_tool_calls": {
             "type": "boolean",
@@ -50846,24 +44857,13 @@
             "default": true
           },
           "conversation": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
               }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            ],
+            "nullable": true
           },
           "agent": {
             "allOf": [
@@ -50878,14 +44878,13 @@
             "description": "The session identifier for this response. Currently only relevant for hosted agents.\nAlways returned for hosted agents — either the caller-provided value, the auto-derived value,\nor an auto-generated UUID. Use for session-scoped operations and to maintain sandbox\naffinity in follow-up calls."
           },
           "agent_reference": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/AgentReference"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "description": "The agent used for this response"
           },
           "content_filters": {
@@ -50924,15 +44923,10 @@
           },
           "delta": {
             "type": "string",
-            "contentEncoding": "base64",
+            "format": "base64",
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -50964,11 +44958,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -51005,11 +44994,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -51041,11 +45025,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -51096,11 +45075,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -51151,11 +45125,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -51201,11 +45170,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -51251,11 +45215,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -51301,11 +45260,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -51346,11 +45300,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -51414,11 +45363,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -51482,11 +45426,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -51527,11 +45466,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -51582,11 +45516,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -51638,11 +45567,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -51711,28 +45635,16 @@
             "x-stainless-const": true
           },
           "code": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "message": {
             "type": "string",
             "description": "The error message."
           },
           "param": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "sequence_number": {
             "allOf": [
@@ -51743,11 +45655,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -51788,11 +45695,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -51838,11 +45740,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -51888,11 +45785,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -51938,11 +45830,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -52017,20 +45904,14 @@
             "$ref": "#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
       "OpenAI.ResponseFormatJsonSchemaSchema": {
         "type": "object",
-        "unevaluatedProperties": {},
+        "additionalProperties": {},
         "description": "The schema for the response format, described as a JSON Schema object.\nLearn how to build JSON schemas [here](https://json-schema.org/).",
         "title": "JSON schema"
       },
@@ -52095,11 +45976,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -52154,11 +46030,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -52204,11 +46075,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -52255,11 +46121,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -52306,11 +46167,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -52371,11 +46227,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -52417,11 +46268,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -52474,11 +46320,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -52510,7 +46351,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -52569,11 +46410,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -52625,11 +46461,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -52676,11 +46507,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -52727,11 +46553,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -52778,11 +46599,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -52829,11 +46645,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -52880,11 +46691,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -52931,11 +46737,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -52986,11 +46787,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -53040,11 +46836,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -53117,11 +46908,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -53132,7 +46918,7 @@
       },
       "OpenAI.ResponsePromptVariables": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "anyOf": [
             {
               "type": "string"
@@ -53186,11 +46972,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -53255,11 +47036,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -53342,11 +47118,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -53425,11 +47196,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -53489,11 +47255,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -53553,11 +47314,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -53617,11 +47373,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -53681,11 +47432,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -53745,151 +47491,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -53961,11 +47568,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -54033,11 +47635,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -54170,11 +47767,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -54220,11 +47812,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -54270,11 +47857,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -54294,7 +47876,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -54321,7 +47904,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -54354,19 +47938,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -54377,13 +47948,6 @@
         "description": "A scroll action.",
         "title": "Scroll"
       },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
       "OpenAI.SearchContextSize": {
         "type": "string",
         "enum": [
@@ -54393,31 +47957,16 @@
         ]
       },
       "OpenAI.ServiceTier": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
           "flex",
+          "scale",
           "priority"
-        ]
+        ],
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.",
+        "nullable": true
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -54432,7 +47981,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -54463,7 +48013,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -54486,7 +48037,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -54510,7 +48062,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -54537,7 +48090,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -54660,14 +48214,8 @@
             "$ref": "#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema"
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "boolean",
+            "nullable": true
           }
         },
         "allOf": [
@@ -54716,10 +48264,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -54752,7 +48297,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "unevaluatedProperties": {}
+              "additionalProperties": {}
             },
             "description": "A list of tool definitions that the model should be allowed to call.\n  For the Responses API, the list of tool definitions might look like:\n  ```json\n  [\n    { \"type\": \"function\", \"name\": \"get_weather\" },\n    { \"type\": \"mcp\", \"server_label\": \"deepwiki\" },\n    { \"type\": \"image_generation\" }\n  ]\n  ```"
           }
@@ -54775,46 +48320,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -54961,14 +48466,8 @@
             "description": "The label of the MCP server to use."
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "allOf": [
@@ -55013,9 +48512,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -55039,9 +48536,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -55086,64 +48581,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -55154,7 +48591,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -55163,8 +48599,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -55229,7 +48663,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -55251,14 +48686,13 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
             ],
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be         useful for storing additional information about the object in a structured         format, and querying for objects via API or the dashboard.\n  Keys are strings with a maximum length of 64 characters. Values are strings         with a maximum length of 512 characters."
           }
         }
@@ -55279,7 +48713,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -55317,7 +48752,7 @@
       },
       "OpenAI.VectorStoreFileAttributes": {
         "type": "object",
-        "unevaluatedProperties": {
+        "additionalProperties": {
           "anyOf": [
             {
               "type": "string"
@@ -55334,20 +48769,14 @@
         "x-oaiTypeLabel": "map"
       },
       "OpenAI.Verbosity": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
-          },
-          {
-            "type": "null"
-          }
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high"
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`.",
+        "nullable": true
       },
       "OpenAI.WaitParam": {
         "type": "object",
@@ -55361,7 +48790,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -55416,15 +48846,9 @@
             "x-stainless-const": true
           },
           "url": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "format": "uri",
+            "nullable": true,
             "description": "The URL opened by the model."
           }
         },
@@ -55434,7 +48858,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -55447,7 +48872,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -55485,8 +48910,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -55506,44 +48930,20 @@
             "default": "approximate"
           },
           "country": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "region": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "city": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "nullable": true
           }
         },
         "description": "The approximate location of the user.",
@@ -55561,17 +48961,17 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "allOf": [
@@ -55580,12 +48980,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -55607,27 +49001,26 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchToolFilters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "type": "string",
@@ -55668,17 +49061,11 @@
         "type": "object",
         "properties": {
           "allowed_domains": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
           }
         }
       },
@@ -55770,7 +49157,7 @@
           },
           "spec": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The openapi function shape, described as a JSON Schema object."
           },
           "auth": {
@@ -55803,7 +49190,7 @@
                 },
                 "parameters": {
                   "type": "object",
-                  "unevaluatedProperties": {},
+                  "additionalProperties": {},
                   "description": "The parameters the functions accepts, described as a JSON Schema object."
                 }
               },
@@ -56054,32 +49441,58 @@
         ],
         "description": "An OpenAPI tool stored in a toolbox."
       },
-      "OptimizationAgentIdentifier": {
+      "OptimizationAgentDefinition": {
         "type": "object",
-        "required": [
-          "agent_name"
-        ],
         "properties": {
-          "agent_name": {
+          "agentName": {
             "type": "string",
-            "description": "Registered Foundry agent name (required)."
+            "description": "Agent name."
           },
-          "agent_version": {
+          "agentVersion": {
             "type": "string",
-            "description": "Pinned agent version. Defaults to latest if omitted."
+            "description": "Agent version."
+          },
+          "model": {
+            "type": "string",
+            "description": "Model deployment name."
+          },
+          "systemPrompt": {
+            "type": "string",
+            "description": "System prompt / instructions."
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Agent skills."
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "description": "Agent tools."
           }
         },
-        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config."
+        "description": "Agent definition returned in response payloads (includes resolved config)."
       },
       "OptimizationCandidate": {
         "type": "object",
         "required": [
           "name",
-          "avg_score",
-          "avg_tokens"
+          "config",
+          "mutations",
+          "avgScore",
+          "avgTokens",
+          "passRate",
+          "taskScores",
+          "isParetoOptimal"
         ],
         "properties": {
-          "candidate_id": {
+          "candidateId": {
             "type": "string",
             "description": "Server-assigned candidate identifier. Use with GET /candidates/{id} sub-endpoints."
           },
@@ -56087,26 +49500,50 @@
             "type": "string",
             "description": "Display name of the candidate (e.g., 'baseline', 'instruction-v2')."
           },
+          "config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationAgentDefinition"
+              }
+            ],
+            "description": "The agent configuration that produced this candidate."
+          },
           "mutations": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "What was mutated from the baseline (e.g., {system_prompt: 'new prompt'})."
+            "additionalProperties": {},
+            "description": "What was mutated from the baseline (e.g., {systemPrompt: 'new prompt'})."
           },
-          "avg_score": {
+          "avgScore": {
             "type": "number",
             "format": "double",
             "description": "Average composite score across all tasks."
           },
-          "avg_tokens": {
+          "avgTokens": {
             "type": "number",
             "format": "double",
             "description": "Average token usage across all tasks."
           },
-          "eval_id": {
+          "passRate": {
+            "type": "number",
+            "format": "double",
+            "description": "Fraction of tasks that met the pass threshold."
+          },
+          "taskScores": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimizationTaskResult"
+            },
+            "description": "Individual task-level scores."
+          },
+          "isParetoOptimal": {
+            "type": "boolean",
+            "description": "Whether this candidate is on the Pareto frontier (score vs cost)."
+          },
+          "evalId": {
             "type": "string",
             "description": "Foundry evaluation identifier used to score this candidate."
           },
-          "eval_run_id": {
+          "evalRunId": {
             "type": "string",
             "description": "Foundry evaluation run identifier for this candidate's scoring run."
           },
@@ -56121,166 +49558,17 @@
         },
         "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks."
       },
-      "OptimizationDatasetCriterion": {
-        "type": "object",
-        "required": [
-          "name",
-          "instruction"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Criterion name."
-          },
-          "instruction": {
-            "type": "string",
-            "description": "Criterion instruction / description."
-          }
-        },
-        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring."
-      },
-      "OptimizationDatasetInput": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationDatasetInputType"
-              }
-            ],
-            "description": "Dataset input type discriminator."
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "inline": "#/components/schemas/OptimizationInlineDatasetInput",
-            "reference": "#/components/schemas/OptimizationReferenceDatasetInput"
-          }
-        },
-        "description": "Base discriminated model for dataset input. Either inline items or a registered reference."
-      },
-      "OptimizationDatasetInputType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "inline",
-              "reference"
-            ]
-          }
-        ],
-        "description": "Discriminator values for the dataset input union."
-      },
-      "OptimizationDatasetItem": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string",
-            "description": "The user query / prompt."
-          },
-          "ground_truth": {
-            "type": "string",
-            "description": "Expected ground truth answer."
-          },
-          "desired_num_turns": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 20,
-            "description": "Desired number of conversation turns for simulation mode (1-20)."
-          },
-          "criteria": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OptimizationDatasetCriterion"
-            },
-            "description": "Per-item evaluation criteria."
-          }
-        },
-        "description": "A single item in an inline dataset."
-      },
-      "OptimizationEvaluatorRef": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Evaluator name."
-          },
-          "version": {
-            "type": "string",
-            "description": "Evaluator version. If not specified, the latest version is used."
-          }
-        },
-        "description": "Reference to a named evaluator, optionally pinned to a version."
-      },
-      "OptimizationInlineDatasetInput": {
-        "type": "object",
-        "required": [
-          "type",
-          "items"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "inline"
-            ],
-            "description": "Dataset input type discriminator."
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OptimizationDatasetItem"
-            },
-            "description": "Dataset items."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OptimizationDatasetInput"
-          }
-        ],
-        "description": "Inline dataset — items supplied directly in the request body."
-      },
       "OptimizationJob": {
         "type": "object",
         "required": [
           "id",
           "status",
-          "created_at",
-          "updated_at"
+          "createdAt"
         ],
         "properties": {
           "id": {
             "type": "string",
             "description": "Server-assigned unique identifier.",
-            "readOnly": true
-          },
-          "inputs": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobInputs"
-              }
-            ],
-            "description": "Caller-supplied inputs."
-          },
-          "result": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobResult"
-              }
-            ],
-            "description": "Result produced on success.",
             "readOnly": true
           },
           "status": {
@@ -56301,7 +49589,24 @@
             "description": "Error details — populated only on failure.",
             "readOnly": true
           },
-          "created_at": {
+          "result": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationJobResult"
+              }
+            ],
+            "description": "Result produced on success.",
+            "readOnly": true
+          },
+          "inputs": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationJobInputs"
+              }
+            ],
+            "description": "Caller-supplied inputs."
+          },
+          "createdAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -56310,7 +49615,7 @@
             "description": "The timestamp when the job was created, represented in Unix time.",
             "readOnly": true
           },
-          "updated_at": {
+          "updatedAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -56325,15 +49630,16 @@
                 "$ref": "#/components/schemas/OptimizationJobProgress"
               }
             ],
-            "description": "Progress snapshot. May be present in terminal states reflecting last-known progress.",
+            "description": "Progress while in flight. Absent in terminal states.",
             "readOnly": true
           },
-          "warnings": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Non-fatal warnings emitted at any point during optimization.",
+          "dataset": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetInfo"
+              }
+            ],
+            "description": "Metadata about the dataset used for this optimization job.",
             "readOnly": true
           }
         },
@@ -56343,30 +49649,29 @@
         "type": "object",
         "required": [
           "agent",
-          "train_dataset",
-          "evaluators"
+          "trainDatasetReference"
         ],
         "properties": {
           "agent": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationAgentIdentifier"
+                "$ref": "#/components/schemas/AgentIdentifier"
               }
             ],
             "description": "The agent (and pinned version) being optimized."
           },
-          "train_dataset": {
+          "trainDatasetReference": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationDatasetInput"
+                "$ref": "#/components/schemas/DatasetRef"
               }
             ],
-            "description": "Training dataset — either inline items or a reference to a registered dataset. Required."
+            "description": "Reference to a registered training dataset (required)."
           },
-          "validation_dataset": {
+          "validationDatasetReference": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OptimizationDatasetInput"
+                "$ref": "#/components/schemas/DatasetRef"
               }
             ],
             "description": "Optional held-out validation dataset for measuring generalization of the final candidate."
@@ -56374,9 +49679,9 @@
           "evaluators": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/OptimizationEvaluatorRef"
+              "type": "string"
             },
-            "description": "Job-level evaluators referenced by name and optional version. Required; at least one must be provided."
+            "description": "Job-level evaluators (referenced by name). Per-task criteria may override. Default: ['task_adherence']."
           },
           "options": {
             "allOf": [
@@ -56389,96 +49694,25 @@
         },
         "description": "Caller-supplied inputs for an optimization job."
       },
-      "OptimizationJobListItem": {
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "created_at",
-          "updated_at"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Server-assigned unique identifier.",
-            "readOnly": true
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/JobStatus"
-              }
-            ],
-            "description": "Current lifecycle status.",
-            "readOnly": true
-          },
-          "error": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Error"
-              }
-            ],
-            "description": "Error details — populated only on failure.",
-            "readOnly": true
-          },
-          "created_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The timestamp when the job was created, represented in Unix time.",
-            "readOnly": true
-          },
-          "updated_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The timestamp when the job was last updated, represented in Unix time.",
-            "readOnly": true
-          },
-          "progress": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationJobProgress"
-              }
-            ],
-            "description": "Progress snapshot. May be present in terminal states reflecting last-known progress.",
-            "readOnly": true
-          },
-          "agent": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OptimizationAgentIdentifier"
-              }
-            ],
-            "description": "The agent targeted by this optimization job.",
-            "readOnly": true
-          }
-        },
-        "description": "Slim job representation returned by the LIST endpoint."
-      },
       "OptimizationJobProgress": {
         "type": "object",
         "required": [
-          "candidates_completed",
-          "best_score",
-          "elapsed_seconds"
+          "currentIteration",
+          "bestScore",
+          "elapsedSeconds"
         ],
         "properties": {
-          "candidates_completed": {
+          "currentIteration": {
             "type": "integer",
             "format": "int32",
-            "description": "Number of candidates whose evaluation has completed so far."
+            "description": "1-based current iteration index."
           },
-          "best_score": {
+          "bestScore": {
             "type": "number",
             "format": "double",
             "description": "Best score observed so far across all candidates."
           },
-          "elapsed_seconds": {
+          "elapsedSeconds": {
             "type": "number",
             "format": "double",
             "description": "Wall-clock time elapsed in seconds since the job began executing."
@@ -56490,12 +49724,20 @@
         "type": "object",
         "properties": {
           "baseline": {
-            "type": "string",
-            "description": "Candidate ID of the original (un-optimized) baseline evaluation."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationCandidate"
+              }
+            ],
+            "description": "Evaluation scores for the original (un-optimized) agent configuration."
           },
           "best": {
-            "type": "string",
-            "description": "Candidate ID of the highest-scoring candidate found during optimization."
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationCandidate"
+              }
+            ],
+            "description": "The highest-scoring candidate found during optimization."
           },
           "candidates": {
             "type": "array",
@@ -56503,6 +49745,25 @@
               "$ref": "#/components/schemas/OptimizationCandidate"
             },
             "description": "All evaluated candidates including baseline."
+          },
+          "options": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimizationOptions"
+              }
+            ],
+            "description": "The options used for this optimization run."
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Non-fatal warnings from the optimization run (e.g., target attribute failures that were skipped)."
+          },
+          "allTargetAttributesFailed": {
+            "type": "boolean",
+            "description": "True when all target attributes failed — only the baseline was evaluated."
           }
         },
         "description": "Terminal-state result body. Populated when status is succeeded or failed."
@@ -56510,27 +49771,26 @@
       "OptimizationOptions": {
         "type": "object",
         "properties": {
-          "max_candidates": {
+          "maxIterations": {
             "type": "integer",
             "format": "int32",
-            "minimum": 1,
-            "description": "Maximum number of optimization candidates to generate. Must be >= 1. Default: 5.",
+            "description": "Maximum optimization iterations per strategy. Must be >= 1. Default: 5.",
             "default": 5
           },
-          "optimization_config": {
+          "optimizationConfig": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "Per-target-attribute configuration overrides. Contains skills, tools, system_prompt for the agent, plus model space for model optimization."
+            "additionalProperties": {},
+            "description": "Per-target-attribute configuration overrides. Contains skills, tools, systemPrompt for the agent, plus model space for model optimization."
           },
-          "eval_model": {
+          "evalModel": {
             "type": "string",
             "description": "Model deployment used for evaluation. Defaults to server config (typically 'gpt-4o')."
           },
-          "optimization_model": {
+          "optimizationModel": {
             "type": "string",
             "description": "Model deployment for optimization reasoning (must be gpt-5 family). Falls back to the default eval model when not set."
           },
-          "evaluation_level": {
+          "evaluationLevel": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/EvaluationLevel"
@@ -56541,35 +49801,73 @@
         },
         "description": "Tuning knobs and run-mode for an optimization job."
       },
-      "OptimizationReferenceDatasetInput": {
+      "OptimizationTaskResult": {
         "type": "object",
         "required": [
-          "type",
-          "name"
+          "taskName",
+          "scores",
+          "compositeScore",
+          "tokens",
+          "durationSeconds",
+          "passed"
         ],
         "properties": {
-          "type": {
+          "taskName": {
             "type": "string",
-            "enum": [
-              "reference"
-            ],
-            "description": "Dataset input type discriminator."
+            "description": "Task name (from the dataset)."
           },
-          "name": {
+          "query": {
             "type": "string",
-            "description": "Registered dataset name."
+            "description": "The user query / input for the task."
           },
-          "version": {
+          "scores": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            },
+            "description": "Per-evaluator scores keyed by evaluator name."
+          },
+          "compositeScore": {
+            "type": "number",
+            "format": "double",
+            "description": "Composite score combining all evaluator scores."
+          },
+          "tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total tokens consumed during the agent run for this task."
+          },
+          "durationSeconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Wall-clock seconds for this task's agent execution."
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the task met the pass threshold."
+          },
+          "errorMessage": {
             "type": "string",
-            "description": "Dataset version. If not specified, the latest version is used."
+            "description": "Error message if the task failed during execution."
+          },
+          "rationales": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Per-evaluator reasoning keyed by evaluator name."
+          },
+          "response": {
+            "type": "string",
+            "description": "Raw agent response text."
+          },
+          "runId": {
+            "type": "string",
+            "description": "Identifier of the agent run that produced this result."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OptimizationDatasetInput"
-          }
-        ],
-        "description": "Reference to a registered Foundry dataset."
+        "description": "Per-task evaluation result for a single candidate."
       },
       "OtlpTelemetryEndpoint": {
         "type": "object",
@@ -56589,9 +49887,7 @@
           "endpoint": {
             "type": "string",
             "description": "The OTLP collector endpoint URL.",
-            "examples": [
-              "https://my-collector.example.com/otlp"
-            ]
+            "example": "https://my-collector.example.com/otlp"
           },
           "protocol": {
             "allOf": [
@@ -56600,9 +49896,7 @@
               }
             ],
             "description": "The transport protocol for the OTLP endpoint.",
-            "examples": [
-              "Http"
-            ]
+            "example": "Http"
           }
         },
         "allOf": [
@@ -57049,15 +50343,43 @@
           ]
         }
       },
-      "PromotionInfo": {
+      "PromoteCandidateRequest": {
         "type": "object",
         "required": [
-          "promoted_at",
-          "agent_name",
-          "agent_version"
+          "agentName",
+          "agentVersion"
         ],
         "properties": {
-          "promoted_at": {
+          "agentName": {
+            "type": "string",
+            "description": "Name of the Foundry agent to promote to."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Version of the Foundry agent to promote to."
+          }
+        },
+        "description": "Request body for promoting a candidate to a Foundry agent version."
+      },
+      "PromoteCandidateResponse": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "status",
+          "promotedAt",
+          "agentName",
+          "agentVersion"
+        ],
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "description": "The promoted candidate id."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status after promotion."
+          },
+          "promotedAt": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/FoundryTimestamp"
@@ -57065,11 +50387,38 @@
             ],
             "description": "Timestamp when promotion occurred, represented in Unix time."
           },
-          "agent_name": {
+          "agentName": {
+            "type": "string",
+            "description": "Name of the Foundry agent promoted to."
+          },
+          "agentVersion": {
+            "type": "string",
+            "description": "Version of the Foundry agent promoted to."
+          }
+        },
+        "description": "Response after successfully promoting a candidate."
+      },
+      "PromotionInfo": {
+        "type": "object",
+        "required": [
+          "promotedAt",
+          "agentName",
+          "agentVersion"
+        ],
+        "properties": {
+          "promotedAt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FoundryTimestamp"
+              }
+            ],
+            "description": "Timestamp when promotion occurred, represented in Unix time."
+          },
+          "agentName": {
             "type": "string",
             "description": "Name of the Foundry agent this candidate was promoted to."
           },
-          "agent_version": {
+          "agentVersion": {
             "type": "string",
             "description": "Version of the Foundry agent this candidate was promoted to."
           }
@@ -57094,55 +50443,36 @@
             "description": "The model deployment to use for this agent."
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
+            "nullable": true,
             "description": "A system (or developer) message inserted into the model's context."
           },
           "temperature": {
-            "anyOf": [
-              {
-                "type": "number",
-                "format": "float"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "number",
+            "format": "float",
+            "nullable": true,
             "minimum": 0,
             "maximum": 2,
             "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\nWe generally recommend altering this or `top_p` but not both. Defaults to `1`.",
             "default": 1
           },
           "top_p": {
-            "anyOf": [
-              {
-                "type": "number",
-                "format": "float"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "number",
+            "format": "float",
+            "nullable": true,
             "minimum": 0,
             "maximum": 1,
             "description": "An alternative to sampling with temperature, called nucleus sampling,\nwhere the model considers the results of the tokens with top_p probability\nmass. So 0.1 means only the tokens comprising the top 10% probability mass\nare considered. We generally recommend altering this or `temperature` but not both.\nDefaults to `1`.",
             "default": 1
           },
           "reasoning": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Reasoning"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "tools": {
             "type": "array",
@@ -57172,7 +50502,7 @@
           },
           "structured_inputs": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/StructuredInputDefinition"
             },
             "description": "Set of structured inputs that can participate in prompt template substitution or tool argument bindings."
@@ -57466,7 +50796,7 @@
           },
           "simulationOnly": {
             "type": "boolean",
-            "description": "Simulation-only or Simulation + Evaluation. If `true` the scan outputs conversation not evaluation result. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Simulation-only or Simulation + Evaluation. Default false, if true the scan outputs conversation not evaluation result.",
             "default": false
           },
           "riskCategories": {
@@ -57482,14 +50812,14 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Red team's tags. Unlike properties, tags are fully mutable."
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Red team's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed."
@@ -57717,7 +51047,7 @@
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Mapping from source fields to response_id field, required for retrieving chat history."
@@ -57767,7 +51097,10 @@
       "Routine": {
         "type": "object",
         "required": [
-          "enabled"
+          "name",
+          "enabled",
+          "triggers",
+          "action"
         ],
         "properties": {
           "name": {
@@ -57786,7 +51119,7 @@
           },
           "triggers": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/RoutineTrigger"
             },
             "description": "The triggers configured for the routine."
@@ -57897,6 +51230,10 @@
       },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
+        "required": [
+          "triggers",
+          "action"
+        ],
         "properties": {
           "description": {
             "type": "string",
@@ -57909,7 +51246,7 @@
           },
           "triggers": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/RoutineTrigger"
             },
             "description": "The triggers configured for the routine. In v1, exactly one trigger entry is supported."
@@ -57982,21 +51319,19 @@
       "RoutineRun": {
         "type": "object",
         "required": [
-          "id"
+          "id",
+          "status",
+          "trigger_type",
+          "started_at"
         ],
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique run identifier for the routine attempt.",
-            "readOnly": true
+            "description": "The MLflow run identifier for the routine attempt."
           },
           "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RoutineRunStatus"
-              }
-            ],
-            "description": "The run status."
+            "type": "string",
+            "description": "The underlying MLflow run status."
           },
           "phase": {
             "allOf": [
@@ -58014,10 +51349,6 @@
             ],
             "description": "The trigger type that produced the routine attempt."
           },
-          "trigger_name": {
-            "type": "string",
-            "description": "The configured trigger name that produced the routine attempt."
-          },
           "attempt_source": {
             "allOf": [
               {
@@ -58034,22 +51365,6 @@
             ],
             "description": "The action type dispatched for the routine attempt."
           },
-          "agent_id": {
-            "type": "string",
-            "description": "The project-scoped agent identifier recorded for the routine attempt."
-          },
-          "agent_endpoint_id": {
-            "type": "string",
-            "description": "The legacy endpoint-scoped agent identifier recorded for the routine attempt."
-          },
-          "conversation_id": {
-            "type": "string",
-            "description": "The conversation identifier used by a responses API dispatch."
-          },
-          "session_id": {
-            "type": "string",
-            "description": "The hosted-agent session identifier used by an invocations API dispatch."
-          },
           "triggered_at": {
             "allOf": [
               {
@@ -58057,14 +51372,6 @@
               }
             ],
             "description": "The logical trigger time recorded for the routine attempt."
-          },
-          "scheduled_fire_at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The scheduled fire time recorded for timer and schedule deliveries."
           },
           "started_at": {
             "allOf": [
@@ -58098,11 +51405,6 @@
             "type": "string",
             "description": "The workspace task identifier linked to the routine attempt, when available."
           },
-          "error_status_code": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The downstream error status code captured for a failed attempt, when available."
-          },
           "error_type": {
             "type": "string",
             "description": "The fully qualified error type captured for a failed attempt, when available."
@@ -58110,9 +51412,55 @@
           "error_message": {
             "type": "string",
             "description": "The truncated failure message captured for a failed attempt, when available."
+          },
+          "diagnostics": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RoutineRunDiagnostics"
+              }
+            ],
+            "description": "Diagnostic data captured for the routine attempt."
           }
         },
         "description": "A single routine run returned from the run history API.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V1Preview"
+          ]
+        }
+      },
+      "RoutineRunDiagnostics": {
+        "type": "object",
+        "required": [
+          "parameters",
+          "tags",
+          "metrics"
+        ],
+        "properties": {
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "MLflow parameters recorded on the run, keyed by parameter name."
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "MLflow tags recorded on the run, keyed by tag name."
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            },
+            "description": "Latest MLflow metric values recorded on the run, keyed by metric name."
+          }
+        },
+        "description": "Generic diagnostics captured on a routine run.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V1Preview"
@@ -58141,15 +51489,6 @@
           ]
         }
       },
-      "RoutineRunStatus": {
-        "type": "string",
-        "description": "The status of a routine run.",
-        "x-ms-foundry-meta": {
-          "conditional_previews": [
-            "Routines=V1Preview"
-          ]
-        }
-      },
       "RoutineTrigger": {
         "type": "object",
         "required": [
@@ -58170,8 +51509,7 @@
           "mapping": {
             "schedule": "#/components/schemas/ScheduleRoutineTrigger",
             "timer": "#/components/schemas/TimerRoutineTrigger",
-            "github_issue": "#/components/schemas/GitHubIssueRoutineTrigger",
-            "custom": "#/components/schemas/CustomRoutineTrigger"
+            "github_issue_opened": "#/components/schemas/GitHubIssueOpenedRoutineTrigger"
           }
         },
         "description": "Base model for a routine trigger.",
@@ -58189,8 +51527,7 @@
           {
             "type": "string",
             "enum": [
-              "custom",
-              "github_issue",
+              "github_issue_opened",
               "schedule",
               "timer"
             ]
@@ -58357,21 +51694,21 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Schedule's tags. Unlike properties, tags are fully mutable."
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Schedule's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed."
           },
           "systemData": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "System metadata for the resource.",
@@ -58468,7 +51805,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Properties of the schedule run.",
@@ -58493,7 +51830,7 @@
           },
           "configuration": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Configuration for the task."
@@ -58557,23 +51894,10 @@
       "SessionDirectoryListResponse": {
         "type": "object",
         "required": [
-          "has_more",
           "path",
           "entries"
         ],
         "properties": {
-          "first_id": {
-            "type": "string",
-            "description": "The first ID represented in this list."
-          },
-          "last_id": {
-            "type": "string",
-            "description": "The last ID represented in this list."
-          },
-          "has_more": {
-            "type": "boolean",
-            "description": "A value indicating whether there are additional values available not captured in this list."
-          },
           "path": {
             "type": "string",
             "description": "The path that was listed, relative to the session home directory."
@@ -58585,7 +51909,8 @@
             },
             "description": "The directory entries."
           }
-        }
+        },
+        "description": "Response from listing a directory in a session sandbox."
       },
       "SessionFileWriteResponse": {
         "type": "object",
@@ -58620,16 +51945,12 @@
               }
             ],
             "description": "The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.",
-            "examples": [
-              "log"
-            ]
+            "example": "log"
           },
           "data": {
             "type": "string",
             "description": "The event payload as plain text. Currently JSON-formatted but the schema is not contractual and may change.",
-            "examples": [
-              "{\"timestamp\":\"2026-03-10T09:33:17.121467567+00:00\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}"
-            ]
+            "example": "{\"timestamp\":\"2026-03-10T09:33:17.121467567+00:00\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}"
           }
         },
         "description": "A single Server-Sent Event frame emitted by the hosted agent session log stream.\n\nEach frame contains an `event` field identifying the event type and a `data`\nfield carrying the payload as plain text. Although the current `data` payload\nis JSON-formatted, its schema is not contractual — additional keys may appear\nand the format may change over time. Clients should treat `data` as an\nopaque string and optionally attempt JSON parsing.\n\nNew event types may be added in the future. Clients should gracefully\nignore unrecognized event types.\n\nWire format:\n```\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:33:17.121Z\",\"stream\":\"stdout\",\"message\":\"Starting server on port 18080\"}\n\nevent: log\ndata: {\"timestamp\":\"2026-03-10T09:34:52.714Z\",\"stream\":\"status\",\"message\":\"Successfully connected to container\"}\n```",
@@ -58908,7 +52229,7 @@
           },
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Arbitrary key-value metadata for additional properties."
@@ -59022,12 +52343,12 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema for the structured input (optional)."
           },
           "required": {
             "type": "boolean",
-            "description": "Whether the input property is required when the agent is invoked. The service defaults to `false` if a value is not specified by the caller.",
+            "description": "Whether the input property is required when the agent is invoked. Defaults to `false`.",
             "default": false
           }
         },
@@ -59052,18 +52373,12 @@
           },
           "schema": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The JSON schema for the structured output."
           },
           "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "boolean",
+            "nullable": true,
             "description": "Whether to enforce strict validation. Default `true`."
           }
         },
@@ -59384,7 +52699,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the taxonomy category."
@@ -59418,7 +52733,7 @@
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Additional properties for the taxonomy sub-category."
@@ -59491,12 +52806,10 @@
               "$ref": "#/components/schemas/TelemetryDataKind"
             },
             "description": "Data types to export to this endpoint. Use an empty array to export no data.",
-            "examples": [
-              [
-                "ContainerStdoutStderr",
-                "ContainerOtel",
-                "Metrics"
-              ]
+            "example": [
+              "ContainerStdoutStderr",
+              "ContainerOtel",
+              "Metrics"
             ]
           },
           "auth": {
@@ -59636,12 +52949,11 @@
           },
           "initialization_parameters": {
             "type": "object",
-            "unevaluatedProperties": {},
             "description": "The initialization parameters for the evaluation. Must support structured outputs."
           },
           "data_mapping": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "The model to use for the evaluation. Must support structured outputs."
@@ -59653,7 +52965,8 @@
       "TimerRoutineTrigger": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "at"
         ],
         "properties": {
           "type": {
@@ -59664,12 +52977,12 @@
             "description": "The trigger type."
           },
           "at": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/FoundryTimestamp"
-              }
-            ],
-            "description": "The UTC date and time at which the timer fires."
+            "type": "string",
+            "description": "A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now."
+          },
+          "time_zone": {
+            "type": "string",
+            "description": "An optional IANA or Windows time zone identifier when the timer uses a local timestamp."
           }
         },
         "allOf": [
@@ -59688,7 +53001,7 @@
         "anyOf": [
           {
             "type": "object",
-            "unevaluatedProperties": {}
+            "additionalProperties": {}
           },
           {
             "type": "string"
@@ -59909,7 +53222,7 @@
           },
           "tool_configs": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
             "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime."
@@ -59960,17 +53273,11 @@
         ],
         "properties": {
           "metadata": {
-            "anyOf": [
-              {
-                "type": "object",
-                "unevaluatedProperties": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
             "x-oaiTypeLabel": "map"
           },
@@ -60412,7 +53719,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -60429,7 +53736,7 @@
           },
           "parameter_values": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "The inputs to the manifest that will result in a fully materialized Agent."
           }
         }
@@ -60442,7 +53749,7 @@
         "properties": {
           "metadata": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.",
@@ -60491,18 +53798,17 @@
             "type": "string"
           },
           "metadata": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "properties": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.\n    Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters."
@@ -60518,7 +53824,7 @@
           },
           "tags": {
             "type": "object",
-            "unevaluatedProperties": {
+            "additionalProperties": {
               "type": "string"
             },
             "description": "Tag dictionary. Tags can be added, removed, and updated."
@@ -60779,24 +54085,22 @@
             ]
           },
           "filters": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchToolFilters"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "user_location": {
-            "anyOf": [
+            "type": "object",
+            "allOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.WebSearchApproximateLocation"
-              },
-              {
-                "type": "null"
               }
-            ]
+            ],
+            "nullable": true
           },
           "search_context_size": {
             "type": "string",
@@ -61022,7 +54326,7 @@
           },
           "modelParams": {
             "type": "object",
-            "unevaluatedProperties": {},
+            "additionalProperties": {},
             "description": "Optional parameters passed to the model for evaluation."
           }
         },

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -1,118 +1,36 @@
-openapi: 3.2.0
+openapi: 3.0.0
 info:
   title: Microsoft Foundry
   version: virtual-public-preview
 tags:
-  - name: EvaluationSuiteGenerationJobs
-  - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
   - name: Agents
-    parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
-    parent: Agents Root
-  - name: Agent Invocations WebSocket
-    parent: Agents Root
-    description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
-    parent: Agents Root
-  - name: Agent Session Files
-    parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
   - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
+  - name: Agent Session Files
+  - name: Agent Invocations
+  - name: Agent Invocations WebSocket
   - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
+  - name: Datasets
   - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
   - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
+  - name: Evaluation Rules
+  - name: EvaluationSuiteGenerationJobs
+  - name: Evaluators
+  - name: EvaluatorGenerationJobs
+  - name: Indexes
   - name: Insights
-    parent: Evaluations
+  - name: Models
+  - name: Memory Stores
+  - name: Conversations
+  - name: Evals
+  - name: Fine-Tuning
+  - name: Responses
+  - name: Redteams
+  - name: Routines
+  - name: Schedules
+  - name: Skills
+  - name: Toolboxes
+  - name: DataGenerationJobs
+  - name: AgentOptimizationJobs
 paths:
   /agent_optimization_jobs:
     post:
@@ -127,7 +45,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: Operation-Id
           in: header
           required: false
@@ -159,14 +77,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -178,15 +90,15 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OptimizationJob'
-        description: The job to create.
+              $ref: '#/components/schemas/OptimizationJobInputs'
+        description: The optimization job inputs.
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
     get:
       operationId: AgentOptimizationJobs_list
       summary: Returns a list of agent optimization jobs.
-      description: List optimization jobs. Supports cursor pagination and optional status / agent_name filters.
+      description: List optimization jobs. Supports cursor pagination and optional status / agentName filters.
       parameters:
         - name: Foundry-Features
           in: header
@@ -195,7 +107,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: limit
           in: query
           required: false
@@ -243,7 +155,7 @@ paths:
           schema:
             $ref: '#/components/schemas/JobStatus'
           explode: false
-        - name: agent_name
+        - name: agentName
           in: query
           required: false
           description: Filter to jobs targeting this agent name.
@@ -271,7 +183,7 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/OptimizationJobListItem'
+                      $ref: '#/components/schemas/OptimizationJob'
                     description: The requested list of items.
                   first_id:
                     type: string
@@ -283,14 +195,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -299,12 +205,12 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
   /agent_optimization_jobs/{jobId}:
     get:
       operationId: AgentOptimizationJobs_get
       summary: Get info about an agent optimization job.
-      description: Get an optimization job by id.
+      description: Get an optimization job by id. Returns 202 while in progress, 200 when terminal.
       parameters:
         - name: Foundry-Features
           in: header
@@ -313,7 +219,7 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
@@ -333,7 +239,6 @@ paths:
           headers:
             Retry-After:
               required: false
-              description: Recommended number of seconds to wait before polling again.
               schema:
                 type: integer
                 format: int32
@@ -341,14 +246,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
+        '202':
+          description: The request has been accepted for processing, but processing has not yet completed.
+          headers:
+            Retry-After:
+              required: false
+              schema:
+                type: integer
+                format: int32
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                $ref: '#/components/schemas/OptimizationJob'
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -357,7 +268,7 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
     delete:
       operationId: AgentOptimizationJobs_delete
       summary: Deletes an agent optimization job.
@@ -370,13 +281,20 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
           description: The ID of the job to delete.
           schema:
             type: string
+        - name: force
+          in: query
+          required: false
+          description: When true, force-delete even if the job is in a non-terminal state.
+          schema:
+            type: boolean
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -387,14 +305,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -403,12 +315,12 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
-  /agent_optimization_jobs/{jobId}:cancel:
-    post:
-      operationId: AgentOptimizationJobs_cancel
-      summary: Cancels an agent optimization job.
-      description: Request cancellation of a running or queued job. Returns an error if the job is already in a terminal state.
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates:
+    get:
+      operationId: AgentOptimizationJobs_listCandidates
+      summary: Returns a list of candidates for an optimization job.
+      description: List candidates produced by a job.
       parameters:
         - name: Foundry-Features
           in: header
@@ -417,7 +329,381 @@ paths:
           schema:
             type: string
             enum:
-              - AgentsOptimization=V2Preview
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - has_more
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OptimizationCandidate'
+                    description: The requested list of items.
+                  first_id:
+                    type: string
+                    description: The first ID represented in this list.
+                  last_id:
+                    type: string
+                    description: The last ID represented in this list.
+                  has_more:
+                    type: boolean
+                    description: A value indicating whether there are additional values available not captured in this list.
+                description: The response data for a requested list of items.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}:
+    get:
+      operationId: AgentOptimizationJobs_getCandidate
+      summary: Get a candidate by id.
+      description: Get a single candidate's metadata, manifest, and promotion info.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateMetadata'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/config:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateConfig
+      summary: Get candidate deploy config.
+      description: Get the candidate's deploy config JSON. Used to compose `agents.create_version(...)` from a candidate.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateDeployConfig'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/files:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateFile
+      summary: Get a candidate file.
+      description: Stream a specific file from the candidate's blob directory.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: Relative path of the file to download (e.g. 'files/examples.jsonl').
+          schema:
+            type: string
+          explode: false
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}/results:
+    get:
+      operationId: AgentOptimizationJobs_getCandidateResults
+      summary: Get candidate evaluation results.
+      description: Get full per-task evaluation results for a candidate.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CandidateResults'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}/candidates/{candidateId}:promote:
+    post:
+      operationId: AgentOptimizationJobs_promoteCandidate
+      summary: Promote a candidate.
+      description: Promotes a candidate, recording the deployment timestamp and target agent version.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
+        - name: jobId
+          in: path
+          required: true
+          description: The optimization job id.
+          schema:
+            type: string
+        - name: candidateId
+          in: path
+          required: true
+          description: The candidate id to promote.
+          schema:
+            type: string
+        - name: api-version
+          in: query
+          required: true
+          description: The API version to use for this operation.
+          schema:
+            type: string
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromoteCandidateResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+      tags:
+        - AgentOptimizationJobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromoteCandidateRequest'
+        description: Promotion details.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - AgentsOptimization=V1Preview
+  /agent_optimization_jobs/{jobId}:cancel:
+    post:
+      operationId: AgentOptimizationJobs_cancel
+      summary: Cancels an agent optimization job.
+      description: Request cancellation. Idempotent on terminal states.
+      parameters:
+        - name: Foundry-Features
+          in: header
+          required: false
+          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
+          schema:
+            type: string
+            enum:
+              - AgentsOptimization=V1Preview
         - name: jobId
           in: path
           required: true
@@ -438,14 +724,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OptimizationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -454,7 +734,7 @@ paths:
         - AgentOptimizationJobs
       x-ms-foundry-meta:
         conditional_previews:
-          - AgentsOptimization=V2Preview
+          - AgentsOptimization=V1Preview
   /agents:
     post:
       operationId: Agents_createAgent_Agents_createAgentFromCode
@@ -486,12 +766,11 @@ paths:
           schema:
             type: string
       description: |-
-        Creates a new agent or a new version of an existing agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.
+        Creates the agent. Creates a new code-based agent. Uploads the code zip and creates the agent in a single call.
         The agent name is provided in the `x-ms-agent-name` header since POST /agents has no name in the URL path.
         The SHA-256 hex digest of the zip is provided in the `x-ms-code-zip-sha256` header for integrity and dedup.
         The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
         Maximum upload size is 250 MB.
-      summary: Create an agent Create a new code-based agent
       responses:
         '200':
           description: The request has succeeded.
@@ -499,20 +778,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new agent or a new version of an existing agent.
-      x-ms-summary-override: Create an agent
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
@@ -532,8 +803,7 @@ paths:
                 contentType: application/json
     get:
       operationId: Agents_listAgents
-      summary: List agents
-      description: Returns a paged collection of agent resources.
+      description: Returns the list of all agents.
       parameters:
         - name: kind
           in: query
@@ -615,14 +885,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -632,7 +896,6 @@ paths:
   /agents/endpoint/protocols/invocations_ws:
     get:
       operationId: AgentWebsocket_connectEndpointWebsocket
-      summary: Establish a WebSocket connection to a hosted agent
       description: |-
         Establishes a WebSocket connection to a hosted agent. The target project and
         agent are passed as query parameters. The service resolves (or creates) a
@@ -706,14 +969,8 @@ paths:
           content:
             application/json:
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -726,8 +983,7 @@ paths:
   /agents/{agent_name}:
     get:
       operationId: Agents_getAgent
-      summary: Get an agent
-      description: Retrieves an agent definition by its unique name.
+      description: Retrieves the agent.
       parameters:
         - name: agent_name
           in: path
@@ -749,14 +1005,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -797,7 +1047,6 @@ paths:
         If the code and definition are unchanged (matched by x-ms-code-zip-sha256 header), returns the existing version.
         The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
         Maximum upload size is 250 MB.
-      summary: Update an agent Update a code-based agent
       responses:
         '200':
           description: The request has succeeded.
@@ -805,20 +1054,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Updates the agent by adding a new version if there are any changes to the agent definition. If no changes, returns the existing agent version.
-      x-ms-summary-override: Update an agent
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
@@ -838,7 +1079,6 @@ paths:
                 contentType: application/json
     delete:
       operationId: Agents_deleteAgent
-      summary: Delete an agent
       description: |-
         Deletes an agent. For hosted agents, if any version has active sessions, the request
         is rejected with HTTP 409 unless `force` is set to true. When force is true, all
@@ -853,7 +1093,7 @@ paths:
         - name: force
           in: query
           required: false
-          description: For Hosted Agents, if `true`, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.
+          description: For Hosted Agents, if true, force-deletes the agent even if its versions have active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.
           schema:
             type: boolean
             default: false
@@ -872,14 +1112,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAgentResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -888,8 +1122,7 @@ paths:
         - Agents
     patch:
       operationId: Agents_patchAgentObject
-      summary: Update an agent endpoint
-      description: Applies a merge-patch update to the specified agent endpoint configuration.
+      description: Updates an agent endpoint.
       parameters:
         - name: Foundry-Features
           in: header
@@ -905,7 +1138,6 @@ paths:
           description: The name of the agent to retrieve.
           schema:
             type: string
-            title: The name of the agent to retrieve
         - name: api-version
           in: query
           required: true
@@ -920,14 +1152,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -946,9 +1172,8 @@ paths:
   /agents/{agent_name}/code:download:
     get:
       operationId: Agents_downloadAgentCode
-      summary: Download agent code
       description: |-
-        Downloads the code zip for a code-based hosted agent.
+        Download the code zip for a code-based hosted agent.
         Returns the previously-uploaded zip (`application/zip`).
 
         If `agent_version` is supplied, returns that version's code zip; otherwise
@@ -1003,15 +1228,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1024,7 +1244,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations:
     post:
       operationId: AgentInvocations_createAgentInvocation
-      summary: Create an agent invocation
       description: Creates an invocation for the specified agent version.
       parameters:
         - name: agent_name
@@ -1078,14 +1297,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1104,7 +1317,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/docs/openapi.json:
     get:
       operationId: AgentInvocations_getAgentInvocationOpenApiSpec
-      summary: Get an agent invocation OpenAPI spec
       description: |-
         Retrieves the OpenAPI specification for an agent version's invocation contract.
         Returns 404 if the agent does not expose an OpenAPI specification.
@@ -1137,15 +1349,9 @@ paths:
             application/json:
               schema:
                 type: object
-                unevaluatedProperties: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                additionalProperties: {}
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1158,7 +1364,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}:
     get:
       operationId: AgentInvocations_getAgentInvocation
-      summary: Get an agent invocation
       description: |-
         Retrieves the invocation with the given ID.
         Returns 404 if the agent does not support this operation or if the invocation ID is not found.
@@ -1208,14 +1413,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1228,7 +1427,6 @@ paths:
   /agents/{agent_name}/endpoint/protocols/invocations/{invocation_id}/cancel:
     post:
       operationId: AgentInvocations_cancelAgentInvocation
-      summary: Cancel an agent invocation
       description: |-
         Cancels an invocation.
         Returns 404 if the agent does not support this operation or if the invocation ID is not found.
@@ -1278,14 +1476,8 @@ paths:
           content:
             '*/*':
               schema: {}
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1304,7 +1496,6 @@ paths:
   /agents/{agent_name}/endpoint/sessions:
     post:
       operationId: Agents_createSession
-      summary: Create a session
       description: |-
         Creates a new session for an agent endpoint.
         The endpoint resolves the backing agent version from `version_indicator` and
@@ -1344,20 +1535,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentSessionResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       requestBody:
         required: true
         content:
@@ -1369,8 +1554,7 @@ paths:
           - AgentEndpoints=V1Preview
     get:
       operationId: Agents_listSessions
-      summary: List sessions for an agent
-      description: Returns a paged collection of sessions associated with the specified agent endpoint.
+      description: Returns a list of sessions for the specified agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1465,30 +1649,23 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files:
     get:
       operationId: AgentSessionFiles_listSessionFiles
-      summary: List session files
       description: |-
-        Returns files and directories at the specified path in the session sandbox.
-        The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
+        List files and directories at a given path in the session sandbox.
+        Returns only the immediate children of the specified directory (non-recursive).
       parameters:
         - name: Foundry-Features
           in: header
@@ -1512,8 +1689,8 @@ paths:
             type: string
         - name: path
           in: query
-          required: false
-          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+          required: true
+          description: The directory path to list, relative to the session home directory.
           schema:
             type: string
           explode: false
@@ -1523,46 +1700,6 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
-        - name: limit
-          in: query
-          required: false
-          description: |-
-            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
-            default is 20.
-          schema:
-            type: integer
-            format: int32
-            default: 20
-          explode: false
-        - name: order
-          in: query
-          required: false
-          description: |-
-            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
-            for descending order.
-          schema:
-            $ref: '#/components/schemas/PageOrder'
-          explode: false
-        - name: after
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include after=obj_foo in order to fetch the next page of the list.
-          schema:
-            type: string
-          explode: false
-        - name: before
-          in: query
-          required: false
-          description: |-
-            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
-            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
-            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
-          schema:
-            type: string
-          explode: false
         - name: api-version
           in: query
           required: true
@@ -1577,14 +1714,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SessionDirectoryListResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1596,10 +1727,9 @@ paths:
           - HostedAgents=V1Preview
     delete:
       operationId: AgentSessionFiles_deleteSessionFile
-      summary: Delete a session file
       description: |-
-        Deletes the specified file or directory from the session sandbox.
-        When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
+        Delete a file or directory from the session sandbox.
+        If `recursive` is false (default) and the target is a non-empty directory, the API returns 409 Conflict.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1631,7 +1761,7 @@ paths:
         - name: recursive
           in: query
           required: false
-          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+          description: Whether to recursively delete directory contents. Defaults to false.
           schema:
             type: boolean
             default: false
@@ -1652,14 +1782,8 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1672,10 +1796,9 @@ paths:
   /agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content:
     put:
       operationId: AgentSessionFiles_uploadSessionFile
-      summary: Upload a session file
       description: |-
-        Uploads binary file content to the specified path in the session sandbox.
-        The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
+        Upload a file to the session sandbox via binary stream.
+        Maximum file size is 50 MB. Uploads exceeding this limit return 413 Payload Too Large.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1724,14 +1847,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SessionFileWriteResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1743,16 +1860,14 @@ paths:
         content:
           application/octet-stream:
             schema:
-              contentMediaType: application/octet-stream
+              type: string
+              format: binary
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
     get:
       operationId: AgentSessionFiles_downloadSessionFile
-      summary: Download a session file
-      description: |-
-        Downloads the file at the specified sandbox path as a binary stream.
-        The path is resolved relative to the session home directory.
+      description: Download a file from the session sandbox as a binary stream.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1800,15 +1915,10 @@ paths:
           content:
             application/octet-stream:
               schema:
-                contentMediaType: application/octet-stream
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -1821,8 +1931,7 @@ paths:
   /agents/{agent_name}/endpoint/sessions/{session_id}:
     get:
       operationId: Agents_getSession
-      summary: Get a session
-      description: Retrieves the details of a hosted agent session by agent name and session identifier.
+      description: Retrieves a session by ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1864,26 +1973,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentSessionResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
     delete:
       operationId: Agents_deleteSession
-      summary: Delete a session
       description: |-
         Deletes a session synchronously.
         Returns 204 No Content when the session is deleted or does not exist.
@@ -1924,28 +2026,23 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/endpoint/sessions/{session_id}:stop:
     post:
       operationId: Agents_stopSession
-      summary: Stop a session
-      description: Terminates the specified hosted agent session and returns 204 No Content when the request succeeds.
+      description: |-
+        Stops a session.
+        Returns 204 No Content when the stop succeeds.
       parameters:
         - name: Foundry-Features
           in: header
@@ -1977,27 +2074,20 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - AgentEndpoints=V1Preview
   /agents/{agent_name}/import:
     post:
       operationId: Agents_updateAgentFromManifest
-      summary: Update an agent from a manifest
       description: |-
         Updates the agent from a manifest by adding a new version if there are any changes to the agent definition.
         If no changes, returns the existing agent version.
@@ -2022,14 +2112,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2045,8 +2129,7 @@ paths:
   /agents/{agent_name}/operations:
     get:
       operationId: AgentContainers_listAgentContainerOperations
-      summary: List agent container operations
-      description: Returns container operations recorded for the specified agent across its container lifecycle.
+      description: List container operations for an agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2135,14 +2218,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2155,8 +2232,7 @@ paths:
   /agents/{agent_name}/operations/{operation_id}:
     get:
       operationId: AgentContainers_getAgentContainerOperation
-      summary: Get an agent container operation
-      description: Retrieves the status and details of the specified container operation for an agent.
+      description: Get the status of a container operation for an agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2192,14 +2268,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerOperationObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2243,13 +2313,7 @@ paths:
           description: SHA-256 hex digest of the uploaded code zip. Used for change detection (dedup) and integrity verification.
           schema:
             type: string
-      description: |-
-        Creates a new version for the specified agent and returns the created version resource. Creates a new agent version from code. Uploads the code zip and creates a new version
-        for an existing agent. The SHA-256 hex digest of the zip is provided in the
-        `x-ms-code-zip-sha256` header for integrity and dedup.
-        The request body is multipart/form-data with a JSON metadata part and a binary code part (part order is irrelevant).
-        Maximum upload size is 250 MB.
-      summary: Create an agent version Create an agent version from code
+      description: Create a new agent version.
       responses:
         '200':
           description: The request has succeeded.
@@ -2257,25 +2321,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new version for the specified agent and returns the created version resource.
-      x-ms-summary-override: Create an agent version
       x-ms-foundry-meta:
         required_previews:
           - CodeAgents=V1Preview
       tags:
-        - Agent Versions
+        - Agents
       requestBody:
         required: true
         content:
@@ -2290,8 +2346,7 @@ paths:
                 contentType: application/json
     get:
       operationId: Agents_listAgentVersions
-      summary: List agent versions
-      description: Returns a paged collection of versions for the specified agent.
+      description: Returns the list of versions of an agent.
       parameters:
         - name: agent_name
           in: path
@@ -2372,25 +2427,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
   /agents/{agent_name}/versions/{agent_version}:
     get:
       operationId: Agents_getAgentVersion
-      summary: Get an agent version
-      description: Retrieves the specified version of an agent by its agent name and version identifier.
+      description: Retrieves a specific version of an agent.
       parameters:
         - name: agent_name
           in: path
@@ -2418,23 +2466,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
     delete:
       operationId: Agents_deleteAgentVersion
-      summary: Delete an agent version
       description: |-
         Deletes a specific version of an agent. For hosted agents, if the version has active
         sessions, the request is rejected with HTTP 409 unless `force` is set to true. When
@@ -2455,7 +2496,7 @@ paths:
         - name: force
           in: query
           required: false
-          description: For Hosted Agents, if `true`, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. The service defaults to `false` if a value is not specified by the caller. This value is not relevant for other Agent types.
+          description: For Hosted Agents, if true, force-deletes the version even if it has active sessions, cascading deletion to all associated sessions. Defaults to `false`. This value is not relevant for other Agent types.
           schema:
             type: boolean
             default: false
@@ -2474,27 +2515,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteAgentVersionResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
   /agents/{agent_name}/versions/{agent_version}/containers/default:
     get:
       operationId: AgentContainers_getAgentContainer
-      summary: Get an agent container
-      description: |-
-        Retrieves the default container resource for the specified agent version.
-        The response includes the current container state and configuration.
+      description: Get a container for a specific version of an agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2530,14 +2562,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2550,8 +2576,7 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default/operations:
     get:
       operationId: AgentContainers_listAgentVersionContainerOperations
-      summary: List agent version container operations
-      description: Returns container operations for the default container of the specified agent version.
+      description: List container operations for a specific version of an agent.
       parameters:
         - name: Foundry-Features
           in: header
@@ -2646,14 +2671,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2666,10 +2685,10 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default:delete:
     post:
       operationId: AgentContainers_deleteAgentContainer
-      summary: Delete an agent container
       description: |-
-        Deletes the default container for the specified agent version.
-        The long-running operation returns an operation resource that can be polled to completion.
+        Delete a container for a specific version of an agent. If the container doesn't exist, the operation will be no-op.
+        The operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.
+        https://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations
       parameters:
         - name: Foundry-Features
           in: header
@@ -2711,14 +2730,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerOperationObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2731,10 +2744,23 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default:logstream:
     post:
       operationId: AgentContainers_streamAgentContainerLogs
-      summary: Stream agent container logs
       description: |-
-        Streams console or system logs from the default container for the specified agent version.
-        Clients can target a specific replica and request trailing log lines before the chunked text stream begins.
+        Container log entry streamed from the container as text chunks.
+        Each chunk is a UTF-8 string that may be either a plain text log line
+        or a JSON-formatted log entry, depending on the type of container log being streamed.
+        Clients should treat each chunk as opaque text and, if needed, attempt
+        to parse it as JSON based on their logging requirements.
+
+        For system logs, the format is JSON with the following structure:
+        {"TimeStamp":"2025-12-15T16:51:33Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Connecting to the events collector...","Reason":"StartingGettingEvents","EventSource":"ContainerAppController","Count":1}
+        {"TimeStamp":"2025-12-15T16:51:34Z","Type":"Normal","ContainerAppName":null,"RevisionName":null,"ReplicaName":null,"Msg":"Successfully connected to events server","Reason":"ConnectedToEventsServer","EventSource":"ContainerAppController","Count":1}
+
+        For console logs, the format is plain text as emitted by the container's stdout/stderr.
+        2025-12-15T08:43:48.72656  Connecting to the container 'agent-container'...
+        2025-12-15T08:43:48.75451  Successfully Connected to container: 'agent-container' [Revision: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b', Replica: 'je90fe655aa742ef9a188b9fd14d6764--7tca06b-6898b9c89f-mpkjc']
+        2025-12-15T08:33:59.0671054Z stdout F INFO:     127.0.0.1:42588 - "GET /readiness HTTP/1.1" 200 OK
+        2025-12-15T08:34:29.0649033Z stdout F INFO:     127.0.0.1:60246 - "GET /readiness HTTP/1.1" 200 OK
+        2025-12-15T08:34:59.0644467Z stdout F INFO:     127.0.0.1:43994 - "GET /readiness HTTP/1.1" 200 OK
       parameters:
         - name: Foundry-Features
           in: header
@@ -2788,14 +2814,8 @@ paths:
       responses:
         '200':
           description: The request has succeeded.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2808,10 +2828,10 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default:start:
     post:
       operationId: AgentContainers_startAgentContainer
-      summary: Start an agent container
       description: |-
-        Starts the default container for the specified agent version.
-        The long-running operation provisions replicas when a container is not already running.
+        Start a container for a specific version of an agent. If the container is already running, the operation will be no-op.
+        The operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.
+        https://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations
       parameters:
         - name: Foundry-Features
           in: header
@@ -2853,14 +2873,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerOperationObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2890,10 +2904,10 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default:stop:
     post:
       operationId: AgentContainers_stopAgentContainer
-      summary: Stop an agent container
       description: |-
-        Stops the default container for the specified agent version.
-        The long-running operation completes even when the container is already stopped.
+        Stop a container for a specific version of an agent. If the container is not running, or already stopped, the operation will be no-op.
+        The operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.
+        https://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations
       parameters:
         - name: Foundry-Features
           in: header
@@ -2935,14 +2949,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerOperationObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -2955,10 +2963,10 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/containers/default:update:
     post:
       operationId: AgentContainers_updateAgentContainer
-      summary: Update an agent container
       description: |-
-        Updates the replica settings for the default container of the specified agent version.
-        The long-running operation applies changes only when a container is already running.
+        Update a container for a specific version of an agent. If the container is not running, the operation will be no-op.
+        The operation is a long-running operation. Following the design guidelines for long-running operations in Azure REST APIs.
+        https://github.com/microsoft/api-guidelines/blob/vNext/azure/ConsiderationsForServiceDesign.md#action-operations
       parameters:
         - name: Foundry-Features
           in: header
@@ -3000,14 +3008,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentContainerOperationObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3035,7 +3037,6 @@ paths:
   /agents/{agent_name}/versions/{agent_version}/sessions/{session_id}:logstream:
     get:
       operationId: Agents_getSessionLogStream
-      summary: Stream console logs for a hosted agent session
       description: |-
         Streams console logs (stdout / stderr) for a specific hosted agent session
         as a Server-Sent Events (SSE) stream.
@@ -3104,28 +3105,21 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/SessionLogEvent'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Sessions
+        - Agents
       x-ms-foundry-meta:
         required_previews:
           - HostedAgents=V1Preview
   /agents/{agent_name}/versions:import:
     post:
       operationId: Agents_createAgentVersionFromManifest
-      summary: Create an agent version from manifest
-      description: Imports the provided manifest to create a new version for the specified agent.
+      description: Create a new agent version from a manifest.
       parameters:
         - name: agent_name
           in: path
@@ -3152,20 +3146,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
-        - Agent Versions
+        - Agents
       requestBody:
         required: true
         content:
@@ -3175,8 +3163,7 @@ paths:
   /agents:import:
     post:
       operationId: Agents_createAgentFromManifest
-      summary: Create an agent from a manifest
-      description: Imports the provided manifest to create an agent and returns the created resource.
+      description: Creates an agent from a manifest.
       parameters:
         - name: api-version
           in: query
@@ -3192,14 +3179,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3215,21 +3196,20 @@ paths:
   /connections:
     get:
       operationId: Connections_list
-      summary: List connections
-      description: Returns the connections available in the current project, optionally filtered by type or default status.
+      description: List all connections in the project, without populating connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: connectionType
           in: query
           required: false
-          description: Lists connections of this specific type
+          description: List connections of this specific type
           schema:
             $ref: '#/components/schemas/ConnectionType'
           explode: false
         - name: defaultConnection
           in: query
           required: false
-          description: Lists connections that are default connections
+          description: List connections that are default connections
           schema:
             type: boolean
           explode: false
@@ -3247,20 +3227,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedConnection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3276,8 +3244,7 @@ paths:
   /connections/{name}:
     get:
       operationId: Connections_get
-      summary: Get a connection
-      description: Retrieves the specified connection and its configuration details without including credential values.
+      description: Get a connection by name, without populating connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3300,20 +3267,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Connection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3329,8 +3284,7 @@ paths:
   /connections/{name}/getConnectionWithCredentials:
     post:
       operationId: Connections_getWithCredentials
-      summary: Get a connection with credentials
-      description: Retrieves the specified connection together with its credential values.
+      description: Get a connection by name, with its connection credentials
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3353,20 +3307,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Connection'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3382,7 +3324,7 @@ paths:
   /data_generation_jobs:
     get:
       operationId: DataGenerationJobs_list
-      summary: List data generation jobs
+      summary: Returns a list of data generation jobs
       description: Returns a list of data generation jobs.
       parameters:
         - name: Foundry-Features
@@ -3466,14 +3408,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3485,8 +3421,8 @@ paths:
           - DataGenerationJobs=V1Preview
     post:
       operationId: DataGenerationJobs_create
-      summary: Create a data generation job
-      description: Submits a new data generation job for asynchronous execution.
+      summary: Creates a data generation job.
+      description: Creates a data generation job.
       parameters:
         - name: Foundry-Features
           in: header
@@ -3527,14 +3463,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3554,8 +3484,8 @@ paths:
   /data_generation_jobs/{jobId}:
     get:
       operationId: DataGenerationJobs_get
-      summary: Get a data generation job
-      description: Retrieves the specified data generation job and its current status.
+      summary: Get info about a data generation job.
+      description: Gets the details of a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -3592,14 +3522,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3611,8 +3535,8 @@ paths:
           - DataGenerationJobs=V1Preview
     delete:
       operationId: DataGenerationJobs_delete
-      summary: Delete a data generation job
-      description: Removes the specified data generation job and its associated output.
+      summary: Deletes a data generation job.
+      description: Deletes a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -3638,14 +3562,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3658,8 +3576,8 @@ paths:
   /data_generation_jobs/{jobId}:cancel:
     post:
       operationId: DataGenerationJobs_cancel
-      summary: Cancel a data generation job
-      description: Cancels the specified data generation job if it is still in progress.
+      summary: Cancels a data generation job.
+      description: Cancels a data generation job by its ID.
       parameters:
         - name: Foundry-Features
           in: header
@@ -3689,14 +3607,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -3709,7 +3621,6 @@ paths:
   /datasets:
     get:
       operationId: Datasets_listLatest
-      summary: List latest versions
       description: List the latest version of each DatasetVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3720,20 +3631,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3749,7 +3648,6 @@ paths:
   /datasets/{name}/versions:
     get:
       operationId: Datasets_listVersions
-      summary: List versions
       description: List all versions of the given DatasetVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3766,20 +3664,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3795,7 +3681,6 @@ paths:
   /datasets/{name}/versions/{version}:
     get:
       operationId: Datasets_getVersion
-      summary: Get a version
       description: Get the specific version of the DatasetVersion. The service returns 404 Not Found error if the DatasetVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3818,20 +3703,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3846,7 +3719,6 @@ paths:
         - Datasets
     delete:
       operationId: Datasets_deleteVersion
-      summary: Delete a version
       description: Delete the specific version of the DatasetVersion. The service returns 204 No Content if the DatasetVersion was deleted successfully or if the DatasetVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3865,20 +3737,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3893,7 +3753,6 @@ paths:
         - Datasets
     patch:
       operationId: Datasets_createOrUpdateVersion
-      summary: Create or update a version
       description: Create a new or update an existing DatasetVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -3922,20 +3781,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -3958,8 +3805,7 @@ paths:
   /datasets/{name}/versions/{version}/credentials:
     post:
       operationId: Datasets_getCredentials
-      summary: Get dataset credentials
-      description: Gets the SAS credential to access the storage account associated with a Dataset version.
+      description: Get the SAS credential to access the storage account associated with a Dataset version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -3981,20 +3827,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4010,8 +3844,7 @@ paths:
   /datasets/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Datasets_startPendingUploadVersion
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified dataset version.
+      description: Start a new or get an existing pending upload of a dataset for a specific version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4033,20 +3866,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PendingUploadResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4069,8 +3890,7 @@ paths:
   /deployments:
     get:
       operationId: Deployments_list
-      summary: List deployments
-      description: Returns the deployed models available in the current project, optionally filtered by publisher, model name, or deployment type.
+      description: List all deployed models in the project
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: modelPublisher
@@ -4108,20 +3928,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedDeployment'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4137,8 +3945,7 @@ paths:
   /deployments/{name}:
     get:
       operationId: Deployments_get
-      summary: Get a deployment
-      description: Gets a deployed model.
+      description: Get a deployed model.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -4161,20 +3968,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Deployment'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4190,7 +3985,7 @@ paths:
   /evaluation_suite_generation_jobs:
     post:
       operationId: EvaluationSuiteGenerationJobs_create
-      summary: Create an evaluation suite generation job
+      summary: Creates an evaluation suite generation job.
       description: Create a new job (preview). Includes optional Foundry-Features header and Operation-Id for idempotent retries.
       parameters:
         - name: Foundry-Features
@@ -4232,14 +4027,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4258,7 +4047,7 @@ paths:
           - Evaluations=V1Preview
     get:
       operationId: EvaluationSuiteGenerationJobs_list
-      summary: List evaluation suite generation jobs
+      summary: Returns a list of evaluation suite generation jobs.
       description: List jobs with cursor-based pagination (preview). Includes optional Foundry-Features header.
       parameters:
         - name: Foundry-Features
@@ -4342,14 +4131,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4362,7 +4145,7 @@ paths:
   /evaluation_suite_generation_jobs/{jobId}:
     get:
       operationId: EvaluationSuiteGenerationJobs_get
-      summary: Get an evaluation suite generation job
+      summary: Get info about an evaluation suite generation job.
       description: Get a job by ID (preview). Includes optional Foundry-Features header.
       parameters:
         - name: Foundry-Features
@@ -4400,14 +4183,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4419,7 +4196,7 @@ paths:
           - Evaluations=V1Preview
     delete:
       operationId: EvaluationSuiteGenerationJobs_delete
-      summary: Delete an evaluation suite generation job
+      summary: Deletes an evaluation suite generation job.
       description: Delete a job (preview). Returns 204 No Content.
       parameters:
         - name: Foundry-Features
@@ -4446,14 +4223,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4466,7 +4237,7 @@ paths:
   /evaluation_suite_generation_jobs/{jobId}:cancel:
     post:
       operationId: EvaluationSuiteGenerationJobs_cancel
-      summary: Cancel an evaluation suite generation job
+      summary: Cancels an evaluation suite generation job.
       description: Cancel a running job (preview). Returns 200 with the updated job.
       parameters:
         - name: Foundry-Features
@@ -4497,14 +4268,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4517,7 +4282,6 @@ paths:
   /evaluation_suites:
     get:
       operationId: EvaluationSuites_listLatest
-      summary: List latest versions
       description: List the latest version of each EvaluationSuiteVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4535,20 +4299,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationSuiteVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4562,7 +4314,6 @@ paths:
   /evaluation_suites/{name}/versions:
     get:
       operationId: EvaluationSuites_listVersions
-      summary: List versions
       description: List all versions of the given EvaluationSuiteVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4579,20 +4330,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationSuiteVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4605,7 +4344,6 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
     post:
       operationId: EvaluationSuites_createEvaluationSuiteVersion
-      summary: Create an evaluation suite version
       description: Create a new EvaluationSuiteVersion with auto incremented version id
       parameters:
         - name: Foundry-Features
@@ -4636,14 +4374,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteVersion'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4661,7 +4393,6 @@ paths:
   /evaluation_suites/{name}/versions/{version}:
     get:
       operationId: EvaluationSuites_getVersion
-      summary: Get a version
       description: Get the specific version of the EvaluationSuiteVersion. The service returns 404 Not Found error if the EvaluationSuiteVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4684,20 +4415,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4710,7 +4429,6 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
     delete:
       operationId: EvaluationSuites_deleteVersion
-      summary: Delete a version
       description: Delete the specific version of the EvaluationSuiteVersion. The service returns 204 No Content if the EvaluationSuiteVersion was deleted successfully or if the EvaluationSuiteVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4729,20 +4447,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4755,7 +4461,6 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
     patch:
       operationId: EvaluationSuites_createOrUpdateVersion
-      summary: Create or update a version
       description: Create a new or update an existing EvaluationSuiteVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -4784,20 +4489,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4818,8 +4511,7 @@ paths:
   /evaluation_suites/{name}:run:
     post:
       operationId: EvaluationSuites_run
-      summary: Run an evaluation suite
-      description: Runs an evaluation using the suite's testing criteria and dataset.
+      description: Run an evaluation using the suite's testing criteria and dataset.
       parameters:
         - name: Foundry-Features
           in: header
@@ -4849,14 +4541,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationSuiteRunResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -4874,8 +4560,7 @@ paths:
   /evaluationrules:
     get:
       operationId: EvaluationRules_list
-      summary: List evaluation rules
-      description: Returns the evaluation rules configured for the project, optionally filtered by action type, agent name, or enabled state.
+      description: List all evaluation rules.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: actionType
@@ -4906,20 +4591,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4935,8 +4608,7 @@ paths:
   /evaluationrules/{id}:
     get:
       operationId: EvaluationRules_get
-      summary: Get an evaluation rule
-      description: Retrieves the specified evaluation rule and its configuration.
+      description: Get an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -4952,20 +4624,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -4980,8 +4640,7 @@ paths:
         - Evaluation Rules
     delete:
       operationId: EvaluationRules_delete
-      summary: Delete an evaluation rule
-      description: Removes the specified evaluation rule from the project.
+      description: Delete an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -4993,20 +4652,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5021,8 +4668,7 @@ paths:
         - Evaluation Rules
     put:
       operationId: EvaluationRules_createOrUpdate
-      summary: Create or update an evaluation rule
-      description: Creates a new evaluation rule, or replaces the existing rule when the identifier matches.
+      description: Create or update an evaluation rule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -5052,20 +4698,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationRule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5088,8 +4722,7 @@ paths:
   /evaluations/runs:
     get:
       operationId: Evaluations_list
-      summary: List evaluation runs
-      description: Returns the evaluation runs available in the current project.
+      description: List evaluation runs
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - $ref: '#/components/parameters/Azure.Core.ClientRequestIdHeader'
@@ -5106,20 +4739,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluation'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5133,8 +4754,7 @@ paths:
   /evaluations/runs/{name}:
     get:
       operationId: Evaluations_get
-      summary: Get an evaluation run
-      description: Retrieves the specified evaluation run and its current status.
+      description: Get an evaluation run by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -5157,20 +4777,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Evaluation'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5183,8 +4791,7 @@ paths:
                 $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
     delete:
       operationId: Evaluations_delete
-      summary: Delete an evaluation run
-      description: Removes the specified evaluation run from the project.
+      description: Delete an evaluation run by name
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -5203,20 +4810,8 @@ paths:
               description: An opaque, globally-unique, client-generated string identifier for the request.
               schema:
                 $ref: '#/components/schemas/Azure.Core.uuid'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5230,8 +4825,7 @@ paths:
   /evaluations/runs/{name}:cancel:
     post:
       operationId: Evaluations_cancel
-      summary: Cancel an evaluation run
-      description: Cancels the specified evaluation run before it completes.
+      description: Cancel an evaluation run by name
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -5250,20 +4844,8 @@ paths:
               description: An opaque, globally-unique, client-generated string identifier for the request.
               schema:
                 $ref: '#/components/schemas/Azure.Core.uuid'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5277,8 +4859,7 @@ paths:
   /evaluations/runs:run:
     post:
       operationId: Evaluations_create
-      summary: Create an evaluation run
-      description: Submits a new evaluation run with the provided configuration.
+      description: Creates an evaluation run.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
       responses:
@@ -5288,20 +4869,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Evaluation'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5322,8 +4891,7 @@ paths:
   /evaluations/runs:runAgent:
     post:
       operationId: Evaluations_createAgentEvaluation
-      summary: Create an agent evaluation run
-      description: Submits a new agent evaluation run with the provided request.
+      description: Creates an agent evaluation run.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
       responses:
@@ -5333,20 +4901,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentEvaluation'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5367,8 +4923,7 @@ paths:
   /evaluationtaxonomies:
     get:
       operationId: EvaluationTaxonomies_list
-      summary: List evaluation taxonomies
-      description: Returns the evaluation taxonomies available in the project, optionally filtered by input name or input type.
+      description: List evaluation taxonomies
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: inputName
@@ -5400,20 +4955,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5429,8 +4972,7 @@ paths:
   /evaluationtaxonomies/{name}:
     get:
       operationId: EvaluationTaxonomies_get
-      summary: Get an evaluation taxonomy
-      description: Retrieves the specified evaluation taxonomy.
+      description: Get an evaluation run by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -5454,20 +4996,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5482,8 +5012,7 @@ paths:
         - Evaluation Taxonomies
     delete:
       operationId: EvaluationTaxonomies_delete
-      summary: Delete an evaluation taxonomy
-      description: Removes the specified evaluation taxonomy from the project.
+      description: Delete an evaluation taxonomy by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -5503,20 +5032,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5531,8 +5048,7 @@ paths:
         - Evaluation Taxonomies
     put:
       operationId: EvaluationTaxonomies_create
-      summary: Create an evaluation taxonomy
-      description: Creates or replaces the specified evaluation taxonomy with the provided definition.
+      description: Create an evaluation taxonomy.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -5562,20 +5078,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5597,7 +5101,6 @@ paths:
         description: The evaluation taxonomy.
     patch:
       operationId: EvaluationTaxonomies_update
-      summary: Update an evaluation taxonomy
       description: Update an evaluation taxonomy.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -5622,20 +5125,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluationTaxonomy'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -5658,7 +5149,7 @@ paths:
   /evaluator_generation_jobs:
     post:
       operationId: EvaluatorGenerationJobs_create
-      summary: Create an evaluator generation job
+      summary: Creates an evaluator generation job.
       description: |-
         Creates an evaluator generation job. The service generates rubric-based evaluator
         definitions from the provided source materials asynchronously.
@@ -5702,14 +5193,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5728,12 +5213,8 @@ paths:
           - Evaluations=V1Preview
     get:
       operationId: EvaluatorGenerationJobs_list
-      summary: List evaluator generation jobs
-      description: |-
-        Returns a list of evaluator generation jobs. The List API has up to a few
-        seconds of propagation delay, so a recently created job may not appear
-        immediately; use the Get evaluator generation job API with the job ID to
-        retrieve a specific job without delay.
+      summary: Returns a list of evaluator generation jobs.
+      description: Returns a list of evaluator generation jobs.
       parameters:
         - name: Foundry-Features
           in: header
@@ -5816,14 +5297,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5836,7 +5311,7 @@ paths:
   /evaluator_generation_jobs/{jobId}:
     get:
       operationId: EvaluatorGenerationJobs_get
-      summary: Get an evaluator generation job
+      summary: Get info about an evaluator generation job.
       description: Gets the details of an evaluator generation job by its ID.
       parameters:
         - name: Foundry-Features
@@ -5874,14 +5349,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5893,7 +5362,6 @@ paths:
           - Evaluations=V1Preview
     delete:
       operationId: EvaluatorGenerationJobs_delete
-      summary: Delete an evaluator generation job
       description: |-
         Deletes an evaluator generation job by its ID. Deletes the job record only;
         the generated evaluator (if any) is preserved.
@@ -5922,14 +5390,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5942,7 +5404,7 @@ paths:
   /evaluator_generation_jobs/{jobId}:cancel:
     post:
       operationId: EvaluatorGenerationJobs_cancel
-      summary: Cancel an evaluator generation job
+      summary: Cancels an evaluator generation job.
       description: Cancels an evaluator generation job by its ID.
       parameters:
         - name: Foundry-Features
@@ -5973,14 +5435,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorGenerationJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -5993,8 +5449,7 @@ paths:
   /evaluators:
     get:
       operationId: Evaluators_listLatestVersions
-      summary: List latest evaluator versions
-      description: Lists the latest version of each evaluator
+      description: List the latest version of each evaluator
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: type
@@ -6032,20 +5487,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6061,8 +5504,7 @@ paths:
   /evaluators/{name}/versions:
     get:
       operationId: Evaluators_listVersions
-      summary: List evaluator versions
-      description: Returns the available versions for the specified evaluator.
+      description: List all versions of the given evaluator
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6106,20 +5548,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedEvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6134,8 +5564,7 @@ paths:
         - Evaluators
     post:
       operationId: Evaluators_createVersion
-      summary: Create an evaluator version
-      description: Creates a new evaluator version with an auto-incremented version identifier.
+      description: Create a new EvaluatorVersion with auto incremented version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6159,20 +5588,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6194,8 +5611,7 @@ paths:
   /evaluators/{name}/versions/{version}:
     get:
       operationId: Evaluators_getVersion
-      summary: Get an evaluator version
-      description: Retrieves the specified evaluator version, returning 404 if it does not exist.
+      description: Get the specific version of the EvaluatorVersion. The service returns 404 Not Found error if the EvaluatorVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6225,20 +5641,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6253,8 +5657,7 @@ paths:
         - Evaluators
     delete:
       operationId: Evaluators_deleteVersion
-      summary: Delete an evaluator version
-      description: Removes the specified evaluator version. Returns 204 whether the version existed or not.
+      description: Delete the specific version of the EvaluatorVersion. The service returns 204 No Content if the EvaluatorVersion was deleted successfully or if the EvaluatorVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6280,20 +5683,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6308,8 +5699,7 @@ paths:
         - Evaluators
     patch:
       operationId: Evaluators_updateVersion
-      summary: Update an evaluator version
-      description: Updates the specified evaluator version in place.
+      description: Update an existing EvaluatorVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -6339,20 +5729,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvaluatorVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6375,8 +5753,7 @@ paths:
   /evaluators/{name}/versions/{version}/credentials:
     post:
       operationId: Evaluators_getCredentials
-      summary: Get evaluator credentials
-      description: Retrieves SAS credentials for accessing the storage account associated with the specified evaluator version.
+      description: Get the SAS credential to access the storage account associated with an Evaluator version.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6411,14 +5788,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6438,8 +5809,7 @@ paths:
   /evaluators/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Evaluators_startPendingUpload
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified evaluator version.
+      description: Start a new or get an existing pending upload of an evaluator for a specific version.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6474,14 +5844,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PendingUploadResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6501,7 +5865,6 @@ paths:
   /indexes:
     get:
       operationId: Indexes_listLatest
-      summary: List latest versions
       description: List the latest version of each Index
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6512,20 +5875,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedIndex'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6541,7 +5892,6 @@ paths:
   /indexes/{name}/versions:
     get:
       operationId: Indexes_listVersions
-      summary: List versions
       description: List all versions of the given Index
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6558,20 +5908,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedIndex'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6587,7 +5925,6 @@ paths:
   /indexes/{name}/versions/{version}:
     get:
       operationId: Indexes_getVersion
-      summary: Get a version
       description: Get the specific version of the Index. The service returns 404 Not Found error if the Index does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6610,20 +5947,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Index'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6638,7 +5963,6 @@ paths:
         - Indexes
     delete:
       operationId: Indexes_deleteVersion
-      summary: Delete a version
       description: Delete the specific version of the Index. The service returns 204 No Content if the Index was deleted successfully or if the Index does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6657,20 +5981,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6685,7 +5997,6 @@ paths:
         - Indexes
     patch:
       operationId: Indexes_createOrUpdateVersion
-      summary: Create or update a version
       description: Create a new or update an existing Index with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -6714,20 +6025,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Index'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -6750,8 +6049,7 @@ paths:
   /insights:
     post:
       operationId: Insights_generate
-      summary: Generate insights
-      description: Generates an insights report from the provided evaluation configuration.
+      description: Generate Insights
       parameters:
         - name: Foundry-Features
           in: header
@@ -6788,14 +6086,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Insight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6811,8 +6103,7 @@ paths:
         description: Complete evaluation configuration including data source, evaluators, and result settings
     get:
       operationId: Insights_list
-      summary: List insights
-      description: Returns insights in reverse chronological order, with the most recent entries first.
+      description: List all insights in reverse chronological order (newest first).
       parameters:
         - name: Foundry-Features
           in: header
@@ -6871,14 +6162,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedInsight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6888,8 +6173,7 @@ paths:
   /insights/{id}:
     get:
       operationId: Insights_get
-      summary: Get an insight
-      description: Retrieves the specified insight report and its results.
+      description: Get a specific insight by Id.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6926,14 +6210,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Insight'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -6943,8 +6221,6 @@ paths:
   /managedAgentIdentityBlueprints:
     get:
       operationId: ManagedAgentIdentityBlueprints_listManagedAgentIdentityBlueprints
-      summary: List blueprints
-      description: Lists all managed agent identity blueprints.
       parameters:
         - name: Foundry-Features
           in: header
@@ -6988,14 +6264,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedManagedAgentIdentityBlueprint'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7006,8 +6276,6 @@ paths:
   /managedAgentIdentityBlueprints/{blueprint_name}:
     put:
       operationId: ManagedAgentIdentityBlueprints_createOrUpdateManagedAgentIdentityBlueprint
-      summary: Create or update a blueprint
-      description: Creates or updates a managed agent identity blueprint.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7037,14 +6305,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManagedAgentIdentityBlueprint'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7060,7 +6322,6 @@ paths:
           - AgentEndpoints=V1Preview
     get:
       operationId: ManagedAgentIdentityBlueprints_getManagedAgentIdentityBlueprint
-      summary: Get a blueprint
       description: Retrieves a managed agent identity blueprint by name.
       parameters:
         - name: Foundry-Features
@@ -7091,14 +6352,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManagedAgentIdentityBlueprint'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7108,7 +6363,6 @@ paths:
           - AgentEndpoints=V1Preview
     delete:
       operationId: ManagedAgentIdentityBlueprints_deleteManagedAgentIdentityBlueprint
-      summary: Delete a blueprint
       description: Deletes a managed agent identity blueprint by name.
       parameters:
         - name: Foundry-Features
@@ -7135,14 +6389,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7153,8 +6401,7 @@ paths:
   /memory_stores:
     post:
       operationId: createMemoryStore
-      summary: Create a memory store
-      description: Creates a memory store resource with the provided configuration.
+      description: Create a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7178,14 +6425,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7209,7 +6450,7 @@ paths:
                   description: A human-readable description of the memory store.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the memory store.
                 definition:
@@ -7224,8 +6465,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: listMemoryStores
-      summary: List memory stores
-      description: Returns the memory stores available to the caller.
+      description: List all memory stores.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7308,14 +6548,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7328,8 +6562,7 @@ paths:
   /memory_stores/{name}:
     post:
       operationId: updateMemoryStore
-      summary: Update a memory store
-      description: Updates the specified memory store with the supplied configuration changes.
+      description: Update a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7359,14 +6592,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7386,7 +6613,7 @@ paths:
                   description: A human-readable description of the memory store.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the memory store.
       x-ms-foundry-meta:
@@ -7394,8 +6621,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: getMemoryStore
-      summary: Get a memory store
-      description: Retrieves the specified memory store and its current configuration.
+      description: Retrieve a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7425,14 +6651,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7444,8 +6664,7 @@ paths:
           - MemoryStores=V1Preview
     delete:
       operationId: deleteMemoryStore
-      summary: Delete a memory store
-      description: Deletes the specified memory store.
+      description: Delete a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7475,14 +6694,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteMemoryStoreResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7495,8 +6708,7 @@ paths:
   /memory_stores/{name}/items:
     post:
       operationId: createMemory
-      summary: Create a memory item
-      description: Creates a memory item in the specified memory store.
+      description: Create a memory item in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7526,14 +6738,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7567,8 +6773,7 @@ paths:
   /memory_stores/{name}/items/{memory_id}:
     post:
       operationId: updateMemory
-      summary: Update a memory item
-      description: Updates the specified memory item in the memory store.
+      description: Update a memory item in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7604,14 +6809,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7635,8 +6834,7 @@ paths:
           - MemoryStores=V1Preview
     get:
       operationId: getMemory
-      summary: Get a memory item
-      description: Retrieves the specified memory item from the memory store.
+      description: Retrieve a memory item from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7672,14 +6870,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7691,8 +6883,7 @@ paths:
           - MemoryStores=V1Preview
     delete:
       operationId: deleteMemory
-      summary: Delete a memory item
-      description: Deletes the specified memory item from the memory store.
+      description: Delete a memory item from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7728,14 +6919,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteMemoryResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7748,8 +6933,7 @@ paths:
   /memory_stores/{name}/items:list:
     post:
       operationId: listMemories
-      summary: List memory items
-      description: Returns memory items from the specified memory store.
+      description: List all memory items in a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7845,14 +7029,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7877,8 +7055,7 @@ paths:
   /memory_stores/{name}/updates/{update_id}:
     get:
       operationId: getUpdateResult
-      summary: Get an update result
-      description: Retrieves the status and result of a memory store update operation.
+      description: Get memory store update result.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7914,14 +7091,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreUpdateResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7934,8 +7105,7 @@ paths:
   /memory_stores/{name}:delete_scope:
     post:
       operationId: deleteScopeMemories
-      summary: Delete memories by scope
-      description: Deletes all memories in the specified memory store that are associated with the provided scope.
+      description: Delete all memories associated with a specific scope from a memory store.
       parameters:
         - name: Foundry-Features
           in: header
@@ -7965,14 +7135,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreDeleteScopeResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -7997,8 +7161,7 @@ paths:
   /memory_stores/{name}:search_memories:
     post:
       operationId: searchMemories
-      summary: Search memories
-      description: Searches the specified memory store for memories relevant to the provided conversation context.
+      description: Search for relevant memories from a memory store based on conversation context.
       parameters:
         - name: Foundry-Features
           in: header
@@ -8028,14 +7191,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreSearchResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8072,10 +7229,7 @@ paths:
   /memory_stores/{name}:update_memories:
     post:
       operationId: updateMemories
-      summary: Update memories
-      description: |-
-        Starts an update that writes conversation memories into the specified memory store.
-        The operation returns a long-running status location for polling the update result.
+      description: Update memory store with conversation memories.
       parameters:
         - name: Foundry-Features
           in: header
@@ -8112,14 +7266,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MemoryStoreUpdateResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8161,7 +7309,6 @@ paths:
   /models:
     get:
       operationId: Models_listLatest
-      summary: List latest versions
       description: List the latest version of each ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -8180,20 +7327,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8209,7 +7344,6 @@ paths:
   /models/{name}/versions:
     get:
       operationId: Models_listVersions
-      summary: List versions
       description: List all versions of the given ModelVersion
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -8234,20 +7368,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8263,8 +7385,7 @@ paths:
   /models/{name}/versions/{version}:
     get:
       operationId: Models_getVersion
-      summary: Get a model version
-      description: Retrieves the specified model version, returning 404 if it does not exist.
+      description: Get the specific version of the ModelVersion. The service returns 404 Not Found error if the ModelVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -8294,20 +7415,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8325,7 +7434,6 @@ paths:
           - Models=V1Preview
     delete:
       operationId: Models_deleteVersion
-      summary: Delete a model version
       description: Delete the specific version of the ModelVersion. The service returns 200 OK if the ModelVersion was deleted successfully or if the ModelVersion does not exist.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -8352,20 +7460,8 @@ paths:
       responses:
         '200':
           description: The request has succeeded.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8383,7 +7479,6 @@ paths:
           - Models=V1Preview
     patch:
       operationId: Models_updateVersion
-      summary: Update a model version
       description: Update an existing ModelVersion with the given version id
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
@@ -8420,20 +7515,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelVersion'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8459,8 +7542,7 @@ paths:
   /models/{name}/versions/{version}/createAsync:
     post:
       operationId: Models_createAsync
-      summary: Create a model version async
-      description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a location header for polling the operation status.
+      description: Creates a model version asynchronously with blob content validation. Returns 202 Accepted with a Location header for polling.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -8503,25 +7585,12 @@ paths:
                     format: uri
                     description: URL to poll for operation status.
                   operationResult:
-                    anyOf:
-                      - type: string
-                        format: uri
-                      - type: 'null'
+                    type: string
+                    format: uri
+                    nullable: true
                     description: URL to the operation result, or null if the operation is still in progress.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8547,8 +7616,7 @@ paths:
   /models/{name}/versions/{version}/credentials:
     post:
       operationId: Models_getCredentials
-      summary: Get model asset credentials
-      description: Retrieves temporary credentials for accessing the storage backing the specified model version.
+      description: Get credentials for a model version asset.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -8578,20 +7646,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetCredentialResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8616,8 +7672,7 @@ paths:
   /models/{name}/versions/{version}/startPendingUpload:
     post:
       operationId: Models_startPendingUpload
-      summary: Start a pending upload
-      description: Initiates a new pending upload or retrieves an existing one for the specified model version.
+      description: Start or retrieve a pending upload for a model version.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -8647,20 +7702,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ModelPendingUploadResponse'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -8685,8 +7728,7 @@ paths:
   /openai/v1/conversations:
     post:
       operationId: createConversation
-      summary: Create a conversation
-      description: Creates a new conversation resource.
+      description: Create a conversation.
       parameters:
         - name: x-ms-user-isolation-key
           in: header
@@ -8701,14 +7743,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8723,8 +7759,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CreateConversationBody'
     get:
       operationId: listConversations
-      summary: List conversations
-      description: Returns the conversations available in the current project.
+      description: Returns the list of all conversations.
       parameters:
         - name: limit
           in: query
@@ -8812,14 +7847,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8829,8 +7858,7 @@ paths:
   /openai/v1/conversations/{conversation_id}:
     post:
       operationId: updateConversation
-      summary: Update a conversation
-      description: Modifies the specified conversation's properties.
+      description: Update a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -8851,14 +7879,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8873,8 +7895,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.UpdateConversationBody'
     get:
       operationId: getConversation
-      summary: Retrieve a conversation
-      description: Retrieves the specified conversation and its metadata.
+      description: Retrieves a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -8895,14 +7916,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8911,8 +7926,7 @@ paths:
         - Conversations
     delete:
       operationId: deleteConversation
-      summary: Delete a conversation
-      description: Removes the specified conversation resource from the current project.
+      description: Deletes a conversation.
       parameters:
         - name: conversation_id
           in: path
@@ -8933,14 +7947,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.DeletedConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -8950,8 +7958,7 @@ paths:
   /openai/v1/conversations/{conversation_id}/items:
     post:
       operationId: createConversationItems
-      summary: Create conversation items
-      description: Adds one or more items to the specified conversation.
+      description: Create items in a conversation with the given ID.
       parameters:
         - name: conversation_id
           in: path
@@ -8983,14 +7990,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationItemList'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9014,8 +8015,7 @@ paths:
                 - items
     get:
       operationId: listConversationItems
-      summary: List conversation items
-      description: Returns the items belonging to the specified conversation.
+      description: List all items for a conversation with the given ID.
       parameters:
         - name: conversation_id
           in: path
@@ -9102,14 +8102,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9119,8 +8113,7 @@ paths:
   /openai/v1/conversations/{conversation_id}/items/{item_id}:
     get:
       operationId: getConversationItem
-      summary: Get a conversation item
-      description: Retrieves a specific item from the specified conversation.
+      description: Get a single item from a conversation with the given IDs.
       parameters:
         - name: conversation_id
           in: path
@@ -9147,14 +8140,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.OutputItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9163,8 +8150,7 @@ paths:
         - Conversations
     delete:
       operationId: deleteConversationItem
-      summary: Delete a conversation item
-      description: Removes the specified item from a conversation.
+      description: Delete an item from a conversation with the given IDs.
       parameters:
         - name: conversation_id
           in: path
@@ -9191,14 +8177,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ConversationResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9208,8 +8188,8 @@ paths:
   /openai/v1/evals:
     get:
       operationId: Evals_listEvals
-      summary: List evaluations
-      description: Returns the evaluations configured in the current project.
+      summary: List all evaluations
+      description: List evaluations for a project.
       parameters:
         - name: after
           in: query
@@ -9223,7 +8203,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -9275,14 +8256,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9291,9 +8266,9 @@ paths:
         - Evals
     post:
       operationId: Evals_createEval
-      summary: Create an evaluation
+      summary: Create evaluation
       description: |-
-        Creates the structure of an evaluation that can be used to test a model's performance.
+        Create the structure of an evaluation that can be used to test a model's performance.
         An evaluation is a set of testing criteria and the config for a data source, which dictates the schema of the data used in the evaluation. After creating an evaluation, you can run it on different models and model parameters. We support several types of graders and datasources.
         For more information, see the [Evals guide](https://platform.openai.com/docs/guides/evals).
       parameters: []
@@ -9304,14 +8279,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9328,7 +8297,7 @@ paths:
     delete:
       operationId: Evals_deleteEval
       summary: Delete an evaluation
-      description: Removes the specified evaluation and its associated data.
+      description: Delete an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -9343,14 +8312,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteEvalResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9360,7 +8323,7 @@ paths:
     get:
       operationId: Evals_getEval
       summary: Get an evaluation
-      description: Retrieves the specified evaluation and its configuration.
+      description: Get an evaluation by ID.
       parameters:
         - name: eval_id
           in: path
@@ -9375,14 +8338,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9392,7 +8349,7 @@ paths:
     post:
       operationId: Evals_updateEval
       summary: Update an evaluation
-      description: Updates certain properties of an evaluation.
+      description: Update certain properties of an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -9407,14 +8364,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Eval'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9430,8 +8381,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs:
     get:
       operationId: Evals_listRuns
-      summary: List evaluation runs
-      description: Returns the runs associated with the specified evaluation.
+      summary: Get a list of runs for an evaluation
+      description: Get a list of runs for an evaluation.
       parameters:
         - name: eval_id
           in: path
@@ -9451,7 +8402,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -9504,14 +8456,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9520,8 +8466,7 @@ paths:
         - Evals
     post:
       operationId: Evals_createEvalRun
-      summary: Create an evaluation run
-      description: Creates an evaluation run for the specified evaluation.
+      summary: Create evaluation run
       parameters:
         - name: eval_id
           in: path
@@ -9536,14 +8481,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9559,8 +8498,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs/{run_id}:
     delete:
       operationId: Evals_deleteEvalRun
-      summary: Delete an evaluation run
-      description: Removes the specified evaluation run.
+      summary: Delete evaluation run
+      description: Delete an eval run.
       parameters:
         - name: eval_id
           in: path
@@ -9581,14 +8520,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteEvalRunResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9598,7 +8531,7 @@ paths:
     get:
       operationId: Evals_getEvalRun
       summary: Get an evaluation run
-      description: Retrieves the specified evaluation run and its current status.
+      description: Get an evaluation run by ID.
       parameters:
         - name: eval_id
           in: path
@@ -9619,14 +8552,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9635,8 +8562,8 @@ paths:
         - Evals
     post:
       operationId: Evals_cancelEvalRun
-      summary: Cancel an evaluation run
-      description: Cancels an ongoing evaluation run.
+      summary: Cancel evaluation run
+      description: Cancel an ongoing evaluation run.
       parameters:
         - name: eval_id
           in: path
@@ -9657,14 +8584,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9674,8 +8595,8 @@ paths:
   /openai/v1/evals/{eval_id}/runs/{run_id}/output_items:
     get:
       operationId: Evals_getEvalRunOutputItems
-      summary: List evaluation run output items
-      description: Returns the output items produced by the specified evaluation run.
+      summary: Get evaluation run output items
+      description: Get a list of output items for an evaluation run.
       parameters:
         - name: eval_id
           in: path
@@ -9700,7 +8621,8 @@ paths:
           required: false
           description: Number of runs to retrieve.
           schema:
-            $ref: '#/components/schemas/integer'
+            allOf:
+              - $ref: '#/components/schemas/integer'
             default: 20
           explode: false
         - name: order
@@ -9751,14 +8673,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9769,7 +8685,7 @@ paths:
     get:
       operationId: Evals_getEvalRunOutputItem
       summary: Get an output item of an evaluation run
-      description: Retrieves a single output item from the specified evaluation run.
+      description: Get an evaluation run output item by ID.
       parameters:
         - name: eval_id
           in: path
@@ -9796,14 +8712,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvalRunOutputItem'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9813,7 +8723,6 @@ paths:
   /openai/v1/fine_tuning/jobs:
     post:
       operationId: createFineTuningJob
-      summary: Create a fine-tuning job
       description: |-
         Creates a fine-tuning job which begins the process of creating a new model from a given dataset.
 
@@ -9835,14 +8744,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9857,8 +8760,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequest'
     get:
       operationId: listPaginatedFineTuningJobs
-      summary: List fine-tuning jobs
-      description: Returns the fine-tuning jobs for the current organization.
+      description: List your organization's fine-tuning jobs
       parameters:
         - name: after
           in: query
@@ -9890,14 +8792,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListPaginatedFineTuningJobsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9907,9 +8803,8 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}:
     get:
       operationId: retrieveFineTuningJob
-      summary: Get a fine-tuning job
       description: |-
-        Gets info about a fine-tuning job.
+        Get info about a fine-tuning job.
 
         [Learn more about fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)
       parameters:
@@ -9933,14 +8828,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9950,8 +8839,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel:
     post:
       operationId: cancelFineTuningJob
-      summary: Cancel a fine-tuning job
-      description: Immediately cancels the specified fine-tuning job.
+      description: Immediately cancel a fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -9973,14 +8861,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -9990,8 +8872,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints:
     get:
       operationId: listFineTuningJobCheckpoints
-      summary: List fine-tuning job checkpoints
-      description: Returns the checkpoints saved during the specified fine-tuning job.
+      description: List checkpoints for a fine-tuning job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -10029,14 +8910,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListFineTuningJobCheckpointsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10046,8 +8921,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/events:
     get:
       operationId: listFineTuningJobEvents
-      summary: List fine-tuning job events
-      description: Returns the status events emitted during the specified fine-tuning job.
+      description: Get fine-grained status updates for a fine-tuning job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -10085,14 +8959,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.ListFineTuningJobEventsResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10102,8 +8970,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/pause:
     post:
       operationId: pauseFineTuningJob
-      summary: Pause a fine-tuning job
-      description: Pauses the specified fine-tuning job while it is running.
+      description: Pause a running fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -10125,14 +8992,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10142,8 +9003,7 @@ paths:
   /openai/v1/fine_tuning/jobs/{fine_tuning_job_id}/resume:
     post:
       operationId: resumeFineTuningJob
-      summary: Resume a fine-tuning job
-      description: Resumes the specified fine-tuning job after it has been paused.
+      description: Resume a paused fine-tune job.
       parameters:
         - name: fine_tuning_job_id
           in: path
@@ -10165,14 +9025,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.FineTuningJob'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10181,9 +9035,7 @@ paths:
         - Fine-Tuning
   /openai/v1/responses:
     post:
-      operationId: createResponse
-      summary: Create a model response
-      description: Creates a model response. Provide text or image inputs to generate text or JSON outputs. Have the model call your own custom code or use built-in tools like web search or file search to use your own data as input for the model’s response.
+      operationId: createResponse_createResponseStream
       parameters:
         - name: x-ms-user-isolation-key
           in: header
@@ -10191,6 +9043,7 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
+      description: Creates a model response. Creates a model response (streaming response).
       responses:
         '200':
           description: The request has succeeded.
@@ -10203,213 +9056,12 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Metadata'
-                      - type: 'null'
-                  top_logprobs:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  temperature:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.numeric'
-                      - type: 'null'
-                    default: 1
-                  top_p:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.numeric'
-                      - type: 'null'
-                    default: 1
-                  user:
-                    type: string
-                    description: |-
-                      This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
-                        A stable identifier for your end-users.
-                        Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                    deprecated: true
-                  safety_identifier:
-                    type: string
-                    maxLength: 64
-                    description: |-
-                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                  prompt_cache_key:
-                    type: string
-                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTier'
-                  prompt_cache_retention:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - in_memory
-                          - 24h
-                      - type: 'null'
-                  previous_response_id:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
-                  model:
-                    type: string
-                    description: The model deployment to use for the creation of this response.
-                  reasoning:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Reasoning'
-                      - type: 'null'
-                  background:
-                    anyOf:
-                      - type: boolean
-                      - type: 'null'
-                  max_tool_calls:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  text:
-                    $ref: '#/components/schemas/OpenAI.ResponseTextParam'
-                  tools:
-                    $ref: '#/components/schemas/OpenAI.ToolsArray'
-                  tool_choice:
-                    oneOf:
-                      - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
-                      - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-                  prompt:
-                    $ref: '#/components/schemas/OpenAI.Prompt'
-                  truncation:
-                    anyOf:
-                      - type: string
-                        enum:
-                          - auto
-                          - disabled
-                      - type: 'null'
-                    default: disabled
-                  id:
-                    type: string
-                    description: Unique identifier for this Response.
-                  object:
-                    type: string
-                    enum:
-                      - response
-                    description: The object type of this resource - always set to `response`.
-                    x-stainless-const: true
-                  status:
-                    type: string
-                    enum:
-                      - completed
-                      - failed
-                      - in_progress
-                      - cancelled
-                      - queued
-                      - incomplete
-                    description: |-
-                      The status of the response generation. One of `completed`, `failed`,
-                        `in_progress`, `cancelled`, `queued`, or `incomplete`.
-                  created_at:
-                    type: integer
-                    format: unixtime
-                    description: Unix timestamp (in seconds) of when this Response was created.
-                  completed_at:
-                    anyOf:
-                      - type: string
-                        format: date-time
-                      - type: 'null'
-                    type: integer
-                    format: unixTimestamp
-                  error:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseError'
-                      - type: 'null'
-                  incomplete_details:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseIncompleteDetails'
-                      - type: 'null'
-                  output:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/OpenAI.OutputItem'
-                    description: |-
-                      An array of content items generated by the model.
-                        - The length and order of items in the `output` array is dependent
-                        on the model's response.
-                        - Rather than accessing the first item in the `output` array and
-                        assuming it's an `assistant` message with the content generated by
-                        the model, you might consider using the `output_text` property where
-                        supported in SDKs.
-                  instructions:
-                    anyOf:
-                      - type: string
-                      - type: array
-                        items:
-                          $ref: '#/components/schemas/OpenAI.InputItem'
-                      - type: 'null'
-                  output_text:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
-                  usage:
-                    $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
-                  parallel_tool_calls:
-                    type: boolean
-                    description: Whether to allow the model to run tool calls in parallel.
-                    default: true
-                  conversation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
-                      - type: 'null'
-                  agent:
-                    allOf:
-                      - $ref: '#/components/schemas/AgentId'
-                    description: |-
-                      (Deprecated) Use agent_reference instead.
-                      The agent used for this response
-                  agent_session_id:
-                    type: string
-                    description: |-
-                      The session identifier for this response. Currently only relevant for hosted agents.
-                      Always returned for hosted agents — either the caller-provided value, the auto-derived value,
-                      or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
-                      affinity in follow-up calls.
-                  agent_reference:
-                    anyOf:
-                      - $ref: '#/components/schemas/AgentReference'
-                      - type: 'null'
-                    description: The agent used for this response
-                  content_filters:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/ContentFilterResult'
-                    description: The content filter evaluation results.
-                required:
-                  - id
-                  - object
-                  - created_at
-                  - error
-                  - incomplete_details
-                  - output
-                  - instructions
-                  - parallel_tool_calls
-                  - agent_reference
+                $ref: '#/components/schemas/OpenAI.Response'
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/OpenAI.CreateResponseStreamingResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10421,161 +9073,298 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                metadata:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Metadata'
-                    - type: 'null'
-                top_logprobs:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                temperature:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.numeric'
-                    - type: 'null'
-                  default: 1
-                top_p:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.numeric'
-                    - type: 'null'
-                  default: 1
-                user:
-                  type: string
-                  description: |-
-                    This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
-                      A stable identifier for your end-users.
-                      Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                  deprecated: true
-                safety_identifier:
-                  type: string
-                  maxLength: 64
-                  description: |-
-                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
-                prompt_cache_key:
-                  type: string
-                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTier'
-                prompt_cache_retention:
-                  anyOf:
-                    - type: string
+              anyOf:
+                - type: object
+                  properties:
+                    metadata:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Metadata'
+                      nullable: true
+                    top_logprobs:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    temperature:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    top_p:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    user:
+                      type: string
+                      description: |-
+                        This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
+                          A stable identifier for your end-users.
+                          Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      deprecated: true
+                    safety_identifier:
+                      type: string
+                      description: |-
+                        A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                          The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    prompt_cache_key:
+                      type: string
+                      description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                    service_tier:
+                      $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    prompt_cache_retention:
+                      type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
-                    - type: 'null'
-                previous_response_id:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                model:
-                  type: string
-                  description: The model deployment to use for the creation of this response.
-                reasoning:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.Reasoning'
-                    - type: 'null'
-                background:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                max_tool_calls:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                text:
-                  $ref: '#/components/schemas/OpenAI.ResponseTextParam'
-                tools:
-                  $ref: '#/components/schemas/OpenAI.ToolsArray'
-                tool_choice:
-                  oneOf:
-                    - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
-                    - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-                prompt:
-                  $ref: '#/components/schemas/OpenAI.Prompt'
-                truncation:
-                  anyOf:
-                    - type: string
+                      nullable: true
+                    previous_response_id:
+                      type: string
+                      nullable: true
+                    model:
+                      type: string
+                      description: The model deployment to use for the creation of this response.
+                    reasoning:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      nullable: true
+                    background:
+                      type: boolean
+                      nullable: true
+                    max_output_tokens:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    max_tool_calls:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    text:
+                      $ref: '#/components/schemas/OpenAI.ResponseTextParam'
+                    tools:
+                      $ref: '#/components/schemas/OpenAI.ToolsArray'
+                    tool_choice:
+                      oneOf:
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
+                    prompt:
+                      $ref: '#/components/schemas/OpenAI.Prompt'
+                    truncation:
+                      type: string
                       enum:
                         - auto
                         - disabled
-                    - type: 'null'
-                  default: disabled
-                input:
-                  $ref: '#/components/schemas/OpenAI.InputParam'
-                include:
-                  anyOf:
-                    - type: array
+                      nullable: true
+                      default: disabled
+                    input:
+                      $ref: '#/components/schemas/OpenAI.InputParam'
+                    include:
+                      type: array
                       items:
                         $ref: '#/components/schemas/OpenAI.IncludeEnum'
-                    - type: 'null'
-                parallel_tool_calls:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                  default: true
-                store:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                  default: true
-                instructions:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
-                stream:
-                  anyOf:
-                    - type: boolean
-                    - type: 'null'
-                stream_options:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
-                    - type: 'null'
-                conversation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ConversationParam'
-                    - type: 'null'
-                context_management:
-                  anyOf:
-                    - type: array
+                      nullable: true
+                    parallel_tool_calls:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    store:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    instructions:
+                      type: string
+                      nullable: true
+                    stream:
+                      type: boolean
+                      nullable: true
+                    stream_options:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
+                      nullable: true
+                    conversation:
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ConversationParam'
+                      nullable: true
+                    context_management:
+                      type: array
                       items:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
-                    - type: 'null'
-                  description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
-                agent:
-                  allOf:
-                    - $ref: '#/components/schemas/AgentReference'
-                  description: |-
-                    (Deprecated) Use agent_reference instead.
-                    The agent to use for generating the response.
-                agent_session_id:
-                  type: string
-                  description: |-
-                    Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
-                    When provided, the request is routed to the same sandbox. When omitted, auto-derived from
-                    conversation_id/prev_response_id or a new UUID is generated.
-                agent_reference:
-                  allOf:
-                    - $ref: '#/components/schemas/AgentReference'
-                  description: The agent to use for generating the response.
-                structured_inputs:
-                  type: object
-                  unevaluatedProperties: {}
-                  description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                      nullable: true
+                      description: Context management configuration for this request.
+                    agent:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: |-
+                        (Deprecated) Use agent_reference instead.
+                        The agent to use for generating the response.
+                    agent_session_id:
+                      type: string
+                      description: |-
+                        Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+                        When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+                        conversation_id/prev_response_id or a new UUID is generated.
+                    agent_reference:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: The agent to use for generating the response.
+                    structured_inputs:
+                      type: object
+                      additionalProperties: {}
+                      description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
+                - type: object
+                  properties:
+                    metadata:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Metadata'
+                      nullable: true
+                    top_logprobs:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    temperature:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    top_p:
+                      type: number
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.numeric'
+                      nullable: true
+                      default: 1
+                    user:
+                      type: string
+                      description: |-
+                        This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.
+                          A stable identifier for your end-users.
+                          Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      deprecated: true
+                    safety_identifier:
+                      type: string
+                      description: |-
+                        A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                          The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    prompt_cache_key:
+                      type: string
+                      description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                    service_tier:
+                      $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    prompt_cache_retention:
+                      type: string
+                      enum:
+                        - in-memory
+                        - 24h
+                      nullable: true
+                    previous_response_id:
+                      type: string
+                      nullable: true
+                    model:
+                      type: string
+                      description: The model deployment to use for the creation of this response.
+                    reasoning:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.Reasoning'
+                      nullable: true
+                    background:
+                      type: boolean
+                      nullable: true
+                    max_output_tokens:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    max_tool_calls:
+                      type: integer
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.integer'
+                      nullable: true
+                    text:
+                      $ref: '#/components/schemas/OpenAI.ResponseTextParam'
+                    tools:
+                      $ref: '#/components/schemas/OpenAI.ToolsArray'
+                    tool_choice:
+                      oneOf:
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceOptions'
+                        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
+                    prompt:
+                      $ref: '#/components/schemas/OpenAI.Prompt'
+                    truncation:
+                      type: string
+                      enum:
+                        - auto
+                        - disabled
+                      nullable: true
+                      default: disabled
+                    input:
+                      $ref: '#/components/schemas/OpenAI.InputParam'
+                    include:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/OpenAI.IncludeEnum'
+                      nullable: true
+                    parallel_tool_calls:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    store:
+                      type: boolean
+                      nullable: true
+                      default: true
+                    instructions:
+                      type: string
+                      nullable: true
+                    stream:
+                      type: boolean
+                      nullable: true
+                    stream_options:
+                      type: object
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ResponseStreamOptions'
+                      nullable: true
+                    conversation:
+                      allOf:
+                        - $ref: '#/components/schemas/OpenAI.ConversationParam'
+                      nullable: true
+                    context_management:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/OpenAI.ContextManagementParam'
+                      nullable: true
+                      description: Context management configuration for this request.
+                    agent:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: |-
+                        (Deprecated) Use agent_reference instead.
+                        The agent to use for generating the response.
+                    agent_session_id:
+                      type: string
+                      description: |-
+                        Optional session identifier for sandbox affinity. Currently only relevant for hosted agents.
+                        When provided, the request is routed to the same sandbox. When omitted, auto-derived from
+                        conversation_id/prev_response_id or a new UUID is generated.
+                    agent_reference:
+                      allOf:
+                        - $ref: '#/components/schemas/AgentReference'
+                      description: The agent to use for generating the response.
+                    structured_inputs:
+                      type: object
+                      additionalProperties: {}
+                      description: The structured inputs to the response that can participate in prompt template substitution or tool argument bindings.
     get:
       operationId: listResponses
-      summary: List responses
-      description: Returns a collection of all stored responses matching specified filter criteria.
+      description: Returns the list of all responses.
       parameters:
         - name: limit
           in: query
@@ -10670,14 +9459,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10687,8 +9470,7 @@ paths:
   /openai/v1/responses/compact:
     post:
       operationId: compactResponseConversation
-      summary: Compact a conversation
-      description: Compacts a conversation into a response object suitable for long-running and zero-data-retention scenarios.
+      description: Produces a compaction of a responses conversation.
       parameters: []
       responses:
         '200':
@@ -10697,14 +9479,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.CompactResource'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10719,9 +9495,7 @@ paths:
               $ref: '#/components/schemas/OpenAI.CompactResponseMethodPublicBody'
   /openai/v1/responses/{response_id}:
     get:
-      operationId: getResponse
-      summary: Retrieve a model response
-      description: Retrieves a model response with the given ID.
+      operationId: getResponse_getResponseStream
       parameters:
         - name: response_id
           in: path
@@ -10756,6 +9530,14 @@ paths:
           description: Opaque per-user isolation key used to scope endpoint-scoped data (responses, conversations, sessions) to a specific end user.
           schema:
             type: string
+        - name: accept
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - text/event-stream
+      description: Retrieves a model response with the given ID. Retrieves a model response with the given ID (streaming response).
       responses:
         '200':
           description: The request has succeeded.
@@ -10772,14 +9554,8 @@ paths:
             text/event-stream:
               schema:
                 $ref: '#/components/schemas/OpenAI.CreateResponseStreamingResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10788,7 +9564,6 @@ paths:
         - Responses
     delete:
       operationId: deleteResponse
-      summary: Delete a model response
       description: Deletes a model response.
       parameters:
         - name: response_id
@@ -10816,14 +9591,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteResponseResult'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10833,8 +9602,7 @@ paths:
   /openai/v1/responses/{response_id}/cancel:
     post:
       operationId: cancelResponse
-      summary: Cancel a model response
-      description: Cancels a model response with the given ID. Only responses created with the background parameter set to true can be cancelled.
+      description: Cancels a model response.
       parameters:
         - name: response_id
           in: path
@@ -10861,14 +9629,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenAI.Response'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10878,8 +9640,7 @@ paths:
   /openai/v1/responses/{response_id}/input_items:
     get:
       operationId: listInputItems
-      summary: List input items for a response
-      description: Retrieves the input items associated with the specified response.
+      description: Returns a list of input items for a given response.
       parameters:
         - name: response_id
           in: path
@@ -10964,14 +9725,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -10981,8 +9736,7 @@ paths:
   /redTeams/runs:
     get:
       operationId: RedTeams_list
-      summary: List redteams
-      description: Returns the redteams available in the current project.
+      description: List a redteam by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: Foundry-Features
@@ -11000,20 +9754,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedRedTeam'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11029,8 +9771,7 @@ paths:
   /redTeams/runs/{name}:
     get:
       operationId: RedTeams_get
-      summary: Get a redteam
-      description: Retrieves the specified redteam and its configuration.
+      description: Get a redteam by name.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: name
@@ -11054,20 +9795,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedTeam'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11083,8 +9812,7 @@ paths:
   /redTeams/runs:run:
     post:
       operationId: RedTeams_create
-      summary: Create a redteam run
-      description: Submits a new redteam run for execution with the provided configuration.
+      description: Creates a redteam run.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11108,14 +9836,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RedTeam'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11132,8 +9854,7 @@ paths:
   /routines:
     get:
       operationId: listRoutines
-      summary: List routines
-      description: Returns the routines available in the current project.
+      description: List routines.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11143,10 +9864,46 @@ paths:
             type: string
             enum:
               - Routines=V1Preview
-        - $ref: '#/components/parameters/ListRoutinesParameters.limit'
-        - $ref: '#/components/parameters/ListRoutinesParameters.after'
-        - $ref: '#/components/parameters/ListRoutinesParameters.before'
-        - $ref: '#/components/parameters/ListRoutinesParameters.order'
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -11180,14 +9937,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11200,8 +9951,7 @@ paths:
   /routines/{routine_name}:
     put:
       operationId: createOrUpdateRoutine
-      summary: Create or update a routine
-      description: Creates a new routine or replaces an existing routine with the supplied definition.
+      description: Create or update a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11226,14 +9976,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11251,8 +9995,7 @@ paths:
           - Routines=V1Preview
     get:
       operationId: getRoutine
-      summary: Get a routine
-      description: Retrieves the specified routine and its current configuration.
+      description: Retrieve a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11277,14 +10020,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11296,8 +10033,7 @@ paths:
           - Routines=V1Preview
     delete:
       operationId: deleteRoutine
-      summary: Delete a routine
-      description: Deletes the specified routine.
+      description: Delete a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11318,14 +10054,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11338,8 +10068,7 @@ paths:
   /routines/{routine_name}/runs:
     get:
       operationId: listRoutineRuns
-      summary: List prior runs for a routine
-      description: Returns prior runs recorded for the specified routine.
+      description: List prior runs for a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11351,10 +10080,46 @@ paths:
               - Routines=V1Preview
         - $ref: '#/components/parameters/ListRoutineRunsParameters.routine_name'
         - $ref: '#/components/parameters/ListRoutineRunsParameters.filter'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.limit'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.after'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.before'
-        - $ref: '#/components/parameters/ListRoutineRunsParameters.order'
+        - name: limit
+          in: query
+          required: false
+          description: |-
+            A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+            default is 20.
+          schema:
+            type: integer
+            format: int32
+            default: 20
+          explode: false
+        - name: order
+          in: query
+          required: false
+          description: |-
+            Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and`desc`
+            for descending order.
+          schema:
+            $ref: '#/components/schemas/PageOrder'
+          explode: false
+        - name: after
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `after` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include after=obj_foo in order to fetch the next page of the list.
+          schema:
+            type: string
+          explode: false
+        - name: before
+          in: query
+          required: false
+          description: |-
+            A cursor for use in pagination. `before` is an object ID that defines your place in the list.
+            For instance, if you make a list request and receive 100 objects, ending with obj_foo, your
+            subsequent call can include before=obj_foo in order to fetch the previous page of the list.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -11388,14 +10153,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11408,8 +10167,7 @@ paths:
   /routines/{routine_name}:disable:
     post:
       operationId: disableRoutine
-      summary: Disable a routine
-      description: Disables the specified routine so it no longer runs.
+      description: Disable a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11434,14 +10192,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11454,8 +10206,7 @@ paths:
   /routines/{routine_name}:dispatch_async:
     post:
       operationId: dispatchRoutineAsync
-      summary: Queue an asynchronous routine dispatch
-      description: Queues an asynchronous dispatch for the specified routine.
+      description: Queue an asynchronous routine dispatch.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11480,14 +10231,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DispatchRoutineResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11506,8 +10251,7 @@ paths:
   /routines/{routine_name}:enable:
     post:
       operationId: enableRoutine
-      summary: Enable a routine
-      description: Enables the specified routine so it can be dispatched.
+      description: Enable a routine.
       parameters:
         - name: Foundry-Features
           in: header
@@ -11532,14 +10276,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Routine'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11552,8 +10290,7 @@ paths:
   /schedules:
     get:
       operationId: Schedules_list
-      summary: List schedules
-      description: Returns schedules that match the supplied type and enabled filters.
+      description: List all schedules.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: type
@@ -11585,20 +10322,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedSchedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11614,8 +10339,7 @@ paths:
   /schedules/{id}:
     delete:
       operationId: Schedules_delete
-      summary: Delete a schedule
-      description: Deletes the specified schedule resource.
+      description: Delete a schedule.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -11635,20 +10359,8 @@ paths:
       responses:
         '204':
           description: There is no content to send for this request, but the headers may be useful.
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11663,8 +10375,7 @@ paths:
         - Schedules
     get:
       operationId: Schedules_get
-      summary: Get a schedule
-      description: Retrieves the specified schedule resource.
+      description: Get a schedule by id.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -11688,20 +10399,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11716,8 +10415,7 @@ paths:
         - Schedules
     put:
       operationId: Schedules_createOrUpdate
-      summary: Create or update a schedule
-      description: Creates a new schedule or updates an existing schedule with the supplied definition.
+      description: Create or update operation template.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -11747,20 +10445,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Schedule'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11783,8 +10469,7 @@ paths:
   /schedules/{id}/runs:
     get:
       operationId: Schedules_listRuns
-      summary: List schedule runs
-      description: Returns schedule runs that match the supplied filters.
+      description: List all schedule runs.
       parameters:
         - $ref: '#/components/parameters/Azure.Core.Foundations.ApiVersionParameter'
         - name: id
@@ -11822,20 +10507,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PagedScheduleRun'
-        4XX:
-          description: Client error
-          headers:
-            x-ms-error-code:
-              required: false
-              description: String error code indicating what went wrong.
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Azure.Core.Foundations.ErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           headers:
             x-ms-error-code:
               required: false
@@ -11851,8 +10524,7 @@ paths:
   /schedules/{schedule_id}/runs/{run_id}:
     get:
       operationId: Schedules_getRun
-      summary: Get a schedule run
-      description: Retrieves the specified run for a schedule.
+      description: Get a schedule run by id.
       parameters:
         - name: schedule_id
           in: path
@@ -11888,14 +10560,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScheduleRun'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -11905,8 +10571,7 @@ paths:
   /skills:
     get:
       operationId: Skills_listSkills
-      summary: List skills
-      description: Returns the skills available in the current project.
+      description: Returns the list of all skills.
       parameters:
         - name: limit
           in: query
@@ -11989,14 +10654,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12009,8 +10668,7 @@ paths:
   /skills/{name}:
     get:
       operationId: Skills_getSkill
-      summary: Retrieve a skill
-      description: Retrieves the specified skill and its current configuration.
+      description: Retrieves a skill.
       parameters:
         - name: name
           in: path
@@ -12040,14 +10698,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Skill'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12059,8 +10711,7 @@ paths:
           - Skills=V1Preview
     post:
       operationId: updateSkill
-      summary: Update a skill
-      description: Modifies the specified skill's configuration.
+      description: Update a skill.
       parameters:
         - name: name
           in: path
@@ -12090,14 +10741,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Skill'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12121,8 +10766,7 @@ paths:
           - Skills=V1Preview
     delete:
       operationId: Skills_deleteSkill
-      summary: Delete a skill
-      description: Removes the specified skill and its associated versions.
+      description: Deletes a skill.
       parameters:
         - name: name
           in: path
@@ -12152,14 +10796,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteSkillResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12172,8 +10810,7 @@ paths:
   /skills/{name}/content:
     get:
       operationId: getSkillContent
-      summary: Download the zip content for the default version of a skill
-      description: Downloads the zip content for the default version of a skill.
+      description: Download the zip content for the default version of a skill.
       parameters:
         - name: name
           in: path
@@ -12202,15 +10839,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12246,7 +10878,6 @@ paths:
             type: string
           explode: false
       description: Creates a new version of a skill. If the skill does not exist, it will be created. Creates a new version of a skill from uploaded files via multipart form data.
-      summary: Create a new version of a skill Create a skill version from uploaded files
       responses:
         '200':
           description: The request has succeeded.
@@ -12254,20 +10885,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SkillVersion'
-        4XX:
-          description: Client error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-      x-ms-description-override: Creates a new version of a skill. If the skill does not exist, it will be created.
-      x-ms-summary-override: Create a new version of a skill
       x-ms-foundry-meta:
         required_previews:
           - Skills=V1Preview
@@ -12297,8 +10920,7 @@ paths:
                 contentType: text/plain
     get:
       operationId: listSkillVersions
-      summary: List skill versions
-      description: Returns the available versions for the specified skill.
+      description: List all versions of a skill.
       parameters:
         - name: name
           in: path
@@ -12387,14 +11009,8 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12407,8 +11023,7 @@ paths:
   /skills/{name}/versions/{version}:
     get:
       operationId: getSkillVersion
-      summary: Retrieve a specific version of a skill
-      description: Retrieves the specified version of a skill by name and version identifier.
+      description: Retrieve a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -12444,14 +11059,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SkillVersion'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12463,8 +11072,7 @@ paths:
           - Skills=V1Preview
     delete:
       operationId: deleteSkillVersion
-      summary: Delete a specific version of a skill
-      description: Removes the specified version of a skill.
+      description: Delete a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -12500,14 +11108,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeleteSkillVersionResponse'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12520,8 +11122,7 @@ paths:
   /skills/{name}/versions/{version}/content:
     get:
       operationId: getSkillVersionContent
-      summary: Download the zip content for a specific version of a skill
-      description: Downloads the zip content for a specific version of a skill.
+      description: Download the zip content for a specific version of a skill.
       parameters:
         - name: name
           in: path
@@ -12556,15 +11157,10 @@ paths:
           content:
             application/zip:
               schema:
-                contentMediaType: application/zip
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+                type: string
+                format: binary
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12577,8 +11173,7 @@ paths:
   /toolboxes:
     get:
       operationId: listToolboxes
-      summary: List toolboxes
-      description: Returns the toolboxes available in the current project.
+      description: List all toolboxes.
       parameters:
         - name: limit
           in: query
@@ -12620,14 +11215,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12661,28 +11248,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}:
     get:
       operationId: getToolbox
-      summary: Retrieve a toolbox
-      description: Retrieves the specified toolbox and its current configuration.
+      description: Retrieve a toolbox.
       parameters:
         - name: name
           in: path
@@ -12690,14 +11267,6 @@ paths:
           description: The name of the toolbox to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12712,37 +11281,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     patch:
       operationId: updateToolbox
-      summary: Update a toolbox to point to a specific version
-      description: Updates the toolbox's default version pointer to the specified version.
+      description: Update a toolbox to point to a specific version.
       parameters:
         - $ref: '#/components/parameters/UpdateToolboxRequest.name'
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12757,14 +11308,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12777,13 +11322,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateToolboxRequest'
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolbox
-      summary: Delete a toolbox
-      description: Removes the specified toolbox along with all of its versions.
+      description: Delete a toolbox and all its versions.
       parameters:
         - name: name
           in: path
@@ -12791,14 +11332,6 @@ paths:
           description: The name of the toolbox to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12809,28 +11342,18 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions:
     post:
       operationId: createToolboxVersion
-      summary: Create a new version of a toolbox
-      description: Creates a new toolbox version, provisioning the toolbox itself if it does not already exist.
+      description: Create a new version of a toolbox. If the toolbox does not exist, it will be created.
       parameters:
         - name: name
           in: path
@@ -12839,14 +11362,6 @@ paths:
           schema:
             type: string
             maxLength: 256
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -12861,14 +11376,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
@@ -12888,7 +11397,7 @@ paths:
                   description: A human-readable description of the toolbox.
                 metadata:
                   type: object
-                  unevaluatedProperties:
+                  additionalProperties:
                     type: string
                   description: Arbitrary key-value metadata to associate with the toolbox.
                 tools:
@@ -12907,13 +11416,9 @@ paths:
                   description: Policy configuration for this toolbox version.
               required:
                 - tools
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     get:
       operationId: listToolboxVersions
-      summary: List toolbox versions
-      description: Returns the available versions for the specified toolbox.
+      description: List all versions of a toolbox.
       parameters:
         - name: name
           in: path
@@ -12961,14 +11466,6 @@ paths:
           schema:
             type: string
           explode: false
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13002,28 +11499,18 @@ paths:
                     type: boolean
                     description: A value indicating whether there are additional values available not captured in this list.
                 description: The response data for a requested list of items.
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
   /toolboxes/{name}/versions/{version}:
     get:
       operationId: getToolboxVersion
-      summary: Retrieve a specific version of a toolbox
-      description: Retrieves the specified version of a toolbox by name and version identifier.
+      description: Retrieve a specific version of a toolbox.
       parameters:
         - name: name
           in: path
@@ -13037,14 +11524,6 @@ paths:
           description: The version identifier to retrieve.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13059,27 +11538,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ToolboxVersionObject'
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
     delete:
       operationId: deleteToolboxVersion
-      summary: Delete a specific version of a toolbox
-      description: Removes the specified version of a toolbox.
+      description: Delete a specific version of a toolbox.
       parameters:
         - name: name
           in: path
@@ -13093,14 +11562,6 @@ paths:
           description: The version identifier to delete.
           schema:
             type: string
-        - name: Foundry-Features
-          in: header
-          required: true
-          description: A feature flag opt-in required when using preview operations or modifying persisted preview resources.
-          schema:
-            type: string
-            enum:
-              - Toolboxes=V1Preview
         - name: api-version
           in: query
           required: true
@@ -13111,23 +11572,14 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
-        4XX:
-          description: Client error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
-        5XX:
-          description: Server error
+        default:
+          description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
       tags:
         - Toolboxes
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Toolboxes=V1Preview
 security:
   - OAuth2Auth:
       - https://ai.azure.com/.default
@@ -13197,44 +11649,11 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutineRunsParameters.after:
-      name: after
-      in: query
-      required: false
-      description: An opaque cursor returned as last_id by the previous list-runs response.
-      schema:
-        type: string
-      explode: false
-    ListRoutineRunsParameters.before:
-      name: before
-      in: query
-      required: false
-      description: Unsupported. Reserved for future backward pagination support.
-      schema:
-        type: string
-      explode: false
     ListRoutineRunsParameters.filter:
       name: filter
       in: query
       required: false
       description: An optional MLflow search-runs filter expression applied within the routine's experiment.
-      schema:
-        type: string
-      explode: false
-    ListRoutineRunsParameters.limit:
-      name: limit
-      in: query
-      required: false
-      description: The maximum number of runs to return.
-      schema:
-        type: integer
-        format: int32
-      explode: false
-    ListRoutineRunsParameters.order:
-      name: order
-      in: query
-      required: false
-      description: The ordering direction. Supported values are asc and desc.
       schema:
         type: string
       explode: false
@@ -13246,39 +11665,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    ListRoutinesParameters.after:
-      name: after
-      in: query
-      required: false
-      description: An opaque cursor returned as last_id by the previous list response.
-      schema:
-        type: string
-      explode: false
-    ListRoutinesParameters.before:
-      name: before
-      in: query
-      required: false
-      description: Unsupported. Reserved for future backward pagination support.
-      schema:
-        type: string
-      explode: false
-    ListRoutinesParameters.limit:
-      name: limit
-      in: query
-      required: false
-      description: The maximum number of routines to return.
-      schema:
-        type: integer
-        format: int32
-      explode: false
-    ListRoutinesParameters.order:
-      name: order
-      in: query
-      required: false
-      description: The ordering direction. Supported values are asc and desc.
-      schema:
-        type: string
-      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -13610,14 +11996,12 @@ components:
           type: integer
           format: int32
           description: The maximum number of replicas for the container. Default is 1.
-          examples:
-            - 10
+          example: 10
         min_replicas:
           type: integer
           format: int32
           description: The minimum number of replicas for the container. Default is 1.
-          examples:
-            - 1
+          example: 1
         error_message:
           type: string
           description: The error message if the container failed to operate, if any.
@@ -13901,7 +12285,7 @@ components:
           description: Identifier of the agent thread. This field is mandatory currently, but it will be optional in the future.
         evaluators:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/EvaluatorConfiguration'
           description: Evaluators to be used for the evaluation.
         samplingConfiguration:
@@ -13955,7 +12339,7 @@ components:
           description: A string explaining why there was an error, if applicable.
         additionalDetails:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties relevant to the evaluator. These will differ between evaluators.
       description: Result for the agent evaluation evaluator run.
@@ -14080,6 +12464,18 @@ components:
         version:
           type: string
           description: The version identifier of the agent.
+    AgentIdentifier:
+      type: object
+      required:
+        - agentName
+      properties:
+        agentName:
+          type: string
+          description: Registered Foundry agent name (required).
+        agentVersion:
+          type: string
+          description: Pinned agent version. Defaults to latest if omitted.
+      description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and systemPrompt are specified in options.optimizationConfig.
     AgentIdentity:
       type: object
       required:
@@ -14177,7 +12573,6 @@ components:
           enum:
             - activity_protocol
             - responses
-            - a2a
             - mcp
             - invocations
             - invocations_ws
@@ -14248,6 +12643,7 @@ components:
             - idle
             - updating
             - failed
+            - stopping
             - deleting
             - deleted
             - expired
@@ -14311,11 +12707,10 @@ components:
         - definition
       properties:
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
             useful for storing additional information about the object in a structured
@@ -15217,7 +13612,7 @@ components:
               description: A description of what the function does, used by the model to choose when and how to call the function.
             parameters:
               type: object
-              unevaluatedProperties: {}
+              additionalProperties: {}
               description: The parameters the functions accepts, described as a JSON Schema object.
           required:
             - name
@@ -15721,6 +14116,116 @@ components:
             - $ref: '#/components/schemas/BrowserAutomationToolConnectionParameters'
           description: The project connection parameters associated with the Browser Automation Tool.
       description: Definition of input parameters for the Browser Automation Tool.
+    CandidateDeployConfig:
+      type: object
+      properties:
+        instructions:
+          type: string
+          description: System prompt / instructions.
+        model:
+          type: string
+          description: Foundry deployment name.
+        temperature:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 2
+          description: Optional sampling temperature.
+        skills:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Optional skill overrides.
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Optional tool overrides.
+      description: Deploy-config blob for a candidate. Suitable for setting OPTIMIZATION_CONFIG on a hosted-agent version.
+    CandidateFileInfo:
+      type: object
+      required:
+        - path
+        - type
+        - sizeBytes
+      properties:
+        path:
+          type: string
+          description: Relative path of the file.
+        type:
+          type: string
+          description: File type category (e.g. 'config', 'results').
+        sizeBytes:
+          type: integer
+          format: int64
+          description: File size in bytes.
+      description: File entry in a candidate's blob directory.
+    CandidateMetadata:
+      type: object
+      required:
+        - candidateId
+        - jobId
+        - candidateName
+        - status
+        - hasResults
+        - createdAt
+        - updatedAt
+        - files
+      properties:
+        candidateId:
+          type: string
+          description: Server-assigned candidate identifier.
+        jobId:
+          type: string
+          description: Owning optimization job id.
+        candidateName:
+          type: string
+          description: Display name of the candidate.
+        status:
+          type: string
+          description: Candidate lifecycle status.
+        score:
+          type: number
+          format: double
+          description: Candidate's aggregate score.
+        hasResults:
+          type: boolean
+          description: Whether detailed results are available for this candidate.
+        createdAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when the candidate was created, represented in Unix time.
+        updatedAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when the candidate was last updated, represented in Unix time.
+        promotion:
+          allOf:
+            - $ref: '#/components/schemas/PromotionInfo'
+          description: Promotion metadata. Null if not promoted.
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/CandidateFileInfo'
+          description: Files in the candidate's blob directory.
+      description: Candidate metadata returned by GET /candidates/{id}.
+    CandidateResults:
+      type: object
+      required:
+        - candidateId
+        - results
+      properties:
+        candidateId:
+          type: string
+          description: Owning candidate id.
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptimizationTaskResult'
+          description: Per-task evaluation rows.
+      description: Full per-task evaluation results for a candidate, returned by GET /candidates/{id}/results.
     CaptureStructuredOutputsTool:
       type: object
       required:
@@ -15798,7 +14303,7 @@ components:
           description: List of clusters identified in the insights.
         coordinates:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/ChartCoordinate'
           description: |2-
               Optional mapping of IDs to 2D coordinates used by the UX for visualization.
@@ -15993,7 +14498,7 @@ components:
           readOnly: true
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata of the connection
           readOnly: true
@@ -16031,21 +14536,18 @@ components:
           items:
             $ref: '#/components/schemas/ProtocolVersionRecord'
           description: The protocols that the agent supports for ingress communication of the containers.
-          examples:
-            - - protocol: responses
-                version: v0.1.1
-              - protocol: a2a
-                version: v0.3.0
+          example:
+            - protocol: responses
+              version: v0.1.1
+            - protocol: a2a
+              version: v0.3.0
         container_app_resource_id:
           type: string
           description: The resource ID of the Azure Container App that hosts this agent. Not mutable across versions.
         ingress_subdomain_suffix:
           type: string
           description: The suffix to apply to the app subdomain when sending ingress to the agent. This can be a label (e.g., '---current'), a specific revision (e.g., '--0000001'), or empty to use the default endpoint for the container app.
-          examples:
-            - --0000001
-            - ---current
-            - ''
+          example: --0000001
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
       description: The container app agent definition.
@@ -16060,8 +14562,7 @@ components:
         image:
           type: string
           description: The container image for the hosted agent.
-          examples:
-            - my-registry.azurecr.io/my-hosted-agent:latest
+          example: my-registry.azurecr.io/my-hosted-agent:latest
       description: Container-based deployment configuration for a hosted agent.
       x-ms-foundry-meta:
         required_previews:
@@ -16167,13 +14668,6 @@ components:
           type: integer
           format: int32
           description: Maximum number of evaluation runs allowed per hour.
-        samplingRate:
-          type: number
-          format: double
-          maximum: 100
-          description: Percentage (0-100] chance that a matching event triggers an evaluation. When omitted, the service-default is to evaluate every event, which is equivalent to setting a sampling rate of 100.
-          exclusiveMinimum: 0
-          default: 100
       allOf:
         - $ref: '#/components/schemas/EvaluationRuleAction'
       description: Evaluation rule action for continuous evaluation.
@@ -16203,7 +14697,7 @@ components:
           default: 5
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Mapping from source fields to response_id field, which is required for retrieving chat history.
         sampling_params:
@@ -16266,6 +14760,8 @@ components:
             - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
+          type: string
+          format: binary
           description: The code zip file (max 250 MB).
       required:
         - metadata
@@ -16287,7 +14783,7 @@ components:
             - Must not exceed 63 characters.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -16306,7 +14802,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     CreateAgentRequest:
       type: object
@@ -16324,7 +14820,7 @@ components:
             - Must not exceed 63 characters.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -16399,6 +14895,8 @@ components:
             - $ref: '#/components/schemas/CreateAgentVersionFromCodeMetadata'
           description: JSON metadata including description and hosted definition.
         code:
+          type: string
+          format: binary
           description: The code zip file (max 250 MB).
       required:
         - metadata
@@ -16414,7 +14912,7 @@ components:
           description: A human-readable description of the agent.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -16444,7 +14942,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -16463,7 +14961,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     CreateAgentVersionRequest:
       type: object
@@ -16472,7 +14970,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -16519,9 +15017,10 @@ components:
           type: string
           description: The name of the evaluation.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         data_source_config:
           oneOf:
             - $ref: '#/components/schemas/OpenAI.CreateEvalCustomDataSourceConfig'
@@ -16543,7 +15042,7 @@ components:
           description: A list of graders for all eval runs in this group. Graders can reference variables in the data source using double curly braces notation, like `{{item.variable_name}}`. To reference the model's output, use the `sample` namespace (ie, `{{sample.output_text}}`).
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -16558,9 +15057,10 @@ components:
           type: string
           description: The name of the run.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         data_source:
           oneOf:
             - $ref: '#/components/schemas/OpenAI.CreateEvalJsonlRunDataSource'
@@ -16570,7 +15070,7 @@ components:
           description: Details about the run's data source.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -16603,7 +15103,9 @@ components:
       properties:
         files:
           type: array
-          items: {}
+          items:
+            type: string
+            format: binary
           description: Skill files to upload. Upload a single zip file or multiple individual files with relative paths.
         default:
           type: boolean
@@ -16669,41 +15171,11 @@ components:
             - CustomKeys
           description: The credential type
           readOnly: true
-      unevaluatedProperties:
+      additionalProperties:
         type: string
       allOf:
         - $ref: '#/components/schemas/BaseCredentials'
       description: Custom credential definition
-    CustomRoutineTrigger:
-      type: object
-      required:
-        - type
-        - provider
-        - parameters
-      properties:
-        type:
-          type: string
-          enum:
-            - custom
-          description: The trigger type.
-        provider:
-          type: string
-          maxLength: 128
-          description: The external provider that emits the custom event.
-        event_name:
-          type: string
-          maxLength: 256
-          description: The provider-specific event name that fires the routine.
-        parameters:
-          type: object
-          unevaluatedProperties: {}
-          description: Provider-specific trigger parameters.
-      allOf:
-        - $ref: '#/components/schemas/RoutineTrigger'
-      description: A custom event routine trigger.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
     DailyRecurrenceSchedule:
       type: object
       required:
@@ -16851,7 +15323,7 @@ components:
           description: Description to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tags to assign to the output. Applies only to dataset outputs (evaluation scenario); ignored for Azure OpenAI file outputs.
       description: Output options for data generation job.
@@ -16973,12 +15445,11 @@ components:
           description: The data source type discriminator.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -17008,7 +15479,7 @@ components:
           readOnly: true
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary of the output dataset.
           readOnly: true
@@ -17061,6 +15532,38 @@ components:
       allOf:
         - $ref: '#/components/schemas/EvaluatorGenerationJobSource'
       description: Dataset source for evaluator generation jobs — reference to a dataset.
+    DatasetInfo:
+      type: object
+      required:
+        - taskCount
+        - isInline
+      properties:
+        name:
+          type: string
+          description: Dataset name when using a registered dataset reference. Null for inline datasets.
+        version:
+          type: string
+          description: Dataset version when using a registered dataset reference. Null for inline datasets.
+        taskCount:
+          type: integer
+          format: int32
+          description: Number of tasks/rows in the dataset.
+        isInline:
+          type: boolean
+          description: True when the dataset was provided inline in the request body.
+      description: Metadata about the dataset used for optimization, surfaced in the response.
+    DatasetRef:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Dataset name.
+        version:
+          type: string
+          description: Dataset version. If not specified, the latest version is used.
+      description: Reference to a registered dataset in the Foundry Dataset Service.
     DatasetReference:
       type: object
       required:
@@ -17138,7 +15641,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       discriminator:
@@ -17403,7 +15906,7 @@ components:
           description: Relative weight of this dimension (1-10). The generation pipeline assigns exactly one dimension weight 8-10; all others use 1-6. User edits are not constrained by this heuristic.
         always_applicable:
           type: boolean
-          description: When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. The service defaults to `false` if a value is not specified by the caller.
+          description: When true, the LLM judge always scores this dimension regardless of relevance (skips applicability assessment). The service-generated general quality/policy dimension has this set to true and is non-editable. Users may set this on their own custom dimensions. Defaults to `false`.
           default: false
       description: A single dimension — one independent, measurable quality dimension within a rubric evaluator's scoring blueprint.
     DispatchRoutineRequest:
@@ -17527,9 +16030,10 @@ components:
           format: unixtime
           description: The Unix timestamp (in seconds) for when the eval was created.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         modified_at:
           allOf:
             - $ref: '#/components/schemas/integer'
@@ -17539,7 +16043,7 @@ components:
           description: the name of the person who created the run.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -17710,9 +16214,10 @@ components:
             - $ref: '#/components/schemas/EvalRunDataSource'
           description: Information about the run's data source.
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         error:
           $ref: '#/components/schemas/OpenAI.EvalApiError'
         modified_at:
@@ -17724,7 +16229,7 @@ components:
           description: the name of the person who created the run.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -17983,7 +16488,7 @@ components:
           description: The identifier for the data source item.
         datasource_item:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Details of the input data source item.
         results:
           type: array
@@ -18073,10 +16578,9 @@ components:
           type: boolean
           description: Whether the grader considered the output a pass.
         sample:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
           description: Optional sample or intermediate data produced by the grader.
         status:
           allOf:
@@ -18097,10 +16601,10 @@ components:
           description: The reason for the test criteria metric.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional details about the test criteria metric.
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: A single grader result for an evaluation run output item.
       title: EvalRunOutputItemResult
     EvalRunOutputItemResultStatus:
@@ -18252,17 +16756,17 @@ components:
           readOnly: true
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Evaluation's tags. Unlike properties, tags are fully mutable.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Evaluation's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.
         evaluators:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/EvaluatorConfiguration'
           description: Evaluators to be used for the evaluation.
         target:
@@ -18413,7 +16917,7 @@ components:
           description: Indicates whether the evaluation rule is enabled. Default is true.
         systemData:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: System metadata for the evaluation rule.
           readOnly: true
@@ -18519,7 +17023,6 @@ components:
           description: Identifier of the evaluation group.
         evalRun:
           type: object
-          unevaluatedProperties: {}
           description: The evaluation run payload.
       allOf:
         - $ref: '#/components/schemas/ScheduleTask'
@@ -18625,7 +17128,7 @@ components:
           default: quality
         initialization_parameters:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: |-
             Optional initialization parameters applied to all generated evaluators.
             For example, deployment_name for LLM judge model, default threshold.
@@ -18900,7 +17403,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: |-
@@ -18969,7 +17472,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: |-
@@ -19027,7 +17530,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -19041,7 +17544,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
         taxonomyInput:
@@ -19055,7 +17558,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -19103,7 +17606,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
         taxonomyInput:
@@ -19117,7 +17620,7 @@ components:
           description: List of taxonomy categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the evaluation taxonomy.
       description: Evaluation Taxonomy Definition
@@ -19140,11 +17643,11 @@ components:
           description: Identifier of the evaluator.
         initParams:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Initialization parameters of the evaluator.
         dataMapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Data parameters of the evaluator.
       description: Evaluator Configuration
@@ -19172,15 +17675,15 @@ components:
           description: The type of evaluator definition
         init_parameters:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema (Draft 2020-12) for the evaluator's input parameters. This includes parameters like type, properties, required.
         data_schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema (Draft 2020-12) for the evaluator's input data. This includes parameters like type, properties, required.
         metrics:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/EvaluatorMetric'
           description: List of output metrics produced by this evaluator
       discriminator:
@@ -19417,7 +17920,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         evaluator_type:
@@ -19429,13 +17932,6 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19482,7 +17978,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         evaluator_type:
@@ -19494,13 +17990,6 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         definition:
           allOf:
             - $ref: '#/components/schemas/EvaluatorDefinition'
@@ -19510,7 +17999,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Evaluator Definition
@@ -19522,7 +18011,7 @@ components:
           description: Display Name for evaluator. It helps to find the evaluator easily in AI Foundry. It does not need to be unique.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Metadata about the evaluator
         categories:
@@ -19530,19 +18019,12 @@ components:
           items:
             $ref: '#/components/schemas/EvaluatorCategory'
           description: The categories of the evaluator
-        supported_evaluation_levels:
-          type: array
-          items:
-            $ref: '#/components/schemas/EvaluationLevel'
-          description: Evaluation levels this evaluator supports (e.g., `turn`, `conversation`). When omitted on create, the service defaults to `["turn"]`. On update, omitting this field leaves it unchanged; an empty list is rejected. Custom code-based evaluators support only `turn`; custom prompt-based evaluators support exactly one level (`turn` or `conversation`).
-          default:
-            - turn
         description:
           type: string
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Evaluator Definition
@@ -19657,9 +18139,12 @@ components:
           description: (Optional) The URL of the FabricIQ MCP server. If not provided, the URL from the project connection will be used.
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
-            - type: 'null'
+              nullable: true
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
         name:
@@ -19693,9 +18178,12 @@ components:
           description: (Optional) The URL of the FabricIQ MCP server. If not provided, the URL from the project connection will be used.
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
-            - type: 'null'
+              nullable: true
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
       allOf:
@@ -19785,9 +18273,9 @@ components:
             - $ref: '#/components/schemas/OpenAI.RankingOptions'
           description: Ranking options for search.
         filters:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
-            - type: 'null'
+          nullable: true
         vector_store_ids:
           type: array
           items:
@@ -19923,50 +18411,34 @@ components:
           type: string
           description: The arguments to call the function with, as generated by the model in JSON format.
       description: Details of a function tool call.
-    GitHubIssueEvent:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - opened
-            - closed
-      description: Known GitHub issue events that can fire a routine.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    GitHubIssueRoutineTrigger:
+    GitHubIssueOpenedRoutineTrigger:
       type: object
       required:
         - type
         - connection_id
-        - owner
+        - assignee
         - repository
-        - issue_event
       properties:
         type:
           type: string
           enum:
-            - github_issue
+            - github_issue_opened
           description: The trigger type.
         connection_id:
           type: string
           maxLength: 256
           description: The workspace connection identifier that resolves the GitHub configuration for the trigger.
-        owner:
+        assignee:
           type: string
           maxLength: 128
-          description: The GitHub owner or organization that scopes which issues can fire the trigger.
+          description: The GitHub assignee or organization filter that scopes which issues can fire the trigger.
         repository:
           type: string
           maxLength: 128
           description: The GitHub repository filter that scopes which issues can fire the trigger.
-        issue_event:
-          allOf:
-            - $ref: '#/components/schemas/GitHubIssueEvent'
-          description: The GitHub issue event that fires the routine.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
-      description: A GitHub issue routine trigger.
+      description: A GitHub issue-opened routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -20000,18 +18472,15 @@ components:
         header_name:
           type: string
           description: The name of the HTTP header to inject the secret value into.
-          examples:
-            - X-Otlp-Api-Key
+          example: X-Otlp-Api-Key
         secret_id:
           type: string
           description: The identifier of the secret store or connection.
-          examples:
-            - my-secret-store
+          example: my-secret-store
         secret_key:
           type: string
           description: The key within the secret to retrieve the authentication value.
-          examples:
-            - OTLP_KEY
+          example: OTLP_KEY
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpointAuth'
       description: Header-based secret authentication for a telemetry endpoint. The resolved secret value is injected as an HTTP header.
@@ -20039,21 +18508,19 @@ components:
         cpu:
           type: string
           description: The CPU configuration for the hosted agent.
-          examples:
-            - '0.25'
+          example: '0.25'
         memory:
           type: string
           description: The memory configuration for the hosted agent.
-          examples:
-            - 0.5Gi
+          example: 0.5Gi
         environment_variables:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Environment variables to set in the hosted agent container.
-          examples:
-            - name: LOG_LEVEL
-              value: debug
+          example:
+            name: LOG_LEVEL
+            value: debug
         container_configuration:
           allOf:
             - $ref: '#/components/schemas/ContainerConfiguration'
@@ -20066,11 +18533,11 @@ components:
           items:
             $ref: '#/components/schemas/ProtocolVersionRecord'
           description: The protocols that the agent supports for ingress communication.
-          examples:
-            - - protocol: responses
-                version: v0.1.1
-              - protocol: a2a
-                version: v0.3.0
+          example:
+            - protocol: responses
+              version: v0.1.1
+            - protocol: a2a
+              version: v0.3.0
           x-ms-foundry-meta:
             required_previews:
               - CodeAgents=V1Preview
@@ -20189,7 +18656,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       discriminator:
@@ -20362,11 +18829,11 @@ components:
           description: Sample type
         features:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Features to help with additional filtering of data in UX.
         correlationInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Info about the correlation for the analysis sample.
       discriminator:
         propertyName: type
@@ -20446,7 +18913,6 @@ components:
       type: object
       required:
         - type
-        - input
       properties:
         type:
           type: string
@@ -20454,7 +18920,9 @@ components:
             - invoke_agent_invocations_api
           description: The manual dispatch payload type.
         input:
-          description: The JSON value sent as the complete downstream invocations input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
+          type: string
+          maxLength: 32768
+          description: The raw input sent to the downstream invocations target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test an invocations API routine dispatch.
@@ -20465,29 +18933,24 @@ components:
       type: object
       required:
         - type
+        - agent_endpoint_id
       properties:
         type:
           type: string
           enum:
             - invoke_agent_invocations_api
           description: The action type.
-        agent_name:
-          type: string
-          maxLength: 256
-          description: The project-scoped agent name for routine dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: Legacy endpoint-scoped agent identifier for routine dispatch.
-        input:
-          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
+          description: The endpoint-scoped agent identifier for invocations API dispatch.
         session_id:
           type: string
           maxLength: 256
           description: An optional existing hosted-agent session identifier to continue during the downstream dispatch.
       allOf:
         - $ref: '#/components/schemas/RoutineAction'
-      description: Dispatches a routine through the raw invocations API. Exactly one of agent_name or agent_endpoint_id must be provided.
+      description: Dispatches a routine through the raw invocations API.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -20495,7 +18958,6 @@ components:
       type: object
       required:
         - type
-        - input
       properties:
         type:
           type: string
@@ -20503,7 +18965,9 @@ components:
             - invoke_agent_responses_api
           description: The manual dispatch payload type.
         input:
-          description: The JSON value sent as the complete downstream responses input. The value is passed through as-is and can be an object, string, number, boolean, array, or null.
+          type: string
+          maxLength: 32768
+          description: The user input sent to the downstream responses target.
       allOf:
         - $ref: '#/components/schemas/RoutineDispatchPayload'
       description: A manual payload used to test a responses API routine dispatch.
@@ -20523,14 +18987,12 @@ components:
         agent_name:
           type: string
           maxLength: 256
-          description: The project-scoped agent name for routine dispatch.
+          description: The project-scoped agent name for responses API dispatch.
         agent_endpoint_id:
           type: string
           maxLength: 256
-          description: Legacy endpoint-scoped agent identifier for routine dispatch.
-        input:
-          description: Static JSON value sent as the complete downstream input when the routine fires. The value is passed through as-is; no templating is applied.
-        conversation:
+          description: The endpoint-scoped agent identifier for responses API dispatch.
+        conversation_id:
           type: string
           maxLength: 256
           description: An optional existing conversation identifier to continue during the downstream dispatch.
@@ -20582,7 +19044,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -20681,30 +19142,32 @@ components:
           type: string
           description: Optional description of the MCP server, used to provide more context.
         headers:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         allowed_tools:
           anyOf:
             - type: array
               items:
                 type: string
-            - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
-            - type: 'null'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
+              nullable: true
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
               enum:
                 - always
                 - never
-            - type: 'null'
+              nullable: true
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -21004,11 +19467,10 @@ components:
             - $ref: '#/components/schemas/ToolCallStatus'
           description: The status of the tool call.
         memories:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/MemoryItem'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoryItem'
+          nullable: true
           description: The results returned from the memory search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
@@ -21060,7 +19522,7 @@ components:
           default: true
         procedural_memory_enabled:
           type: boolean
-          description: Whether to enable procedural memory extraction and storage. The service defaults to `true` if a value is not specified by the caller.
+          description: Whether to enable procedural memory extraction and storage. Defaults to `true`.
           default: true
         default_ttl_seconds:
           type: integer
@@ -21160,7 +19622,7 @@ components:
           description: A human-readable description of the memory store.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Arbitrary key-value metadata to associate with the memory store.
         definition:
@@ -21379,7 +19841,7 @@ components:
           readOnly: true
         capabilities:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Capabilities of deployed model
           readOnly: true
@@ -21528,7 +19990,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Model Version Definition
@@ -21670,6 +20132,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -21693,6 +20156,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -21717,6 +20181,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -21736,6 +20201,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -21801,6 +20267,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -21818,6 +20285,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -21841,6 +20309,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -21866,21 +20335,17 @@ components:
           x-stainless-const: true
           default: approximate
         country:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         region:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         city:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         timezone:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.AutoCodeInterpreterToolParam:
       type: object
       required:
@@ -21900,9 +20365,9 @@ components:
           maxItems: 50
           description: An optional list of uploaded files to make available to your code.
         memory_limit:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ContainerMemoryLimit'
-            - type: 'null'
+          nullable: true
         network_policy:
           $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
       description: Configuration for a code interpreter container. Optionally specify the IDs of the files to run the code on.
@@ -21926,12 +20391,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -22026,6 +20485,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -22038,12 +20498,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -22161,27 +20615,13 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          nullable: true
         previous_response_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         instructions:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -22198,8 +20638,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -22271,14 +20709,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -22302,13 +20732,11 @@ components:
           type: string
           description: The ID of the pending safety check.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: A pending safety check for the computer call.
     OpenAI.ComputerEnvironment:
       type: string
@@ -22324,7 +20752,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -22332,19 +20759,14 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -22371,21 +20793,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -22400,6 +20807,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -22427,6 +20835,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -22434,9 +20843,9 @@ components:
           maxItems: 50
           description: An optional list of uploaded files to make available to your code.
         memory_limit:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ContainerMemoryLimit'
-            - type: 'null'
+          nullable: true
         skills:
           type: array
           items:
@@ -22463,6 +20872,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -22503,12 +20913,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -22522,8 +20939,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -22556,6 +20994,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -22590,9 +21029,10 @@ components:
           type: string
           description: The context management entry type. Currently only 'compaction' is supported.
         compact_threshold:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
     OpenAI.ConversationItem:
       type: object
       required:
@@ -22604,18 +21044,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -22627,39 +21063,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -22724,9 +21131,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -22767,54 +21173,26 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -22832,8 +21210,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -22854,11 +21230,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -22872,7 +21247,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -22896,15 +21270,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -22927,60 +21328,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -23015,11 +21366,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: |-
@@ -23055,12 +21405,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -23093,7 +21444,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -23101,9 +21452,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -23111,56 +21463,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -23170,7 +21475,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -23200,8 +21504,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -23228,9 +21567,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: An image generation request made by the model.
@@ -23325,13 +21663,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a local shell tool call.
@@ -23391,9 +21728,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A response to an MCP approval request.
@@ -23424,7 +21760,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -23457,20 +21794,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: An invocation of a tool on an MCP server.
@@ -23507,10 +21842,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -23532,9 +21863,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -23562,87 +21892,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -23656,11 +21905,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -23796,7 +22041,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -23852,15 +22096,15 @@ components:
       type: object
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         items:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.InputItem'
+          nullable: true
     OpenAI.CreateEvalCompletionsRunDataSource:
       type: object
       required:
@@ -23981,7 +22225,7 @@ components:
           default: custom
         item_schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The json schema for each row in the data source.
         include_sample_schema:
           type: boolean
@@ -24053,7 +22297,7 @@ components:
           default: logs
         metadata:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Metadata filters for the logs data source.
       description: |-
         A data source config which specifies the metadata property of your logs query.
@@ -24198,7 +22442,7 @@ components:
           default: stored_completions
         metadata:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Metadata filters for the stored completions data source.
       description: Deprecated in favor of LogsDataSourceConfig.
       title: StoredCompletionsDataSourceConfig
@@ -24248,18 +22492,16 @@ components:
               This value is now deprecated in favor of `method`, and should be passed in under the `method` parameter.
           deprecated: true
         suffix:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           minLength: 1
           maxLength: 64
           description: |-
             A string of up to 64 characters that will be added to your fine-tuned model name.
               For example, a `suffix` of "custom-model-name" would produce a model name like `ft:gpt-4o-mini:openai:custom-model-name:7p4lURel`.
         validation_file:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           description: |-
             The ID of an uploaded file that contains validation data.
               If you provide this file, the data is used to generate validation
@@ -24269,16 +22511,16 @@ components:
               Your dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.
               See the [fine-tuning guide](/docs/guides/model-optimization) for more details.
         integrations:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.CreateFineTuningJobRequestIntegrations'
+          nullable: true
           description: A list of integrations to enable for your fine-tuning job.
         seed:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
           minimum: 0
           maximum: 2147483647
           description: |-
@@ -24287,9 +22529,10 @@ components:
         method:
           $ref: '#/components/schemas/OpenAI.FineTuneMethod'
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
     OpenAI.CreateFineTuningJobRequestHyperparameters:
       type: object
       properties:
@@ -24335,13 +22578,11 @@ components:
         project:
           type: string
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         entity:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         tags:
           type: array
           items:
@@ -24414,6 +22655,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -24436,6 +22678,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -24452,6 +22695,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -24462,9 +22706,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -24512,14 +22753,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -24527,6 +22766,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -24535,12 +22775,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -24557,6 +22791,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -24569,12 +22804,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -24603,10 +22832,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -24631,8 +22856,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -24640,15 +22863,13 @@ components:
         - message
       properties:
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
           type: string
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
         details:
@@ -24657,10 +22878,10 @@ components:
             $ref: '#/components/schemas/OpenAI.Error'
         additionalInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         debugInfo:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
     OpenAI.EvalApiError:
       type: object
       required:
@@ -24790,22 +23011,26 @@ components:
       type: object
       properties:
         seed:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         max_completions_tokens:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         reasoning_effort:
           $ref: '#/components/schemas/OpenAI.ReasoningEffort'
     OpenAI.EvalGraderStringCheck:
@@ -25058,10 +23283,10 @@ components:
       properties:
         item:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         sample:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
     OpenAI.EvalJsonlFileIdSource:
       type: object
       required:
@@ -25090,50 +23315,49 @@ components:
             - responses
           description: The type of run data source. Always `responses`.
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
         model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         instructions_search:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_after:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_before:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         reasoning_effort:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ReasoningEffort'
-            - type: 'null'
+          nullable: true
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
         users:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
         tools:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
       description: A EvalResponsesSource object describing a run data source configuration.
       title: EvalResponsesSource
       x-oaiMeta:
@@ -25279,25 +23503,28 @@ components:
           x-stainless-const: true
           default: stored_completions
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_after:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_before:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         limit:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: A StoredCompletionsRunDataSource configuration describing a set of filters
       title: StoredCompletionsRunDataSource
       x-oaiMeta:
@@ -25326,6 +23553,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -25340,11 +23568,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -25381,6 +23604,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -25395,9 +23619,9 @@ components:
             - $ref: '#/components/schemas/OpenAI.RankingOptions'
           description: Ranking options for search.
         filters:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
-            - type: 'null'
+          nullable: true
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -25418,9 +23642,10 @@ components:
         filename:
           type: string
         attributes:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.VectorStoreFileAttributes'
-            - type: 'null'
+          nullable: true
         score:
           type: number
           format: float
@@ -25628,13 +23853,11 @@ components:
         project:
           type: string
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         entity:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         tags:
           type: array
           items:
@@ -25666,20 +23889,17 @@ components:
           format: unixtime
           description: The Unix timestamp (in seconds) for when the fine-tuning job was created.
         error:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FineTuningJobError'
-            - type: 'null'
+          nullable: true
         fine_tuned_model:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         finished_at:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         hyperparameters:
           allOf:
             - $ref: '#/components/schemas/OpenAI.FineTuningJobHyperparameters'
@@ -25712,39 +23932,36 @@ components:
             - cancelled
           description: The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.
         trained_tokens:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         training_file:
           type: string
           description: The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).
         validation_file:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         integrations:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FineTuningIntegration'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FineTuningIntegration'
+          nullable: true
         seed:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The seed used for the fine-tuning job.
         estimated_finish:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         method:
           $ref: '#/components/schemas/OpenAI.FineTuneMethod'
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
       description: The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.
       title: FineTuningJob
       x-oaiMeta:
@@ -25876,9 +24093,8 @@ components:
         message:
           type: string
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
     OpenAI.FineTuningJobEvent:
       type: object
       required:
@@ -25944,8 +24160,11 @@ components:
             - type: string
               enum:
                 - auto
-            - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+              nullable: true
+            - type: integer
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.integer'
+              nullable: true
           default: auto
         learning_rate_multiplier:
           oneOf:
@@ -25987,23 +24206,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -26022,18 +24236,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -26072,18 +24284,6 @@ components:
         - in_progress
         - completed
         - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionObject:
       type: object
       required:
@@ -26098,12 +24298,11 @@ components:
         parameters:
           $ref: '#/components/schemas/OpenAI.FunctionParameters'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
     OpenAI.FunctionParameters:
       type: object
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: |-
         The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.
         Omitting `parameters` defines a function with an empty parameter list.
@@ -26119,13 +24318,15 @@ components:
           items:
             type: string
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: Execute a shell command.
       title: Shell exec action
     OpenAI.FunctionShellActionParam:
@@ -26139,13 +24340,15 @@ components:
             type: string
           description: Ordered shell commands for the execution environment to run.
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       description: Commands and limits describing how to run the shell tool call.
       title: Shell action
     OpenAI.FunctionShellCallEnvironment:
@@ -26289,6 +24492,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -26309,6 +24513,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -26359,12 +24564,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -26376,6 +24575,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -26391,16 +24591,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -26412,10 +24607,12 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
-            - type: 'null'
+          nullable: true
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -26499,61 +24696,67 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
         description:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         parameters:
-          anyOf:
-            - type: object
-              unevaluatedProperties: {}
-            - type: 'null'
+          type: object
+          additionalProperties: {}
+          nullable: true
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-        defer_loading:
           type: boolean
-          description: Whether this function is deferred and loaded via tool search.
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -26930,7 +25133,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -26948,6 +25150,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -26969,15 +25172,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -27014,9 +25217,9 @@ components:
               `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.InputFidelity'
-            - type: 'null'
+          nullable: true
         input_image_mask:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenToolInputImageMask'
@@ -27067,7 +25270,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -27089,6 +25291,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -27185,23 +25388,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -27220,18 +25418,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -27283,23 +25479,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -27315,26 +25506,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         file_data:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         file_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+          type: string
+          format: uri
+          nullable: true
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -27351,18 +25534,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -27378,18 +25559,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.DetailEnum'
-            - type: 'null'
+          nullable: true
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision)
       title: Input image
     OpenAI.InputItem:
@@ -27411,9 +25590,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -27434,38 +25610,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -27482,9 +25626,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27517,9 +25660,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call_output
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27530,9 +25672,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatusParam'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The streamed output emitted by an apply patch tool call.
@@ -27570,17 +25711,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A tool call to run code.
@@ -27592,9 +25731,8 @@ components:
         - encrypted_content
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
           enum:
@@ -27618,9 +25756,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27636,15 +25773,14 @@ components:
         output:
           $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
         acknowledged_safety_checks:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
+          nullable: true
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a computer tool call.
@@ -27655,6 +25791,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27672,8 +25809,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27714,9 +25849,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -27793,11 +25925,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: |-
@@ -27812,9 +25943,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27838,9 +25968,9 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a function tool call.
@@ -27853,9 +25983,8 @@ components:
         - action
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27873,13 +26002,14 @@ components:
             - $ref: '#/components/schemas/OpenAI.FunctionShellActionParam'
           description: The shell commands and limits that describe how to run the tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A tool representing a request to execute one or more shell commands.
@@ -27892,9 +26022,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -27913,13 +26042,14 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContentParam'
           description: Captured chunks of stdout and stderr output, along with their associated outcomes.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The streamed output items emitted by a shell tool call.
@@ -27927,7 +26057,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -27936,7 +26065,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27946,9 +26074,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -27996,9 +26121,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: An image generation request made by the model.
@@ -28057,13 +26181,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: The output of a local shell tool call.
@@ -28113,9 +26236,8 @@ components:
           description: The type of the item. Always `mcp_approval_response`.
           x-stainless-const: true
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         approval_request_id:
           type: string
           description: The ID of the approval request being answered.
@@ -28123,9 +26245,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A response to an MCP approval request.
@@ -28156,7 +26277,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -28189,20 +26311,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: An invocation of a tool on an MCP server.
@@ -28236,10 +26356,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -28270,9 +26386,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -28300,77 +26415,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -28384,9 +26428,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -28443,6 +26484,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -28451,6 +26530,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -28512,7 +26628,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -28520,9 +26636,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -28540,38 +26653,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -28588,9 +26669,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -28623,9 +26703,8 @@ components:
           x-stainless-const: true
           default: apply_patch_call_output
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -28636,9 +26715,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatusParam'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The streamed output emitted by an apply patch tool call.
@@ -28676,17 +26754,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A tool call to run code.
@@ -28698,9 +26774,8 @@ components:
         - encrypted_content
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         type:
           type: string
           enum:
@@ -28724,9 +26799,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -28742,15 +26816,14 @@ components:
         output:
           $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
         acknowledged_safety_checks:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
+          nullable: true
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a computer tool call.
@@ -28761,6 +26834,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -28778,8 +26852,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -28820,9 +26892,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -28875,17 +26944,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -28902,35 +26968,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -28995,9 +27032,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -29038,17 +27074,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A tool call to run code.
@@ -29086,6 +27120,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -29103,8 +27138,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -29125,11 +27158,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -29143,7 +27175,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -29167,8 +27198,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -29189,9 +27218,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -29268,11 +27294,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: |-
@@ -29308,12 +27333,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -29346,7 +27372,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -29354,9 +27380,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -29367,7 +27394,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29376,7 +27402,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29386,9 +27411,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29410,51 +27432,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -29481,9 +27458,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: An image generation request made by the model.
@@ -29542,13 +27518,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: The output of a local shell tool call.
@@ -29608,9 +27583,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A response to an MCP approval request.
@@ -29641,7 +27615,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -29674,20 +27649,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: An invocation of a tool on an MCP server.
@@ -29724,10 +27697,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -29749,9 +27718,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -29779,87 +27747,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -29867,9 +27754,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -29964,11 +27848,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: |-
@@ -29983,9 +27866,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -30009,9 +27891,9 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a function tool call.
@@ -30024,9 +27906,8 @@ components:
         - action
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -30044,13 +27925,14 @@ components:
             - $ref: '#/components/schemas/OpenAI.FunctionShellActionParam'
           description: The shell commands and limits that describe how to run the tool call.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemParamEnvironment'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A tool representing a request to execute one or more shell commands.
@@ -30063,9 +27945,8 @@ components:
         - output
       properties:
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         call_id:
           type: string
           minLength: 1
@@ -30084,13 +27965,14 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContentParam'
           description: Captured chunks of stdout and stderr output, along with their associated outcomes.
         status:
-          anyOf:
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallItemStatus'
-            - type: 'null'
+          nullable: true
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The streamed output items emitted by a shell tool call.
@@ -30098,7 +27980,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -30107,7 +27988,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -30117,9 +27997,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -30167,57 +28044,12 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -30272,13 +28104,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: The output of a local shell tool call.
@@ -30328,9 +28159,8 @@ components:
           description: The type of the item. Always `mcp_approval_response`.
           x-stainless-const: true
         id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         approval_request_id:
           type: string
           description: The ID of the approval request being answered.
@@ -30338,9 +28168,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A response to an MCP approval request.
@@ -30371,7 +28200,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -30404,20 +28234,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An invocation of a tool on an MCP server.
@@ -30451,10 +28279,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30485,9 +28309,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -30527,6 +28350,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -30544,19 +28368,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -30569,38 +28388,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -30665,9 +28453,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -30708,54 +28495,26 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -30773,8 +28532,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -30795,11 +28552,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -30813,7 +28569,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -30837,91 +28592,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -30956,11 +28626,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: |-
@@ -30996,12 +28665,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -31034,7 +28704,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -31042,9 +28712,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -31052,56 +28723,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -31111,7 +28735,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -31141,8 +28764,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -31169,57 +28827,12 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -31274,13 +28887,12 @@ components:
           type: string
           description: A JSON string of the output of the local shell tool call.
         status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a local shell tool call.
@@ -31340,9 +28952,8 @@ components:
           type: boolean
           description: Whether the request was approved.
         reason:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A response to an MCP approval request.
@@ -31373,7 +28984,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -31406,20 +29018,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An invocation of a tool on an MCP server.
@@ -31453,10 +29063,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -31470,134 +29076,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -31611,11 +29089,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -31628,8 +29101,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -31693,77 +29164,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -31777,9 +29177,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -31871,6 +29268,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -31898,13 +29296,11 @@ components:
             - list
           x-stainless-const: true
         first_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         last_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           x-ms-list-continuation-token: true
         has_more:
           type: boolean
@@ -31957,10 +29353,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -31981,23 +29390,22 @@ components:
             type: string
           description: The command to run.
         timeout_ms:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         working_directory:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         env:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Environment variables to set for the command.
           x-oaiTypeLabel: map
         user:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: Execute a shell command on the server.
       title: Local shell exec action
     OpenAI.LocalShellToolParam:
@@ -32011,6 +29419,7 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+          default: local_shell
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
@@ -32069,17 +29478,17 @@ components:
           type: string
           description: The name of the tool.
         description:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         input_schema:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPListToolsToolInputSchema'
           description: The JSON schema describing the tool's input.
         annotations:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.MCPListToolsToolAnnotations'
-            - type: 'null'
+          nullable: true
       description: A tool available on an MCP server.
       title: MCP list tools tool
     OpenAI.MCPListToolsToolAnnotations:
@@ -32141,30 +29550,32 @@ components:
           type: string
           description: Optional description of the MCP server, used to provide more context.
         headers:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
         allowed_tools:
           anyOf:
             - type: array
               items:
                 type: string
-            - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
-            - type: 'null'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolFilter'
+              nullable: true
         require_approval:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/OpenAI.MCPToolRequireApproval'
+              nullable: true
             - type: string
               enum:
                 - always
                 - never
-            - type: 'null'
+              nullable: true
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -32224,7 +29635,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -32239,23 +29649,18 @@ components:
           x-stainless-const: true
           default: input_file
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -32274,18 +29679,16 @@ components:
           x-stainless-const: true
           default: input_image
         image_url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
         file_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -32395,15 +29798,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -32423,7 +29817,7 @@ components:
         - incomplete
     OpenAI.Metadata:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         type: string
       description: |-
         Set of 16 key-value pairs that can be attached to an object. This can be
@@ -32434,9 +29828,13 @@ components:
       x-oaiTypeLabel: map
     OpenAI.ModelIdsCompaction:
       anyOf:
-        - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
+        - allOf:
+            - $ref: '#/components/schemas/OpenAI.ModelIdsResponses'
+          description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
+          nullable: true
         - type: string
-        - type: 'null'
+          description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
+          nullable: true
       description: Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.
     OpenAI.ModelIdsResponses:
       anyOf:
@@ -32461,125 +29859,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -32593,6 +29872,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -32601,50 +29881,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -32786,19 +30026,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -32806,38 +30040,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -32902,9 +30105,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ApplyPatchCallOutputStatus'
           description: The status of the apply patch tool call output. One of `completed` or `failed`.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call output.
@@ -32945,17 +30147,15 @@ components:
           type: string
           description: The ID of the container used to run the code.
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         outputs:
-          anyOf:
-            - type: array
-              items:
-                anyOf:
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
-                  - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
-            - type: 'null'
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputLogs'
+              - $ref: '#/components/schemas/OpenAI.CodeInterpreterOutputImage'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run code.
@@ -32993,6 +30193,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -33010,8 +30211,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -33032,99 +30231,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -33138,27 +30251,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -33193,11 +30295,10 @@ components:
             type: string
           description: The queries used to search for files.
         results:
-          anyOf:
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
-            - type: 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FileSearchToolCallResults'
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: |-
@@ -33233,12 +30334,13 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The ID of the entity that created this tool call.
@@ -33271,7 +30373,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -33279,9 +30381,10 @@ components:
             $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
           description: An array of shell call output contents
         max_output_length:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         created_by:
           type: string
           description: The identifier of the actor that created the item.
@@ -33292,7 +30395,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -33301,7 +30403,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -33311,9 +30412,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -33335,51 +30433,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -33406,9 +30459,8 @@ components:
             - failed
           description: The status of the image generation call.
         result:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An image generation request made by the model.
@@ -33447,37 +30499,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -33509,37 +30530,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -33566,7 +30556,8 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -33599,20 +30590,18 @@ components:
           type: string
           description: A JSON string of the arguments passed to the tool.
         output:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         error:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         status:
           allOf:
             - $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
         approval_request_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An invocation of a tool on an MCP server.
@@ -33646,10 +30635,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -33680,9 +30665,8 @@ components:
           type: string
           description: The unique identifier of the reasoning content.
         encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         summary:
           type: array
           items:
@@ -33710,87 +30694,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -33799,19 +30702,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -33819,9 +30716,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -33964,21 +30859,16 @@ components:
           type: string
           description: The unique identifier of the prompt template to use.
         version:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         variables:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponsePromptVariables'
-            - type: 'null'
+          nullable: true
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -33999,118 +30889,39 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
         effort:
           $ref: '#/components/schemas/OpenAI.ReasoningEffort'
         summary:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - concise
-                - detailed
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - concise
+            - detailed
+          nullable: true
         generate_summary:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - concise
-                - detailed
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - concise
+            - detailed
+          nullable: true
       description: |-
         **gpt-5 and o-series models only**
         Configuration options for
         [reasoning models](https://platform.openai.com/docs/guides/reasoning).
       title: Reasoning
     OpenAI.ReasoningEffort:
-      anyOf:
-        - type: string
-          enum:
-            - none
-            - minimal
-            - low
-            - medium
-            - high
-            - xhigh
-        - type: 'null'
+      type: string
+      enum:
+        - none
+        - minimal
+        - low
+        - medium
+        - high
+        - xhigh
       description: |-
         Constrains effort on reasoning for
         [reasoning models](https://platform.openai.com/docs/guides/reasoning).
@@ -34121,6 +30932,7 @@ components:
         - All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.
         - The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.
         - `xhigh` is supported for all models after `gpt-5.1-codex-max`.
+      nullable: true
     OpenAI.ReasoningTextContent:
       type: object
       required:
@@ -34153,22 +30965,26 @@ components:
         - agent_reference
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         top_logprobs:
-          anyOf:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         temperature:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         top_p:
-          anyOf:
+          type: number
+          allOf:
             - $ref: '#/components/schemas/OpenAI.numeric'
-            - type: 'null'
+          nullable: true
           default: 1
         user:
           type: string
@@ -34179,41 +30995,44 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
-          anyOf:
-            - type: string
-              enum:
-                - in_memory
-                - 24h
-            - type: 'null'
+          type: string
+          enum:
+            - in-memory
+            - 24h
+          nullable: true
         previous_response_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         model:
           type: string
           description: The model deployment to use for the creation of this response.
         reasoning:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
+          nullable: true
         background:
-          anyOf:
-            - type: boolean
-            - type: 'null'
-        max_tool_calls:
-          anyOf:
+          type: boolean
+          nullable: true
+        max_output_tokens:
+          type: integer
+          allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
+        max_tool_calls:
+          type: integer
+          allOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
+          nullable: true
         text:
           $ref: '#/components/schemas/OpenAI.ResponseTextParam'
         tools:
@@ -34225,12 +31044,11 @@ components:
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
         truncation:
-          anyOf:
-            - type: string
-              enum:
-                - auto
-                - disabled
-            - type: 'null'
+          type: string
+          enum:
+            - auto
+            - disabled
+          nullable: true
           default: disabled
         id:
           type: string
@@ -34258,20 +31076,19 @@ components:
           format: unixtime
           description: Unix timestamp (in seconds) of when this Response was created.
         completed_at:
-          anyOf:
-            - type: string
-              format: date-time
-            - type: 'null'
           type: integer
-          format: unixTimestamp
+          format: unixtime
+          nullable: true
         error:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseError'
-            - type: 'null'
+          nullable: true
         incomplete_details:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseIncompleteDetails'
-            - type: 'null'
+          nullable: true
         output:
           type: array
           items:
@@ -34290,29 +31107,21 @@ components:
             - type: array
               items:
                 $ref: '#/components/schemas/OpenAI.InputItem'
-            - type: 'null'
+          nullable: true
         output_text:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
           default: true
         conversation:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
-            - type: 'null'
+          nullable: true
         agent:
           allOf:
             - $ref: '#/components/schemas/AgentId'
@@ -34327,9 +31136,10 @@ components:
             or an auto-generated UUID. Use for session-scoped operations and to maintain sandbox
             affinity in follow-up calls.
         agent_reference:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/AgentReference'
-            - type: 'null'
+          nullable: true
           description: The agent used for this response
         content_filters:
           type: array
@@ -34356,10 +31166,8 @@ components:
           description: A sequence number for this chunk of the stream response.
         delta:
           type: string
-          contentEncoding: base64
+          format: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -34387,8 +31195,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -34419,8 +31225,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -34448,8 +31252,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -34489,8 +31291,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -34532,8 +31332,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -34571,8 +31369,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -34609,8 +31405,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -34647,8 +31441,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -34681,8 +31473,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -34777,8 +31567,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -34831,8 +31619,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -34871,8 +31657,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -34944,8 +31728,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -34987,8 +31769,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -35051,22 +31831,18 @@ components:
           description: The type of the event. Always `error`.
           x-stainless-const: true
         code:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         message:
           type: string
           description: The error message.
         param:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         sequence_number:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -35100,8 +31876,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -35167,8 +31941,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -35205,8 +31977,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -35243,8 +32013,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -35308,12 +32076,11 @@ components:
         schema:
           $ref: '#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
     OpenAI.ResponseFormatJsonSchemaSchema:
       type: object
-      unevaluatedProperties: {}
+      additionalProperties: {}
       description: |-
         The schema for the response format, described as a JSON Schema object.
         Learn how to build JSON schemas [here](https://json-schema.org/).
@@ -35360,8 +32127,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -35406,8 +32171,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -35446,8 +32209,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -35485,8 +32246,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -35524,8 +32283,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -35572,8 +32329,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -35609,8 +32364,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -35682,8 +32435,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -35741,7 +32492,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -35782,8 +32533,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -35826,8 +32575,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -35866,8 +32613,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -35905,8 +32650,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -35944,8 +32687,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -35983,8 +32724,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -36022,8 +32761,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -36061,8 +32798,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -36101,8 +32836,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -36146,8 +32879,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -36211,8 +32942,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -36235,7 +32964,7 @@ components:
           }
     OpenAI.ResponsePromptVariables:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         anyOf:
           - type: string
           - $ref: '#/components/schemas/OpenAI.InputTextContent'
@@ -36269,8 +32998,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -36322,8 +33049,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -36388,8 +33113,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -36455,8 +33178,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -36506,8 +33227,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -36557,8 +33276,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -36606,8 +33323,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -36655,8 +33370,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -36704,8 +33417,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -36719,127 +33430,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -36894,8 +33484,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -36949,8 +33537,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -37047,8 +33633,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -37085,8 +33669,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -37123,8 +33705,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -37147,6 +33727,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -37166,6 +33747,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -37182,21 +33764,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -37204,15 +33775,13 @@ components:
         - medium
         - high
     OpenAI.ServiceTier:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-        - type: 'null'
+      type: string
+      enum:
+        - auto
+        - default
+        - flex
+        - scale
+        - priority
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
@@ -37220,13 +33789,7 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
+      nullable: true
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -37239,6 +33802,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -37260,6 +33824,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -37275,6 +33840,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -37291,6 +33857,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -37309,6 +33876,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -37406,9 +33974,8 @@ components:
         schema:
           $ref: '#/components/schemas/OpenAI.ResponseFormatJsonSchemaSchema'
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.TextResponseFormatConfiguration'
       description: |-
@@ -37451,9 +34018,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -37482,7 +34046,7 @@ components:
           type: array
           items:
             type: object
-            unevaluatedProperties: {}
+            additionalProperties: {}
           description: |-
             A list of tool definitions that the model should be allowed to call.
               For the Responses API, the list of tool definitions might look like:
@@ -37506,34 +34070,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -37635,9 +34171,8 @@ components:
           type: string
           description: The label of the MCP server to use.
         name:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Use this option to force the model to call a specific tool on a remote MCP server.
@@ -37677,8 +34212,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -37700,8 +34233,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -37730,38 +34261,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -37769,7 +34268,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -37778,8 +34276,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -37845,6 +34341,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -37858,9 +34355,10 @@ components:
         - metadata
       properties:
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be         useful for storing additional information about the object in a structured         format, and querying for objects via API or the dashboard.
               Keys are strings with a maximum length of 64 characters. Values are strings         with a maximum length of 512 characters.
@@ -37879,6 +34377,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -37900,7 +34399,7 @@ components:
       title: URL citation
     OpenAI.VectorStoreFileAttributes:
       type: object
-      unevaluatedProperties:
+      additionalProperties:
         anyOf:
           - type: string
           - $ref: '#/components/schemas/OpenAI.numeric'
@@ -37913,17 +34412,16 @@ components:
         length of 512 characters, booleans, or numbers.
       x-oaiTypeLabel: map
     OpenAI.Verbosity:
-      anyOf:
-        - type: string
-          enum:
-            - low
-            - medium
-            - high
-        - type: 'null'
+      type: string
+      enum:
+        - low
+        - medium
+        - high
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
         Currently supported values are `low`, `medium`, and `high`.
+      nullable: true
     OpenAI.WaitParam:
       type: object
       required:
@@ -37935,6 +34433,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -37973,10 +34472,9 @@ components:
           description: The action type.
           x-stainless-const: true
         url:
-          anyOf:
-            - type: string
-              format: uri
-            - type: 'null'
+          type: string
+          format: uri
+          nullable: true
           description: The URL opened by the model.
       description: Action type "open_page" - Opens a specific URL from search results.
       title: Open page action
@@ -37984,6 +34482,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -37993,7 +34492,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -38022,7 +34521,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -38036,21 +34534,17 @@ components:
           x-stainless-const: true
           default: approximate
         country:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         region:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         city:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
         timezone:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
       description: The approximate location of the user.
       title: Web search approximate location
     OpenAI.WebSearchPreviewTool:
@@ -38064,18 +34558,16 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -38090,14 +34582,17 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
-            - type: 'null'
+          nullable: true
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           type: string
           enum:
@@ -38128,11 +34623,10 @@ components:
       type: object
       properties:
         allowed_domains:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
+          type: array
+          items:
+            type: string
+          nullable: true
     OpenAI.integer:
       type: integer
       format: int64
@@ -38196,7 +34690,7 @@ components:
           description: A description of what the function does, used by the model to choose when and how to call the function.
         spec:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The openapi function shape, described as a JSON Schema object.
         auth:
           allOf:
@@ -38220,7 +34714,7 @@ components:
                 description: A description of what the function does, used by the model to choose when and how to call the function.
               parameters:
                 type: object
-                unevaluatedProperties: {}
+                additionalProperties: {}
                 description: The parameters the functions accepts, described as a JSON Schema object.
             required:
               - name
@@ -38375,47 +34869,84 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An OpenAPI tool stored in a toolbox.
-    OptimizationAgentIdentifier:
+    OptimizationAgentDefinition:
       type: object
-      required:
-        - agent_name
       properties:
-        agent_name:
+        agentName:
           type: string
-          description: Registered Foundry agent name (required).
-        agent_version:
+          description: Agent name.
+        agentVersion:
           type: string
-          description: Pinned agent version. Defaults to latest if omitted.
-      description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.
+          description: Agent version.
+        model:
+          type: string
+          description: Model deployment name.
+        systemPrompt:
+          type: string
+          description: System prompt / instructions.
+        skills:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Agent skills.
+        tools:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          description: Agent tools.
+      description: Agent definition returned in response payloads (includes resolved config).
     OptimizationCandidate:
       type: object
       required:
         - name
-        - avg_score
-        - avg_tokens
+        - config
+        - mutations
+        - avgScore
+        - avgTokens
+        - passRate
+        - taskScores
+        - isParetoOptimal
       properties:
-        candidate_id:
+        candidateId:
           type: string
           description: Server-assigned candidate identifier. Use with GET /candidates/{id} sub-endpoints.
         name:
           type: string
           description: Display name of the candidate (e.g., 'baseline', 'instruction-v2').
+        config:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationAgentDefinition'
+          description: The agent configuration that produced this candidate.
         mutations:
           type: object
-          unevaluatedProperties: {}
-          description: "What was mutated from the baseline (e.g., {system_prompt: 'new prompt'})."
-        avg_score:
+          additionalProperties: {}
+          description: "What was mutated from the baseline (e.g., {systemPrompt: 'new prompt'})."
+        avgScore:
           type: number
           format: double
           description: Average composite score across all tasks.
-        avg_tokens:
+        avgTokens:
           type: number
           format: double
           description: Average token usage across all tasks.
-        eval_id:
+        passRate:
+          type: number
+          format: double
+          description: Fraction of tasks that met the pass threshold.
+        taskScores:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptimizationTaskResult'
+          description: Individual task-level scores.
+        isParetoOptimal:
+          type: boolean
+          description: Whether this candidate is on the Pareto frontier (score vs cost).
+        evalId:
           type: string
           description: Foundry evaluation identifier used to score this candidate.
-        eval_run_id:
+        evalRunId:
           type: string
           description: Foundry evaluation run identifier for this candidate's scoring run.
         promotion:
@@ -38423,114 +34954,16 @@ components:
             - $ref: '#/components/schemas/PromotionInfo'
           description: Promotion metadata. Null if the candidate has not been promoted.
       description: Aggregated evaluation result for a single candidate agent configuration across all tasks.
-    OptimizationDatasetCriterion:
-      type: object
-      required:
-        - name
-        - instruction
-      properties:
-        name:
-          type: string
-          description: Criterion name.
-        instruction:
-          type: string
-          description: Criterion instruction / description.
-      description: 'Evaluation criterion: a name + instruction pair used for per-item scoring.'
-    OptimizationDatasetInput:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInputType'
-          description: Dataset input type discriminator.
-      discriminator:
-        propertyName: type
-        mapping:
-          inline: '#/components/schemas/OptimizationInlineDatasetInput'
-          reference: '#/components/schemas/OptimizationReferenceDatasetInput'
-      description: Base discriminated model for dataset input. Either inline items or a registered reference.
-    OptimizationDatasetInputType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - inline
-            - reference
-      description: Discriminator values for the dataset input union.
-    OptimizationDatasetItem:
-      type: object
-      properties:
-        query:
-          type: string
-          description: The user query / prompt.
-        ground_truth:
-          type: string
-          description: Expected ground truth answer.
-        desired_num_turns:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 20
-          description: Desired number of conversation turns for simulation mode (1-20).
-        criteria:
-          type: array
-          items:
-            $ref: '#/components/schemas/OptimizationDatasetCriterion'
-          description: Per-item evaluation criteria.
-      description: A single item in an inline dataset.
-    OptimizationEvaluatorRef:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Evaluator name.
-        version:
-          type: string
-          description: Evaluator version. If not specified, the latest version is used.
-      description: Reference to a named evaluator, optionally pinned to a version.
-    OptimizationInlineDatasetInput:
-      type: object
-      required:
-        - type
-        - items
-      properties:
-        type:
-          type: string
-          enum:
-            - inline
-          description: Dataset input type discriminator.
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/OptimizationDatasetItem'
-          description: Dataset items.
-      allOf:
-        - $ref: '#/components/schemas/OptimizationDatasetInput'
-      description: Inline dataset — items supplied directly in the request body.
     OptimizationJob:
       type: object
       required:
         - id
         - status
-        - created_at
-        - updated_at
+        - createdAt
       properties:
         id:
           type: string
           description: Server-assigned unique identifier.
-          readOnly: true
-        inputs:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobInputs'
-          description: Caller-supplied inputs.
-        result:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobResult'
-          description: Result produced on success.
           readOnly: true
         status:
           allOf:
@@ -38542,12 +34975,21 @@ components:
             - $ref: '#/components/schemas/OpenAI.Error'
           description: Error details — populated only on failure.
           readOnly: true
-        created_at:
+        result:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationJobResult'
+          description: Result produced on success.
+          readOnly: true
+        inputs:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationJobInputs'
+          description: Caller-supplied inputs.
+        createdAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The timestamp when the job was created, represented in Unix time.
           readOnly: true
-        updated_at:
+        updatedAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The timestamp when the job was last updated, represented in Unix time.
@@ -38555,103 +34997,58 @@ components:
         progress:
           allOf:
             - $ref: '#/components/schemas/OptimizationJobProgress'
-          description: Progress snapshot. May be present in terminal states reflecting last-known progress.
+          description: Progress while in flight. Absent in terminal states.
           readOnly: true
-        warnings:
-          type: array
-          items:
-            type: string
-          description: Non-fatal warnings emitted at any point during optimization.
+        dataset:
+          allOf:
+            - $ref: '#/components/schemas/DatasetInfo'
+          description: Metadata about the dataset used for this optimization job.
           readOnly: true
       description: Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.
     OptimizationJobInputs:
       type: object
       required:
         - agent
-        - train_dataset
-        - evaluators
+        - trainDatasetReference
       properties:
         agent:
           allOf:
-            - $ref: '#/components/schemas/OptimizationAgentIdentifier'
+            - $ref: '#/components/schemas/AgentIdentifier'
           description: The agent (and pinned version) being optimized.
-        train_dataset:
+        trainDatasetReference:
           allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInput'
-          description: Training dataset — either inline items or a reference to a registered dataset. Required.
-        validation_dataset:
+            - $ref: '#/components/schemas/DatasetRef'
+          description: Reference to a registered training dataset (required).
+        validationDatasetReference:
           allOf:
-            - $ref: '#/components/schemas/OptimizationDatasetInput'
+            - $ref: '#/components/schemas/DatasetRef'
           description: Optional held-out validation dataset for measuring generalization of the final candidate.
         evaluators:
           type: array
           items:
-            $ref: '#/components/schemas/OptimizationEvaluatorRef'
-          description: Job-level evaluators referenced by name and optional version. Required; at least one must be provided.
+            type: string
+          description: "Job-level evaluators (referenced by name). Per-task criteria may override. Default: ['task_adherence']."
         options:
           allOf:
             - $ref: '#/components/schemas/OptimizationOptions'
           description: Tuning knobs and run-mode.
       description: Caller-supplied inputs for an optimization job.
-    OptimizationJobListItem:
-      type: object
-      required:
-        - id
-        - status
-        - created_at
-        - updated_at
-      properties:
-        id:
-          type: string
-          description: Server-assigned unique identifier.
-          readOnly: true
-        status:
-          allOf:
-            - $ref: '#/components/schemas/JobStatus'
-          description: Current lifecycle status.
-          readOnly: true
-        error:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.Error'
-          description: Error details — populated only on failure.
-          readOnly: true
-        created_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The timestamp when the job was created, represented in Unix time.
-          readOnly: true
-        updated_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The timestamp when the job was last updated, represented in Unix time.
-          readOnly: true
-        progress:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationJobProgress'
-          description: Progress snapshot. May be present in terminal states reflecting last-known progress.
-          readOnly: true
-        agent:
-          allOf:
-            - $ref: '#/components/schemas/OptimizationAgentIdentifier'
-          description: The agent targeted by this optimization job.
-          readOnly: true
-      description: Slim job representation returned by the LIST endpoint.
     OptimizationJobProgress:
       type: object
       required:
-        - candidates_completed
-        - best_score
-        - elapsed_seconds
+        - currentIteration
+        - bestScore
+        - elapsedSeconds
       properties:
-        candidates_completed:
+        currentIteration:
           type: integer
           format: int32
-          description: Number of candidates whose evaluation has completed so far.
-        best_score:
+          description: 1-based current iteration index.
+        bestScore:
           type: number
           format: double
           description: Best score observed so far across all candidates.
-        elapsed_seconds:
+        elapsedSeconds:
           type: number
           format: double
           description: Wall-clock time elapsed in seconds since the job began executing.
@@ -38660,61 +35057,106 @@ components:
       type: object
       properties:
         baseline:
-          type: string
-          description: Candidate ID of the original (un-optimized) baseline evaluation.
+          allOf:
+            - $ref: '#/components/schemas/OptimizationCandidate'
+          description: Evaluation scores for the original (un-optimized) agent configuration.
         best:
-          type: string
-          description: Candidate ID of the highest-scoring candidate found during optimization.
+          allOf:
+            - $ref: '#/components/schemas/OptimizationCandidate'
+          description: The highest-scoring candidate found during optimization.
         candidates:
           type: array
           items:
             $ref: '#/components/schemas/OptimizationCandidate'
           description: All evaluated candidates including baseline.
+        options:
+          allOf:
+            - $ref: '#/components/schemas/OptimizationOptions'
+          description: The options used for this optimization run.
+        warnings:
+          type: array
+          items:
+            type: string
+          description: Non-fatal warnings from the optimization run (e.g., target attribute failures that were skipped).
+        allTargetAttributesFailed:
+          type: boolean
+          description: True when all target attributes failed — only the baseline was evaluated.
       description: Terminal-state result body. Populated when status is succeeded or failed.
     OptimizationOptions:
       type: object
       properties:
-        max_candidates:
+        maxIterations:
           type: integer
           format: int32
-          minimum: 1
-          description: 'Maximum number of optimization candidates to generate. Must be >= 1. Default: 5.'
+          description: 'Maximum optimization iterations per strategy. Must be >= 1. Default: 5.'
           default: 5
-        optimization_config:
+        optimizationConfig:
           type: object
-          unevaluatedProperties: {}
-          description: Per-target-attribute configuration overrides. Contains skills, tools, system_prompt for the agent, plus model space for model optimization.
-        eval_model:
+          additionalProperties: {}
+          description: Per-target-attribute configuration overrides. Contains skills, tools, systemPrompt for the agent, plus model space for model optimization.
+        evalModel:
           type: string
           description: Model deployment used for evaluation. Defaults to server config (typically 'gpt-4o').
-        optimization_model:
+        optimizationModel:
           type: string
           description: Model deployment for optimization reasoning (must be gpt-5 family). Falls back to the default eval model when not set.
-        evaluation_level:
+        evaluationLevel:
           allOf:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
       description: Tuning knobs and run-mode for an optimization job.
-    OptimizationReferenceDatasetInput:
+    OptimizationTaskResult:
       type: object
       required:
-        - type
-        - name
+        - taskName
+        - scores
+        - compositeScore
+        - tokens
+        - durationSeconds
+        - passed
       properties:
-        type:
+        taskName:
           type: string
-          enum:
-            - reference
-          description: Dataset input type discriminator.
-        name:
+          description: Task name (from the dataset).
+        query:
           type: string
-          description: Registered dataset name.
-        version:
+          description: The user query / input for the task.
+        scores:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          description: Per-evaluator scores keyed by evaluator name.
+        compositeScore:
+          type: number
+          format: double
+          description: Composite score combining all evaluator scores.
+        tokens:
+          type: integer
+          format: int32
+          description: Total tokens consumed during the agent run for this task.
+        durationSeconds:
+          type: number
+          format: double
+          description: Wall-clock seconds for this task's agent execution.
+        passed:
+          type: boolean
+          description: Whether the task met the pass threshold.
+        errorMessage:
           type: string
-          description: Dataset version. If not specified, the latest version is used.
-      allOf:
-        - $ref: '#/components/schemas/OptimizationDatasetInput'
-      description: Reference to a registered Foundry dataset.
+          description: Error message if the task failed during execution.
+        rationales:
+          type: object
+          additionalProperties:
+            type: string
+          description: Per-evaluator reasoning keyed by evaluator name.
+        response:
+          type: string
+          description: Raw agent response text.
+        runId:
+          type: string
+          description: Identifier of the agent run that produced this result.
+      description: Per-task evaluation result for a single candidate.
     OtlpTelemetryEndpoint:
       type: object
       required:
@@ -38730,14 +35172,12 @@ components:
         endpoint:
           type: string
           description: The OTLP collector endpoint URL.
-          examples:
-            - https://my-collector.example.com/otlp
+          example: https://my-collector.example.com/otlp
         protocol:
           allOf:
             - $ref: '#/components/schemas/TelemetryTransportProtocol'
           description: The transport protocol for the OTLP endpoint.
-          examples:
-            - Http
+          example: Http
       allOf:
         - $ref: '#/components/schemas/TelemetryEndpoint'
       description: An OTLP (OpenTelemetry Protocol) telemetry export endpoint.
@@ -39044,21 +35484,60 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - MemoryStores=V1Preview
-    PromotionInfo:
+    PromoteCandidateRequest:
       type: object
       required:
-        - promoted_at
-        - agent_name
-        - agent_version
+        - agentName
+        - agentVersion
       properties:
-        promoted_at:
+        agentName:
+          type: string
+          description: Name of the Foundry agent to promote to.
+        agentVersion:
+          type: string
+          description: Version of the Foundry agent to promote to.
+      description: Request body for promoting a candidate to a Foundry agent version.
+    PromoteCandidateResponse:
+      type: object
+      required:
+        - candidateId
+        - status
+        - promotedAt
+        - agentName
+        - agentVersion
+      properties:
+        candidateId:
+          type: string
+          description: The promoted candidate id.
+        status:
+          type: string
+          description: Status after promotion.
+        promotedAt:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: Timestamp when promotion occurred, represented in Unix time.
-        agent_name:
+        agentName:
+          type: string
+          description: Name of the Foundry agent promoted to.
+        agentVersion:
+          type: string
+          description: Version of the Foundry agent promoted to.
+      description: Response after successfully promoting a candidate.
+    PromotionInfo:
+      type: object
+      required:
+        - promotedAt
+        - agentName
+        - agentVersion
+      properties:
+        promotedAt:
+          allOf:
+            - $ref: '#/components/schemas/FoundryTimestamp'
+          description: Timestamp when promotion occurred, represented in Unix time.
+        agentName:
           type: string
           description: Name of the Foundry agent this candidate was promoted to.
-        agent_version:
+        agentVersion:
           type: string
           description: Version of the Foundry agent this candidate was promoted to.
       description: Promotion metadata recorded when a candidate is deployed to a Foundry agent.
@@ -39076,15 +35555,13 @@ components:
           type: string
           description: The model deployment to use for this agent.
         instructions:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
           description: A system (or developer) message inserted into the model's context.
         temperature:
-          anyOf:
-            - type: number
-              format: float
-            - type: 'null'
+          type: number
+          format: float
+          nullable: true
           minimum: 0
           maximum: 2
           description: |-
@@ -39092,10 +35569,9 @@ components:
             We generally recommend altering this or `top_p` but not both. Defaults to `1`.
           default: 1
         top_p:
-          anyOf:
-            - type: number
-              format: float
-            - type: 'null'
+          type: number
+          format: float
+          nullable: true
           minimum: 0
           maximum: 1
           description: |-
@@ -39106,9 +35582,10 @@ components:
             Defaults to `1`.
           default: 1
         reasoning:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Reasoning'
-            - type: 'null'
+          nullable: true
         tools:
           type: array
           items:
@@ -39129,7 +35606,7 @@ components:
           description: Configuration options for a text response from the model. Can be plain text or structured JSON data.
         structured_inputs:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that can participate in prompt template substitution or tool argument bindings.
       allOf:
@@ -39324,7 +35801,7 @@ components:
           description: List of attack strategies or nested lists of attack strategies.
         simulationOnly:
           type: boolean
-          description: Simulation-only or Simulation + Evaluation. If `true` the scan outputs conversation not evaluation result. The service defaults to `false` if a value is not specified by the caller.
+          description: Simulation-only or Simulation + Evaluation. Default false, if true the scan outputs conversation not evaluation result.
           default: false
         riskCategories:
           type: array
@@ -39336,12 +35813,12 @@ components:
           description: Application scenario for the red team operation, to generate scenario specific attacks.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Red team's tags. Unlike properties, tags are fully mutable.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Red team's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.
         status:
@@ -39493,7 +35970,7 @@ components:
           description: The maximum number of turns of chat history to evaluate.
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Mapping from source fields to response_id field, required for retrieving chat history.
         source:
@@ -39523,7 +36000,10 @@ components:
     Routine:
       type: object
       required:
+        - name
         - enabled
+        - triggers
+        - action
       properties:
         name:
           type: string
@@ -39538,7 +36018,7 @@ components:
           description: Whether the routine is enabled.
         triggers:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/RoutineTrigger'
           description: The triggers configured for the routine.
         action:
@@ -39602,6 +36082,9 @@ components:
           - Routines=V1Preview
     RoutineCreateOrUpdateRequest:
       type: object
+      required:
+        - triggers
+        - action
       properties:
         description:
           type: string
@@ -39612,7 +36095,7 @@ components:
           description: Whether the routine is enabled.
         triggers:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/RoutineTrigger'
           description: The triggers configured for the routine. In v1, exactly one trigger entry is supported.
         action:
@@ -39656,15 +36139,16 @@ components:
       type: object
       required:
         - id
+        - status
+        - trigger_type
+        - started_at
       properties:
         id:
           type: string
-          description: The unique run identifier for the routine attempt.
-          readOnly: true
+          description: The MLflow run identifier for the routine attempt.
         status:
-          allOf:
-            - $ref: '#/components/schemas/RoutineRunStatus'
-          description: The run status.
+          type: string
+          description: The underlying MLflow run status.
         phase:
           allOf:
             - $ref: '#/components/schemas/RoutineRunPhase'
@@ -39673,9 +36157,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineTriggerType'
           description: The trigger type that produced the routine attempt.
-        trigger_name:
-          type: string
-          description: The configured trigger name that produced the routine attempt.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'
@@ -39684,26 +36165,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/RoutineActionType'
           description: The action type dispatched for the routine attempt.
-        agent_id:
-          type: string
-          description: The project-scoped agent identifier recorded for the routine attempt.
-        agent_endpoint_id:
-          type: string
-          description: The legacy endpoint-scoped agent identifier recorded for the routine attempt.
-        conversation_id:
-          type: string
-          description: The conversation identifier used by a responses API dispatch.
-        session_id:
-          type: string
-          description: The hosted-agent session identifier used by an invocations API dispatch.
         triggered_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
           description: The logical trigger time recorded for the routine attempt.
-        scheduled_fire_at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The scheduled fire time recorded for timer and schedule deliveries.
         started_at:
           allOf:
             - $ref: '#/components/schemas/FoundryTimestamp'
@@ -39724,17 +36189,44 @@ components:
         task_id:
           type: string
           description: The workspace task identifier linked to the routine attempt, when available.
-        error_status_code:
-          type: integer
-          format: int32
-          description: The downstream error status code captured for a failed attempt, when available.
         error_type:
           type: string
           description: The fully qualified error type captured for a failed attempt, when available.
         error_message:
           type: string
           description: The truncated failure message captured for a failed attempt, when available.
+        diagnostics:
+          allOf:
+            - $ref: '#/components/schemas/RoutineRunDiagnostics'
+          description: Diagnostic data captured for the routine attempt.
       description: A single routine run returned from the run history API.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V1Preview
+    RoutineRunDiagnostics:
+      type: object
+      required:
+        - parameters
+        - tags
+        - metrics
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+          description: MLflow parameters recorded on the run, keyed by parameter name.
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: MLflow tags recorded on the run, keyed by tag name.
+        metrics:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          description: Latest MLflow metric values recorded on the run, keyed by metric name.
+      description: Generic diagnostics captured on a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -39748,12 +36240,6 @@ components:
             - completed
             - failed
       description: Known lifecycle phases recorded for a routine run.
-      x-ms-foundry-meta:
-        conditional_previews:
-          - Routines=V1Preview
-    RoutineRunStatus:
-      type: string
-      description: The status of a routine run.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V1Preview
@@ -39771,8 +36257,7 @@ components:
         mapping:
           schedule: '#/components/schemas/ScheduleRoutineTrigger'
           timer: '#/components/schemas/TimerRoutineTrigger'
-          github_issue: '#/components/schemas/GitHubIssueRoutineTrigger'
-          custom: '#/components/schemas/CustomRoutineTrigger'
+          github_issue_opened: '#/components/schemas/GitHubIssueOpenedRoutineTrigger'
       description: Base model for a routine trigger.
       x-ms-foundry-meta:
         conditional_previews:
@@ -39782,8 +36267,7 @@ components:
         - type: string
         - type: string
           enum:
-            - custom
-            - github_issue
+            - github_issue_opened
             - schedule
             - timer
       description: The discriminator values supported for routine triggers.
@@ -39894,17 +36378,17 @@ components:
           description: Task for the schedule.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Schedule's tags. Unlike properties, tags are fully mutable.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Schedule's properties. Unlike tags, properties are add-only. Once added, a property cannot be removed.
         systemData:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: System metadata for the resource.
           readOnly: true
@@ -39972,7 +36456,7 @@ components:
           readOnly: true
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Properties of the schedule run.
           readOnly: true
@@ -39988,7 +36472,7 @@ components:
           description: Type of the task.
         configuration:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Configuration for the task.
       discriminator:
@@ -40032,19 +36516,9 @@ components:
     SessionDirectoryListResponse:
       type: object
       required:
-        - has_more
         - path
         - entries
       properties:
-        first_id:
-          type: string
-          description: The first ID represented in this list.
-        last_id:
-          type: string
-          description: The last ID represented in this list.
-        has_more:
-          type: boolean
-          description: A value indicating whether there are additional values available not captured in this list.
         path:
           type: string
           description: The path that was listed, relative to the session home directory.
@@ -40053,6 +36527,7 @@ components:
           items:
             $ref: '#/components/schemas/SessionDirectoryEntry'
           description: The directory entries.
+      description: Response from listing a directory in a session sandbox.
     SessionFileWriteResponse:
       type: object
       required:
@@ -40077,13 +36552,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/SessionLogEventType'
           description: The SSE event type. Currently `log`, but additional event types may be added in the future. Clients should ignore unrecognized event types.
-          examples:
-            - log
+          example: log
         data:
           type: string
           description: The event payload as plain text. Currently JSON-formatted but the schema is not contractual and may change.
-          examples:
-            - '{"timestamp":"2026-03-10T09:33:17.121467567+00:00","stream":"stdout","message":"Starting server on port 18080"}'
+          example: '{"timestamp":"2026-03-10T09:33:17.121467567+00:00","stream":"stdout","message":"Starting server on port 18080"}'
       description: |-
         A single Server-Sent Event frame emitted by the hosted agent session log stream.
 
@@ -40285,7 +36758,7 @@ components:
           description: Environment requirements or compatibility notes for the skill.
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Arbitrary key-value metadata for additional properties.
         allowed_tools:
@@ -40367,11 +36840,11 @@ components:
           description: The default value for the input if no run-time value is provided.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema for the structured input (optional).
         required:
           type: boolean
-          description: Whether the input property is required when the agent is invoked. The service defaults to `false` if a value is not specified by the caller.
+          description: Whether the input property is required when the agent is invoked. Defaults to `false`.
           default: false
       description: An structured input that can participate in prompt template substitutions and tool argument binding.
     StructuredOutputDefinition:
@@ -40390,12 +36863,11 @@ components:
           description: A description of the output to emit. Used by the model to determine when to emit the output.
         schema:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The JSON schema for the structured output.
         strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          type: boolean
+          nullable: true
           description: Whether to enforce strict validation. Default `true`.
       description: A structured output that can be produced by the agent.
     StructuredOutputsOutputItem:
@@ -40600,7 +37072,7 @@ components:
           description: List of taxonomy sub categories.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the taxonomy category.
       description: Taxonomy category definition.
@@ -40625,7 +37097,7 @@ components:
           description: List of taxonomy items under this sub-category.
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Additional properties for the taxonomy sub-category.
       description: Taxonomy sub-category definition.
@@ -40672,10 +37144,10 @@ components:
           items:
             $ref: '#/components/schemas/TelemetryDataKind'
           description: Data types to export to this endpoint. Use an empty array to export no data.
-          examples:
-            - - ContainerStdoutStderr
-              - ContainerOtel
-              - Metrics
+          example:
+            - ContainerStdoutStderr
+            - ContainerOtel
+            - Metrics
         auth:
           allOf:
             - $ref: '#/components/schemas/TelemetryEndpointAuth'
@@ -40759,11 +37231,10 @@ components:
           description: The version of the evaluator. Latest version if not specified.
         initialization_parameters:
           type: object
-          unevaluatedProperties: {}
           description: The initialization parameters for the evaluation. Must support structured outputs.
         data_mapping:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: The model to use for the evaluation. Must support structured outputs.
       description: An Azure AI Evaluator grader used as testing criterion in evaluations.
@@ -40772,6 +37243,7 @@ components:
       type: object
       required:
         - type
+        - at
       properties:
         type:
           type: string
@@ -40779,9 +37251,11 @@ components:
             - timer
           description: The trigger type.
         at:
-          allOf:
-            - $ref: '#/components/schemas/FoundryTimestamp'
-          description: The UTC date and time at which the timer fires.
+          type: string
+          description: A future timer expression. Supported values include an ISO-8601 timestamp with an explicit offset, a local timestamp paired with time_zone, or a positive duration from now.
+        time_zone:
+          type: string
+          description: An optional IANA or Windows time zone identifier when the timer uses a local timestamp.
       allOf:
         - $ref: '#/components/schemas/RoutineTrigger'
       description: A one-shot timer routine trigger.
@@ -40791,7 +37265,7 @@ components:
     ToolCallOutputContent:
       anyOf:
         - type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
         - type: string
         - type: array
           items: {}
@@ -40941,7 +37415,7 @@ components:
           description: Optional user-defined description for this tool or configuration.
         tool_configs:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             $ref: '#/components/schemas/ToolConfig'
           description: |-
             Per-tool configuration map. Keys are tool names or `*` (catch-all default).
@@ -40986,11 +37460,10 @@ components:
         - tools
       properties:
         metadata:
-          anyOf:
-            - type: object
-              unevaluatedProperties:
-                type: string
-            - type: 'null'
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
             useful for storing additional information about the object in a structured
@@ -41285,7 +37758,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -41304,7 +37777,7 @@ components:
           description: The manifest ID to import the agent version from.
         parameter_values:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: The inputs to the manifest that will result in a fully materialized Agent.
     UpdateAgentRequest:
       type: object
@@ -41313,7 +37786,7 @@ components:
       properties:
         metadata:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of 16 key-value pairs that can be attached to an object. This can be
@@ -41350,12 +37823,13 @@ components:
         name:
           type: string
         metadata:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
+          nullable: true
         properties:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: |-
             Set of immutable 16 key-value pairs that can be attached to an object for storing additional information.
@@ -41368,7 +37842,7 @@ components:
           description: The asset description text.
         tags:
           type: object
-          unevaluatedProperties:
+          additionalProperties:
             type: string
           description: Tag dictionary. Tags can be added, removed, and updated.
       description: Request body for updating a model version. Only description and tags can be modified.
@@ -41532,13 +38006,15 @@ components:
           enum:
             - web_search
         filters:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
-            - type: 'null'
+          nullable: true
         user_location:
-          anyOf:
+          type: object
+          allOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchApproximateLocation'
-            - type: 'null'
+          nullable: true
         search_context_size:
           type: string
           enum:
@@ -41692,7 +38168,7 @@ components:
           description: The model deployment to be evaluated. Accepts either the deployment name alone or with the connection name as '{connectionName}/modelDeploymentName'.
         modelParams:
           type: object
-          unevaluatedProperties: {}
+          additionalProperties: {}
           description: Optional parameters passed to the model for evaluation.
       allOf:
         - $ref: '#/components/schemas/EvaluationTarget'

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -56,20 +56,31 @@ alias ToolFields<Source> = {
   ...OmitProperties<Source, "name" | "description" | "type">;
 };
 
+alias ToolboxCodeInterpreterToolType = "code_interpreter";
+alias ToolboxFileSearchToolType = "file_search";
+alias ToolboxWebSearchToolType = "web_search";
+alias ToolboxMCPToolType = "mcp";
+alias ToolboxAzureAISearchToolType = "azure_ai_search";
+alias ToolboxOpenApiToolType = "openapi";
+alias ToolboxA2APreviewToolType = "a2a_preview";
+alias ToolboxWorkIQPreviewToolType = "work_iq_preview";
+alias ToolboxFabricIQPreviewToolType = "fabric_iq_preview";
+alias ToolboxSearchPreviewToolType = "toolbox_search_preview";
+
 /**
  * Supported tool types for tools stored in a toolbox.
  */
 union ToolboxToolType {
-  code_interpreter: "code_interpreter",
-  file_search: "file_search",
-  web_search: "web_search",
-  mcp: "mcp",
-  azure_ai_search: "azure_ai_search",
-  openapi: "openapi",
-  a2a_preview: "a2a_preview",
-  work_iq_preview: "work_iq_preview",
-  fabric_iq_preview: "fabric_iq_preview",
-  toolbox_search_preview: "toolbox_search_preview",
+  code_interpreter: ToolboxCodeInterpreterToolType,
+  file_search: ToolboxFileSearchToolType,
+  web_search: ToolboxWebSearchToolType,
+  mcp: ToolboxMCPToolType,
+  azure_ai_search: ToolboxAzureAISearchToolType,
+  openapi: ToolboxOpenApiToolType,
+  a2a_preview: ToolboxA2APreviewToolType,
+  work_iq_preview: ToolboxWorkIQPreviewToolType,
+  fabric_iq_preview: ToolboxFabricIQPreviewToolType,
+  toolbox_search_preview: ToolboxSearchPreviewToolType,
 }
 
 /**
@@ -90,7 +101,7 @@ model ToolboxTool {
  * A code interpreter tool stored in a toolbox.
  */
 model CodeInterpreterToolboxTool extends ToolboxTool {
-  type: "code_interpreter";
+  type: ToolboxCodeInterpreterToolType;
 
   ...ToolFields<OpenAI.CodeInterpreterTool>;
 }
@@ -99,7 +110,7 @@ model CodeInterpreterToolboxTool extends ToolboxTool {
  * A file search tool stored in a toolbox.
  */
 model FileSearchToolboxTool extends ToolboxTool {
-  type: "file_search";
+  type: ToolboxFileSearchToolType;
 
   ...WithFieldsOptional<
     ToolFields<OpenAI.FileSearchTool>,
@@ -111,7 +122,7 @@ model FileSearchToolboxTool extends ToolboxTool {
  * A web search tool stored in a toolbox.
  */
 model WebSearchToolboxTool extends ToolboxTool {
-  type: "web_search";
+  type: ToolboxWebSearchToolType;
 
   ...ToolFields<OpenAI.WebSearchTool>;
 }
@@ -120,7 +131,7 @@ model WebSearchToolboxTool extends ToolboxTool {
  * An MCP tool stored in a toolbox.
  */
 model MCPToolboxTool extends ToolboxTool {
-  type: "mcp";
+  type: ToolboxMCPToolType;
 
   ...ToolFields<OpenAI.MCPTool>;
 }
@@ -129,7 +140,7 @@ model MCPToolboxTool extends ToolboxTool {
  * An Azure AI Search tool stored in a toolbox.
  */
 model AzureAISearchToolboxTool extends ToolboxTool {
-  type: "azure_ai_search";
+  type: ToolboxAzureAISearchToolType;
 
   ...ToolFields<AzureAISearchTool>;
 }
@@ -138,7 +149,7 @@ model AzureAISearchToolboxTool extends ToolboxTool {
  * An OpenAPI tool stored in a toolbox.
  */
 model OpenApiToolboxTool extends ToolboxTool {
-  type: "openapi";
+  type: ToolboxOpenApiToolType;
 
   ...ToolFields<OpenApiTool>;
 }
@@ -147,7 +158,7 @@ model OpenApiToolboxTool extends ToolboxTool {
  * An A2A tool stored in a toolbox.
  */
 model A2APreviewToolboxTool extends ToolboxTool {
-  type: "a2a_preview";
+  type: ToolboxA2APreviewToolType;
 
   ...ToolFields<A2APreviewTool>;
 }
@@ -156,7 +167,7 @@ model A2APreviewToolboxTool extends ToolboxTool {
  * A WorkIQ tool stored in a toolbox.
  */
 model WorkIQPreviewToolboxTool extends ToolboxTool {
-  type: "work_iq_preview";
+  type: ToolboxWorkIQPreviewToolType;
 
   ...ToolFields<WorkIQPreviewTool>;
 }
@@ -165,7 +176,7 @@ model WorkIQPreviewToolboxTool extends ToolboxTool {
  * A FabricIQ tool stored in a toolbox.
  */
 model FabricIQPreviewToolboxTool extends ToolboxTool {
-  type: "fabric_iq_preview";
+  type: ToolboxFabricIQPreviewToolType;
 
   ...ToolFields<FabricIQPreviewTool>;
 }
@@ -177,7 +188,7 @@ model ToolboxSearchPreviewToolboxTool extends ToolboxTool {
   /**
    * The type of the tool. Always `toolbox_search_preview`.
    */
-  type: "toolbox_search_preview";
+  type: ToolboxSearchPreviewToolType;
 }
 
 @doc("Policy configuration for a toolbox, including content safety and other governance settings.")


### PR DESCRIPTION
**Description:**

Removes duplicated raw string literals in `ToolboxToolType` by introducing per-tool literal aliases and referencing them consistently in both the union definition and each derived model's discriminator property.

**Changes:**
- `src/toolboxes/models.tsp`: Added `ToolboxCodeInterpreterToolType`, `ToolboxFileSearchToolType`, etc. as named string literal aliases. Updated `ToolboxToolType` union members and all derived toolbox model `type` properties to reference these aliases instead of repeating raw strings.

**Why aliases instead of union member references (`ToolboxToolType.member`):**
TypeSpec treats union variant references as `UnionVariant` types, which are not valid in discriminator override positions. String literal aliases resolve to plain string literal types and satisfy the discriminator contract.

**Testing:** `npx tsp compile .` passes.