### PR TITLE
Annotate agents optimization models with required preview

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -50582,7 +50582,12 @@
             "description": "Pinned agent version. Defaults to latest if omitted."
           }
         },
-        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config."
+        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationCandidate": {
         "type": "object",
@@ -50632,7 +50637,12 @@
             "description": "Promotion metadata. Null if the candidate has not been promoted."
           }
         },
-        "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks."
+        "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetCriterion": {
         "type": "object",
@@ -50650,7 +50660,12 @@
             "description": "Criterion instruction / description."
           }
         },
-        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring."
+        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetInput": {
         "type": "object",
@@ -50674,7 +50689,12 @@
             "reference": "#/components/schemas/OptimizationReferenceDatasetInput"
           }
         },
-        "description": "Base discriminated model for dataset input. Either inline items or a registered reference."
+        "description": "Base discriminated model for dataset input. Either inline items or a registered reference.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetInputType": {
         "anyOf": [
@@ -50717,7 +50737,12 @@
             "description": "Per-item evaluation criteria."
           }
         },
-        "description": "A single item in an inline dataset."
+        "description": "A single item in an inline dataset.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationEvaluatorRef": {
         "type": "object",
@@ -50734,7 +50759,12 @@
             "description": "Evaluator version. If not specified, the latest version is used."
           }
         },
-        "description": "Reference to a named evaluator, optionally pinned to a version."
+        "description": "Reference to a named evaluator, optionally pinned to a version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationInlineDatasetInput": {
         "type": "object",
@@ -50763,7 +50793,12 @@
             "$ref": "#/components/schemas/OptimizationDatasetInput"
           }
         ],
-        "description": "Inline dataset — items supplied directly in the request body."
+        "description": "Inline dataset — items supplied directly in the request body.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJob": {
         "type": "object",
@@ -50850,7 +50885,12 @@
             "readOnly": true
           }
         },
-        "description": "Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates."
+        "description": "Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobInputs": {
         "type": "object",
@@ -50900,7 +50940,12 @@
             "description": "Tuning knobs and run-mode."
           }
         },
-        "description": "Caller-supplied inputs for an optimization job."
+        "description": "Caller-supplied inputs for an optimization job.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobListItem": {
         "type": "object",
@@ -50971,7 +51016,12 @@
             "readOnly": true
           }
         },
-        "description": "Slim job representation returned by the LIST endpoint."
+        "description": "Slim job representation returned by the LIST endpoint.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobProgress": {
         "type": "object",
@@ -50997,7 +51047,12 @@
             "description": "Wall-clock time elapsed in seconds since the job began executing."
           }
         },
-        "description": "In-flight progress; only populated while status is queued or in_progress."
+        "description": "In-flight progress; only populated while status is queued or in_progress.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobResult": {
         "type": "object",
@@ -51018,7 +51073,12 @@
             "description": "All evaluated candidates including baseline."
           }
         },
-        "description": "Terminal-state result body. Populated when status is succeeded or failed."
+        "description": "Terminal-state result body. Populated when status is succeeded or failed.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationOptions": {
         "type": "object",
@@ -51052,7 +51112,12 @@
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
           }
         },
-        "description": "Tuning knobs and run-mode for an optimization job."
+        "description": "Tuning knobs and run-mode for an optimization job.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationReferenceDatasetInput": {
         "type": "object",
@@ -51082,7 +51147,12 @@
             "$ref": "#/components/schemas/OptimizationDatasetInput"
           }
         ],
-        "description": "Reference to a registered Foundry dataset."
+        "description": "Reference to a registered Foundry dataset.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OtlpTelemetryEndpoint": {
         "type": "object",
@@ -51514,7 +51584,12 @@
             "description": "Version of the Foundry agent this candidate was promoted to."
           }
         },
