### PR TITLE
Add reminder_preview tool to Foundry tools and toolbox models

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -46510,6 +46510,7 @@
             "work_iq_preview": "#/components/schemas/WorkIQPreviewTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
+            "reminder_preview": "#/components/schemas/ReminderPreviewTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
             "file_search": "#/components/schemas/OpenAI.FileSearchTool",
             "web_search": "#/components/schemas/OpenAI.WebSearchTool",
@@ -46870,6 +46871,7 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
+              "reminder_preview",
               "work_iq_preview",
               "fabric_iq_preview",
               "azure_ai_search",
@@ -49278,6 +49280,47 @@
         ],
         "description": "Represents the parameters for red team taxonomy item generation."
       },
+      "ReminderPreviewTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "reminder_preview"
+            ],
+            "description": "The type of the tool. Always `reminder_preview`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "A built-in tool that schedules the agent to re-invoke itself after a delay.\nThe model passes a single `minutes` argument (positive integer) when calling\nthis tool. The service creates a one-shot timer routine that fires after the\nspecified delay and re-invokes the agent on the same conversation thread.\nNo pre-created routine is required."
+      },
+      "ReminderPreviewToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "reminder_preview"
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A reminder tool stored in a toolbox."
+      },
       "ResponseRetrievalItemGenerationParams": {
         "type": "object",
         "required": [
@@ -51431,6 +51474,7 @@
             "openapi": "#/components/schemas/OpenApiToolboxTool",
             "a2a_preview": "#/components/schemas/A2APreviewToolboxTool",
             "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewToolboxTool",
+            "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
@@ -51449,6 +51493,7 @@
           "openapi",
           "a2a_preview",
           "browser_automation_preview",
+          "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
           "toolbox_search_preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -32041,6 +32041,7 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewTool'
           memory_search_preview: '#/components/schemas/MemorySearchPreviewTool'
+          reminder_preview: '#/components/schemas/ReminderPreviewTool'
           code_interpreter: '#/components/schemas/OpenAI.CodeInterpreterTool'
           file_search: '#/components/schemas/OpenAI.FileSearchTool'
           web_search: '#/components/schemas/OpenAI.WebSearchTool'
@@ -32320,6 +32321,7 @@ components:
             - fabric_dataagent_preview
             - sharepoint_grounding_preview
             - memory_search_preview
+            - reminder_preview
             - work_iq_preview
             - fabric_iq_preview
             - azure_ai_search
@@ -33929,6 +33931,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team taxonomy item generation.
+    ReminderPreviewTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - reminder_preview
+          description: The type of the tool. Always `reminder_preview`.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Tool'
+      description: |-
+        A built-in tool that schedules the agent to re-invoke itself after a delay.
+        The model passes a single `minutes` argument (positive integer) when calling
+        this tool. The service creates a one-shot timer routine that fires after the
+        specified delay and re-invokes the agent on the same conversation thread.
+        No pre-created routine is required.
+    ReminderPreviewToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - reminder_preview
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A reminder tool stored in a toolbox.
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -35363,6 +35395,7 @@ components:
           openapi: '#/components/schemas/OpenApiToolboxTool'
           a2a_preview: '#/components/schemas/A2APreviewToolboxTool'
           browser_automation_preview: '#/components/schemas/BrowserAutomationPreviewToolboxTool'
+          reminder_preview: '#/components/schemas/ReminderPreviewToolboxTool'
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
@@ -35378,6 +35411,7 @@ components:
         - openapi
         - a2a_preview
         - browser_automation_preview
+        - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
         - toolbox_search_preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -51175,6 +51175,7 @@
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
             "memory_search": "#/components/schemas/MemorySearchTool",
+            "reminder_preview": "#/components/schemas/ReminderPreviewTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
             "file_search": "#/components/schemas/OpenAI.FileSearchTool",
             "web_search": "#/components/schemas/OpenAI.WebSearchTool",
@@ -51535,6 +51536,7 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
+              "reminder_preview",
               "work_iq_preview",
               "fabric_iq_preview",
               "azure_ai_search",
@@ -54037,6 +54039,47 @@
         ],
         "description": "Represents the parameters for red team taxonomy item generation."
       },
