### PR TITLE
[KeyVault] Mark generated C# Secrets and Certificates transport types as internal via @access

### DIFF
--- a/specification/keyvault/data-plane/Certificates/client.tsp
+++ b/specification/keyvault/data-plane/Certificates/client.tsp
@@ -43,6 +43,8 @@ namespace Customizations;
 );
 @@clientName(IssuerParameters, "IssuerParametersBundle", "csharp");
 
+@@access(KeyVault, Access.internal, "csharp");
+
 using KeyVault;
 
 // Make optional path parameter required for all languages

--- a/specification/keyvault/data-plane/Secrets/client.tsp
+++ b/specification/keyvault/data-plane/Secrets/client.tsp
@@ -22,6 +22,8 @@ namespace Customizations;
 @@clientName(KeyVault, "KeyVaultSecretsClient", "csharp");
 @@clientName(SecretAttributes, "SecretAttributesBundle", "csharp");
 
+@@access(KeyVault, Access.internal, "csharp");
+
 using KeyVault;
 
 // Make optional path parameter required for all languages


### PR DESCRIPTION
## Why

The customer-facing surface for `Azure.Security.KeyVault.Secrets` and `Azure.Security.KeyVault.Certificates` in .NET is the hand-written `SecretClient` / `CertificateClient`. The TypeSpec-generated `KeyVaultSecretsClient` / `KeyVaultCertificatesClient` and their parameter/response models are an implementation detail consumed only from inside the same assembly.

Today, the .NET SDK repo runs a post-emit PowerShell script (`Internalize-Generated.ps1`) in each library to regex-rewrite `public` to `internal` on every generated type. This is fragile (silently no-ops if the emitter renames anything) and was flagged by `@JoshLove-msft` as not the right approach on https://github.com/Azure/azure-sdk-for-net/pull/59972 / Certificates review thread.

## What

Adds a single line to each of:

- `specification/keyvault/data-plane/Secrets/client.tsp`
- `specification/keyvault/data-plane/Certificates/client.tsp`

```tsp
@@access(KeyVault, Access.internal, "csharp");
```

This marks the generated transport client + all spec-defined models as `internal` at emit time for the C# emitter only. Other languages (Java/Python/Go/JavaScript/Rust) are unaffected.

## Prior art

Identical pattern already used by sibling `Azure.Security.KeyVault.Administration`:

https://github.com/Azure/azure-rest-api-specs/blob/main/specification/keyvault/data-plane/Administration/client.tsp#L133

```tsp
@@access(KeyVault, Access.internal, "csharp");
```

## Impact

- **C#**: `KeyVaultSecretsClient` / `KeyVaultCertificatesClient` and all generated models are `internal`. Lets the .NET SDK remove `eng/Internalize-Generated.ps1` and the MSBuild target that runs it from both libraries.
- **Java / Python / Go / JavaScript / Rust**: no change. The decorator is scoped to `"csharp"`.
- **Wire / api-versions**: no change. This is a generator-visibility hint only; no operations, models, or properties are added/removed/modified.
