### PR TITLE
Python client renames related to session file upload/download

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1916,13 +1916,32 @@
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.path"
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "limit",
@@ -2019,16 +2038,43 @@
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The file or directory path to delete, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.recursive"
+            "name": "recursive",
+            "in": "query",
+            "required": false,
+            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2078,13 +2124,32 @@
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The destination file path within the sandbox, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2149,13 +2214,32 @@
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The file path to download from the sandbox, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -16474,45 +16558,6 @@
           "maxLength": 128
         }
       },
-      "DeleteSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DeleteSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DeleteSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The file or directory path to delete, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "DeleteSessionFileParams.recursive": {
-        "name": "recursive",
-        "in": "query",
-        "required": false,
-        "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
-        "schema": {
-          "type": "boolean",
-          "default": false
-        },
-        "explode": false
-      },
       "DisableRoutineParameters": {
         "name": "routine_name",
         "in": "path",
@@ -16532,34 +16577,6 @@
           "type": "string",
           "maxLength": 128
         }
-      },
-      "DownloadSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DownloadSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DownloadSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The file path to download from the sandbox, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       },
       "EnableRoutineParameters": {
         "name": "routine_name",
@@ -16683,34 +16700,6 @@
         },
         "explode": false
       },
-      "ListSessionFilesParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "ListSessionFilesParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "ListSessionFilesParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": false,
-        "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
       "UpdateToolboxRequest.name": {
         "name": "name",
         "in": "path",
@@ -16719,34 +16708,6 @@
         "schema": {
           "type": "string"
         }
-      },
-      "UploadSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "UploadSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "UploadSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The destination file path within the sandbox, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       }
     },
     "schemas": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1916,32 +1916,13 @@
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/ListSessionFilesParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/ListSessionFilesParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": false,
-            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListSessionFilesParams.path"
           },
           {
             "name": "limit",
@@ -2038,43 +2019,16 @@
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The file or directory path to delete, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DeleteSessionFileParams.path"
           },
           {
-            "name": "recursive",
-            "in": "query",
-            "required": false,
-            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DeleteSessionFileParams.recursive"
           },
           {
             "name": "api-version",
@@ -2124,32 +2078,13 @@
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/UploadSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/UploadSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The destination file path within the sandbox, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/UploadSessionFileParams.path"
           },
           {
             "name": "api-version",
@@ -2214,32 +2149,13 @@
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The file path to download from the sandbox, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DownloadSessionFileParams.path"
           },
           {
             "name": "api-version",
@@ -16558,6 +16474,45 @@
           "maxLength": 128
         }
       },
+      "DeleteSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DeleteSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DeleteSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The file or directory path to delete, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "DeleteSessionFileParams.recursive": {
+        "name": "recursive",
+        "in": "query",
+        "required": false,
+        "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        },
+        "explode": false
+      },
       "DisableRoutineParameters": {
         "name": "routine_name",
         "in": "path",
@@ -16577,6 +16532,34 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "DownloadSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DownloadSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DownloadSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The file path to download from the sandbox, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "EnableRoutineParameters": {
         "name": "routine_name",
@@ -16700,6 +16683,34 @@
         },
         "explode": false
       },
+      "ListSessionFilesParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ListSessionFilesParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ListSessionFilesParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": false,
+        "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "UpdateToolboxRequest.name": {
         "name": "name",
         "in": "path",
@@ -16708,6 +16719,34 @@
         "schema": {
           "type": "string"
         }
+      },
+      "UploadSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "UploadSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "UploadSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The destination file path within the sandbox, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       }
     },
     "schemas": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -52465,6 +52465,11 @@
             "type": "string",
             "description": "The configured trigger name that produced the routine attempt."
           },
