### PR TITLE
Move tool name/description to toolbox and add browser automation tool…

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9,30 +9,179 @@
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Insights",
+      "parent": "Evaluations"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Evalsuite",
+      "parent": "Evaluations"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Redteams",
+      "parent": "Evaluations",
+      "description": "Red Teaming"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Evaluation Taxonomies",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Evaluators",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agent Invocations",
+      "name": "Evaluation Rules",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evals",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evaluations"
+    },
+    {
+      "name": "EvaluatorGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Evaluator generation jobs"
+    },
+    {
+      "name": "AgentOptimizationJobs",
+      "parent": "Platform APIs",
+      "description": "Agent optimization jobs"
+    },
+    {
+      "name": "DataGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Data generation jobs"
+    },
+    {
+      "name": "Deployments",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Toolboxes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Skills",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Schedules",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Routines",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Videos",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Vector stores",
+      "parent": "Platform APIs",
+      "description": "Vector Stores"
+    },
+    {
+      "name": "Uploads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Threads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Realtime",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Moderations",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Images",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Files",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Embeddings",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Containers",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Completions",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Batch",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Audio",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Assistants",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Chat",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Memory Stores",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Models",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Fine-tuning",
+      "parent": "Platform APIs",
+      "description": "Fine-Tuning"
+    },
+    {
+      "name": "Scheduler",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Connections",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Indexes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Datasets",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Platform APIs"
+    },
+    {
+      "name": "Agent Containers",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Versions",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Session Files",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Sessions",
       "parent": "Agents Root"
     },
     {
@@ -41,180 +190,31 @@
       "description": "Agent Invocations (WebSocket)"
     },
     {
-      "name": "Agent Sessions",
+      "name": "Agent Invocations",
       "parent": "Agents Root"
     },
     {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
+      "name": "Agents",
+      "parent": "Agents Root",
+      "description": "Agent Management"
     },
     {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
+      "name": "Agents Root",
+      "description": "Agents"
     },
     {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
+      "name": "Conversations",
+      "parent": "Responses Root",
+      "description": "Conversations (OpenAI)"
     },
     {
-      "name": "Platform APIs"
+      "name": "Responses",
+      "parent": "Responses Root",
+      "description": "Responses (OpenAI)"
     },
     {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "Responses Root",
+      "description": "Responses"
     }
   ],
   "paths": {
@@ -12330,8 +12330,7 @@
                     },
                     "safety_identifier": {
                       "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
                       "type": "string",
@@ -12345,7 +12344,7 @@
                         {
                           "type": "string",
                           "enum": [
-                            "in_memory",
+                            "in-memory",
                             "24h"
                           ]
                         },
@@ -12382,6 +12381,16 @@
                       "anyOf": [
                         {
                           "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "max_output_tokens": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -12530,16 +12539,6 @@
                     "usage": {
                       "$ref": "#/components/schemas/OpenAI.ResponseUsage"
                     },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "parallel_tool_calls": {
                       "type": "boolean",
                       "description": "Whether to allow the model to run tool calls in parallel.",
@@ -12549,16 +12548,6 @@
                       "anyOf": [
                         {
                           "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -12684,8 +12673,7 @@
                   },
                   "safety_identifier": {
                     "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
                     "type": "string",
@@ -12699,7 +12687,7 @@
                       {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
                         ]
                       },
@@ -12736,6 +12724,16 @@
                     "anyOf": [
                       {
                         "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "max_output_tokens": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.integer"
                       },
                       {
                         "type": "null"
@@ -12834,16 +12832,6 @@
                       }
                     ]
                   },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "stream": {
                     "anyOf": [
                       {
@@ -12887,16 +12875,6 @@
                       }
                     ],
                     "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   },
                   "agent_reference": {
                     "allOf": [
@@ -16890,14 +16868,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the A2A server.\nThe connection stores authentication and other connection details needed to connect to the A2A server."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -18591,14 +18561,6 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -19477,14 +19439,6 @@
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -19659,14 +19613,6 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -19845,14 +19791,6 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -19868,6 +19806,35 @@
           }
         ],
         "description": "The input definition information for a Browser Automation Tool, as used to configure an Agent."
+      },
+      "BrowserAutomationPreviewToolboxTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "browser_automation_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "browser_automation_preview"
+            ]
+          },
+          "browser_automation_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BrowserAutomationToolParameters"
+              }
+            ],
+            "description": "The Browser Automation Tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A browser automation tool stored in a toolbox."
       },
       "BrowserAutomationToolCall": {
         "type": "object",
@@ -19993,14 +19960,6 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [
@@ -21568,9 +21527,7 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -24266,14 +24223,6 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -25587,8 +25536,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -25748,10 +25696,6 @@
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -26083,14 +26027,6 @@
               "memory_search_preview"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -26616,14 +26552,6 @@
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "fabric_dataagent_preview": {
             "allOf": [
               {
@@ -27117,7 +27045,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -27150,7 +27079,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -27184,7 +27114,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27212,7 +27143,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27312,7 +27244,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -27337,7 +27270,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27370,7 +27304,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27513,12 +27448,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -27618,7 +27547,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -27643,19 +27573,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -27728,14 +27645,6 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -27847,36 +27756,6 @@
                 "type": "null"
               }
             ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         }
       },
@@ -27896,9 +27775,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -28000,14 +27877,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -28077,8 +27946,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -28087,7 +27955,8 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
             "anyOf": [
@@ -28109,14 +27978,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -28154,29 +28015,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -28192,7 +28030,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -28239,7 +28078,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -28294,7 +28134,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -28355,7 +28196,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -28364,6 +28206,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -28384,7 +28234,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -28392,6 +28243,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -28439,7 +28316,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -28521,18 +28399,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -28544,56 +28418,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -28787,50 +28617,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -28853,9 +28646,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -28882,11 +28672,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -28902,8 +28691,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -28933,17 +28721,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -28975,18 +28802,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -28994,65 +28809,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -29154,7 +28912,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -29213,7 +28971,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -29248,67 +29006,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -29316,8 +29016,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -29359,9 +29058,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -29679,7 +29425,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -29810,16 +29563,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -29892,138 +29635,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -30040,11 +29651,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -30233,8 +29840,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -31163,7 +30769,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -31198,7 +30805,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -31222,7 +30830,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -31239,10 +30848,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -31315,8 +30920,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -31324,8 +30928,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -31334,7 +30937,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -31351,19 +30955,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31387,7 +30978,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -31395,19 +30987,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31447,16 +31026,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -31482,9 +31051,6 @@
         ],
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
-      },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
       },
       "OpenAI.Error": {
         "type": "object",
@@ -32511,7 +32077,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -32537,13 +32104,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -32595,7 +32155,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -32629,14 +32190,6 @@
                 "type": "null"
               }
             ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -33510,22 +33063,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -33579,7 +33124,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -33635,22 +33180,6 @@
         ]
       },
       "OpenAI.FunctionCallItemStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
         "type": "string",
         "enum": [
           "in_progress",
@@ -33975,7 +33504,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -34007,7 +33537,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -34094,14 +33625,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -34114,7 +33637,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -34137,7 +33661,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -34147,14 +33672,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -34168,7 +33685,8 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
             "anyOf": [
@@ -34179,14 +33697,6 @@
                 "type": "null"
               }
             ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -34303,7 +33813,8 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
@@ -34339,10 +33850,6 @@
                 "type": "null"
               }
             ]
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
           }
         },
         "allOf": [
@@ -34353,62 +33860,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -34756,8 +34262,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -34780,7 +34285,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -34810,21 +34316,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -34902,14 +34401,6 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -34952,7 +34443,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -34969,7 +34460,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -35123,22 +34615,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -35192,7 +34676,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -35284,22 +34768,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -35360,14 +34836,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
           }
         },
         "description": "A file input to the model.",
