### PR TITLE
CognitiveServices: add infrastructureSettings to account and project

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1663,6 +1663,12 @@ model AccountProperties {
    * Specifies the projects, by project name, that are associated with this resource.
    */
   associatedProjects?: string[];
+
+  /**
+   * Reusable default agent infrastructure settings inherited by child projects.
+   */
+  @added(Versions.v2026_05_01)
+  infrastructureSettings?: InfrastructureSettings;
 }
 
 /**
@@ -2130,6 +2136,41 @@ model NetworkInjection {
    * Boolean to enable Microsoft Managed Network for subnet delegation
    */
   useMicrosoftManagedNetwork?: boolean;
+}
+
+/**
+ * Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent
+ * storage dependencies. Modeled as an object so future capability-backed resources can be added
+ * without changing the account or project contract.
+ */
+@added(Versions.v2026_05_01)
+model InfrastructureSettings {
+  /**
+   * Azure resource ID of the document store used by agent runtime state.
+   */
+  documentStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.DocumentDB/databaseAccounts";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the vector store used by agent retrieval and indexing.
+   */
+  vectorStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Search/searchServices";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the blob store used by agent file and artifact storage.
+   */
+  blobStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Storage/storageAccounts";
+    }
+  ]>;
 }
 
 /**
@@ -4099,6 +4140,15 @@ model ProjectProperties {
    */
   @visibility(Lifecycle.Read)
   isDefault?: boolean;
+
+  /**
+   * Effective agent infrastructure settings for the project. Optional partial override of the
+   * account defaults; omitted fields inherit from the parent account when present. Settable only
+   * at create time.
+   */
+  @added(Versions.v2026_05_01)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  infrastructureSettings?: InfrastructureSettings;
 }
 
 /**


### PR DESCRIPTION
Adds `infrastructureSettings` property to the CognitiveServices account and project models in the TypeSpec specification.