+          "trigger_event_payload": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "The event payload captured from the event that triggered the routine attempt, when available."
+          },
           "attempt_source": {
             "allOf": [
               {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -1293,9 +1293,25 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - $ref: '#/components/parameters/ListSessionFilesParams.agent_name'
-        - $ref: '#/components/parameters/ListSessionFilesParams.agent_session_id'
-        - $ref: '#/components/parameters/ListSessionFilesParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+          schema:
+            type: string
+          explode: false
         - name: limit
           in: query
           required: false
@@ -1371,10 +1387,33 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.path'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.recursive'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The file or directory path to delete, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
+        - name: recursive
+          in: query
+          required: false
+          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+          schema:
+            type: boolean
+            default: false
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1407,9 +1446,25 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - $ref: '#/components/parameters/UploadSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/UploadSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/UploadSessionFileParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The destination file path within the sandbox, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1451,9 +1506,25 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/DownloadSessionFileParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The file path to download from the sandbox, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -10796,37 +10867,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    DeleteSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    DeleteSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    DeleteSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The file or directory path to delete, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
-    DeleteSessionFileParams.recursive:
-      name: recursive
-      in: query
-      required: false
-      description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
-      schema:
-        type: boolean
-        default: false
-      explode: false
     DisableRoutineParameters:
       name: routine_name
       in: path
@@ -10843,28 +10883,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    DownloadSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    DownloadSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    DownloadSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The file path to download from the sandbox, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
     EnableRoutineParameters:
       name: routine_name
       in: path
@@ -10963,28 +10981,6 @@ components:
       schema:
         type: string
       explode: false
-    ListSessionFilesParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    ListSessionFilesParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    ListSessionFilesParams.path:
-      name: path
-      in: query
-      required: false
-      description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
-      schema:
-        type: string
-      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -10992,28 +10988,6 @@ components:
       description: The name of the toolbox to update.
       schema:
         type: string
-    UploadSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    UploadSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    UploadSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The destination file path within the sandbox, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
   schemas:
     A2APreviewTool:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -35949,6 +35949,10 @@ components:
         trigger_name:
           type: string
           description: The configured trigger name that produced the routine attempt.
+        trigger_event_payload:
+          type: object
+          unevaluatedProperties: {}
+          description: The event payload captured from the event that triggered the routine attempt, when available.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -1293,25 +1293,9 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: false
-          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListSessionFilesParams.agent_name'
+        - $ref: '#/components/parameters/ListSessionFilesParams.agent_session_id'
+        - $ref: '#/components/parameters/ListSessionFilesParams.path'
         - name: limit
           in: query
           required: false
@@ -1387,33 +1371,10 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The file or directory path to delete, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
-        - name: recursive
-          in: query
-          required: false
-          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
-          schema:
-            type: boolean
-            default: false
-          explode: false
+        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.path'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.recursive'
         - name: api-version
           in: query
           required: true
@@ -1446,25 +1407,9 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The destination file path within the sandbox, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/UploadSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/UploadSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/UploadSessionFileParams.path'
         - name: api-version
           in: query
           required: true
@@ -1506,25 +1451,9 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The file path to download from the sandbox, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/DownloadSessionFileParams.path'
         - name: api-version
           in: query
           required: true
@@ -10867,6 +10796,37 @@ components:
       schema:
         type: string
         maxLength: 128
+    DeleteSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    DeleteSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    DeleteSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The file or directory path to delete, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
+    DeleteSessionFileParams.recursive:
+      name: recursive
+      in: query
+      required: false
+      description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+      schema:
+        type: boolean
+        default: false
+      explode: false
     DisableRoutineParameters:
       name: routine_name
       in: path
@@ -10883,6 +10843,28 @@ components:
       schema:
         type: string
         maxLength: 128
+    DownloadSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    DownloadSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    DownloadSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The file path to download from the sandbox, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
     EnableRoutineParameters:
       name: routine_name
       in: path
@@ -10981,6 +10963,28 @@ components:
       schema:
         type: string
       explode: false
+    ListSessionFilesParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    ListSessionFilesParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    ListSessionFilesParams.path:
+      name: path
+      in: query
+      required: false
+      description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -10988,6 +10992,28 @@ components:
       description: The name of the toolbox to update.
       schema:
         type: string
+    UploadSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    UploadSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    UploadSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The destination file path within the sandbox, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
   schemas:
     A2APreviewTool:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -57229,6 +57229,11 @@
             "type": "string",
             "description": "The configured trigger name that produced the routine attempt."
           },
+          "trigger_event_payload": {
+            "type": "object",
+            "unevaluatedProperties": {},
+            "description": "The event payload captured from the event that triggered the routine attempt, when available."
+          },
           "attempt_source": {
             "allOf": [
               {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -2043,13 +2043,32 @@
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/ListSessionFilesParams.path"
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "limit",
@@ -2146,16 +2165,43 @@
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The file or directory path to delete, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
-            "$ref": "#/components/parameters/DeleteSessionFileParams.recursive"
+            "name": "recursive",
+            "in": "query",
+            "required": false,
+            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2205,13 +2251,32 @@
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/UploadSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The destination file path within the sandbox, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -2276,13 +2341,32 @@
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_name"
+            "name": "agent_name",
+            "in": "path",
+            "required": true,
+            "description": "The name of the agent.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_session_id"
+            "name": "agent_session_id",
+            "in": "path",
+            "required": true,
+            "description": "The session ID.",
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "$ref": "#/components/parameters/DownloadSessionFileParams.path"
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "description": "The file path to download from the sandbox, relative to the session home directory.",
+            "schema": {
+              "type": "string"
+            },
+            "explode": false
           },
           {
             "name": "api-version",
@@ -19416,45 +19500,6 @@
           "maxLength": 128
         }
       },
-      "DeleteSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DeleteSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DeleteSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The file or directory path to delete, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
-      "DeleteSessionFileParams.recursive": {
-        "name": "recursive",
-        "in": "query",
-        "required": false,
-        "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
-        "schema": {
-          "type": "boolean",
-          "default": false
-        },
-        "explode": false
-      },
       "DisableRoutineParameters": {
         "name": "routine_name",
         "in": "path",
@@ -19474,34 +19519,6 @@
           "type": "string",
           "maxLength": 128
         }
-      },
-      "DownloadSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DownloadSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "DownloadSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The file path to download from the sandbox, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       },
       "EnableRoutineParameters": {
         "name": "routine_name",
@@ -19625,34 +19642,6 @@
         },
         "explode": false
       },
