### PR TITLE
Compute Bulkactions: mark bulk operations internal for C# via @@access

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -251,7 +251,11 @@ namespace Microsoft.Compute;
 // derive the location from the resource group. Mark the generated
 // operations internal so only those wrappers are public.
 // =====================================================================
-@@access(VirtualMachineBulkOperations.bulkDeallocate, Access.internal, "csharp");
+@@access(
+  VirtualMachineBulkOperations.bulkDeallocate,
+  Access.internal,
+  "csharp"
+);
 @@access(VirtualMachineBulkOperations.bulkHibernate, Access.internal, "csharp");
 @@access(VirtualMachineBulkOperations.bulkStart, Access.internal, "csharp");
 @@access(VirtualMachineBulkOperations.bulkDelete, Access.internal, "csharp");

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -244,3 +244,34 @@ namespace Microsoft.Compute;
   "GetBulkOperationStatusContent",
   "csharp"
 );
+
+// =====================================================================
+// C# only: each bulk operation takes a location path parameter, but the
+// public surface exposes hand-authored wrapper extension methods that
+// derive the location from the resource group. Mark the generated
+// operations internal so only those wrappers are public.
+// =====================================================================
+@@access(VirtualMachineBulkOperations.bulkDeallocate, Access.internal, "csharp");
+@@access(VirtualMachineBulkOperations.bulkHibernate, Access.internal, "csharp");
+@@access(VirtualMachineBulkOperations.bulkStart, Access.internal, "csharp");
+@@access(VirtualMachineBulkOperations.bulkDelete, Access.internal, "csharp");
+@@access(
+  VirtualMachineBulkOperations.bulkGetOperationsStatus,
+  Access.internal,
+  "csharp"
+);
+@@access(VirtualMachineBulkOperations.bulkCancel, Access.internal, "csharp");
+
+// Keep the request/response models public; the wrapper methods expose them.
+@@access(ExecuteDeallocateRequest, Access.public, "csharp");
+@@access(ExecuteHibernateRequest, Access.public, "csharp");
+@@access(ExecuteStartRequest, Access.public, "csharp");
+@@access(ExecuteDeleteRequest, Access.public, "csharp");
+@@access(GetOperationStatusRequest, Access.public, "csharp");
+@@access(CancelOperationsRequest, Access.public, "csharp");
+@@access(DeallocateResourceOperationResponse, Access.public, "csharp");
+@@access(HibernateResourceOperationResponse, Access.public, "csharp");
+@@access(StartResourceOperationResponse, Access.public, "csharp");
+@@access(DeleteResourceOperationResponse, Access.public, "csharp");
+@@access(GetOperationStatusResponse, Access.public, "csharp");
+@@access(CancelOperationsResponse, Access.public, "csharp");


### PR DESCRIPTION
## Summary

The C# (.NET) SDK for Compute Bulkactions exposes hand-authored wrapper extension methods that derive the location from the resource group, so the generated location-taking bulk operations should not be part of the public surface.

This change adds `@@access(..., Access.internal, "csharp")` for the six bulk operations so the generator emits them as `internal`, and explicitly keeps their request/response models `public` (since the `internal` access would otherwise propagate to the models, which the public wrapper methods expose).

### Operations marked internal (csharp scope)
- `bulkDeallocate`, `bulkHibernate`, `bulkStart`, `bulkDelete`, `bulkGetOperationsStatus`, `bulkCancel`

### Models kept public (csharp scope)
- Requests: `ExecuteDeallocateRequest`, `ExecuteHibernateRequest`, `ExecuteStartRequest`, `ExecuteDeleteRequest`, `GetOperationStatusRequest`, `CancelOperationsRequest`
- Responses: `DeallocateResourceOperationResponse`, `HibernateResourceOperationResponse`, `StartResourceOperationResponse`, `DeleteResourceOperationResponse`, `GetOperationStatusResponse`, `CancelOperationsResponse`

This is a C#-only client customization (`client.tsp`); it does not change the REST API or any other language's surface.
