### PR TITLE
[Foundry] Fix RBAC permission name for x-ms-user-identity delegation header

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -30,13 +30,13 @@ alias AcceptJsonHeader = {
 
 /**
  * Optional request header carrying an opaque per-user identity for delegation.
- * When present and the caller has the `agents/endpoint/delegateViaUserId` RBAC permission,
+ * When present and the caller has the `agents/endpoints/delegateViaUserId/action` RBAC permission,
  * the service scopes endpoint-scoped data (responses, conversations, sessions) to the
  * supplied user identity instead of the caller's own identity.
  * If the caller has delegation RBAC but does not pass this header, the caller's own identity is used.
  */
 alias UserDelegationHeader = {
-  /** Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission. */
+  /** Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/delegateViaUserId/action` RBAC permission. */
   @header("x-ms-user-identity") user_identity?: string;
 };
 


### PR DESCRIPTION
## Summary

Corrects the RBAC permission name in the `UserDelegationHeader` documentation from `agents/endpoint/delegateViaUserId` to `agents/endpoints/delegateViaUserId/action` to match the actual registered dataAction.

### Changes
- `common/models.tsp`: Update RBAC permission reference in both the doc comment and the field description for `UserDelegationHeader`.