-      "ListSessionFilesParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "ListSessionFilesParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "ListSessionFilesParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": false,
-        "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
-      },
       "UpdateToolboxRequest.name": {
         "name": "name",
         "in": "path",
@@ -19661,34 +19650,6 @@
         "schema": {
           "type": "string"
         }
-      },
-      "UploadSessionFileParams.agent_name": {
-        "name": "agent_name",
-        "in": "path",
-        "required": true,
-        "description": "The name of the agent.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "UploadSessionFileParams.agent_session_id": {
-        "name": "agent_session_id",
-        "in": "path",
-        "required": true,
-        "description": "The session ID.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "UploadSessionFileParams.path": {
-        "name": "path",
-        "in": "query",
-        "required": true,
-        "description": "The destination file path within the sandbox, relative to the session home directory.",
-        "schema": {
-          "type": "string"
-        },
-        "explode": false
       }
     },
     "schemas": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -2043,32 +2043,13 @@
         "description": "Returns files and directories at the specified path in the session sandbox.\nThe response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/ListSessionFilesParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/ListSessionFilesParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": false,
-            "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/ListSessionFilesParams.path"
           },
           {
             "name": "limit",
@@ -2165,43 +2146,16 @@
         "description": "Deletes the specified file or directory from the session sandbox.\nWhen `recursive` is false, deleting a non-empty directory returns 409 Conflict.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DeleteSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The file or directory path to delete, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DeleteSessionFileParams.path"
           },
           {
-            "name": "recursive",
-            "in": "query",
-            "required": false,
-            "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DeleteSessionFileParams.recursive"
           },
           {
             "name": "api-version",
@@ -2251,32 +2205,13 @@
         "description": "Uploads binary file content to the specified path in the session sandbox.\nThe service stores the file relative to the session home directory and rejects payloads larger than 50 MB.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/UploadSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/UploadSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The destination file path within the sandbox, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/UploadSessionFileParams.path"
           },
           {
             "name": "api-version",
@@ -2341,32 +2276,13 @@
         "description": "Downloads the file at the specified sandbox path as a binary stream.\nThe path is resolved relative to the session home directory.",
         "parameters": [
           {
-            "name": "agent_name",
-            "in": "path",
-            "required": true,
-            "description": "The name of the agent.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_name"
           },
           {
-            "name": "agent_session_id",
-            "in": "path",
-            "required": true,
-            "description": "The session ID.",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/DownloadSessionFileParams.agent_session_id"
           },
           {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "description": "The file path to download from the sandbox, relative to the session home directory.",
-            "schema": {
-              "type": "string"
-            },
-            "explode": false
+            "$ref": "#/components/parameters/DownloadSessionFileParams.path"
           },
           {
             "name": "api-version",
@@ -19500,6 +19416,45 @@
           "maxLength": 128
         }
       },
+      "DeleteSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DeleteSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DeleteSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The file or directory path to delete, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
+      "DeleteSessionFileParams.recursive": {
+        "name": "recursive",
+        "in": "query",
+        "required": false,
+        "description": "Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        },
+        "explode": false
+      },
       "DisableRoutineParameters": {
         "name": "routine_name",
         "in": "path",
@@ -19519,6 +19474,34 @@
           "type": "string",
           "maxLength": 128
         }
+      },
+      "DownloadSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DownloadSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DownloadSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The file path to download from the sandbox, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       },
       "EnableRoutineParameters": {
         "name": "routine_name",
@@ -19642,6 +19625,34 @@
         },
         "explode": false
       },
