### PR TITLE
Fix HybridNetwork mgmt emitter output path

### DIFF
--- a/specification/hybridnetwork/HybridNetwork.Management/tspconfig.yaml
+++ b/specification/hybridnetwork/HybridNetwork.Management/tspconfig.yaml
@@ -49,6 +49,7 @@ options:
     model-namespace: false
     namespace: "Azure.ResourceManager.HybridNetwork"
   "@azure-typespec/http-client-csharp-mgmt":
+    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: "Azure.ResourceManager.HybridNetwork"
 linter:
   extends:


### PR DESCRIPTION
## Description

Add the missing http-client-csharp-mgmt emitter output directory for HybridNetwork so SDK regeneration writes to sdk/hybridnetwork/Azure.ResourceManager.HybridNetwork instead of the default @azure-typespec/http-client-csharp-mgmt folder.

This is intended to fix the extra generated files seen in Azure/azure-sdk-for-net PR 60094.

## Validation

Verified the tspconfig.yaml diff contains only the new emitter-output-dir option under @azure-typespec/http-client-csharp-mgmt.