### PR TITLE
Updating Java config for custom beta class emitters

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects-agents/tspconfig.yaml
@@ -9,6 +9,18 @@ options:
     api-version: "v1"
     # plugins:
     #   - "../codegen"
+  # Exports the @extension("x-ms-foundry-meta", ...) beta entities as grouped class/field lists
+  # - run `tsp-client sync` from package folder
+  # - run `cd TempTypeSpecFiles && npm install --no-save typespec-extension-exporter`
+  # - still from `TempTypeSpecFiles` folder, run `npx tsp compile .\sdk-csharp-azure-ai-projects-agents\client.tsp --emit typespec-extension-exporter`
+  # - TODO: define output-dir
+  # - run `cd .. && tsp-client generate`
+  "typespec-extension-exporter":
+    keys: x-ms-foundry-meta
+    output-shape: list
+    output-format: yaml
+    output-file: list.yaml
+    language: csharp
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - specification/ai-foundry/data-plane/Foundry/src/agents

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-csharp-azure-ai-projects-agents/tspconfig.yaml
@@ -9,18 +9,6 @@ options:
     api-version: "v1"
     # plugins:
     #   - "../codegen"
-  # Exports the @extension("x-ms-foundry-meta", ...) beta entities as grouped class/field lists
-  # - run `tsp-client sync` from package folder
-  # - run `cd TempTypeSpecFiles && npm install --no-save typespec-extension-exporter`
-  # - still from `TempTypeSpecFiles` folder, run `npx tsp compile .\sdk-csharp-azure-ai-projects-agents\client.tsp --emit typespec-extension-exporter`
-  # - TODO: define output-dir
-  # - run `cd .. && tsp-client generate`
-  "typespec-extension-exporter":
-    keys: x-ms-foundry-meta
-    output-shape: list
-    output-format: yaml
-    output-file: list.yaml
-    language: csharp
   "@azure-tools/typespec-client-generator-cli":
     additionalDirectories:
       - specification/ai-foundry/data-plane/Foundry/src/agents

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
@@ -55,7 +55,7 @@ options:
     output-format: csv
     output-file: beta-annotations.csv
     emitter-output-dir: "{cwd}/../customizations" # run npx tsp compile from within `TempTypeSpecFiles` folder
-    java-namespace: com.azure.ai.agents
+    namespace: com.azure.ai.agents
 imports:
   - "@azure-tools/typespec-azure-core"
   - "@azure-tools/typespec-azure-core/experimental"

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-agents/tspconfig.yaml
@@ -51,6 +51,7 @@ options:
   # - run `cd .. && tsp-client generate`
   "typespec-extension-exporter":
     keys: x-ms-foundry-meta
+    language: java
     output-shape: tsp-ast-input
     output-format: csv
     output-file: beta-annotations.csv

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
@@ -24,6 +24,7 @@ options:
   # - run `cd .. && tsp-client generate`
   "typespec-extension-exporter":
     keys: x-ms-foundry-meta
+    language: java
     output-shape: tsp-ast-input
     output-format: csv
     output-file: beta-annotations.csv

--- a/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/src/sdk-java-azure-ai-projects/tspconfig.yaml
@@ -28,7 +28,7 @@ options:
     output-format: csv
     output-file: beta-annotations.csv
     emitter-output-dir: "{cwd}/../customizations" # run npx tsp compile from within `TempTypeSpecFiles` folder
-    java-namespace: com.azure.ai.projects
+    namespace: com.azure.ai.projects
 imports:
   - "@azure-tools/typespec-azure-core"
   - "@azure-tools/typespec-azure-core/experimental"


### PR DESCRIPTION
version `0.4.0` supports a more language agnostic config name and we did the breaking change of renaming `java-namespace` -> `namespace`