### PR TITLE
CognitiveServices: add infrastructureSettings to account and project

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateAccount.json
@@ -21,7 +21,7 @@
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
         ],
-        "infrastructureSettings": {
+        "capabilitySettings": {
           "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
           "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
           "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -67,7 +67,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -107,7 +107,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -147,7 +147,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateAccount.json
@@ -20,7 +20,12 @@
           {
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
-        ]
+        ],
+        "infrastructureSettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+          "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+        }
       },
       "sku": {
         "name": "S0"
@@ -61,7 +66,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -96,7 +106,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -131,7 +146,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateProject.json
@@ -10,7 +10,11 @@
       "location": "West US",
       "properties": {
         "description": "Description of this project",
-        "displayName": "p1"
+        "displayName": "p1",
+        "infrastructureSettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
+        }
       }
     },
     "projectName": "testProject1",
@@ -40,7 +44,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -65,7 +74,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -90,7 +104,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     }

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-05-15-preview/CreateProject.json
@@ -11,7 +11,7 @@
       "properties": {
         "description": "Description of this project",
         "displayName": "p1",
-        "infrastructureSettings": {
+        "capabilitySettings": {
           "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
           "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
         }
@@ -45,7 +45,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -75,7 +75,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -105,7 +105,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1665,6 +1665,12 @@ model AccountProperties {
    * Specifies the projects, by project name, that are associated with this resource.
    */
   associatedProjects?: string[];
+
+  /**
+   * Reusable default agent infrastructure settings inherited by child projects.
+   */
+  @added(Versions.v2026_05_15_preview)
+  infrastructureSettings?: InfrastructureSettings;
 }
 
 /**
@@ -2134,6 +2140,41 @@ model NetworkInjection {
    * Boolean to enable Microsoft Managed Network for subnet delegation
    */
   useMicrosoftManagedNetwork?: boolean;
+}
+
+/**
+ * Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent
+ * storage dependencies. Modeled as an object so future capability-backed resources can be added
+ * without changing the account or project contract.
+ */
+@added(Versions.v2026_05_15_preview)
+model InfrastructureSettings {
+  /**
+   * Azure resource ID of the document store used by agent runtime state.
+   */
+  documentStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.DocumentDB/databaseAccounts";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the vector store used by agent retrieval and indexing.
+   */
+  vectorStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Search/searchServices";
+    }
+  ]>;
+
+  /**
+   * Azure resource ID of the blob store used by agent file and artifact storage.
+   */
+  blobStore?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Storage/storageAccounts";
+    }
+  ]>;
 }
 
 /**
@@ -4131,6 +4172,15 @@ model ProjectProperties {
    */
   @visibility(Lifecycle.Read)
   isDefault?: boolean;
