### PR TITLE
Remove StorageCache C# visibility decorators

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/client.tsp
@@ -357,9 +357,6 @@ using Microsoft.StorageCache;
 );
 @@alternateType(StorageTarget.location, Azure.Core.azureLocation, "csharp");
 
-@@visibility(CacheProperties.primingJobs, Lifecycle.Read);
-@@visibility(AutoExportJobProperties.status, Lifecycle.Read, Lifecycle.Create);
-
 @@clientName(Caches.spaceAllocation, "UpdateSpaceAllocation", "csharp");
 @@clientName(Caches.debugInfo, "EnableDebugInfo", "csharp");
 @@clientName(StorageTargets.dnsRefresh, "RefreshDns", "csharp");


### PR DESCRIPTION
Removes the StorageCache C# visibility decorators from `client.tsp` because SDK visibility customizations should not live in the spec.

This is paired with an Azure SDK for .NET PR that mitigates the generated C# API impact in SDK custom code.