### PR TITLE
Fix Purview data-plane endpoint host paths (DEH: dataestate->health, DataAccess: access->dataaccess)

### DIFF
--- a/specification/purviewdatagovernance/data-plane/DataAccess/main.tsp
+++ b/specification/purviewdatagovernance/data-plane/DataAccess/main.tsp
@@ -12,7 +12,7 @@ using TypeSpec.Versioning;
  */
 @service(#{ title: "PurviewDataAccess" })
 @server(
-  "{endpoint}/datagovernance/access",
+  "{endpoint}/datagovernance/dataaccess",
   "Purview Data Access Service manages data subscriptions, workflows, and policy sets for governing access to data products within Microsoft Purview.",
   {
     @doc("The endpoint of the Purview Data Access service. Example: https://api.purview-service.microsoft.com/")

--- a/specification/purviewdatagovernance/data-plane/DataAccess/preview/2023-10-01-preview/DataAccessApiService.json
+++ b/specification/purviewdatagovernance/data-plane/DataAccess/preview/2023-10-01-preview/DataAccessApiService.json
@@ -14,7 +14,7 @@
     "https"
   ],
   "x-ms-parameterized-host": {
-    "hostTemplate": "{endpoint}/datagovernance/access",
+    "hostTemplate": "{endpoint}/datagovernance/dataaccess",
     "useSchemePrefix": false,
     "parameters": [
       {

--- a/specification/purviewdatagovernance/data-plane/DataEstateHealth/main.tsp
+++ b/specification/purviewdatagovernance/data-plane/DataEstateHealth/main.tsp
@@ -12,7 +12,7 @@ using TypeSpec.Versioning;
  */
 @service(#{ title: "PurviewDataEstateHealth" })
 @server(
-  "{endpoint}/datagovernance/dataestate",
+  "{endpoint}/datagovernance/health",
   "Purview Data Estate Health Service provides health monitoring, data quality assessments, governance controls, and estate management across Azure data assets.",
   {
     @doc("The endpoint of the Purview Data Estate Health service. Example: https://api.purview-service.microsoft.com/")

--- a/specification/purviewdatagovernance/data-plane/DataEstateHealth/preview/2024-02-01-preview/DataEstateHealthApiService.json
+++ b/specification/purviewdatagovernance/data-plane/DataEstateHealth/preview/2024-02-01-preview/DataEstateHealthApiService.json
@@ -14,7 +14,7 @@
     "https"
   ],
   "x-ms-parameterized-host": {
-    "hostTemplate": "{endpoint}/datagovernance/dataestate",
+    "hostTemplate": "{endpoint}/datagovernance/health",
     "useSchemePrefix": false,
     "parameters": [
       {


### PR DESCRIPTION
## What

Corrects the **data-plane `@server` host templates** for two Purview Data Governance services so the documented endpoint paths match the intended segments. Each `hostTemplate` (`x-ms-parameterized-host`) drives the Microsoft Learn REST API reference docs.

| Service | File | Before | After |
| --- | --- | --- | --- |
| Data Estate Health (`2024-02-01-preview`) | `DataEstateHealth/main.tsp` | `{endpoint}/datagovernance/dataestate` | `{endpoint}/datagovernance/health` |
| Data Access (`2023-10-01-preview`) | `DataAccess/main.tsp` | `{endpoint}/datagovernance/access` | `{endpoint}/datagovernance/dataaccess` |

The generated `*ApiService.json` files are regenerated accordingly.

## Why

The published Learn REST API reference shows the wrong path segments (`dataestate`, `access`); the correct segments are `health` and `dataaccess`.

## Context

Follow-up to #42433, which added the Data Estate Health and Data Access specs.

## ⚠️ Breaking change

Both changes alter the host path of already-published preview data-plane APIs. The services must actually serve `/datagovernance/health` and `/datagovernance/dataaccess`, otherwise the docs and runtime will diverge. Please confirm service routing before merge.

## Validation

- `tsp compile .` succeeds for both projects
- TypeSpec validation passes for both projects
- Diff is exactly 4 lines (2 × `main.tsp` + 2 × generated swagger)
