### PR TITLE
Use exact names for CDN enum members

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/client.tsp
@@ -305,19 +305,61 @@ using Azure.ResourceManager;
   "csharp"
 );
 @@clientName(AfdUrlSigningAction, "FrontDoorUrlSigningAction", "csharp");
-// AfdCipherSuiteSetType / AfdCustomizedCipherSuiteForTls12 / AfdCustomizedCipherSuiteForTls13:
-// These type names cannot be renamed — they are inline union types referenced by
-// original name in generated serialization code and as property types on generated
-// classes (FrontDoorCustomDomainHttpsContent.CipherSuiteSetType,
-// FrontDoorCustomDomainHttpsCustomizedCipherSuiteSet properties). Renaming causes an
-// unfixable ApiCompat break.
-// The generator-produced member names (e.g. TLS102019, DHERSAAES128GCMSHA256,
-// TLSAES128GCMSHA256) duplicate the underscored names that shipped in v1.5.1
-// (Tls1_0_2019, Dhe_Rsa_Aes128_Gcm_Sha256, Tls_Aes_128_Gcm_Sha256). The C# name
-// sanitizer strips underscores between digits/letters, so @@clientName cannot
-// produce the underscored form. Instead, the duplicated generator-produced
-// members are suppressed via [CodeGenSuppress] in the SDK customization, and the
-// underscored members are re-introduced there to preserve the v1.5.1 API surface.
+@@clientName(
+  AfdCipherSuiteSetType.TLS10_2019,
+  Azure.ClientGenerator.Core.exact("Tls1_0_2019"),
+  "csharp"
+);
+@@clientName(
+  AfdCipherSuiteSetType.TLS12_2022,
+  Azure.ClientGenerator.Core.exact("Tls1_2_2022"),
+  "csharp"
+);
+@@clientName(
+  AfdCipherSuiteSetType.TLS12_2023,
+  Azure.ClientGenerator.Core.exact("Tls1_2_2023"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.ECDHE_RSA_AES128_GCM_SHA256,
+  Azure.ClientGenerator.Core.exact("Ecdhe_Rsa_Aes128_Gcm_Sha256"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.ECDHE_RSA_AES256_GCM_SHA384,
+  Azure.ClientGenerator.Core.exact("Ecdhe_Rsa_Aes256_Gcm_Sha384"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.DHE_RSA_AES256_GCM_SHA384,
+  Azure.ClientGenerator.Core.exact("Dhe_Rsa_Aes256_Gcm_Sha384"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.DHE_RSA_AES128_GCM_SHA256,
+  Azure.ClientGenerator.Core.exact("Dhe_Rsa_Aes128_Gcm_Sha256"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.ECDHE_RSA_AES128_SHA256,
+  Azure.ClientGenerator.Core.exact("Ecdhe_Rsa_Aes128_Sha256"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls12.ECDHE_RSA_AES256_SHA384,
+  Azure.ClientGenerator.Core.exact("Ecdhe_Rsa_Aes256_Sha384"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls13.TLS_AES_128_GCM_SHA256,
+  Azure.ClientGenerator.Core.exact("Tls_Aes_128_Gcm_Sha256"),
+  "csharp"
+);
+@@clientName(
+  AfdCustomizedCipherSuiteForTls13.TLS_AES_256_GCM_SHA384,
+  Azure.ClientGenerator.Core.exact("Tls_Aes_256_Gcm_Sha384"),
+  "csharp"
+);
 @@clientName(CustomRuleAfd, "CustomRuleFrontDoor", "csharp");
 @@clientName(
   ManagedRuleGroupOverrideAfd,
@@ -547,6 +589,21 @@ using Azure.ResourceManager;
 @@clientName(SecurityPolicyPropertiesParameters.type, "PolicyType", "csharp");
 @@clientName(AfdCertificateType, "FrontDoorCertificateType", "csharp");
 @@clientName(AfdMinimumTlsVersion, "FrontDoorMinimumTlsVersion", "csharp");
+@@clientName(
+  AfdMinimumTlsVersion.TLS10,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  AfdMinimumTlsVersion.TLS12,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
+@@clientName(
+  AfdMinimumTlsVersion.TLS13,
+  Azure.ClientGenerator.Core.exact("Tls1_3"),
+  "csharp"
+);
 @@clientName(EdgeNodeProperties.ipAddressGroups, "IPAddressGroups", "csharp");
 @@clientName(
   AfdQueryStringCachingBehavior,
@@ -564,8 +621,33 @@ using Azure.ResourceManager;
   "csharp"
 );
 @@clientName(MinimumTlsVersion, "CdnMinimumTlsVersion", "csharp");
+@@clientName(
+  MinimumTlsVersion.TLS10,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  MinimumTlsVersion.TLS12,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
 @@clientName(ResourceType, "CdnResourceType", "csharp");
 @@clientName(SslProtocol, "DeliveryRuleSslProtocol", "csharp");
+@@clientName(
+  SslProtocol.TLSv1,
+  Azure.ClientGenerator.Core.exact("Tls1_0"),
+  "csharp"
+);
+@@clientName(
+  SslProtocol.`TLSv1.1`,
+  Azure.ClientGenerator.Core.exact("Tls1_1"),
+  "csharp"
+);
+@@clientName(
+  SslProtocol.`TLSv1.2`,
+  Azure.ClientGenerator.Core.exact("Tls1_2"),
+  "csharp"
+);
 @@clientName(ManagedRuleEnabledState, "ManagedRuleSetupState", "csharp");
 @@clientName(ActionType, "OverrideActionType", "csharp");
 @@clientName(Transform, "PreTransformCategory", "csharp");

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
@@ -53,6 +53,7 @@ options:
     package-name: "Azure.ResourceManager.Cdn"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     enable-wire-path-attribute: true
+    api-version: "2025-09-01-preview"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary
- Add C# exact client names for CDN enum members with underscore-preserving names
- Enables the .NET SDK to remove matching enum CodeGenMember customizations

## Validation
- `tsp compile specification/cdn/resource-manager/Microsoft.Cdn/Cdn`