-        "description": "Promotion metadata recorded when a candidate is deployed to a Foundry agent."
+        "description": "Promotion metadata recorded when a candidate is deployed to a Foundry agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "PromptAgentDefinition": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -34776,6 +34776,9 @@ components:
           type: string
           description: Pinned agent version. Defaults to latest if omitted.
       description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationCandidate:
       type: object
       required:
@@ -34812,6 +34815,9 @@ components:
             - $ref: '#/components/schemas/PromotionInfo'
           description: Promotion metadata. Null if the candidate has not been promoted.
       description: Aggregated evaluation result for a single candidate agent configuration across all tasks.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetCriterion:
       type: object
       required:
@@ -34825,6 +34831,9 @@ components:
           type: string
           description: Criterion instruction / description.
       description: 'Evaluation criterion: a name + instruction pair used for per-item scoring.'
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetInput:
       type: object
       required:
@@ -34840,6 +34849,9 @@ components:
           inline: '#/components/schemas/OptimizationInlineDatasetInput'
           reference: '#/components/schemas/OptimizationReferenceDatasetInput'
       description: Base discriminated model for dataset input. Either inline items or a registered reference.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetInputType:
       anyOf:
         - type: string
@@ -34869,6 +34881,9 @@ components:
             $ref: '#/components/schemas/OptimizationDatasetCriterion'
           description: Per-item evaluation criteria.
       description: A single item in an inline dataset.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationEvaluatorRef:
       type: object
       required:
@@ -34881,6 +34896,9 @@ components:
           type: string
           description: Evaluator version. If not specified, the latest version is used.
       description: Reference to a named evaluator, optionally pinned to a version.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationInlineDatasetInput:
       type: object
       required:
@@ -34900,6 +34918,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OptimizationDatasetInput'
       description: Inline dataset — items supplied directly in the request body.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJob:
       type: object
       required:
@@ -34953,6 +34974,9 @@ components:
           description: Non-fatal warnings emitted at any point during optimization.
           readOnly: true
       description: Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobInputs:
       type: object
       required:
@@ -34982,6 +35006,9 @@ components:
             - $ref: '#/components/schemas/OptimizationOptions'
           description: Tuning knobs and run-mode.
       description: Caller-supplied inputs for an optimization job.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobListItem:
       type: object
       required:
@@ -35025,6 +35052,9 @@ components:
           description: The agent targeted by this optimization job.
           readOnly: true
       description: Slim job representation returned by the LIST endpoint.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobProgress:
       type: object
       required:
@@ -35045,6 +35075,9 @@ components:
           format: double
           description: Wall-clock time elapsed in seconds since the job began executing.
       description: In-flight progress; only populated while status is queued or in_progress.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobResult:
       type: object
       properties:
@@ -35060,6 +35093,9 @@ components:
             $ref: '#/components/schemas/OptimizationCandidate'
           description: All evaluated candidates including baseline.
       description: Terminal-state result body. Populated when status is succeeded or failed.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationOptions:
       type: object
       properties:
@@ -35084,6 +35120,9 @@ components:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
       description: Tuning knobs and run-mode for an optimization job.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationReferenceDatasetInput:
       type: object
       required:
@@ -35104,6 +35143,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OptimizationDatasetInput'
       description: Reference to a registered Foundry dataset.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OtlpTelemetryEndpoint:
       type: object
       required:
@@ -35400,6 +35442,9 @@ components:
           type: string
           description: Version of the Foundry agent this candidate was promoted to.
       description: Promotion metadata recorded when a candidate is deployed to a Foundry agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     PromptAgentDefinition:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -55263,7 +55263,12 @@
             "description": "Pinned agent version. Defaults to latest if omitted."
           }
         },
-        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config."
+        "description": "Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationCandidate": {
         "type": "object",
@@ -55313,7 +55318,12 @@
             "description": "Promotion metadata. Null if the candidate has not been promoted."
           }
         },
-        "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks."
+        "description": "Aggregated evaluation result for a single candidate agent configuration across all tasks.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetCriterion": {
         "type": "object",
@@ -55331,7 +55341,12 @@
             "description": "Criterion instruction / description."
           }
         },