+      "ListSessionFilesParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ListSessionFilesParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ListSessionFilesParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": false,
+        "description": "The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
+      },
       "UpdateToolboxRequest.name": {
         "name": "name",
         "in": "path",
@@ -19650,6 +19661,34 @@
         "schema": {
           "type": "string"
         }
+      },
+      "UploadSessionFileParams.agent_name": {
+        "name": "agent_name",
+        "in": "path",
+        "required": true,
+        "description": "The name of the agent.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "UploadSessionFileParams.agent_session_id": {
+        "name": "agent_session_id",
+        "in": "path",
+        "required": true,
+        "description": "The session ID.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "UploadSessionFileParams.path": {
+        "name": "path",
+        "in": "query",
+        "required": true,
+        "description": "The destination file path within the sandbox, relative to the session home directory.",
+        "schema": {
+          "type": "string"
+        },
+        "explode": false
       }
     },
     "schemas": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -39164,6 +39164,10 @@ components:
         trigger_name:
           type: string
           description: The configured trigger name that produced the routine attempt.
+        trigger_event_payload:
+          type: object
+          unevaluatedProperties: {}
+          description: The event payload captured from the event that triggered the routine attempt, when available.
         attempt_source:
           allOf:
             - $ref: '#/components/schemas/RoutineAttemptSource'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -1382,9 +1382,25 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - $ref: '#/components/parameters/ListSessionFilesParams.agent_name'
-        - $ref: '#/components/parameters/ListSessionFilesParams.agent_session_id'
-        - $ref: '#/components/parameters/ListSessionFilesParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: false
+          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+          schema:
+            type: string
+          explode: false
         - name: limit
           in: query
           required: false
@@ -1460,10 +1476,33 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.path'
-        - $ref: '#/components/parameters/DeleteSessionFileParams.recursive'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The file or directory path to delete, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
+        - name: recursive
+          in: query
+          required: false
+          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+          schema:
+            type: boolean
+            default: false
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1496,9 +1535,25 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - $ref: '#/components/parameters/UploadSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/UploadSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/UploadSessionFileParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The destination file path within the sandbox, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -1540,9 +1595,25 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_name'
-        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_session_id'
-        - $ref: '#/components/parameters/DownloadSessionFileParams.path'
+        - name: agent_name
+          in: path
+          required: true
+          description: The name of the agent.
+          schema:
+            type: string
+        - name: agent_session_id
+          in: path
+          required: true
+          description: The session ID.
+          schema:
+            type: string
+        - name: path
+          in: query
+          required: true
+          description: The file path to download from the sandbox, relative to the session home directory.
+          schema:
+            type: string
+          explode: false
         - name: api-version
           in: query
           required: true
@@ -12750,37 +12821,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    DeleteSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    DeleteSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    DeleteSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The file or directory path to delete, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
-    DeleteSessionFileParams.recursive:
-      name: recursive
-      in: query
-      required: false
-      description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
-      schema:
-        type: boolean
-        default: false
-      explode: false
     DisableRoutineParameters:
       name: routine_name
       in: path
@@ -12797,28 +12837,6 @@ components:
       schema:
         type: string
         maxLength: 128
-    DownloadSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    DownloadSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    DownloadSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The file path to download from the sandbox, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
     EnableRoutineParameters:
       name: routine_name
       in: path
@@ -12917,28 +12935,6 @@ components:
       schema:
         type: string
       explode: false
-    ListSessionFilesParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    ListSessionFilesParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    ListSessionFilesParams.path:
-      name: path
-      in: query
-      required: false
-      description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
-      schema:
-        type: string
-      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -12946,28 +12942,6 @@ components:
       description: The name of the toolbox to update.
       schema:
         type: string
-    UploadSessionFileParams.agent_name:
-      name: agent_name
-      in: path
-      required: true
-      description: The name of the agent.
-      schema:
-        type: string
-    UploadSessionFileParams.agent_session_id:
-      name: agent_session_id
-      in: path
-      required: true
-      description: The session ID.
-      schema:
-        type: string
-    UploadSessionFileParams.path:
-      name: path
-      in: query
-      required: true
-      description: The destination file path within the sandbox, relative to the session home directory.
-      schema:
-        type: string
-      explode: false
   schemas:
     A2APreviewTool:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -1382,25 +1382,9 @@ paths:
         Returns files and directories at the specified path in the session sandbox.
         The response includes only the immediate children of the target directory and defaults to the session home directory when no path is supplied.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: false
