### PR TITLE
Mitigate Java SDK breaks for qumulo (flattenProperty on FileSystemResource)

### DIFF
--- a/specification/liftrqumulo/Qumulo.Storage.Management/client.tsp
+++ b/specification/liftrqumulo/Qumulo.Storage.Management/client.tsp
@@ -53,7 +53,7 @@ namespace LiftrBase;
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "for backward compatibility purpose"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(
   LiftrBase.Storage.FileSystemResource.properties,
-  "csharp"
+  "csharp,java"
 );
 
 /**


### PR DESCRIPTION
Mitigate Java SDK breaking changes for **qumulo** caused by migration to TypeSpec.

The Swagger/autorest generation flattened FileSystemResource.properties, exposing accessors directly on FileSystemResource. The TypeSpec generation applied `@@Azure.ClientGenerator.Core.Legacy.flattenProperty` only to `autorest` and `csharp` scopes, so the Java SDK lost the flattened getters (`availabilityZone`, `storageSku`, `privateIPs`, `provisioningState`, `adminPassword`, `userDetails`, `marketplaceDetails`, `clusterLoginUrl`, `delegatedSubnetId`). This breaks versioning rules for the stable `azure-resourcemanager-qumulo` 1.2.0 release (Azure/azure-sdk-for-java#49566).

This change adds `java` to the `flattenProperty` scope in `client.tsp` to restore backward compatibility for the Java SDK.

Only `client.tsp` is modified. Verified with `tsp compile`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>