### PR TITLE
Rename A2aProtocolConfiguration to A2AProtocolConfiguration

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -16778,6 +16778,10 @@
         ],
         "description": "An A2A tool stored in a toolbox."
       },
+      "A2AProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the A2A protocol."
+      },
       "A2AToolCall": {
         "type": "object",
         "required": [
@@ -16868,10 +16872,6 @@
           }
         ],
         "description": "The output of an A2A (Agent-to-Agent) tool call."
-      },
-      "A2aProtocolConfiguration": {
-        "type": "object",
-        "description": "Configuration specific to the A2A protocol."
       },
       "AISearchIndexResource": {
         "type": "object",
@@ -51671,7 +51671,7 @@
           "a2a": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/A2aProtocolConfiguration"
+                "$ref": "#/components/schemas/A2AProtocolConfiguration"
               }
             ],
             "description": "Configuration for the A2A protocol."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -11042,6 +11042,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
+    A2AProtocolConfiguration:
+      type: object
+      description: Configuration specific to the A2A protocol.
     A2AToolCall:
       type: object
       required:
@@ -11100,9 +11103,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: The output of an A2A (Agent-to-Agent) tool call.
-    A2aProtocolConfiguration:
-      type: object
-      description: Configuration specific to the A2A protocol.
     AISearchIndexResource:
       type: object
       properties:
@@ -35436,7 +35436,7 @@ components:
           description: Configuration for the responses protocol.
         a2a:
           allOf:
-            - $ref: '#/components/schemas/A2aProtocolConfiguration'
+            - $ref: '#/components/schemas/A2AProtocolConfiguration'
           description: Configuration for the A2A protocol.
         mcp:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -19720,6 +19720,10 @@
         ],
         "description": "An A2A tool stored in a toolbox."
       },
+      "A2AProtocolConfiguration": {
+        "type": "object",
+        "description": "Configuration specific to the A2A protocol."
+      },
       "A2AToolCall": {
         "type": "object",
         "required": [
@@ -19810,10 +19814,6 @@
           }
         ],
         "description": "The output of an A2A (Agent-to-Agent) tool call."
-      },
-      "A2aProtocolConfiguration": {
-        "type": "object",
-        "description": "Configuration specific to the A2A protocol."
       },
       "AISearchIndexResource": {
         "type": "object",
@@ -56435,7 +56435,7 @@
           "a2a": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/A2aProtocolConfiguration"
+                "$ref": "#/components/schemas/A2AProtocolConfiguration"
               }
             ],
             "description": "Configuration for the A2A protocol."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -12996,6 +12996,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
+    A2AProtocolConfiguration:
+      type: object
+      description: Configuration specific to the A2A protocol.
     A2AToolCall:
       type: object
       required:
@@ -13054,9 +13057,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: The output of an A2A (Agent-to-Agent) tool call.
-    A2aProtocolConfiguration:
-      type: object
-      description: Configuration specific to the A2A protocol.
     AISearchIndexResource:
       type: object
       properties:
@@ -38651,7 +38651,7 @@ components:
           description: Configuration for the responses protocol.
         a2a:
           allOf:
-            - $ref: '#/components/schemas/A2aProtocolConfiguration'
+            - $ref: '#/components/schemas/A2AProtocolConfiguration'
           description: Configuration for the A2A protocol.
         mcp:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -610,7 +610,7 @@ model ProtocolConfiguration {
   responses?: ResponsesProtocolConfiguration;
 
   @doc("Configuration for the A2A protocol.")
-  a2a?: A2aProtocolConfiguration;
+  a2a?: A2AProtocolConfiguration;
 
   @doc("Configuration for the MCP protocol.")
   mcp?: McpProtocolConfiguration;
@@ -632,7 +632,7 @@ model ActivityProtocolConfiguration {
 model ResponsesProtocolConfiguration {}
 
 @doc("Configuration specific to the A2A protocol.")
-model A2aProtocolConfiguration {}
+model A2AProtocolConfiguration {}
 
 @doc("Configuration specific to the MCP protocol.")
 model McpProtocolConfiguration {}


### PR DESCRIPTION
We have A2AToolCall, A2AToolCallOutput, A2APreviewToolType, .... So we should have A2AProtocolConfiguration instead of A2aProtocolConfiguration