@@ -35416,7 +34884,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -35494,9 +34962,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -35516,56 +34981,6 @@
           }
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
-      },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
       },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -35878,6 +35293,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -35900,9 +35316,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -35953,10 +35366,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -36301,7 +35710,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -36310,8 +35718,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -36324,10 +35731,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -36629,7 +36032,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -36752,16 +36162,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -36842,143 +36242,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -36995,9 +36258,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -37073,6 +36333,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -37080,6 +36386,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -37157,7 +36512,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -37165,9 +36520,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -37187,56 +36539,6 @@
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
       },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -37549,6 +36851,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -37571,9 +36874,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -37624,10 +36924,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -37706,17 +37002,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -37735,50 +37028,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -38016,6 +37265,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -38038,9 +37288,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -38067,11 +37314,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -38087,8 +37333,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -38118,9 +37363,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -38146,10 +37389,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -38315,7 +37554,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -38374,7 +37613,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -38412,7 +37651,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -38421,8 +37659,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -38435,10 +37672,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -38465,64 +37698,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -38793,7 +37968,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -38924,16 +38106,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -39006,138 +38178,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -39148,9 +38188,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -39509,7 +38546,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -39518,8 +38554,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -39532,10 +38567,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -39612,59 +38643,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -39890,7 +38868,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -40013,16 +38998,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -40116,7 +39091,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -40144,19 +39120,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -40168,56 +39139,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -40411,50 +39336,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -40477,9 +39365,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -40506,11 +39391,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -40526,8 +39410,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -40557,126 +39440,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -40778,7 +39542,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -40837,7 +39601,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -40872,67 +39636,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -40940,8 +39646,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -40983,9 +39688,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -41036,59 +39788,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -41309,7 +40008,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -41432,16 +40138,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -41460,200 +40156,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -41670,11 +40172,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -41687,8 +40184,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -41771,143 +40266,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -41924,9 +40282,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -42038,7 +40393,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -42170,7 +40526,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -42180,6 +40537,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -42259,15 +40632,8 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "x-stainless-const": true,
+            "default": "local_shell"
           }
         },
         "allOf": [
@@ -42473,10 +40839,6 @@
             ],
             "default": "always"
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
@@ -42550,8 +40912,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -42585,22 +40946,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -42654,7 +41007,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -42817,14 +41170,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -42904,182 +41249,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -43094,7 +41263,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -43111,19 +41281,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -43133,57 +41290,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -43373,19 +41479,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -43393,55 +41493,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -43679,6 +41733,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -43701,9 +41756,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -43730,128 +41782,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -43870,10 +41807,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -43881,18 +41814,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -43900,7 +41821,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -44002,7 +41924,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -44061,7 +41983,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -44099,7 +42021,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -44108,8 +42029,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -44122,10 +42042,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -44152,64 +42068,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -44308,54 +42166,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -44399,54 +42209,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -44480,7 +42242,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -44603,16 +42372,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -44693,138 +42452,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -44836,19 +42463,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -44856,9 +42477,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -45079,13 +42698,6 @@
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
       },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
-      },
       "OpenAI.RankerVersionType": {
         "type": "string",
         "enum": [
@@ -45121,123 +42733,6 @@
             "description": "Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled."
           }
         }
-      },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
       },
       "OpenAI.Reasoning": {
         "type": "object",
@@ -45385,8 +42880,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -45400,7 +42894,7 @@
               {
                 "type": "string",
                 "enum": [
-                  "in_memory",
+                  "in-memory",
                   "24h"
                 ]
               },
@@ -45437,6 +42931,16 @@
             "anyOf": [
               {
                 "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -45585,16 +43089,6 @@
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
           },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "parallel_tool_calls": {
             "type": "boolean",
             "description": "Whether to allow the model to run tool calls in parallel.",
@@ -45604,16 +43098,6 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -45671,11 +43155,6 @@
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -45707,11 +43186,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -45748,11 +43222,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -45784,11 +43253,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -45839,11 +43303,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -45894,11 +43353,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -45944,11 +43398,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -45994,11 +43443,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -46044,11 +43488,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -46089,11 +43528,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -46157,11 +43591,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -46225,11 +43654,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -46270,11 +43694,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -46325,11 +43744,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -46381,11 +43795,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -46486,11 +43895,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -46531,11 +43935,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -46581,11 +43980,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -46631,11 +44025,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -46681,11 +44070,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -46838,11 +44222,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -46897,11 +44276,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -46947,11 +44321,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -46998,11 +44367,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -47049,11 +44413,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -47114,11 +44473,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -47160,11 +44514,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -47217,11 +44566,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -47253,7 +44597,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -47312,11 +44656,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -47368,11 +44707,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -47419,11 +44753,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -47470,11 +44799,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -47521,11 +44845,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -47572,11 +44891,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -47623,11 +44937,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -47674,11 +44983,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -47729,11 +45033,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -47783,11 +45082,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -47860,11 +45154,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -47929,11 +45218,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -47998,11 +45282,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -48085,11 +45364,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -48168,11 +45442,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -48232,11 +45501,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -48296,11 +45560,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -48360,11 +45619,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -48424,11 +45678,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -48488,151 +45737,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -48704,11 +45814,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -48776,11 +45881,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -48913,11 +46013,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -48963,11 +46058,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -49013,11 +46103,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -49037,7 +46122,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -49064,7 +46150,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -49097,19 +46184,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -49119,13 +46193,6 @@
         ],
         "description": "A scroll action.",
         "title": "Scroll"
-      },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
       },
       "OpenAI.SearchContextSize": {
         "type": "string",
@@ -49153,15 +46220,6 @@
         ],
         "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