-        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring."
+        "description": "Evaluation criterion: a name + instruction pair used for per-item scoring.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetInput": {
         "type": "object",
@@ -55355,7 +55370,12 @@
             "reference": "#/components/schemas/OptimizationReferenceDatasetInput"
           }
         },
-        "description": "Base discriminated model for dataset input. Either inline items or a registered reference."
+        "description": "Base discriminated model for dataset input. Either inline items or a registered reference.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationDatasetInputType": {
         "anyOf": [
@@ -55398,7 +55418,12 @@
             "description": "Per-item evaluation criteria."
           }
         },
-        "description": "A single item in an inline dataset."
+        "description": "A single item in an inline dataset.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationEvaluatorRef": {
         "type": "object",
@@ -55415,7 +55440,12 @@
             "description": "Evaluator version. If not specified, the latest version is used."
           }
         },
-        "description": "Reference to a named evaluator, optionally pinned to a version."
+        "description": "Reference to a named evaluator, optionally pinned to a version.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationInlineDatasetInput": {
         "type": "object",
@@ -55444,7 +55474,12 @@
             "$ref": "#/components/schemas/OptimizationDatasetInput"
           }
         ],
-        "description": "Inline dataset — items supplied directly in the request body."
+        "description": "Inline dataset — items supplied directly in the request body.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJob": {
         "type": "object",
@@ -55531,7 +55566,12 @@
             "readOnly": true
           }
         },
-        "description": "Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates."
+        "description": "Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobInputs": {
         "type": "object",
@@ -55581,7 +55621,12 @@
             "description": "Tuning knobs and run-mode."
           }
         },
-        "description": "Caller-supplied inputs for an optimization job."
+        "description": "Caller-supplied inputs for an optimization job.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobListItem": {
         "type": "object",
@@ -55652,7 +55697,12 @@
             "readOnly": true
           }
         },
-        "description": "Slim job representation returned by the LIST endpoint."
+        "description": "Slim job representation returned by the LIST endpoint.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobProgress": {
         "type": "object",
@@ -55678,7 +55728,12 @@
             "description": "Wall-clock time elapsed in seconds since the job began executing."
           }
         },
-        "description": "In-flight progress; only populated while status is queued or in_progress."
+        "description": "In-flight progress; only populated while status is queued or in_progress.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationJobResult": {
         "type": "object",
@@ -55699,7 +55754,12 @@
             "description": "All evaluated candidates including baseline."
           }
         },
-        "description": "Terminal-state result body. Populated when status is succeeded or failed."
+        "description": "Terminal-state result body. Populated when status is succeeded or failed.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationOptions": {
         "type": "object",
@@ -55733,7 +55793,12 @@
             "description": "Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring."
           }
         },
-        "description": "Tuning knobs and run-mode for an optimization job."
+        "description": "Tuning knobs and run-mode for an optimization job.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OptimizationReferenceDatasetInput": {
         "type": "object",
@@ -55763,7 +55828,12 @@
             "$ref": "#/components/schemas/OptimizationDatasetInput"
           }
         ],
-        "description": "Reference to a registered Foundry dataset."
+        "description": "Reference to a registered Foundry dataset.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "OtlpTelemetryEndpoint": {
         "type": "object",
@@ -56258,7 +56328,12 @@
             "description": "Version of the Foundry agent this candidate was promoted to."
           }
         },
-        "description": "Promotion metadata recorded when a candidate is deployed to a Foundry agent."
+        "description": "Promotion metadata recorded when a candidate is deployed to a Foundry agent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "AgentsOptimization=V2Preview"
+          ]
+        }
       },
       "PromptAgentDefinition": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -37936,6 +37936,9 @@ components:
           type: string
           description: Pinned agent version. Defaults to latest if omitted.
       description: Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationCandidate:
       type: object
       required:
@@ -37972,6 +37975,9 @@ components:
             - $ref: '#/components/schemas/PromotionInfo'
           description: Promotion metadata. Null if the candidate has not been promoted.
       description: Aggregated evaluation result for a single candidate agent configuration across all tasks.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetCriterion:
       type: object
       required:
@@ -37985,6 +37991,9 @@ components:
           type: string
           description: Criterion instruction / description.
       description: 'Evaluation criterion: a name + instruction pair used for per-item scoring.'
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetInput:
       type: object
       required:
@@ -38000,6 +38009,9 @@ components:
           inline: '#/components/schemas/OptimizationInlineDatasetInput'
           reference: '#/components/schemas/OptimizationReferenceDatasetInput'
       description: Base discriminated model for dataset input. Either inline items or a registered reference.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationDatasetInputType:
       anyOf:
         - type: string
@@ -38029,6 +38041,9 @@ components:
             $ref: '#/components/schemas/OptimizationDatasetCriterion'
           description: Per-item evaluation criteria.
       description: A single item in an inline dataset.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationEvaluatorRef:
       type: object
       required:
@@ -38041,6 +38056,9 @@ components:
           type: string
           description: Evaluator version. If not specified, the latest version is used.
       description: Reference to a named evaluator, optionally pinned to a version.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationInlineDatasetInput:
       type: object
       required:
@@ -38060,6 +38078,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OptimizationDatasetInput'
       description: Inline dataset — items supplied directly in the request body.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJob:
       type: object
       required:
@@ -38113,6 +38134,9 @@ components:
           description: Non-fatal warnings emitted at any point during optimization.
           readOnly: true
       description: Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobInputs:
       type: object
       required:
@@ -38142,6 +38166,9 @@ components:
             - $ref: '#/components/schemas/OptimizationOptions'
           description: Tuning knobs and run-mode.
       description: Caller-supplied inputs for an optimization job.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobListItem:
       type: object
       required:
@@ -38185,6 +38212,9 @@ components:
           description: The agent targeted by this optimization job.
           readOnly: true
       description: Slim job representation returned by the LIST endpoint.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobProgress:
       type: object
       required:
@@ -38205,6 +38235,9 @@ components:
           format: double
           description: Wall-clock time elapsed in seconds since the job began executing.
       description: In-flight progress; only populated while status is queued or in_progress.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationJobResult:
       type: object
       properties:
@@ -38220,6 +38253,9 @@ components:
             $ref: '#/components/schemas/OptimizationCandidate'
           description: All evaluated candidates including baseline.
       description: Terminal-state result body. Populated when status is succeeded or failed.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationOptions:
       type: object
       properties:
@@ -38244,6 +38280,9 @@ components:
             - $ref: '#/components/schemas/EvaluationLevel'
           description: Evaluation granularity. Null/omitted means per-item single-turn. Set to 'conversation' for per-conversation multi-turn simulation scoring.
       description: Tuning knobs and run-mode for an optimization job.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OptimizationReferenceDatasetInput:
       type: object
       required:
@@ -38264,6 +38303,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/OptimizationDatasetInput'
       description: Reference to a registered Foundry dataset.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     OtlpTelemetryEndpoint:
       type: object
       required:
@@ -38605,6 +38647,9 @@ components:
           type: string
           description: Version of the Foundry agent this candidate was promoted to.
       description: Promotion metadata recorded when a candidate is deployed to a Foundry agent.
+      x-ms-foundry-meta:
+        required_previews:
+          - AgentsOptimization=V2Preview
     PromptAgentDefinition:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-optimization/models.tsp
@@ -11,9 +11,14 @@ import "../common/models.tsp";
 import "../common/servicepatterns.tsp";
 import "../openai-evaluations/models.tsp";
 
+using TypeSpec.OpenAPI;
 using TypeSpec.Rest;
 
 namespace Azure.AI.Projects;
+
+const AgentsOptimizationPreview = #{
+  required_previews: #[FoundryFeaturesOptInKeys.agents_optimization_v2_preview],
+};
 
 // ---------------------------------------------------------------------------
 // Enums / unions
