### PR TITLE
refactor(ai-foundry/tools): remove obsolete agent ReminderPreviewTool

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -49154,7 +49154,6 @@
             "work_iq_preview": "#/components/schemas/WorkIQPreviewTool",
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
-            "reminder_preview": "#/components/schemas/ReminderPreviewTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
             "file_search": "#/components/schemas/OpenAI.FileSearchTool",
             "web_search": "#/components/schemas/OpenAI.WebSearchTool",
@@ -49623,7 +49622,6 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
-              "reminder_preview",
               "work_iq_preview",
               "fabric_iq_preview",
               "toolbox_search_preview",
@@ -52087,35 +52085,6 @@
           }
         ],
         "description": "Represents the parameters for red team taxonomy item generation."
-      },
-      "ReminderPreviewTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reminder_preview"
-            ],
-            "description": "The type of the tool. Always `reminder_preview`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A built-in tool that schedules the agent to re-invoke itself after a delay.\nThe model passes a single `minutes` argument (positive integer) when calling\nthis tool. The service creates a one-shot timer routine that fires after the\nspecified delay and re-invokes the agent on the same conversation thread.\nNo pre-created routine is required."
       },
       "ReminderPreviewToolboxTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -33720,7 +33720,6 @@ components:
           work_iq_preview: '#/components/schemas/WorkIQPreviewTool'
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewTool'
           memory_search_preview: '#/components/schemas/MemorySearchPreviewTool'
-          reminder_preview: '#/components/schemas/ReminderPreviewTool'
           code_interpreter: '#/components/schemas/OpenAI.CodeInterpreterTool'
           file_search: '#/components/schemas/OpenAI.FileSearchTool'
           web_search: '#/components/schemas/OpenAI.WebSearchTool'
@@ -34070,7 +34069,6 @@ components:
             - fabric_dataagent_preview
             - sharepoint_grounding_preview
             - memory_search_preview
-            - reminder_preview
             - work_iq_preview
             - fabric_iq_preview
             - toolbox_search_preview
@@ -35708,30 +35706,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team taxonomy item generation.
-    ReminderPreviewTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - reminder_preview
-          description: The type of the tool. Always `reminder_preview`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: |-
-        A built-in tool that schedules the agent to re-invoke itself after a delay.
-        The model passes a single `minutes` argument (positive integer) when calling
-        this tool. The service creates a one-shot timer routine that fires after the
-        specified delay and re-invokes the agent on the same conversation thread.
-        No pre-created routine is required.
     ReminderPreviewToolboxTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -53824,7 +53824,6 @@
             "fabric_iq_preview": "#/components/schemas/FabricIQPreviewTool",
             "memory_search_preview": "#/components/schemas/MemorySearchPreviewTool",
             "memory_search": "#/components/schemas/MemorySearchTool",
-            "reminder_preview": "#/components/schemas/ReminderPreviewTool",
             "code_interpreter": "#/components/schemas/OpenAI.CodeInterpreterTool",
             "file_search": "#/components/schemas/OpenAI.FileSearchTool",
             "web_search": "#/components/schemas/OpenAI.WebSearchTool",
@@ -54293,7 +54292,6 @@
               "fabric_dataagent_preview",
               "sharepoint_grounding_preview",
               "memory_search_preview",
-              "reminder_preview",
               "work_iq_preview",
               "fabric_iq_preview",
               "toolbox_search_preview",
@@ -56851,35 +56849,6 @@
           }
         ],
         "description": "Represents the parameters for red team taxonomy item generation."
-      },
-      "ReminderPreviewTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reminder_preview"
-            ],
-            "description": "The type of the tool. Always `reminder_preview`."
-          },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A built-in tool that schedules the agent to re-invoke itself after a delay.\nThe model passes a single `minutes` argument (positive integer) when calling\nthis tool. The service creates a one-shot timer routine that fires after the\nspecified delay and re-invokes the agent on the same conversation thread.\nNo pre-created routine is required."
       },
       "ReminderPreviewToolboxTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -36869,7 +36869,6 @@ components:
           fabric_iq_preview: '#/components/schemas/FabricIQPreviewTool'
           memory_search_preview: '#/components/schemas/MemorySearchPreviewTool'
           memory_search: '#/components/schemas/MemorySearchTool'
-          reminder_preview: '#/components/schemas/ReminderPreviewTool'
           code_interpreter: '#/components/schemas/OpenAI.CodeInterpreterTool'
           file_search: '#/components/schemas/OpenAI.FileSearchTool'
           web_search: '#/components/schemas/OpenAI.WebSearchTool'
@@ -37219,7 +37218,6 @@ components:
             - fabric_dataagent_preview
             - sharepoint_grounding_preview
             - memory_search_preview
-            - reminder_preview
             - work_iq_preview
             - fabric_iq_preview
             - toolbox_search_preview
@@ -38923,30 +38921,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for red team taxonomy item generation.
-    ReminderPreviewTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - reminder_preview
-          description: The type of the tool. Always `reminder_preview`.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: |-
-        A built-in tool that schedules the agent to re-invoke itself after a delay.
-        The model passes a single `minutes` argument (positive integer) when calling
-        this tool. The service creates a one-shot timer routine that fires after the
-        specified delay and re-invokes the agent on the same conversation thread.
-        No pre-created routine is required.
     ReminderPreviewToolboxTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -17,7 +17,6 @@ namespace Azure.AI.Projects {
     fabric_dataagent_preview: "fabric_dataagent_preview",
     sharepoint_grounding_preview: "sharepoint_grounding_preview",
     memory_search_preview: "memory_search_preview",
-    reminder_preview: "reminder_preview",
     work_iq_preview: "work_iq_preview",
     fabric_iq_preview: "fabric_iq_preview",
     toolbox_search_preview: "toolbox_search_preview",
@@ -814,26 +813,6 @@ namespace Azure.AI.Projects {
      * Time to wait before updating memories after inactivity (seconds). Default 300.
      */
     update_delay?: int32 = 300;
-  }
-
-  // ==============================================================================
-  // Reminder Preview Tool
-  // ==============================================================================
-
-  /**
-   * A built-in tool that schedules the agent to re-invoke itself after a delay.
-   * The model passes a single `minutes` argument (positive integer) when calling
-   * this tool. The service creates a one-shot timer routine that fires after the
-   * specified delay and re-invokes the agent on the same conversation thread.
-   * No pre-created routine is required.
-   */
-  model ReminderPreviewTool extends OpenAI.Tool {
-    /**
-     * The type of the tool. Always `reminder_preview`.
-     */
-    type: "reminder_preview";
-
-    ...ToolNameAndDescriptionExtension;
   }
 
   // ==============================================================================


### PR DESCRIPTION
## Summary

Removes the obsolete agent-level `ReminderPreviewTool`. The reminder tool is already provided in the toolbox format as `ReminderPreviewToolboxTool` (added by #43467 "Decouple toolbox tool schemas"), which is the canonical representation. This deletes the now-redundant agent-level model.

## Changes

- **`src/tools/models.tsp`**
  - Remove the `model ReminderPreviewTool` definition.
  - Remove the `reminder_preview` entry from the agent preview tool-type union.
- **`openapi3/**`** — regenerated from the updated TypeSpec (drops the `ReminderPreviewTool` schema and discriminator entry).

## Notes

- No new schemas are added; this is a pure removal.
- The toolbox-stored `ReminderPreviewToolboxTool` (`type: "reminder_preview"`) remains the supported way to configure the reminder tool.