-      "OpenAI.ServiceTierEnum": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "default",
-          "flex",
-          "priority"
-        ]
-      },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
         "required": [
@@ -49175,7 +46233,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -49206,7 +46265,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -49229,7 +46289,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -49253,7 +46314,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -49280,7 +46342,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -49458,10 +46521,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -49517,46 +46577,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -49755,9 +46775,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -49781,9 +46799,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -49828,64 +46844,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -49896,7 +46854,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -49905,8 +46862,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -49970,7 +46925,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -50020,7 +46976,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -50102,7 +47059,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -50175,7 +47133,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -50188,7 +47147,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -50226,8 +47185,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -50302,7 +47260,8 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
             "anyOf": [
@@ -50321,12 +47280,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -50348,7 +47301,8 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
             "anyOf": [
@@ -50379,14 +47333,6 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -53395,14 +50341,6 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -54492,6 +51430,7 @@
             "azure_ai_search": "#/components/schemas/AzureAISearchToolboxTool",
             "openapi": "#/components/schemas/OpenApiToolboxTool",
             "a2a_preview": "#/components/schemas/A2APreviewToolboxTool",
+            "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
@@ -54509,6 +51448,7 @@
           "azure_ai_search",
           "openapi",
           "a2a_preview",
+          "browser_automation_preview",
           "work_iq_preview",
           "fabric_iq_preview",
           "toolbox_search_preview"
@@ -55315,14 +52255,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4,114 +4,114 @@ info:
   version: v1
 tags:
   - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
-  - name: Agents
+  - name: Insights
+    parent: Evaluations
+  - name: Evalsuite
+    parent: Evaluations
+  - name: Redteams
+    parent: Evaluations
+    description: Red Teaming
+  - name: Evaluation Taxonomies
+    parent: Evaluations
+  - name: Evaluators
+    parent: Evaluations
+  - name: Evaluation Rules
+    parent: Evaluations
+  - name: Evals
+    parent: Evaluations
+  - name: Evaluations
+  - name: EvaluatorGenerationJobs
+    parent: Platform APIs
+    description: Evaluator generation jobs
+  - name: AgentOptimizationJobs
+    parent: Platform APIs
+    description: Agent optimization jobs
+  - name: DataGenerationJobs
+    parent: Platform APIs
+    description: Data generation jobs
+  - name: Deployments
+    parent: Platform APIs
+  - name: Toolboxes
+    parent: Platform APIs
+  - name: Skills
+    parent: Platform APIs
+  - name: Schedules
+    parent: Platform APIs
+  - name: Routines
+    parent: Platform APIs
+  - name: Videos
+    parent: Platform APIs
+  - name: Vector stores
+    parent: Platform APIs
+    description: Vector Stores
+  - name: Uploads
+    parent: Platform APIs
+  - name: Threads
+    parent: Platform APIs
+  - name: Realtime
+    parent: Platform APIs
+  - name: Moderations
+    parent: Platform APIs
+  - name: Images
+    parent: Platform APIs
+  - name: Files
+    parent: Platform APIs
+  - name: Embeddings
+    parent: Platform APIs
+  - name: Containers
+    parent: Platform APIs
+  - name: Completions
+    parent: Platform APIs
+  - name: Batch
+    parent: Platform APIs
+  - name: Audio
+    parent: Platform APIs
+  - name: Assistants
+    parent: Platform APIs
+  - name: Chat
+    parent: Platform APIs
+  - name: Memory Stores
+    parent: Platform APIs
+  - name: Models
+    parent: Platform APIs
+  - name: Fine-tuning
+    parent: Platform APIs
+    description: Fine-Tuning
+  - name: Scheduler
+    parent: Platform APIs
+  - name: Connections
+    parent: Platform APIs
+  - name: Indexes
+    parent: Platform APIs
+  - name: Datasets
+    parent: Platform APIs
+  - name: Platform APIs
+  - name: Agent Containers
     parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
+  - name: Agent Versions
+    parent: Agents Root
+  - name: Agent Session Files
+    parent: Agents Root
+  - name: Agent Sessions
     parent: Agents Root
   - name: Agent Invocations WebSocket
     parent: Agents Root
     description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
+  - name: Agent Invocations
     parent: Agents Root
-  - name: Agent Session Files
+  - name: Agents
     parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
-  - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
-  - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
-  - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
-  - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
-  - name: Insights
-    parent: Evaluations
+    description: Agent Management
+  - name: Agents Root
+    description: Agents
+  - name: Conversations
+    parent: Responses Root
+    description: Conversations (OpenAI)
+  - name: Responses
+    parent: Responses Root
+    description: Responses (OpenAI)
+  - name: Responses Root
+    description: Responses
 paths:
   /agent_optimization_jobs:
     post:
@@ -8149,10 +8149,9 @@ paths:
                     deprecated: true
                   safety_identifier:
                     type: string
-                    maxLength: 64
                     description: |-
                       A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                        The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
                     type: string
                     description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -8162,7 +8161,7 @@ paths:
                     anyOf:
                       - type: string
                         enum:
-                          - in_memory
+                          - in-memory
                           - 24h
                       - type: 'null'
                   previous_response_id:
@@ -8179,6 +8178,10 @@ paths:
                   background:
                     anyOf:
                       - type: boolean
+                      - type: 'null'
+                  max_output_tokens:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   max_tool_calls:
                     anyOf:
@@ -8267,10 +8270,6 @@ paths:
                       - type: 'null'
                   usage:
                     $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
                   parallel_tool_calls:
                     type: boolean
                     description: Whether to allow the model to run tool calls in parallel.
@@ -8278,10 +8277,6 @@ paths:
                   conversation:
                     anyOf:
                       - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   agent_reference:
                     anyOf:
@@ -8354,10 +8349,9 @@ paths:
                   deprecated: true
                 safety_identifier:
                   type: string
-                  maxLength: 64
                   description: |-
                     A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
                   type: string
                   description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -8367,7 +8361,7 @@ paths:
                   anyOf:
                     - type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
                     - type: 'null'
                 previous_response_id:
@@ -8384,6 +8378,10 @@ paths:
                 background:
                   anyOf:
                     - type: boolean
+                    - type: 'null'
+                max_output_tokens:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.integer'
                     - type: 'null'
                 max_tool_calls:
                   anyOf:
@@ -8429,10 +8427,6 @@ paths:
                   anyOf:
                     - type: string
                     - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
                 stream:
                   anyOf:
                     - type: boolean
@@ -8452,10 +8446,6 @@ paths:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
                     - type: 'null'
                   description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
                 agent_reference:
                   allOf:
                     - $ref: '#/components/schemas/AgentReference'
@@ -11115,12 +11105,6 @@ components:
           description: |-
             The connection ID in the project for the A2A server.
             The connection stores authentication and other connection details needed to connect to the A2A server.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -12240,12 +12224,6 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12813,12 +12791,6 @@ components:
           enum:
             - bing_custom_search_preview
           description: The object type, which is always 'bing_custom_search_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -12937,12 +12909,6 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -13052,12 +13018,6 @@ components:
           enum:
             - browser_automation_preview
           description: The object type, which is always 'browser_automation_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -13065,6 +13025,23 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for a Browser Automation Tool, as used to configure an Agent.
+    BrowserAutomationPreviewToolboxTool:
+      type: object
+      required:
+        - type
+        - browser_automation_preview
+      properties:
+        type:
+          type: string
+          enum:
+            - browser_automation_preview
+        browser_automation_preview:
+          allOf:
+            - $ref: '#/components/schemas/BrowserAutomationToolParameters'
+          description: The Browser Automation Tool parameters.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A browser automation tool stored in a toolbox.
     BrowserAutomationToolCall:
       type: object
       required:
@@ -13145,12 +13122,6 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -14235,8 +14206,7 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -16308,12 +16278,6 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -17155,7 +17119,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -17275,9 +17238,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -17485,12 +17445,6 @@ components:
           enum:
             - memory_search_preview
           description: The type of the tool. Always `memory_search_preview`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -17827,12 +17781,6 @@ components:
           enum:
             - fabric_dataagent_preview
           description: The object type, which is always 'fabric_dataagent_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -18170,6 +18118,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -18193,6 +18142,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -18217,6 +18167,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -18236,6 +18187,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -18301,6 +18253,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -18318,6 +18271,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -18341,6 +18295,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -18426,12 +18381,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -18526,6 +18475,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -18538,12 +18488,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -18596,12 +18540,6 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         container:
           anyOf:
             - type: string
@@ -18670,18 +18608,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -18698,8 +18624,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -18771,14 +18695,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -18824,7 +18740,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -18832,6 +18747,7 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
           anyOf:
             - type: string
@@ -18841,10 +18757,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -18871,21 +18783,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -18900,6 +18797,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -18927,6 +18825,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -18963,6 +18862,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -19003,12 +18903,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -19022,8 +18929,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -19056,6 +18984,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -19104,18 +19033,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -19127,39 +19052,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -19282,39 +19178,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -19332,8 +19202,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -19354,11 +19222,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -19372,7 +19239,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -19396,15 +19262,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -19427,60 +19320,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -19555,7 +19398,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -19593,7 +19436,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -19611,56 +19454,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -19670,7 +19466,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -19700,8 +19495,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -19924,7 +19754,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -20007,10 +19839,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -20062,87 +19890,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -20156,11 +19903,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -20296,7 +20039,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -20914,6 +20656,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -20936,6 +20679,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -20952,6 +20696,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -20962,9 +20707,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -21012,14 +20754,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -21027,6 +20767,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -21035,12 +20776,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -21057,6 +20792,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -21069,12 +20805,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -21103,10 +20833,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -21131,8 +20857,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -21826,6 +21550,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -21840,11 +21565,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -21881,6 +21601,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -21898,12 +21619,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -22493,17 +22208,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -22533,7 +22244,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -22567,18 +22278,6 @@ components:
             - input_image
             - input_file
     OpenAI.FunctionCallItemStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
       type: string
       enum:
         - in_progress
@@ -22789,6 +22488,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -22809,6 +22509,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -22859,12 +22560,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -22876,6 +22571,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -22891,16 +22587,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -22912,16 +22603,11 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -22999,6 +22685,7 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
@@ -23015,45 +22702,53 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-        defer_loading:
-          type: boolean
-          description: Whether this function is deferred and loaded via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -23430,7 +23125,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -23448,6 +23142,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -23469,15 +23164,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -23533,12 +23228,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -23567,7 +23256,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -23589,6 +23277,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -23691,17 +23380,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -23731,7 +23416,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -23789,17 +23474,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -23831,10 +23512,6 @@ components:
             - type: string
               format: uri
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -23862,7 +23539,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -23911,9 +23588,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -23934,38 +23608,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -24155,6 +23797,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -24172,8 +23815,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -24214,9 +23855,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -24427,7 +24065,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -24436,7 +24073,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -24446,9 +24082,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -24656,7 +24289,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -24736,10 +24371,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -24800,77 +24431,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -24884,9 +24444,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -24943,6 +24500,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -24951,6 +24546,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -25012,7 +24644,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -25020,9 +24652,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -25040,38 +24669,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -25261,6 +24858,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25278,8 +24876,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25320,9 +24916,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -25375,17 +24968,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -25402,35 +24992,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -25586,6 +25147,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25603,8 +25165,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25625,11 +25185,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -25643,7 +25202,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -25667,8 +25225,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -25689,9 +25245,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -25808,7 +25361,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -25846,7 +25399,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -25867,7 +25420,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -25876,7 +25428,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -25886,9 +25437,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -25910,51 +25458,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -26141,7 +25644,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -26224,10 +25729,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -26279,87 +25780,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -26367,9 +25787,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -26598,7 +26015,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -26607,7 +26023,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -26617,9 +26032,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -26674,50 +26086,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -26871,7 +26239,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -26951,10 +26321,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27027,6 +26393,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -27044,19 +26411,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -27069,38 +26431,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -27223,39 +26554,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27273,8 +26578,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27295,11 +26598,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -27313,7 +26615,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -27337,91 +26638,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -27496,7 +26712,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -27534,7 +26750,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -27552,56 +26768,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -27611,7 +26780,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27641,8 +26809,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -27676,50 +26879,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -27873,7 +27032,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -27953,10 +27114,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27970,134 +27127,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -28111,11 +27140,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -28128,8 +27152,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -28193,77 +27215,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -28277,9 +27228,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -28371,6 +27319,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -28457,10 +27406,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -28511,12 +27473,7 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
+          default: local_shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -28662,9 +27619,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -28724,7 +27678,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -28745,17 +27698,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -28785,7 +27734,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -28895,15 +27844,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -28961,125 +27901,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -29093,6 +27914,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -29101,50 +27923,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -29281,19 +28063,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -29301,38 +28077,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -29488,6 +28233,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -29505,8 +28251,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -29527,99 +28271,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -29633,27 +28291,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -29728,7 +28375,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -29766,7 +28413,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -29787,7 +28434,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29796,7 +28442,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29806,9 +28451,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29830,51 +28472,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -29942,37 +28539,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -30004,37 +28570,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -30061,7 +28596,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -30141,10 +28678,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30205,87 +28738,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -30294,19 +28746,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -30314,9 +28760,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -30469,11 +28913,6 @@ components:
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -30494,81 +28933,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
@@ -30674,10 +29038,9 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -30687,7 +29050,7 @@ components:
           anyOf:
             - type: string
               enum:
-                - in_memory
+                - in-memory
                 - 24h
             - type: 'null'
         previous_response_id:
@@ -30704,6 +29067,10 @@ components:
         background:
           anyOf:
             - type: boolean
+            - type: 'null'
+        max_output_tokens:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         max_tool_calls:
           anyOf:
@@ -30792,10 +29159,6 @@ components:
             - type: 'null'
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
@@ -30803,10 +29166,6 @@ components:
         conversation:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         agent_reference:
           anyOf:
@@ -30840,8 +29199,6 @@ components:
           type: string
           contentEncoding: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -30869,8 +29226,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -30901,8 +29256,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -30930,8 +29283,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -30971,8 +29322,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -31014,8 +29363,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -31053,8 +29400,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -31091,8 +29436,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -31129,8 +29472,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -31163,8 +29504,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -31259,8 +29598,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -31313,8 +29650,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -31353,8 +29688,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -31426,8 +29759,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -31469,8 +29800,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -31547,8 +29876,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -31582,8 +29909,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -31649,8 +29974,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -31687,8 +30010,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -31725,8 +30046,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -31842,8 +30161,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -31888,8 +30205,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -31928,8 +30243,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -31967,8 +30280,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -32006,8 +30317,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -32054,8 +30363,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -32091,8 +30398,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -32164,8 +30469,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -32223,7 +30526,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -32264,8 +30567,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -32308,8 +30609,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -32348,8 +30647,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -32387,8 +30684,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -32426,8 +30721,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -32465,8 +30758,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -32504,8 +30795,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -32543,8 +30832,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -32583,8 +30870,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -32628,8 +30913,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -32693,8 +30976,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -32751,8 +31032,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -32804,8 +31083,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -32870,8 +31147,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -32937,8 +31212,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -32988,8 +31261,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -33039,8 +31310,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -33088,8 +31357,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -33137,8 +31404,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -33186,8 +31451,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -33201,127 +31464,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -33376,8 +31518,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -33431,8 +31571,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -33529,8 +31667,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -33567,8 +31703,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -33605,8 +31739,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -33629,6 +31761,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -33648,6 +31781,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -33664,21 +31798,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -33702,13 +31825,6 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -33721,6 +31837,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -33742,6 +31859,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -33757,6 +31875,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -33773,6 +31892,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -33791,6 +31911,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -33932,9 +32053,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -33987,34 +32105,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -34158,8 +32248,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -34181,8 +32269,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -34211,38 +32297,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -34250,7 +32304,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -34259,8 +32312,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -34325,6 +32376,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -34359,6 +32411,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -34415,6 +32468,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -34464,6 +32518,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -34473,7 +32528,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -34502,7 +32557,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -34544,6 +32598,7 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
@@ -34552,10 +32607,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -34570,6 +32621,7 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -34586,12 +32638,6 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -36595,12 +34641,6 @@ components:
           enum:
             - sharepoint_grounding_preview
           description: The object type, which is always 'sharepoint_grounding_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -37322,6 +35362,7 @@ components:
           azure_ai_search: '#/components/schemas/AzureAISearchToolboxTool'
           openapi: '#/components/schemas/OpenApiToolboxTool'
           a2a_preview: '#/components/schemas/A2APreviewToolboxTool'
+          browser_automation_preview: '#/components/schemas/BrowserAutomationPreviewToolboxTool'
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
@@ -37336,6 +35377,7 @@ components:
         - azure_ai_search
         - openapi
         - a2a_preview
+        - browser_automation_preview
         - work_iq_preview
         - fabric_iq_preview
         - toolbox_search_preview
@@ -37877,12 +35919,6 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -12,30 +12,179 @@
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Insights",
+      "parent": "Evaluations"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Evalsuite",
+      "parent": "Evaluations"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Redteams",
+      "parent": "Evaluations",
+      "description": "Red Teaming"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Evaluation Taxonomies",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Evaluators",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agent Invocations",
+      "name": "Evaluation Rules",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evals",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evaluations"
+    },
+    {
+      "name": "EvaluatorGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Evaluator generation jobs"
+    },
+    {
+      "name": "AgentOptimizationJobs",
+      "parent": "Platform APIs",
+      "description": "Agent optimization jobs"
+    },
+    {
+      "name": "DataGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Data generation jobs"
+    },
+    {
+      "name": "Deployments",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Toolboxes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Skills",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Schedules",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Routines",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Videos",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Vector stores",
+      "parent": "Platform APIs",
+      "description": "Vector Stores"
+    },
+    {
+      "name": "Uploads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Threads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Realtime",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Moderations",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Images",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Files",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Embeddings",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Containers",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Completions",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Batch",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Audio",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Assistants",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Chat",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Memory Stores",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Models",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Fine-tuning",
+      "parent": "Platform APIs",
+      "description": "Fine-Tuning"
+    },
+    {
+      "name": "Scheduler",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Connections",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Indexes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Datasets",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Platform APIs"
+    },
+    {
+      "name": "Agent Containers",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Versions",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Session Files",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Sessions",
       "parent": "Agents Root"
     },
     {
@@ -44,180 +193,31 @@
       "description": "Agent Invocations (WebSocket)"
     },
     {
-      "name": "Agent Sessions",
+      "name": "Agent Invocations",
       "parent": "Agents Root"
     },
     {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
+      "name": "Agents",
+      "parent": "Agents Root",
+      "description": "Agent Management"
     },
     {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
+      "name": "Agents Root",
+      "description": "Agents"
     },
     {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
+      "name": "Conversations",
+      "parent": "Responses Root",
+      "description": "Conversations (OpenAI)"
     },
     {
-      "name": "Platform APIs"
+      "name": "Responses",
+      "parent": "Responses Root",
+      "description": "Responses (OpenAI)"
     },
     {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "Responses Root",
+      "description": "Responses"
     }
   ],
   "paths": {
@@ -15257,8 +15257,7 @@
                     },
                     "safety_identifier": {
                       "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
                       "type": "string",
@@ -15272,7 +15271,7 @@
                         {
                           "type": "string",
                           "enum": [
-                            "in_memory",
+                            "in-memory",
                             "24h"
                           ]
                         },
@@ -15309,6 +15308,16 @@
                       "anyOf": [
                         {
                           "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "max_output_tokens": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -15457,16 +15466,6 @@
                     "usage": {
                       "$ref": "#/components/schemas/OpenAI.ResponseUsage"
                     },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "parallel_tool_calls": {
                       "type": "boolean",
                       "description": "Whether to allow the model to run tool calls in parallel.",
@@ -15476,16 +15475,6 @@
                       "anyOf": [
                         {
                           "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -15623,8 +15612,7 @@
                   },
                   "safety_identifier": {
                     "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
                     "type": "string",
@@ -15638,7 +15626,7 @@
                       {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
                         ]
                       },
@@ -15675,6 +15663,16 @@
                     "anyOf": [
                       {
                         "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "max_output_tokens": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.integer"
                       },
                       {
                         "type": "null"
@@ -15773,16 +15771,6 @@
                       }
                     ]
                   },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "stream": {
                     "anyOf": [
                       {
@@ -15826,16 +15814,6 @@
                       }
                     ],
                     "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   },
                   "agent": {
                     "allOf": [
@@ -19841,14 +19819,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the A2A server.\nThe connection stores authentication and other connection details needed to connect to the A2A server."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -22009,14 +21979,6 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -22895,14 +22857,6 @@
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -23077,14 +23031,6 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -23263,14 +23209,6 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -23286,6 +23224,35 @@
           }
         ],
         "description": "The input definition information for a Browser Automation Tool, as used to configure an Agent."
+      },
+      "BrowserAutomationPreviewToolboxTool": {
+        "type": "object",
+        "required": [
+          "type",
+          "browser_automation_preview"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "browser_automation_preview"
+            ]
+          },
+          "browser_automation_preview": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BrowserAutomationToolParameters"
+              }
+            ],
+            "description": "The Browser Automation Tool parameters."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A browser automation tool stored in a toolbox."
       },
       "BrowserAutomationToolCall": {
         "type": "object",
@@ -23411,14 +23378,6 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [
@@ -25163,9 +25122,7 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -28742,14 +28699,6 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -30136,8 +30085,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -30297,10 +30245,6 @@
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -30645,14 +30589,6 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -30697,14 +30633,6 @@
               "memory_search"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -31265,14 +31193,6 @@
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "fabric_dataagent_preview": {
             "allOf": [
               {
@@ -31766,7 +31686,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -31799,7 +31720,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -31833,7 +31755,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -31861,7 +31784,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -31961,7 +31885,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -31986,7 +31911,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -32019,7 +31945,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -32162,12 +32089,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -32267,7 +32188,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -32292,19 +32214,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -32377,14 +32286,6 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -32496,36 +32397,6 @@
                 "type": "null"
               }
             ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         }
       },
@@ -32545,9 +32416,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -32649,14 +32518,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -32726,8 +32587,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -32736,7 +32596,8 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
             "anyOf": [
@@ -32758,14 +32619,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -32803,29 +32656,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -32841,7 +32671,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -32888,7 +32719,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -32943,7 +32775,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -33004,7 +32837,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -33013,6 +32847,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -33033,7 +32875,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -33041,6 +32884,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -33088,7 +32957,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -33170,18 +33040,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -33193,56 +33059,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -33436,50 +33258,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -33502,9 +33287,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -33531,11 +33313,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -33551,8 +33332,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -33582,17 +33362,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -33624,18 +33443,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -33643,65 +33450,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -33803,7 +33553,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -33862,7 +33612,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -33897,67 +33647,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -33965,8 +33657,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -34008,9 +33699,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -34328,7 +34066,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -34459,16 +34204,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -34541,138 +34276,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -34689,11 +34292,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -34882,8 +34481,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -35812,7 +35410,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -35847,7 +35446,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -35871,7 +35471,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -35888,10 +35489,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -35964,8 +35561,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -35973,8 +35569,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -35983,7 +35578,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -36000,19 +35596,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -36036,7 +35619,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -36044,19 +35628,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -36096,16 +35667,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -36131,9 +35692,6 @@
         ],
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
-      },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
       },
       "OpenAI.Error": {
         "type": "object",
@@ -37160,7 +36718,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -37186,13 +36745,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -37244,7 +36796,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -37278,14 +36831,6 @@
                 "type": "null"
               }
             ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -38159,22 +37704,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -38228,7 +37765,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -38284,22 +37821,6 @@
         ]
       },
       "OpenAI.FunctionCallItemStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
         "type": "string",
         "enum": [
           "in_progress",
@@ -38624,7 +38145,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -38656,7 +38178,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -38743,14 +38266,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -38763,7 +38278,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -38786,7 +38302,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -38796,14 +38313,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -38817,7 +38326,8 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
             "anyOf": [
@@ -38828,14 +38338,6 @@
                 "type": "null"
               }
             ]
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -38952,7 +38454,8 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
@@ -38988,10 +38491,6 @@
                 "type": "null"
               }
             ]
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
           }
         },
         "allOf": [
@@ -39002,62 +38501,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -39405,8 +38903,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -39429,7 +38926,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -39459,21 +38957,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -39551,14 +39042,6 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -39601,7 +39084,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -39618,7 +39101,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -39772,22 +39256,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -39841,7 +39317,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -39933,22 +39409,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -40009,14 +39477,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
           }
         },
         "description": "A file input to the model.",
