### PR TITLE
Rename Compute automatic SKU migration flag for C#

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -1627,6 +1627,11 @@ model VMSizePropertiesWithAdditionalProperties {
 @@alternateType(KeyVaultKeyReference.keyUrl, url, "csharp");
 @@alternateType(KeyVaultSecretReference.secretUrl, url, "csharp");
 @@useSystemTextJsonConverter(KeyVaultSecretReference, "csharp");
+@@clientName(
+  AutomaticSkuMigrationPolicy.enabled,
+  "isAutomaticSkuMigrationPolicyEnabled",
+  "csharp"
+);
 @@alternateType(LogAnalyticsInputBase.blobContainerSasUri, url, "csharp");
 @@alternateType(
   RetrieveBootDiagnosticsDataResult.consoleScreenshotBlobUri,


### PR DESCRIPTION
Renames the generated C# property for Compute automatic SKU migration from \AutomaticSkuMigrationPolicyEnabled\ to \IsAutomaticSkuMigrationPolicyEnabled\ using a C#-scoped \@@clientName\ decorator.\n\nThis addresses the .NET management SDK boolean naming rule for the new Compute API surface.