+
+  /**
+   * Effective agent infrastructure settings for the project. Optional partial override of the
+   * account defaults; omitted fields inherit from the parent account when present. Settable only
+   * at create time.
+   */
+  @added(Versions.v2026_05_15_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  infrastructureSettings?: InfrastructureSettings;
 }
 
 /**

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -2143,9 +2143,7 @@ model NetworkInjection {
 }
 
 /**
- * Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent
- * storage dependencies. Modeled as an object so future capability-backed resources can be added
- * without changing the account or project contract.
+ * Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.
  */
 @added(Versions.v2026_05_15_preview)
 model InfrastructureSettings {
@@ -4174,9 +4172,7 @@ model ProjectProperties {
   isDefault?: boolean;
 
   /**
-   * Effective agent infrastructure settings for the project. Optional partial override of the
-   * account defaults; omitted fields inherit from the parent account when present. Settable only
-   * at create time.
+   * Effective agent infrastructure settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.
    */
   @added(Versions.v2026_05_15_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create)

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1667,10 +1667,10 @@ model AccountProperties {
   associatedProjects?: string[];
 
   /**
-   * Reusable default agent infrastructure settings inherited by child projects.
+   * Reusable default agent capability settings inherited by child projects.
    */
   @added(Versions.v2026_05_15_preview)
-  infrastructureSettings?: InfrastructureSettings;
+  capabilitySettings?: CapabilitySettings;
 }
 
 /**
@@ -2143,10 +2143,10 @@ model NetworkInjection {
 }
 
 /**
- * Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.
+ * Extensible agent capability configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.
  */
 @added(Versions.v2026_05_15_preview)
-model InfrastructureSettings {
+model CapabilitySettings {
   /**
    * Azure resource ID of the document store used by agent runtime state.
    */
@@ -4172,11 +4172,11 @@ model ProjectProperties {
   isDefault?: boolean;
 
   /**
-   * Effective agent infrastructure settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.
+   * Effective agent capability settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.
    */
   @added(Versions.v2026_05_15_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  infrastructureSettings?: InfrastructureSettings;
+  capabilitySettings?: CapabilitySettings;
 }
 
 /**

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -11740,6 +11740,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "infrastructureSettings": {
+          "$ref": "#/definitions/InfrastructureSettings",
+          "description": "Reusable default agent infrastructure settings inherited by child projects."
         }
       }
     },
@@ -15877,6 +15881,48 @@
       },
       "readOnly": true
     },
+    "InfrastructureSettings": {
+      "type": "object",
+      "description": "Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent\nstorage dependencies. Modeled as an object so future capability-backed resources can be added\nwithout changing the account or project contract.",
+      "properties": {
+        "documentStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the document store used by agent runtime state.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DocumentDB/databaseAccounts"
+              }
+            ]
+          }
+        },
+        "vectorStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the vector store used by agent retrieval and indexing.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Search/searchServices"
+              }
+            ]
+          }
+        },
+        "blobStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the blob store used by agent file and artifact storage.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        }
+      }
+    },
     "IpRule": {
       "type": "object",
       "description": "A rule governing the accessibility from a specific ip address or ip range.",
@@ -17823,6 +17869,14 @@
           "type": "boolean",
           "description": "Indicates whether the project is the default project for the account.",
           "readOnly": true
+        },
+        "infrastructureSettings": {
+          "$ref": "#/definitions/InfrastructureSettings",
+          "description": "Effective agent infrastructure settings for the project. Optional partial override of the\naccount defaults; omitted fields inherit from the parent account when present. Settable only\nat create time.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -11741,9 +11741,9 @@
             "type": "string"
           }
         },
-        "infrastructureSettings": {
-          "$ref": "#/definitions/InfrastructureSettings",
-          "description": "Reusable default agent infrastructure settings inherited by child projects."
+        "capabilitySettings": {
+          "$ref": "#/definitions/CapabilitySettings",
+          "description": "Reusable default agent capability settings inherited by child projects."
         }
       }
     },
@@ -12793,6 +12793,48 @@
           "description": "An array of objects of type Capability Host.",
           "items": {
             "$ref": "#/definitions/CapabilityHost"
+          }
+        }
+      }
+    },
+    "CapabilitySettings": {
+      "type": "object",
+      "description": "Extensible agent capability configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.",
+      "properties": {
+        "documentStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the document store used by agent runtime state.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.DocumentDB/databaseAccounts"
+              }
+            ]
+          }
+        },
+        "vectorStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the vector store used by agent retrieval and indexing.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Search/searchServices"
+              }
+            ]
+          }
+        },
+        "blobStore": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID of the blob store used by agent file and artifact storage.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
           }
         }
       }
@@ -15881,48 +15923,6 @@
       },
       "readOnly": true
     },
-    "InfrastructureSettings": {
-      "type": "object",
-      "description": "Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.",
-      "properties": {
-        "documentStore": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Azure resource ID of the document store used by agent runtime state.",
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.DocumentDB/databaseAccounts"
-              }
-            ]
-          }
-        },
-        "vectorStore": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Azure resource ID of the vector store used by agent retrieval and indexing.",
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.Search/searchServices"
-              }
-            ]
-          }
-        },
-        "blobStore": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "Azure resource ID of the blob store used by agent file and artifact storage.",
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.Storage/storageAccounts"
-              }
-            ]
-          }
-        }
-      }
-    },
     "IpRule": {
       "type": "object",
       "description": "A rule governing the accessibility from a specific ip address or ip range.",
@@ -17870,9 +17870,9 @@
           "description": "Indicates whether the project is the default project for the account.",
           "readOnly": true
         },
-        "infrastructureSettings": {
-          "$ref": "#/definitions/InfrastructureSettings",
-          "description": "Effective agent infrastructure settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.",
+        "capabilitySettings": {
+          "$ref": "#/definitions/CapabilitySettings",
+          "description": "Effective agent capability settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -15883,7 +15883,7 @@
     },
     "InfrastructureSettings": {
       "type": "object",
-      "description": "Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent\nstorage dependencies. Modeled as an object so future capability-backed resources can be added\nwithout changing the account or project contract.",
+      "description": "Extensible agent infrastructure configuration. Carries the Azure resource IDs of the agent storage dependencies. Modeled as an object so future capability-backed resources can be added without changing the account or project contract.",
       "properties": {
         "documentStore": {
           "type": "string",
@@ -17872,7 +17872,7 @@
         },
         "infrastructureSettings": {
           "$ref": "#/definitions/InfrastructureSettings",
-          "description": "Effective agent infrastructure settings for the project. Optional partial override of the\naccount defaults; omitted fields inherit from the parent account when present. Settable only\nat create time.",
+          "description": "Effective agent infrastructure settings for the project. Optional partial override of the account defaults; omitted fields inherit from the parent account when present. Settable only at create time.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateAccount.json
@@ -21,7 +21,7 @@
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
         ],
-        "infrastructureSettings": {
+        "capabilitySettings": {
           "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
           "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
           "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -67,7 +67,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -107,7 +107,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -147,7 +147,7 @@
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
           ],
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateAccount.json
@@ -20,7 +20,12 @@
           {
             "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
           }
-        ]
+        ],
+        "infrastructureSettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+          "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+        }
       },
       "sku": {
         "name": "S0"
@@ -61,7 +66,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -96,7 +106,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"
@@ -131,7 +146,12 @@
             {
               "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
             }
-          ]
+          ],
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/mySearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         },
         "sku": {
           "name": "S0"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateProject.json
@@ -10,7 +10,11 @@
       "location": "West US",
       "properties": {
         "description": "Description of this project",
-        "displayName": "p1"
+        "displayName": "p1",
+        "infrastructureSettings": {
+          "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+          "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
+        }
       }
     },
     "projectName": "testProject1",
@@ -40,7 +44,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -65,7 +74,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     },
@@ -90,7 +104,12 @@
             "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
           },
           "isDefault": true,
-          "provisioningState": "Succeeded"
+          "provisioningState": "Succeeded",
+          "infrastructureSettings": {
+            "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
+            "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
+            "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
         }
       }
     }

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/examples/CreateProject.json
@@ -11,7 +11,7 @@
       "properties": {
         "description": "Description of this project",
         "displayName": "p1",
-        "infrastructureSettings": {
+        "capabilitySettings": {
           "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
           "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService"
         }
@@ -45,7 +45,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -75,7 +75,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
@@ -105,7 +105,7 @@
           },
           "isDefault": true,
           "provisioningState": "Succeeded",
-          "infrastructureSettings": {
+          "capabilitySettings": {
             "documentStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/myProjectCosmosAccount",
             "vectorStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Search/searchServices/myProjectSearchService",
             "blobStore": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"


### PR DESCRIPTION
Adds `infrastructureSettings` property to the CognitiveServices account and project models in the 2026-05-15-preview TypeSpec specification.