@@ -40065,7 +39525,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -40143,9 +39603,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -40165,56 +39622,6 @@
           }
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
-      },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
       },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -40527,6 +39934,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -40549,9 +39957,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -40602,10 +40007,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -40950,7 +40351,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -40959,8 +40359,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -40973,10 +40372,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -41278,7 +40673,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -41401,16 +40803,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -41491,143 +40883,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -41644,9 +40899,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -41722,6 +40974,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -41729,6 +41027,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -41806,7 +41153,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -41814,9 +41161,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -41836,56 +41180,6 @@
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
       },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -42198,6 +41492,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -42220,9 +41515,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -42273,10 +41565,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -42355,17 +41643,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -42384,50 +41669,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -42665,6 +41906,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -42687,9 +41929,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -42716,11 +41955,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -42736,8 +41974,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -42767,9 +42004,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -42795,10 +42030,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -42964,7 +42195,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -43023,7 +42254,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -43061,7 +42292,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -43070,8 +42300,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -43084,10 +42313,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -43114,64 +42339,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -43442,7 +42609,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -43573,16 +42747,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -43655,138 +42819,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -43797,9 +42829,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -44158,7 +43187,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -44167,8 +43195,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -44181,10 +43208,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -44261,59 +43284,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -44539,7 +43509,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -44662,16 +43639,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -44765,7 +43732,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -44793,19 +43761,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -44817,56 +43780,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -45060,50 +43977,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -45126,9 +44006,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -45155,11 +44032,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -45175,8 +44051,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -45206,126 +44081,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -45427,7 +44183,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -45486,7 +44242,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -45521,67 +44277,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -45589,8 +44287,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -45632,9 +44329,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -45685,59 +44429,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -45958,7 +44649,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -46081,16 +44779,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -46109,200 +44797,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -46319,11 +44813,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -46336,8 +44825,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -46420,143 +44907,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -46573,9 +44923,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -46687,7 +45034,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -46819,7 +45167,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -46829,6 +45178,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -46908,15 +45273,8 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "x-stainless-const": true,
