### PR TITLE
Add exact C# TLS version names for Redis

### DIFF
--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
@@ -317,6 +317,9 @@ model RedisCommonPropertiesRedisConfigurationRecordString {
 @@usage(RedisLinkedServer, Usage.output, "csharp");
 
 @@clientName(TlsVersion, "RedisTlsVersion", "csharp");
+@@clientName(Microsoft.Cache.TlsVersion.`1.0`, Azure.ClientGenerator.Core.exact("Tls1_0"), "csharp");
+@@clientName(Microsoft.Cache.TlsVersion.`1.1`, Azure.ClientGenerator.Core.exact("Tls1_1"), "csharp");
+@@clientName(Microsoft.Cache.TlsVersion.`1.2`, Azure.ClientGenerator.Core.exact("Tls1_2"), "csharp");
 
 // we add this model in this namespace in order to replace some models with this model via alternateType decorator
 namespace Azure.ResourceManager.Models {

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/client.tsp
@@ -317,9 +317,21 @@ model RedisCommonPropertiesRedisConfigurationRecordString {
 @@usage(RedisLinkedServer, Usage.output, "csharp");
 
 @@clientName(TlsVersion, "RedisTlsVersion", "csharp");
-@@clientName(Microsoft.Cache.TlsVersion.`1.0`, Azure.ClientGenerator.Core.exact("Tls1_0"), "csharp");
-@@clientName(Microsoft.Cache.TlsVersion.`1.1`, Azure.ClientGenerator.Core.exact("Tls1_1"), "csharp");
-@@clientName(Microsoft.Cache.TlsVersion.`1.2`, Azure.ClientGenerator.Core.exact("Tls1_2"), "csharp");
+@@clientName(
+  Microsoft.Cache.TlsVersion.`1.0`,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  Microsoft.Cache.TlsVersion.`1.1`,
+  Azure.ClientGenerator.Core.exact("Tls1_1"),
+  "csharp"
+);
+@@clientName(
+  Microsoft.Cache.TlsVersion.`1.2`,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
 
 // we add this model in this namespace in order to replace some models with this model via alternateType decorator
 namespace Azure.ResourceManager.Models {


### PR DESCRIPTION
Add C# exact client names for Redis TLS version union values so the management SDK can generate the existing Tls1_0/Tls1_1/Tls1_2 API directly without SDK-side CodeGenMember customizations.