-          description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/ListSessionFilesParams.agent_name'
+        - $ref: '#/components/parameters/ListSessionFilesParams.agent_session_id'
+        - $ref: '#/components/parameters/ListSessionFilesParams.path'
         - name: limit
           in: query
           required: false
@@ -1476,33 +1460,10 @@ paths:
         Deletes the specified file or directory from the session sandbox.
         When `recursive` is false, deleting a non-empty directory returns 409 Conflict.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The file or directory path to delete, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
-        - name: recursive
-          in: query
-          required: false
-          description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
-          schema:
-            type: boolean
-            default: false
-          explode: false
+        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.path'
+        - $ref: '#/components/parameters/DeleteSessionFileParams.recursive'
         - name: api-version
           in: query
           required: true
@@ -1535,25 +1496,9 @@ paths:
         Uploads binary file content to the specified path in the session sandbox.
         The service stores the file relative to the session home directory and rejects payloads larger than 50 MB.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The destination file path within the sandbox, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/UploadSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/UploadSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/UploadSessionFileParams.path'
         - name: api-version
           in: query
           required: true
@@ -1595,25 +1540,9 @@ paths:
         Downloads the file at the specified sandbox path as a binary stream.
         The path is resolved relative to the session home directory.
       parameters:
-        - name: agent_name
-          in: path
-          required: true
-          description: The name of the agent.
-          schema:
-            type: string
-        - name: agent_session_id
-          in: path
-          required: true
-          description: The session ID.
-          schema:
-            type: string
-        - name: path
-          in: query
-          required: true
-          description: The file path to download from the sandbox, relative to the session home directory.
-          schema:
-            type: string
-          explode: false
+        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_name'
+        - $ref: '#/components/parameters/DownloadSessionFileParams.agent_session_id'
+        - $ref: '#/components/parameters/DownloadSessionFileParams.path'
         - name: api-version
           in: query
           required: true
@@ -12821,6 +12750,37 @@ components:
       schema:
         type: string
         maxLength: 128
+    DeleteSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    DeleteSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    DeleteSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The file or directory path to delete, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
+    DeleteSessionFileParams.recursive:
+      name: recursive
+      in: query
+      required: false
+      description: Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller.
+      schema:
+        type: boolean
+        default: false
+      explode: false
     DisableRoutineParameters:
       name: routine_name
       in: path
@@ -12837,6 +12797,28 @@ components:
       schema:
         type: string
         maxLength: 128
+    DownloadSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    DownloadSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    DownloadSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The file path to download from the sandbox, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
     EnableRoutineParameters:
       name: routine_name
       in: path
@@ -12935,6 +12917,28 @@ components:
       schema:
         type: string
       explode: false
+    ListSessionFilesParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    ListSessionFilesParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    ListSessionFilesParams.path:
+      name: path
+      in: query
+      required: false
+      description: The directory path to list, relative to the session home directory. Defaults to the home directory if not provided.
+      schema:
+        type: string
+      explode: false
     UpdateToolboxRequest.name:
       name: name
       in: path
@@ -12942,6 +12946,28 @@ components:
       description: The name of the toolbox to update.
       schema:
         type: string
+    UploadSessionFileParams.agent_name:
+      name: agent_name
+      in: path
+      required: true
+      description: The name of the agent.
+      schema:
+        type: string
+    UploadSessionFileParams.agent_session_id:
+      name: agent_session_id
+      in: path
+      required: true
+      description: The session ID.
+      schema:
+        type: string
+    UploadSessionFileParams.path:
+      name: path
+      in: query
+      required: true
+      description: The destination file path within the sandbox, relative to the session home directory.
+      schema:
+        type: string
+      explode: false
   schemas:
     A2APreviewTool:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -1,4 +1,66 @@
+using TypeSpec.Http;
+
 namespace Azure.AI.Projects;