+            "default": "local_shell"
           }
         },
         "allOf": [
@@ -47122,10 +45480,6 @@
             ],
             "default": "always"
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
@@ -47199,8 +45553,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -47234,22 +45587,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -47303,7 +45648,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -47466,14 +45811,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -47553,182 +45890,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -47743,7 +45904,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -47760,19 +45922,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -47782,57 +45931,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -48033,19 +46131,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -48053,55 +46145,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -48339,6 +46385,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -48361,9 +46408,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -48390,128 +46434,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -48530,10 +46459,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -48541,18 +46466,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -48560,7 +46473,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -48662,7 +46576,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -48721,7 +46635,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -48759,7 +46673,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -48768,8 +46681,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -48782,10 +46694,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -48812,64 +46720,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -48968,54 +46818,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -49059,54 +46861,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -49140,7 +46894,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -49263,16 +47024,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -49353,138 +47104,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -49496,19 +47115,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -49516,9 +47129,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -49739,13 +47350,6 @@
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
       },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
-      },
       "OpenAI.RankerVersionType": {
         "type": "string",
         "enum": [
@@ -49781,123 +47385,6 @@
             "description": "Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled."
           }
         }
-      },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
       },
       "OpenAI.Reasoning": {
         "type": "object",
@@ -50045,8 +47532,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -50060,7 +47546,7 @@
               {
                 "type": "string",
                 "enum": [
-                  "in_memory",
+                  "in-memory",
                   "24h"
                 ]
               },
@@ -50097,6 +47583,16 @@
             "anyOf": [
               {
                 "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -50245,16 +47741,6 @@
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
           },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "parallel_tool_calls": {
             "type": "boolean",
             "description": "Whether to allow the model to run tool calls in parallel.",
@@ -50264,16 +47750,6 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -50343,11 +47819,6 @@
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -50379,11 +47850,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -50420,11 +47886,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -50456,11 +47917,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -50511,11 +47967,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -50566,11 +48017,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -50616,11 +48062,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -50666,11 +48107,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -50716,11 +48152,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -50761,11 +48192,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -50829,11 +48255,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -50897,11 +48318,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -50942,11 +48358,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -50997,11 +48408,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -51053,11 +48459,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -51158,11 +48559,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -51203,11 +48599,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -51253,11 +48644,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -51303,11 +48689,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -51353,11 +48734,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -51510,11 +48886,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -51569,11 +48940,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -51619,11 +48985,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -51670,11 +49031,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -51721,11 +49077,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -51786,11 +49137,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -51832,11 +49178,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -51889,11 +49230,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -51925,7 +49261,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -51984,11 +49320,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -52040,11 +49371,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -52091,11 +49417,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -52142,11 +49463,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -52193,11 +49509,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -52244,11 +49555,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -52295,11 +49601,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -52346,11 +49647,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -52401,11 +49697,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -52455,11 +49746,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -52532,11 +49818,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -52601,11 +49882,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -52670,11 +49946,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -52757,11 +50028,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -52840,11 +50106,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -52904,11 +50165,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -52968,11 +50224,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -53032,11 +50283,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -53096,11 +50342,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -53160,151 +50401,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -53376,11 +50478,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -53448,11 +50545,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -53585,11 +50677,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -53635,11 +50722,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -53685,11 +50767,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -53709,7 +50786,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -53736,7 +50814,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -53769,19 +50848,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -53791,13 +50857,6 @@
         ],
         "description": "A scroll action.",
         "title": "Scroll"
-      },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
       },
       "OpenAI.SearchContextSize": {
         "type": "string",
@@ -53825,15 +50884,6 @@
         ],
         "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
