### PR TITLE
Add csharp @@clientName decorators for MongoDB Atlas Project/Cluster resources

### DIFF
--- a/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
+++ b/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
@@ -38,3 +38,20 @@ using MongoDB.Atlas;
   "MongoDBAtlasResourceProvisioningState",
   "csharp"
 );
+
+// Project and Cluster resources (preview). Renaming the resource models to the
+// MongoDBAtlas* prefix makes the generator emit MongoDBAtlas*Resource/*Data/*Collection,
+// matching the package naming convention (same pattern as OrganizationResource above).
+@@clientName(MongoDB.Atlas.Project, "MongoDBAtlasProject", "csharp");
+@@clientName(MongoDB.Atlas.Cluster, "MongoDBAtlasCluster", "csharp");
+@@clientName(
+  MongoDB.Atlas.ProjectProperties,
+  "MongoDBAtlasProjectProperties",
+  "csharp"
+);
+@@clientName(
+  MongoDB.Atlas.ClusterProperties,
+  "MongoDBAtlasClusterProperties",
+  "csharp"
+);
+@@clientName(MongoDB.Atlas.ClusterTier, "MongoDBAtlasClusterTier", "csharp");


### PR DESCRIPTION
## Summary

Adds `@@clientName` client customizations in `client.tsp` so the C# (.NET) management SDK generates the MongoDB Atlas **Project** and **Cluster** resources with the required `MongoDBAtlas*` prefix:

| Spec model | C# name |
| --- | --- |
| `Project` | `MongoDBAtlasProject` |
| `Cluster` | `MongoDBAtlasCluster` |
| `ProjectProperties` | `MongoDBAtlasProjectProperties` |
| `ClusterProperties` | `MongoDBAtlasClusterProperties` |
| `ClusterTier` | `MongoDBAtlasClusterTier` |

This is a **C#-only** client customization (`"csharp"` scope). It does not change the OpenAPI/wire contract or any other language emitter.

## Why — naming trouble surfaced in the SDK

The `Azure.ResourceManager.MongoDBAtlas` .NET SDK follows the management-plane convention that **every** generated resource type carries the service prefix (`MongoDBAtlas*`). The existing `Organization` resource already does this via `client.tsp` (`MongoDBAtlasOrganization`).

Without these decorators the generator emitted the Project/Cluster types **unprefixed** — `ProjectResource` / `ClusterResource` / `ProjectData` / `ClusterData` / `ProjectProperties` / `ClusterProperties` / `ClusterTier` — which:

- violates the `MongoDBAtlas*` package naming convention, and
- forced `[CodeGenType]` customization workarounds in the SDK repo to rename the types after generation.

Moving the renames to the spec source (`client.tsp`) removes the SDK-side workarounds and keeps naming consistent with `MongoDBAtlasOrganization`.

## Related

- SDK PR: **Azure/azure-sdk-for-net#60084**

which was failing
