### PR TITLE
Add client.tsp import for storage cache

### DIFF
--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/main.tsp
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/main.tsp
@@ -21,6 +21,7 @@ import "./ExpansionJob.tsp";
 import "./Cache.tsp";
 import "./StorageTarget.tsp";
 import "./routes.tsp";
+import "./client.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;

--- a/specification/suppressions.yaml
+++ b/specification/suppressions.yaml
@@ -339,5 +339,4 @@
   rules: [ClientTspImport]
   paths:
     - migrate/resource-manager/Microsoft.Migrate/Waves
-    - storagecache/resource-manager/Microsoft.StorageCache/StorageCache
     - frontdoor/resource-manager/Microsoft.Network/FrontDoor


### PR DESCRIPTION
PR https://github.com/Azure/azure-rest-api-specs/pull/44124 fixed the issue preventing storage cache from being migrated