@@ -60,6 +65,7 @@ union OptimizationDatasetInputType {
 }
 
 /** Base discriminated model for dataset input. Either inline items or a registered reference. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @discriminator("type")
 model OptimizationDatasetInput {
   @doc("Dataset input type discriminator.")
@@ -67,6 +73,7 @@ model OptimizationDatasetInput {
 }
 
 /** Inline dataset — items supplied directly in the request body. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 model OptimizationInlineDatasetInput extends OptimizationDatasetInput {
   @doc("Dataset input type discriminator.")
   type: OptimizationDatasetInputType.inline;
@@ -76,6 +83,7 @@ model OptimizationInlineDatasetInput extends OptimizationDatasetInput {
 }
 
 /** Reference to a registered Foundry dataset. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 model OptimizationReferenceDatasetInput extends OptimizationDatasetInput {
   @doc("Dataset input type discriminator.")
   type: OptimizationDatasetInputType.reference;
@@ -88,6 +96,7 @@ model OptimizationReferenceDatasetInput extends OptimizationDatasetInput {
 }
 
 /** A single item in an inline dataset. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 model OptimizationDatasetItem {
   @doc("The user query / prompt.")
   query?: string;
@@ -105,6 +114,7 @@ model OptimizationDatasetItem {
 }
 
 /** Evaluation criterion: a name + instruction pair used for per-item scoring. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 model OptimizationDatasetCriterion {
   @doc("Criterion name.")
   name: string;
@@ -118,6 +128,7 @@ model OptimizationDatasetCriterion {
 // ---------------------------------------------------------------------------
 
 /** Reference to a named evaluator, optionally pinned to a version. */
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 model OptimizationEvaluatorRef {
   @doc("Evaluator name.")
   name: string;
@@ -130,6 +141,7 @@ model OptimizationEvaluatorRef {
 // Input models
 // ---------------------------------------------------------------------------
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Identifies the registered Foundry agent to optimize (request-only). Skills, tools, and system_prompt are specified in options.optimization_config.")
 model OptimizationAgentIdentifier {
   @doc("Registered Foundry agent name (required).")
@@ -139,6 +151,7 @@ model OptimizationAgentIdentifier {
   agent_version?: string;
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Agent definition returned in response payloads (includes resolved config).")
 model OptimizationAgentDefinition {
   @doc("Agent name.")
@@ -160,6 +173,7 @@ model OptimizationAgentDefinition {
   tools?: Record<unknown>[];
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Tuning knobs and run-mode for an optimization job.")
 model OptimizationOptions {
   @doc("Maximum number of optimization candidates to generate. Must be >= 1. Default: 5.")
@@ -179,6 +193,7 @@ model OptimizationOptions {
   evaluation_level?: EvaluationLevel;
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Caller-supplied inputs for an optimization job.")
 model OptimizationJobInputs {
   @doc("The agent (and pinned version) being optimized.")
@@ -201,6 +216,7 @@ model OptimizationJobInputs {
 // Progress / result models
 // ---------------------------------------------------------------------------
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("In-flight progress; only populated while status is queued or in_progress.")
 model OptimizationJobProgress {
   @doc("Number of candidates whose evaluation has completed so far.")
@@ -213,6 +229,7 @@ model OptimizationJobProgress {
   elapsed_seconds: float64;
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Aggregated evaluation result for a single candidate agent configuration across all tasks.")
 model OptimizationCandidate {
   @doc("Server-assigned candidate identifier. Use with GET /candidates/{id} sub-endpoints.")
@@ -240,6 +257,7 @@ model OptimizationCandidate {
   promotion?: PromotionInfo;
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Per-task evaluation result for a single candidate.")
 model OptimizationTaskResult {
   @doc("Task name (from the dataset).")
@@ -277,6 +295,7 @@ model OptimizationTaskResult {
   run_id?: string;
 }
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Terminal-state result body. Populated when status is succeeded or failed.")
 model OptimizationJobResult {
   @doc("Candidate ID of the original (un-optimized) baseline evaluation.")
@@ -293,6 +312,7 @@ model OptimizationJobResult {
 // Job resource — extends JobLike per Foundry job guidelines
 // ---------------------------------------------------------------------------
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Agent optimization job resource — a long-running job that optimizes an agent's configuration (instructions, model, skills, tools) to maximize evaluation scores. On success, the result contains scored candidates.")
 model OptimizationJob is JobLike<OptimizationJobResult, OptimizationJobInputs> {
   @doc("The timestamp when the job was created, represented in Unix time.")
@@ -316,6 +336,7 @@ model OptimizationJob is JobLike<OptimizationJobResult, OptimizationJobInputs> {
 // Slim list item — returned by LIST
 // ---------------------------------------------------------------------------
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Slim job representation returned by the LIST endpoint.")
 model OptimizationJobListItem
   is OmitProperties<OptimizationJob, "inputs" | "result" | "warnings"> {
@@ -328,6 +349,7 @@ model OptimizationJobListItem
 // Promotion models
 // ---------------------------------------------------------------------------
 
+@extension("x-ms-foundry-meta", AgentsOptimizationPreview)
 @doc("Promotion metadata recorded when a candidate is deployed to a Foundry agent.")
 model PromotionInfo {
   @doc("Timestamp when promotion occurred, represented in Unix time.")


### PR DESCRIPTION
This pull request updates the OpenAPI specification for the Foundry data plane by adding preview requirement metadata to several agent optimization-related schemas. The primary change is the addition of the `x-ms-foundry-meta` field specifying that these schemas require the `AgentsOptimization=V2Preview` feature flag. This ensures that these API components are only available to clients who have enabled the V2 preview for agent optimization features.

The most important changes are:

**Preview requirement metadata added to agent optimization schemas:**

* Added the `x-ms-foundry-meta` field with `required_previews: [AgentsOptimization=V2Preview]` to the following schemas in both the JSON and YAML OpenAPI files: `OptimizationAgentRef`, `OptimizationCandidate`, `OptimizationDatasetCriterion`, `OptimizationDatasetInput`, `OptimizationDatasetItem`, `OptimizationEvaluatorRef`, `OptimizationInlineDatasetInput`, `OptimizationJob`, `OptimizationJobInputs`, `OptimizationJobListItem`, `OptimizationJobProgress`, `OptimizationJobResult`, `OptimizationOptions`, `OptimizationReferenceDatasetInput`, and `PromotionInfo`. [[1]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50585-R50590) [[2]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50635-R50645) [[3]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50653-R50668) [[4]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50677-R50697) [[5]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50720-R50745) [[6]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50737-R50767) [[7]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50766-R50801) [[8]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50853-R50893) [[9]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50903-R50948) [[10]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L50974-R51024) [[11]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L51000-R51055) [[12]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L51021-R51081) [[13]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L51055-R51120) [[14]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L51085-R51155) [[15]](diffhunk://#diff-26a46343c76bb939ba16af77ea80cfff9250ec3bbb97978f4bbc2556df68f0a8L51517-R51592) [[16]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34779-R34781) [[17]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34818-R34820) [[18]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34834-R34836) [[19]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34852-R34854) [[20]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34884-R34886) [[21]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34899-R34901) [[22]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34921-R34923) [[23]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R34977-R34979) [[24]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35009-R35011) [[25]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35055-R35057) [[26]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35078-R35080) [[27]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35096-R35098) [[28]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35123-R35125) [[29]](diffhunk://#diff-5a0d2f3caa0469e2911d9d995b03cc06016e59c1f5206db5b564137382d0efe8R35146-R35148)

**No functional API changes:**

* These updates do not alter the structure or behavior of the API, but annotate the schemas to enforce preview gating for agent optimization features. (all references above)

This change helps ensure that only clients with the appropriate preview enabled can access or interact with the agent optimization endpoints and data structures.