### PR TITLE
Fix OperationalInsights .NET service directory casing

### DIFF
--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -32,7 +32,6 @@ options:
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-operationalinsights"
     flavor: azure
-    service-dir: "sdk/operationalinsights"
     compatibility-lro: true
     experimental-extensible-enums: true
     package-details:

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/operationalInsights"
+    default: "sdk/operationalinsights"
 emit:
   - "@azure-tools/typespec-autorest"
 options:


### PR DESCRIPTION
## Summary
- Update OperationalInsights TypeSpec `service-dir` default to use the existing lower-case `sdk/operationalinsights` path.
- Remove the redundant TypeScript `service-dir` override because it had the same lower-case value as the corrected default.
- Prevent .NET SDK generation from creating a duplicate mixed-case `sdk/operationalInsights` directory.

## `service-dir` consumers

The top-level `parameters."service-dir".default` is only used by emitters that do not define an emitter-local `service-dir` option. After this change, .NET and TypeScript intentionally share the same lower-case SDK service directory, while other languages keep their explicit language-specific paths.

| Emitter | Uses top-level default? | Effective value |
|---|---:|---|
| `@azure-typespec/http-client-csharp-mgmt` | Yes | `sdk/operationalinsights` |
| `@azure-tools/typespec-ts` | Yes | `sdk/operationalinsights` |
| `@azure-tools/typespec-python` | No | `sdk/loganalytics` |
| `@azure-tools/typespec-java` | No | `sdk/loganalytics` |
| `@azure-tools/typespec-go` | No | `sdk/resourcemanager/operationalinsights` |

## Validation
- Verified `tspconfig.yaml` no longer references the mixed-case `sdk/operationalInsights` path.
- Verified emitters with different SDK service directories still have explicit overrides.