+
+// ---------------------------------------------------------------------------
+// Request parameter models
+// ---------------------------------------------------------------------------
+
+@doc("Parameters for uploading a file to a session sandbox.")
+model UploadSessionFileParams {
+  /** The name of the agent. */
+  @path agent_name: string;
+
+  /** The session ID. */
+  @path agent_session_id: string;
+
+  /** The destination file path within the sandbox, relative to the session home directory. */
+  @query path: string;
+
+  /** The binary file content to upload. */
+  @header("Content-Type") contentType: "application/octet-stream";
+
+  @body content: bytes;
+}
+
+@doc("Parameters for downloading a file from a session sandbox.")
+model DownloadSessionFileParams {
+  /** The name of the agent. */
+  @path agent_name: string;
+
+  /** The session ID. */
+  @path agent_session_id: string;
+
+  /** The file path to download from the sandbox, relative to the session home directory. */
+  @query path: string;
+}
+
+@doc("Parameters for listing files in a session sandbox.")
+model ListSessionFilesParams {
+  /** The name of the agent. */
+  @path agent_name: string;
+
+  /** The session ID. */
+  @path agent_session_id: string;
+
+  /** The directory path to list, relative to the session home directory. Defaults to the home directory if not provided. */
+  @query path?: string;
+}
+
+@doc("Parameters for deleting a file from a session sandbox.")
+model DeleteSessionFileParams {
+  /** The name of the agent. */
+  @path agent_name: string;
+
+  /** The session ID. */
+  @path agent_session_id: string;
+
+  /** The file or directory path to delete, relative to the session home directory. */
+  @query path: string;
+
+  /** Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller. */
+  @query recursive?: boolean = false;
+}
 
 // ---------------------------------------------------------------------------
 // Response models

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/models.tsp
@@ -6,8 +6,8 @@ namespace Azure.AI.Projects;
 // Request parameter models
 // ---------------------------------------------------------------------------
 