-      "OpenAI.ServiceTierEnum": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "default",
-          "flex",
-          "priority"
-        ]
-      },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
         "required": [
@@ -53847,7 +50897,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -53878,7 +50929,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -53901,7 +50953,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -53925,7 +50978,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -53952,7 +51006,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -54131,10 +51186,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -54190,46 +51242,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -54428,9 +51440,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -54454,9 +51464,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -54501,64 +51509,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -54569,7 +51519,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -54578,8 +51527,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -54644,7 +51591,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -54694,7 +51642,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -54776,7 +51725,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -54849,7 +51799,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -54862,7 +51813,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -54900,8 +51851,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -54976,7 +51926,8 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
             "anyOf": [
@@ -54995,12 +51946,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -55022,7 +51967,8 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
             "anyOf": [
@@ -55053,14 +51999,6 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -58162,14 +55100,6 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -59285,6 +56215,7 @@
             "azure_ai_search": "#/components/schemas/AzureAISearchToolboxTool",
             "openapi": "#/components/schemas/OpenApiToolboxTool",
             "a2a_preview": "#/components/schemas/A2APreviewToolboxTool",
+            "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
@@ -59302,6 +56233,7 @@
           "azure_ai_search",
           "openapi",
           "a2a_preview",
+          "browser_automation_preview",
           "work_iq_preview",
           "fabric_iq_preview",
           "toolbox_search_preview"
@@ -60188,14 +57120,6 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -5,114 +5,114 @@ info:
 tags:
   - name: EvaluationSuiteGenerationJobs
   - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
-  - name: Agents
+  - name: Insights
+    parent: Evaluations
+  - name: Evalsuite
+    parent: Evaluations
+  - name: Redteams
+    parent: Evaluations
+    description: Red Teaming
+  - name: Evaluation Taxonomies
+    parent: Evaluations
+  - name: Evaluators
+    parent: Evaluations
+  - name: Evaluation Rules
+    parent: Evaluations
+  - name: Evals
+    parent: Evaluations
+  - name: Evaluations
+  - name: EvaluatorGenerationJobs
+    parent: Platform APIs
+    description: Evaluator generation jobs
+  - name: AgentOptimizationJobs
+    parent: Platform APIs
+    description: Agent optimization jobs
+  - name: DataGenerationJobs
+    parent: Platform APIs
+    description: Data generation jobs
+  - name: Deployments
+    parent: Platform APIs
+  - name: Toolboxes
+    parent: Platform APIs
+  - name: Skills
+    parent: Platform APIs
+  - name: Schedules
+    parent: Platform APIs
+  - name: Routines
+    parent: Platform APIs
+  - name: Videos
+    parent: Platform APIs
+  - name: Vector stores
+    parent: Platform APIs
+    description: Vector Stores
+  - name: Uploads
+    parent: Platform APIs
+  - name: Threads
+    parent: Platform APIs
+  - name: Realtime
+    parent: Platform APIs
+  - name: Moderations
+    parent: Platform APIs
+  - name: Images
+    parent: Platform APIs
+  - name: Files
+    parent: Platform APIs
+  - name: Embeddings
+    parent: Platform APIs
+  - name: Containers
+    parent: Platform APIs
+  - name: Completions
+    parent: Platform APIs
+  - name: Batch
+    parent: Platform APIs
+  - name: Audio
+    parent: Platform APIs
+  - name: Assistants
+    parent: Platform APIs
+  - name: Chat
+    parent: Platform APIs
+  - name: Memory Stores
+    parent: Platform APIs
+  - name: Models
+    parent: Platform APIs
+  - name: Fine-tuning
+    parent: Platform APIs
+    description: Fine-Tuning
+  - name: Scheduler
+    parent: Platform APIs
+  - name: Connections
+    parent: Platform APIs
+  - name: Indexes
+    parent: Platform APIs
+  - name: Datasets
+    parent: Platform APIs
+  - name: Platform APIs
+  - name: Agent Containers
     parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
+  - name: Agent Versions
+    parent: Agents Root
+  - name: Agent Session Files
+    parent: Agents Root
+  - name: Agent Sessions
     parent: Agents Root
   - name: Agent Invocations WebSocket
     parent: Agents Root
     description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
+  - name: Agent Invocations
     parent: Agents Root
-  - name: Agent Session Files
+  - name: Agents
     parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
-  - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
-  - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
-  - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
-  - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
-  - name: Insights
-    parent: Evaluations
+    description: Agent Management
+  - name: Agents Root
+    description: Agents
+  - name: Conversations
+    parent: Responses Root
+    description: Conversations (OpenAI)
+  - name: Responses
+    parent: Responses Root
+    description: Responses (OpenAI)
+  - name: Responses Root
+    description: Responses
 paths:
   /agent_optimization_jobs:
     post:
@@ -10084,10 +10084,9 @@ paths:
                     deprecated: true
                   safety_identifier:
                     type: string
-                    maxLength: 64
                     description: |-
                       A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                        The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
                     type: string
                     description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -10097,7 +10096,7 @@ paths:
                     anyOf:
                       - type: string
                         enum:
-                          - in_memory
+                          - in-memory
                           - 24h
                       - type: 'null'
                   previous_response_id:
@@ -10114,6 +10113,10 @@ paths:
                   background:
                     anyOf:
                       - type: boolean
+                      - type: 'null'
+                  max_output_tokens:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   max_tool_calls:
                     anyOf:
@@ -10202,10 +10205,6 @@ paths:
                       - type: 'null'
                   usage:
                     $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
                   parallel_tool_calls:
                     type: boolean
                     description: Whether to allow the model to run tool calls in parallel.
@@ -10213,10 +10212,6 @@ paths:
                   conversation:
                     anyOf:
                       - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   agent:
                     allOf:
@@ -10302,10 +10297,9 @@ paths:
                   deprecated: true
                 safety_identifier:
                   type: string
-                  maxLength: 64
                   description: |-
                     A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
                   type: string
                   description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -10315,7 +10309,7 @@ paths:
                   anyOf:
                     - type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
                     - type: 'null'
                 previous_response_id:
@@ -10332,6 +10326,10 @@ paths:
                 background:
                   anyOf:
                     - type: boolean
+                    - type: 'null'
+                max_output_tokens:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.integer'
                     - type: 'null'
                 max_tool_calls:
                   anyOf:
@@ -10377,10 +10375,6 @@ paths:
                   anyOf:
                     - type: string
                     - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
                 stream:
                   anyOf:
                     - type: boolean
@@ -10400,10 +10394,6 @@ paths:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
                     - type: 'null'
                   description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
                 agent:
                   allOf:
                     - $ref: '#/components/schemas/AgentReference'
@@ -13075,12 +13065,6 @@ components:
           description: |-
             The connection ID in the project for the A2A server.
             The connection stores authentication and other connection details needed to connect to the A2A server.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -14525,12 +14509,6 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -15098,12 +15076,6 @@ components:
           enum:
             - bing_custom_search_preview
           description: The object type, which is always 'bing_custom_search_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -15222,12 +15194,6 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -15337,12 +15303,6 @@ components:
           enum:
             - browser_automation_preview
           description: The object type, which is always 'browser_automation_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -15350,6 +15310,23 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: The input definition information for a Browser Automation Tool, as used to configure an Agent.
+    BrowserAutomationPreviewToolboxTool:
+      type: object
+      required:
+        - type
+        - browser_automation_preview
+      properties:
+        type:
+          type: string
+          enum:
+            - browser_automation_preview
+        browser_automation_preview:
+          allOf:
+            - $ref: '#/components/schemas/BrowserAutomationToolParameters'
+          description: The Browser Automation Tool parameters.
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A browser automation tool stored in a toolbox.
     BrowserAutomationToolCall:
       type: object
       required:
@@ -15430,12 +15407,6 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -16645,8 +16616,7 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -19324,12 +19294,6 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -20217,7 +20181,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -20337,9 +20300,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -20555,12 +20515,6 @@ components:
           enum:
             - memory_search_preview
           description: The type of the tool. Always `memory_search_preview`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20594,12 +20548,6 @@ components:
           enum:
             - memory_search
           description: The type of the tool. Always `memory_search_preview`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20959,12 +20907,6 @@ components:
           enum:
             - fabric_dataagent_preview
           description: The object type, which is always 'fabric_dataagent_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -21302,6 +21244,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -21325,6 +21268,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -21349,6 +21293,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -21368,6 +21313,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -21433,6 +21379,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -21450,6 +21397,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -21473,6 +21421,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -21558,12 +21507,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -21658,6 +21601,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -21670,12 +21614,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -21728,12 +21666,6 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         container:
           anyOf:
             - type: string
@@ -21802,18 +21734,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -21830,8 +21750,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -21903,14 +21821,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -21956,7 +21866,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -21964,6 +21873,7 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
           anyOf:
             - type: string
@@ -21973,10 +21883,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -22003,21 +21909,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -22032,6 +21923,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -22059,6 +21951,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -22095,6 +21988,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -22135,12 +22029,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -22154,8 +22055,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -22188,6 +22110,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -22236,18 +22159,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -22259,39 +22178,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -22414,39 +22304,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -22464,8 +22328,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -22486,11 +22348,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -22504,7 +22365,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -22528,15 +22388,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -22559,60 +22446,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -22687,7 +22524,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -22725,7 +22562,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -22743,56 +22580,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -22802,7 +22592,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -22832,8 +22621,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -23056,7 +22880,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -23139,10 +22965,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -23194,87 +23016,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -23288,11 +23029,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -23428,7 +23165,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -24046,6 +23782,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -24068,6 +23805,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -24084,6 +23822,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -24094,9 +23833,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -24144,14 +23880,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -24159,6 +23893,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -24167,12 +23902,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -24189,6 +23918,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -24201,12 +23931,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -24235,10 +23959,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -24263,8 +23983,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -24958,6 +24676,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -24972,11 +24691,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -25013,6 +24727,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -25030,12 +24745,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -25625,17 +25334,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -25665,7 +25370,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -25699,18 +25404,6 @@ components:
             - input_image
             - input_file
     OpenAI.FunctionCallItemStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
       type: string
       enum:
         - in_progress
@@ -25921,6 +25614,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -25941,6 +25635,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -25991,12 +25686,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -26008,6 +25697,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -26023,16 +25713,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -26044,16 +25729,11 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -26131,6 +25811,7 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
@@ -26147,45 +25828,53 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-        defer_loading:
-          type: boolean
-          description: Whether this function is deferred and loaded via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -26562,7 +26251,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -26580,6 +26268,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -26601,15 +26290,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -26665,12 +26354,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -26699,7 +26382,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -26721,6 +26403,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -26823,17 +26506,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -26863,7 +26542,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -26921,17 +26600,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -26963,10 +26638,6 @@ components:
             - type: string
               format: uri
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -26994,7 +26665,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -27043,9 +26714,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -27066,38 +26734,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -27287,6 +26923,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27304,8 +26941,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27346,9 +26981,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -27559,7 +27191,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -27568,7 +27199,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27578,9 +27208,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -27788,7 +27415,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -27868,10 +27497,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27932,77 +27557,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -28016,9 +27570,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -28075,6 +27626,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -28083,6 +27672,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -28144,7 +27770,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -28152,9 +27778,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -28172,38 +27795,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -28393,6 +27984,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -28410,8 +28002,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -28452,9 +28042,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -28507,17 +28094,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -28534,35 +28118,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -28718,6 +28273,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -28735,8 +28291,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -28757,11 +28311,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -28775,7 +28328,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -28799,8 +28351,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -28821,9 +28371,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -28940,7 +28487,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -28978,7 +28525,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -28999,7 +28546,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29008,7 +28554,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29018,9 +28563,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29042,51 +28584,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -29273,7 +28770,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -29356,10 +28855,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -29411,87 +28906,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -29499,9 +28913,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -29730,7 +29141,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29739,7 +29149,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29749,9 +29158,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29806,50 +29212,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -30003,7 +29365,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -30083,10 +29447,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30159,6 +29519,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -30176,19 +29537,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -30201,38 +29557,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -30355,39 +29680,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -30405,8 +29704,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -30427,11 +29724,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -30445,7 +29741,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -30469,91 +29764,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -30628,7 +29838,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -30666,7 +29876,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -30684,56 +29894,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -30743,7 +29906,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -30773,8 +29935,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -30808,50 +30005,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -31005,7 +30158,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -31085,10 +30240,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -31102,134 +30253,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -31243,11 +30266,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -31260,8 +30278,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -31325,77 +30341,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -31409,9 +30354,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -31503,6 +30445,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -31589,10 +30532,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -31643,12 +30599,7 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
+          default: local_shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -31794,9 +30745,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -31856,7 +30804,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -31877,17 +30824,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -31917,7 +30860,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -32027,15 +30970,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -32093,125 +31027,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -32225,6 +31040,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -32233,50 +31049,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -32418,19 +31194,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -32438,38 +31208,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -32625,6 +31364,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -32642,8 +31382,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -32664,99 +31402,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -32770,27 +31422,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -32865,7 +31506,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -32903,7 +31544,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -32924,7 +31565,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -32933,7 +31573,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -32943,9 +31582,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -32967,51 +31603,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -33079,37 +31670,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -33141,37 +31701,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -33198,7 +31727,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -33278,10 +31809,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -33342,87 +31869,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -33431,19 +31877,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -33451,9 +31891,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -33606,11 +32044,6 @@ components:
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -33631,81 +32064,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
@@ -33811,10 +32169,9 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -33824,7 +32181,7 @@ components:
           anyOf:
             - type: string
               enum:
-                - in_memory
+                - in-memory
                 - 24h
             - type: 'null'
         previous_response_id:
@@ -33841,6 +32198,10 @@ components:
         background:
           anyOf:
             - type: boolean
+            - type: 'null'
+        max_output_tokens:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         max_tool_calls:
           anyOf:
@@ -33929,10 +32290,6 @@ components:
             - type: 'null'
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
@@ -33940,10 +32297,6 @@ components:
         conversation:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         agent:
           allOf:
@@ -33990,8 +32343,6 @@ components:
           type: string
           contentEncoding: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -34019,8 +32370,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -34051,8 +32400,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -34080,8 +32427,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -34121,8 +32466,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -34164,8 +32507,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -34203,8 +32544,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -34241,8 +32580,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -34279,8 +32616,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -34313,8 +32648,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -34409,8 +32742,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -34463,8 +32794,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -34503,8 +32832,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -34576,8 +32903,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -34619,8 +32944,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -34697,8 +33020,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -34732,8 +33053,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -34799,8 +33118,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -34837,8 +33154,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -34875,8 +33190,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -34992,8 +33305,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -35038,8 +33349,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -35078,8 +33387,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -35117,8 +33424,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -35156,8 +33461,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -35204,8 +33507,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -35241,8 +33542,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -35314,8 +33613,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -35373,7 +33670,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -35414,8 +33711,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -35458,8 +33753,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -35498,8 +33791,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -35537,8 +33828,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -35576,8 +33865,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -35615,8 +33902,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -35654,8 +33939,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -35693,8 +33976,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -35733,8 +34014,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -35778,8 +34057,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -35843,8 +34120,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -35901,8 +34176,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -35954,8 +34227,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -36020,8 +34291,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -36087,8 +34356,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -36138,8 +34405,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -36189,8 +34454,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -36238,8 +34501,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -36287,8 +34548,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -36336,8 +34595,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -36351,127 +34608,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -36526,8 +34662,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -36581,8 +34715,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -36679,8 +34811,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -36717,8 +34847,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -36755,8 +34883,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -36779,6 +34905,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -36798,6 +34925,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -36814,21 +34942,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -36852,13 +34969,6 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -36871,6 +34981,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -36892,6 +35003,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -36907,6 +35019,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -36923,6 +35036,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -36941,6 +35055,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -37083,9 +35198,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -37138,34 +35250,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -37309,8 +35393,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -37332,8 +35414,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -37362,38 +35442,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -37401,7 +35449,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -37410,8 +35457,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -37477,6 +35522,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -37511,6 +35557,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -37567,6 +35614,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -37616,6 +35664,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -37625,7 +35674,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -37654,7 +35703,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -37696,6 +35744,7 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
@@ -37704,10 +35753,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -37722,6 +35767,7 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -37738,12 +35784,6 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -39812,12 +37852,6 @@ components:
           enum:
             - sharepoint_grounding_preview
           description: The object type, which is always 'sharepoint_grounding_preview'.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -40556,6 +38590,7 @@ components:
           azure_ai_search: '#/components/schemas/AzureAISearchToolboxTool'
           openapi: '#/components/schemas/OpenApiToolboxTool'
           a2a_preview: '#/components/schemas/A2APreviewToolboxTool'
+          browser_automation_preview: '#/components/schemas/BrowserAutomationPreviewToolboxTool'
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
@@ -40570,6 +38605,7 @@ components:
         - azure_ai_search
         - openapi
         - a2a_preview
+        - browser_automation_preview
         - work_iq_preview
         - fabric_iq_preview
         - toolbox_search_preview
@@ -41162,12 +39198,6 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -7,6 +7,10 @@ using TypeSpec.Http;
 
 namespace Azure.AI.Projects;
 
+const ToolboxesRequiredPreviews = #{
+  conditional_previews: #[FoundryFeaturesOptInKeys.toolboxes_v1_preview],
+};
+
 /**
  * Per-tool configuration that controls tool visibility and search behavior.
  */
@@ -38,6 +42,21 @@ alias ToolConfigExtension = {
 };
 
 /**
+ * Optional name and description fields for tool definitions and nested tool configurations.
+ */
+alias ToolNameAndDescriptionExtension = {
+  /**
+   * Optional user-defined name for this tool or configuration.
+   */
+  name?: string;
+
+  /**
+   * Optional user-defined description for this tool or configuration.
+   */
+  description?: string;
+};
+
+/**
  * Spreads `Source`, changing the selected properties to optional.
  */
 model WithFieldsOptional<Source, Keys extends string> {
@@ -59,6 +78,7 @@ alias ToolboxMCPToolType = "mcp";
 alias ToolboxAzureAISearchToolType = "azure_ai_search";
 alias ToolboxOpenApiToolType = "openapi";
 alias ToolboxA2APreviewToolType = "a2a_preview";
+alias ToolboxBrowserAutomationPreviewToolType = "browser_automation_preview";
 alias ToolboxWorkIQPreviewToolType = "work_iq_preview";
 alias ToolboxFabricIQPreviewToolType = "fabric_iq_preview";
 alias ToolboxSearchPreviewToolType = "toolbox_search_preview";
@@ -74,6 +94,7 @@ union ToolboxToolType {
   azure_ai_search: ToolboxAzureAISearchToolType,
   openapi: ToolboxOpenApiToolType,
   a2a_preview: ToolboxA2APreviewToolType,
+  browser_automation_preview: ToolboxBrowserAutomationPreviewToolType,
   work_iq_preview: ToolboxWorkIQPreviewToolType,
   fabric_iq_preview: ToolboxFabricIQPreviewToolType,
   toolbox_search_preview: ToolboxSearchPreviewToolType,
@@ -160,6 +181,15 @@ model A2APreviewToolboxTool extends ToolboxTool {
 }
 
 /**
+ * A browser automation tool stored in a toolbox.
+ */
+model BrowserAutomationPreviewToolboxTool extends ToolboxTool {
+  type: ToolboxBrowserAutomationPreviewToolType;
+
+  ...ToolFields<BrowserAutomationPreviewTool>;
+}
+
+/**
  * A WorkIQ tool stored in a toolbox.
  */
 model WorkIQPreviewToolboxTool extends ToolboxTool {
@@ -186,7 +216,6 @@ model ToolboxSearchPreviewToolboxTool extends ToolboxTool {
    */
   type: ToolboxSearchPreviewToolType;
 }
-
 @doc("Policy configuration for a toolbox, including content safety and other governance settings.")
 model ToolboxPolicies {
   @doc("Responsible AI content filtering configuration.")

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -58,53 +58,11 @@ namespace Azure.AI.Projects {
   @@copyProperties(
     OpenAI.WebSearchTool,
     {
-      ...ToolNameAndDescriptionExtension,
-
       /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
        * resource attached to the tool.
        */
       custom_search_configuration?: WebSearchConfiguration,
-    }
-  );
-
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(
-    OpenAI.CodeInterpreterTool,
-    {
-      ...ToolNameAndDescriptionExtension,
-    }
-  );
-
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(
-    OpenAI.ImageGenTool,
-    {
-      ...ToolNameAndDescriptionExtension,
-    }
-  );
-
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(
-    OpenAI.LocalShellToolParam,
-    {
-      ...ToolNameAndDescriptionExtension,
-    }
-  );
-
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(
-    OpenAI.FunctionShellToolParam,
-    {
-      ...ToolNameAndDescriptionExtension,
-    }
-  );
-
-  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
-  @@copyProperties(
-    OpenAI.FileSearchTool,
-    {
-      ...ToolNameAndDescriptionExtension,
     }
   );
 
@@ -124,21 +82,6 @@ namespace Azure.AI.Projects {
   }
 
   /**
-   * Optional name and description fields for tool definitions and nested tool configurations.
-   */
-  alias ToolNameAndDescriptionExtension = {
-    /**
-     * Optional user-defined name for this tool or configuration.
-     */
-    name?: string;
-
-    /**
-     * Optional user-defined description for this tool or configuration.
-     */
-    description?: string;
-  };
-
-  /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
   model BingGroundingTool extends OpenAI.Tool {
@@ -146,8 +89,6 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'bing_grounding'.
      */
     type: "bing_grounding";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -176,8 +117,6 @@ namespace Azure.AI.Projects {
      */
     type: "fabric_dataagent_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The fabric data agent tool parameters.
      */
@@ -205,8 +144,6 @@ namespace Azure.AI.Projects {
      */
     type: "sharepoint_grounding_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The sharepoint grounding tool parameters.
      */
@@ -221,8 +158,6 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'azure_ai_search'.
      */
     type: "azure_ai_search";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The azure ai search index resource.
@@ -328,8 +263,6 @@ namespace Azure.AI.Projects {
      */
     type: "bing_custom_search_preview";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The bing custom search tool parameters.
      */
@@ -344,8 +277,6 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'browser_automation_preview'.
      */
     type: "browser_automation_preview";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The Browser Automation Tool parameters.
@@ -735,8 +666,6 @@ namespace Azure.AI.Projects {
      */
     type: "capture_structured_outputs";
 
-    ...ToolNameAndDescriptionExtension;
-
     /**
      * The structured outputs to capture from the model.
      */
@@ -769,7 +698,6 @@ namespace Azure.AI.Projects {
      */
     project_connection_id?: string;
 
-    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -786,7 +714,6 @@ namespace Azure.AI.Projects {
      */
     project_connection_id: string;
 
-    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -820,7 +747,6 @@ namespace Azure.AI.Projects {
     #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Matching OpenAI MCP tool pattern."
     require_approval?: OpenAI.MCPToolRequireApproval | string | null = "always";
 
-    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -831,8 +757,6 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search_preview";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.
@@ -866,8 +790,6 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search";
-
-    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.


### PR DESCRIPTION
## Summary
This PR aligns toolbox modeling with the same separation approach used for tool_config.

- Moved ToolNameAndDescriptionExtension to the toolbox model surface.
- Removed ToolNameAndDescriptionExtension from OpenAI tool shapes.
- Added browser automation support to toolbox tools:
  - Added browser_automation_preview to ToolboxToolType.
  - Added BrowserAutomationPreviewToolboxTool model declaration.

## Why
Tool name and description are toolbox-specific metadata and should live with toolbox tool contracts, not with the base OpenAI tool contract. This keeps ownership clear, reduces unused fields on OpenAI tool types, and keeps toolbox behavior consistent with prior tool_config cleanup.

## Validation
- TypeSpec compile succeeded for the Foundry project (`npx tsp compile .`).

## Impact
- No functional change intended for existing OpenAI tool execution behavior.
- Contract cleanup and modeling consistency for toolbox-specific scenarios.
- Browser automation is now explicitly represented in toolbox tool typing.