### PR TITLE
Fix service linker missing client.tsp import

### DIFF
--- a/specification/servicelinker/ServiceLinker.Management/client.tsp
+++ b/specification/servicelinker/ServiceLinker.Management/client.tsp
@@ -24,7 +24,7 @@ using TypeSpec.Versioning;
 // Go SDK Breaking Changes Resolution for TypeSpec conversion
 @@clientName(DatabaseAadAuthInfo, "DatabaseAADAuthInfo", "go");
 
-@@clientName(ActionType, "ActionTypeFlag");
+@@clientName(ActionType, "ActionTypeFlag", "!autorest");
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "customization"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "customization"

--- a/specification/servicelinker/ServiceLinker.Management/main.tsp
+++ b/specification/servicelinker/ServiceLinker.Management/main.tsp
@@ -16,6 +16,7 @@ import "./DryrunResource.tsp";
 import "./LinkerResource.tsp";
 import "./routes.tsp";
 import "./back-compatible.tsp";
+import "./client.tsp";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;


### PR DESCRIPTION
PR https://github.com/Azure/azure-rest-api-specs/pull/34326 merged a new service that didn't respect the new setup