-@doc("Parameters for uploading a file to a session sandbox.")
-model UploadSessionFileParams {
+// Parameters for uploading a file to a session sandbox
+alias UploadSessionFileParams = {
   /** The name of the agent. */
   @path agent_name: string;
 
@@ -21,10 +21,10 @@ model UploadSessionFileParams {
   @header("Content-Type") contentType: "application/octet-stream";
 
   @body content: bytes;
-}
+};
 
-@doc("Parameters for downloading a file from a session sandbox.")
-model DownloadSessionFileParams {
+// Parameters for downloading a file from a session sandbox
+alias DownloadSessionFileParams = {
   /** The name of the agent. */
   @path agent_name: string;
 
@@ -33,10 +33,10 @@ model DownloadSessionFileParams {
 
   /** The file path to download from the sandbox, relative to the session home directory. */
   @query path: string;
-}
+};
 
-@doc("Parameters for listing files in a session sandbox.")
-model ListSessionFilesParams {
+// Parameters for listing files in a session sandbox
+alias ListSessionFilesParams = {
   /** The name of the agent. */
   @path agent_name: string;
 
@@ -45,10 +45,10 @@ model ListSessionFilesParams {
 
   /** The directory path to list, relative to the session home directory. Defaults to the home directory if not provided. */
   @query path?: string;
-}
+};
 
-@doc("Parameters for deleting a file from a session sandbox.")
-model DeleteSessionFileParams {
+// Parameters for deleting a file from a session sandbox
+alias DeleteSessionFileParams = {
   /** The name of the agent. */
   @path agent_name: string;
 
@@ -60,7 +60,7 @@ model DeleteSessionFileParams {
 
   /** Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller. */
   @query recursive?: boolean = false;
-}
+};
 
 // ---------------------------------------------------------------------------
 // Response models

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -30,7 +30,6 @@ interface AgentSessionFiles {
   uploadSessionFile is FoundryDataPlaneOperation<
     {
       ...UploadSessionFileParams;
-      ...UserIsolationKeyHeader;
     },
     ResourceCreatedResponse<SessionFileWriteResponse>
   >;
@@ -45,7 +44,6 @@ interface AgentSessionFiles {
   downloadSessionFile is FoundryDataPlaneOperation<
     {
       ...DownloadSessionFileParams;
-      ...UserIsolationKeyHeader;
     },
     bytes
   >;
@@ -61,7 +59,6 @@ interface AgentSessionFiles {
   listSessionFiles is FoundryDataPlaneOperation<
     {
       ...ListSessionFilesParams;
-      ...UserIsolationKeyHeader;
       ...CommonPageQueryParameters;
     },
     SessionDirectoryListResponse
@@ -77,7 +74,6 @@ interface AgentSessionFiles {
   deleteSessionFile is FoundryDataPlaneOperation<
     {
       ...DeleteSessionFileParams;
-      ...UserIsolationKeyHeader;
     },
     void
   >;

--- a/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents-session-files/routes.tsp
@@ -3,8 +3,6 @@ import "../common/servicepatterns.tsp";
 import "./models.tsp";
 
 using TypeSpec.Http;
-using TypeSpec.OpenAPI;
-using TypeSpec.Versioning;
 
 namespace Azure.AI.Projects;
 
@@ -31,19 +29,7 @@ interface AgentSessionFiles {
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
   uploadSessionFile is FoundryDataPlaneOperation<
     {
-      /** The name of the agent. */
-      @path agent_name: string;
-
-      /** The session ID. */
-      @path agent_session_id: string;
-
-      /** The destination file path within the sandbox, relative to the session home directory. */
-      @query path: string;
-
-      /** The binary file content to upload. */
-      @header("Content-Type") contentType: "application/octet-stream";
-
-      @body content: bytes;
+      ...UploadSessionFileParams;
       ...UserIsolationKeyHeader;
     },
     ResourceCreatedResponse<SessionFileWriteResponse>
@@ -58,15 +44,7 @@ interface AgentSessionFiles {
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files/content")
   downloadSessionFile is FoundryDataPlaneOperation<
     {
-      /** The name of the agent. */
-      @path agent_name: string;
-
-      /** The session ID. */
-      @path agent_session_id: string;
-
-      /** The file path to download from the sandbox, relative to the session home directory. */
-      @query path: string;
-
+      ...DownloadSessionFileParams;
       ...UserIsolationKeyHeader;
     },
     bytes
@@ -82,15 +60,7 @@ interface AgentSessionFiles {
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
   listSessionFiles is FoundryDataPlaneOperation<
     {
-      /** The name of the agent. */
-      @path agent_name: string;
-
-      /** The session ID. */
-      @path agent_session_id: string;
-
-      /** The directory path to list, relative to the session home directory. Defaults to the home directory if not provided. */
-      @query path?: string;
-
+      ...ListSessionFilesParams;
       ...UserIsolationKeyHeader;
       ...CommonPageQueryParameters;
     },
@@ -106,18 +76,7 @@ interface AgentSessionFiles {
   @route("/agents/{agent_name}/endpoint/sessions/{agent_session_id}/files")
   deleteSessionFile is FoundryDataPlaneOperation<
     {
-      /** The name of the agent. */
-      @path agent_name: string;
-
-      /** The session ID. */
-      @path agent_session_id: string;
-
-      /** The file or directory path to delete, relative to the session home directory. */
-      @query path: string;
-
-      /** Whether to recursively delete directory contents. The service defaults to `false` if a value is not specified by the caller. */
-      @query recursive?: boolean = false;
-
+      ...DeleteSessionFileParams;
       ...UserIsolationKeyHeader;
     },
     void

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -109,6 +109,40 @@ using Azure.AI.Projects;
 
 @@clientName(OpenAI.ImageGenActionEnum, "ImageGenAction");
 
+// DatasetItem model has a property `response_items?: OpenAI.OutputItem[]`. It is used
+// to define Agent optimization request. If emitted as-is, it pulls in a lot of
+// OpenAI responses classes. We want Foundry SDK to be free of those, therefore for the
+// time being we define output item as a generic dictionary.
+@@alternateType(OpenAI.OutputItem, Record<unknown>);
+
+// Make this method internal, since it's patched with a new one that supports either binary or file-path input
+@@access(AgentSessionFiles.uploadSessionFile, Access.internal, "python");
+@@usage(SessionFileWriteResponse, Usage.output);
+@@access(SessionFileWriteResponse, Access.public);
+
+@@clientName(UploadSessionFileParams.path, "remote_path", "python");
+@@clientName(DownloadSessionFileParams.path, "remote_path", "python");
+@@clientName(ListSessionFilesParams.path, "remote_path", "python");
+@@clientName(DeleteSessionFileParams.path, "remote_path", "python");
+
+// Exclude these operations entirely from emitted SDK. These are convenience REST APIs that we don't think bring
+// real value on SDK surface. We can do everything using createAgentVersionFromCode.
+@@scope(Agents.createAgentFromCode, "!(python, javascript)");
+@@scope(Agents.updateAgentFromCode, "!(python, javascript)");
+
+@@clientName(Agents.downloadAgentCode, "download_code", "python");
+@@clientName(Agents.createAgentVersionFromCode, "createVersionFromCode");
+
+@@clientName(DownloadAgentCodeResponse, "DownloadAgentCodeResult", "python");
+@@clientName(
+  SessionDirectoryListResponse,
+  "SessionDirectoryListResult",
+  "python"
+);
+@@clientName(SessionFileWriteResponse, "SessionFileWriteResult", "python");
+
+@@clientName(AgentEndpointProtocol.a2a, exact("A2A"), "python");
+
 // --------------------------------------------------------------------------------
 // Datasets sub‐client
 // --------------------------------------------------------------------------------
@@ -198,35 +232,6 @@ using Azure.AI.Projects;
 @@clientName(AgentOptimizationJobs.list, "listOptimizationJobs");
 @@clientName(AgentOptimizationJobs.cancel, "cancelOptimizationJob");
 @@clientName(AgentOptimizationJobs.delete, "deleteOptimizationJob");
-
-// DatasetItem model has a property `response_items?: OpenAI.OutputItem[]`. It is used
-// to define Agent optimization request. If emitted as-is, it pulls in a lot of
-// OpenAI responses classes. We want Foundry SDK to be free of those, therefore for the
-// time being we define output item as a generic dictionary.
-@@alternateType(OpenAI.OutputItem, Record<unknown>);
-
-// Make this method internal, since it's patched with a new one that supports either binary or file-path input
-@@access(AgentSessionFiles.uploadSessionFile, Access.internal, "python");
-@@usage(SessionFileWriteResponse, Usage.output);
-@@access(SessionFileWriteResponse, Access.public);
-
-// Exclude these operations entirely from emitted SDK. These are convenience REST APIs that we don't think bring
-// real value on SDK surface. We can do everything using createAgentVersionFromCode.
-@@scope(Agents.createAgentFromCode, "!(python, javascript)");
-@@scope(Agents.updateAgentFromCode, "!(python, javascript)");
-
-@@clientName(Agents.downloadAgentCode, "download_code", "python");
-@@clientName(Agents.createAgentVersionFromCode, "createVersionFromCode");
-
-@@clientName(DownloadAgentCodeResponse, "DownloadAgentCodeResult", "python");
-@@clientName(
-  SessionDirectoryListResponse,
-  "SessionDirectoryListResult",
-  "python"
-);
-@@clientName(SessionFileWriteResponse, "SessionFileWriteResult", "python");
-
-@@clientName(AgentEndpointProtocol.a2a, exact("A2A"), "python");
 
 // All emitted Python classes already have "items" in the base class, so we need to pick another name
 @@clientName(OptimizationInlineDatasetInput.items, "dataset_items", "python");

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-python-js-azure-ai-projects/client.tsp
@@ -94,9 +94,6 @@ using Azure.AI.Projects;
 @@clientName(AgentObject, "Agent", "javascript");
 @@clientName(AgentVersionObject, "AgentVersion", "javascript");
 
-// Python emitter creates enum A2_A_PREVIEW = "a2a_preview". Override it here to "A2A_PREVIEW".
-@@clientName(_PreviewAgentToolType.a2a_preview, "A2A_PREVIEW", "python");
-
 // Python emitter creates enum values ENUM_1_G = "1g", ENUM_4_G = "4g" etc. Override it here as below.
 @@clientName(OpenAI.ContainerMemoryLimit.`1g`, exact("MEMORY_1GB"), "python");
 @@clientName(OpenAI.ContainerMemoryLimit.`4g`, exact("MEMORY_4GB"), "python");
@@ -108,6 +105,7 @@ using Azure.AI.Projects;
 @@clientName(_PreviewAgentToolType.a2a_preview, exact("A2A_PREVIEW"), "python");
 @@clientName(ToolboxToolType.a2a_preview, exact("A2A_PREVIEW"), "python");
 @@clientName(ProtocolConfiguration.a2a, exact("a2a"), "python");
+@@clientName(AgentEndpointProtocol.a2a, exact("A2A"), "python");
 
 @@clientName(OpenAI.ImageGenActionEnum, "ImageGenAction");
 
@@ -143,7 +141,7 @@ using Azure.AI.Projects;
 );
 @@clientName(SessionFileWriteResponse, "SessionFileWriteResult", "python");
 
-@@clientName(AgentEndpointProtocol.a2a, exact("A2A"), "python");
+
 
 // --------------------------------------------------------------------------------
 // Datasets sub‐client


### PR DESCRIPTION
This change does not affect the REST API spec. I allows emitted clients (Python in this case) to update the name of uploaded file path in the sandbox from "path" to something more descriptive like "remote_path". Python client will also have a method to read file directly from disk, and that file name will be called "file_path", so I would like to distinguish between local path to read and target (report) path where it will be stored.

Unfortunately the only way to do this rename in a separate client.tsp file is to define all the request element in a separate TypeSpec model and reference it when defining the operations. That's what I'm doing here for the file session operations.

I'll make a feature request from the emitter team to be able to directly rename an input argument of an operation, without the need to first declare it in a TypeSpec model.