+      "ReminderPreviewTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "reminder_preview"
+            ],
+            "description": "The type of the tool. Always `reminder_preview`."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Tool"
+          }
+        ],
+        "description": "A built-in tool that schedules the agent to re-invoke itself after a delay.\nThe model passes a single `minutes` argument (positive integer) when calling\nthis tool. The service creates a one-shot timer routine that fires after the\nspecified delay and re-invokes the agent on the same conversation thread.\nNo pre-created routine is required."
+      },
+      "ReminderPreviewToolboxTool": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "reminder_preview"
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ToolboxTool"
+          }
+        ],
+        "description": "A reminder tool stored in a toolbox."
+      },
       "ResponseRetrievalItemGenerationParams": {
         "type": "object",
         "required": [
@@ -56216,6 +56259,7 @@
             "openapi": "#/components/schemas/OpenApiToolboxTool",
             "a2a_preview": "#/components/schemas/A2APreviewToolboxTool",
             "browser_automation_preview": "#/components/schemas/BrowserAutomationPreviewToolboxTool",
+            "reminder_preview": "#/components/schemas/ReminderPreviewToolboxTool",
             "work_iq_preview": "#/components/schemas/WorkIQPreviewToolboxTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewToolboxTool",
             "toolbox_search_preview": "#/components/schemas/ToolboxSearchPreviewToolboxTool"
@@ -56234,6 +56278,7 @@
           "openapi",
           "a2a_preview",
           "browser_automation_preview",
+          "reminder_preview",
           "work_iq_preview",
           "fabric_iq_preview",
           "toolbox_search_preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -35186,6 +35186,7 @@ components:
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewTool'
           memory_search_preview: '#/components/schemas/MemorySearchPreviewTool'
           memory_search: '#/components/schemas/MemorySearchTool'
+          reminder_preview: '#/components/schemas/ReminderPreviewTool'
           code_interpreter: '#/components/schemas/OpenAI.CodeInterpreterTool'
           file_search: '#/components/schemas/OpenAI.FileSearchTool'
           web_search: '#/components/schemas/OpenAI.WebSearchTool'
@@ -35465,6 +35466,7 @@ components:
             - fabric_dataagent_preview
             - sharepoint_grounding_preview
             - memory_search_preview
+            - reminder_preview
             - work_iq_preview
             - fabric_iq_preview
             - azure_ai_search
@@ -37140,6 +37142,36 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team taxonomy item generation.
+    ReminderPreviewTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - reminder_preview
+          description: The type of the tool. Always `reminder_preview`.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Tool'
+      description: |-
+        A built-in tool that schedules the agent to re-invoke itself after a delay.
+        The model passes a single `minutes` argument (positive integer) when calling
+        this tool. The service creates a one-shot timer routine that fires after the
+        specified delay and re-invokes the agent on the same conversation thread.
+        No pre-created routine is required.
+    ReminderPreviewToolboxTool:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - reminder_preview
+      allOf:
+        - $ref: '#/components/schemas/ToolboxTool'
+      description: A reminder tool stored in a toolbox.
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -38591,6 +38623,7 @@ components:
           openapi: '#/components/schemas/OpenApiToolboxTool'
           a2a_preview: '#/components/schemas/A2APreviewToolboxTool'
           browser_automation_preview: '#/components/schemas/BrowserAutomationPreviewToolboxTool'
+          reminder_preview: '#/components/schemas/ReminderPreviewToolboxTool'
           work_iq_preview: '#/components/schemas/WorkIQPreviewToolboxTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewToolboxTool'
           toolbox_search_preview: '#/components/schemas/ToolboxSearchPreviewToolboxTool'
@@ -38606,6 +38639,7 @@ components:
         - openapi
         - a2a_preview
         - browser_automation_preview
+        - reminder_preview
         - work_iq_preview
         - fabric_iq_preview
         - toolbox_search_preview

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -79,6 +79,7 @@ alias ToolboxAzureAISearchToolType = "azure_ai_search";
 alias ToolboxOpenApiToolType = "openapi";
 alias ToolboxA2APreviewToolType = "a2a_preview";
 alias ToolboxBrowserAutomationPreviewToolType = "browser_automation_preview";
+alias ToolboxReminderPreviewToolType = "reminder_preview";
 alias ToolboxWorkIQPreviewToolType = "work_iq_preview";
 alias ToolboxFabricIQPreviewToolType = "fabric_iq_preview";
 alias ToolboxSearchPreviewToolType = "toolbox_search_preview";
@@ -95,6 +96,7 @@ union ToolboxToolType {
   openapi: ToolboxOpenApiToolType,
   a2a_preview: ToolboxA2APreviewToolType,
   browser_automation_preview: ToolboxBrowserAutomationPreviewToolType,
+  reminder_preview: ToolboxReminderPreviewToolType,
   work_iq_preview: ToolboxWorkIQPreviewToolType,
   fabric_iq_preview: ToolboxFabricIQPreviewToolType,
   toolbox_search_preview: ToolboxSearchPreviewToolType,
@@ -187,6 +189,13 @@ model BrowserAutomationPreviewToolboxTool extends ToolboxTool {
   type: ToolboxBrowserAutomationPreviewToolType;
 
   ...ToolFields<BrowserAutomationPreviewTool>;
+}
+
+/**
+ * A reminder tool stored in a toolbox.
+ */
+model ReminderPreviewToolboxTool extends ToolboxTool {
+  type: ToolboxReminderPreviewToolType;
 }
 
 /**

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -17,6 +17,7 @@ namespace Azure.AI.Projects {
     fabric_dataagent_preview: "fabric_dataagent_preview",
     sharepoint_grounding_preview: "sharepoint_grounding_preview",
     memory_search_preview: "memory_search_preview",
+    reminder_preview: "reminder_preview",
     work_iq_preview: "work_iq_preview",
     fabric_iq_preview: "fabric_iq_preview",
   }
@@ -812,6 +813,24 @@ namespace Azure.AI.Projects {
      * Time to wait before updating memories after inactivity (seconds). Default 300.
      */
     update_delay?: int32 = 300;
+  }
+
+  // ==============================================================================
+  // Reminder Preview Tool
+  // ==============================================================================
+
+  /**
+   * A built-in tool that schedules the agent to re-invoke itself after a delay.
+   * The model passes a single `minutes` argument (positive integer) when calling
+   * this tool. The service creates a one-shot timer routine that fires after the
+   * specified delay and re-invokes the agent on the same conversation thread.
+   * No pre-created routine is required.
+   */
+  model ReminderPreviewTool extends OpenAI.Tool {
+    /**
+     * The type of the tool. Always `reminder_preview`.
+     */
+    type: "reminder_preview";
   }
 
   // ==============================================================================


### PR DESCRIPTION
Implements reminder_preview tool support in the Foundry TypeSpec project following the tool shape decoupling pattern introduced in PR 43620.

Changes:
- Added reminder_preview to _PreviewAgentToolType union in tools/models.tsp
- Created ReminderPreviewTool model extending OpenAI.Tool
- Added reminder_preview support to toolbox models (toolboxes/models.tsp)
- Created ReminderPreviewToolboxTool model with proper name/description inheritance

Pattern:
- Tool shape (prompt-agent) has only type field, following decoupling pattern
- Toolbox model inherits name/description via ToolNameAndDescriptionExtension
- Auto-generated OpenAPI 3.0 contracts updated

Validation:
- TypeSpec v1.11.0 compilation successful
- No breaking changes to existing APIs