### PR TITLE
[Foundry] Add x-ms-user-identity delegation header to Conversation APIs

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -1382,7 +1382,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -1550,7 +1550,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -1638,7 +1638,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -9933,7 +9933,17 @@
         "operationId": "createConversation",
         "summary": "Create a conversation",
         "description": "Creates a new conversation resource.",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -10046,6 +10056,15 @@
               "type": "string"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10125,6 +10144,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10186,6 +10214,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10234,6 +10271,15 @@
             "in": "path",
             "required": true,
             "description": "The id of the conversation to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -10303,6 +10349,15 @@
               }
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10429,6 +10484,15 @@
               "$ref": "#/components/schemas/OpenAI.ItemType"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10517,6 +10581,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10574,6 +10647,15 @@
             "in": "path",
             "required": true,
             "description": "The id of the conversation item to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -12104,7 +12186,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -12844,7 +12926,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -13016,7 +13098,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -13090,7 +13172,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -13161,7 +13243,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -13273,7 +13355,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -924,7 +924,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -1037,7 +1037,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -1096,7 +1096,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -6556,7 +6556,13 @@ paths:
       operationId: createConversation
       summary: Create a conversation
       description: Creates a new conversation resource.
-      parameters: []
+      parameters:
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6643,6 +6649,12 @@ paths:
           schema:
             type: string
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6695,6 +6707,12 @@ paths:
           description: The id of the conversation to update.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6733,6 +6751,12 @@ paths:
           description: The id of the conversation to retrieve.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6763,6 +6787,12 @@ paths:
           in: path
           required: true
           description: The id of the conversation to delete.
+          schema:
+            type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -6809,6 +6839,12 @@ paths:
             items:
               type: string
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6903,6 +6939,12 @@ paths:
           schema:
             $ref: '#/components/schemas/OpenAI.ItemType'
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6961,6 +7003,12 @@ paths:
           description: The id of the conversation item to retrieve.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -6997,6 +7045,12 @@ paths:
           in: path
           required: true
           description: The id of the conversation item to delete.
+          schema:
+            type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8003,7 +8057,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8431,7 +8485,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8543,7 +8597,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8590,7 +8644,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8635,7 +8689,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8719,7 +8773,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -1509,7 +1509,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -1677,7 +1677,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -1765,7 +1765,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -12851,7 +12851,17 @@
         "operationId": "createConversation",
         "summary": "Create a conversation",
         "description": "Creates a new conversation resource.",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -12964,6 +12974,15 @@
               "type": "string"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13043,6 +13062,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13104,6 +13132,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13152,6 +13189,15 @@
             "in": "path",
             "required": true,
             "description": "The id of the conversation to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -13221,6 +13267,15 @@
               }
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13347,6 +13402,15 @@
               "$ref": "#/components/schemas/OpenAI.ItemType"
             },
             "explode": false
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13435,6 +13499,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -13492,6 +13565,15 @@
             "in": "path",
             "required": true,
             "description": "The id of the conversation item to delete.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-ms-user-identity",
+            "in": "header",
+            "required": false,
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -15022,7 +15104,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -15786,7 +15868,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -15958,7 +16040,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -16032,7 +16114,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -16103,7 +16185,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }
@@ -16215,7 +16297,7 @@
             "name": "x-ms-user-identity",
             "in": "header",
             "required": false,
-            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.",
+            "description": "Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.",
             "schema": {
               "type": "string"
             }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -1013,7 +1013,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -1126,7 +1126,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -1185,7 +1185,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
         - name: api-version
@@ -8485,7 +8485,13 @@ paths:
       operationId: createConversation
       summary: Create a conversation
       description: Creates a new conversation resource.
-      parameters: []
+      parameters:
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8572,6 +8578,12 @@ paths:
           schema:
             type: string
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8624,6 +8636,12 @@ paths:
           description: The id of the conversation to update.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8662,6 +8680,12 @@ paths:
           description: The id of the conversation to retrieve.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8692,6 +8716,12 @@ paths:
           in: path
           required: true
           description: The id of the conversation to delete.
+          schema:
+            type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -8738,6 +8768,12 @@ paths:
             items:
               type: string
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8832,6 +8868,12 @@ paths:
           schema:
             $ref: '#/components/schemas/OpenAI.ItemType'
           explode: false
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8890,6 +8932,12 @@ paths:
           description: The id of the conversation item to retrieve.
           schema:
             type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
+          schema:
+            type: string
       responses:
         '200':
           description: The request has succeeded.
@@ -8926,6 +8974,12 @@ paths:
           in: path
           required: true
           description: The id of the conversation item to delete.
+          schema:
+            type: string
+        - name: x-ms-user-identity
+          in: header
+          required: false
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -9932,7 +9986,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -10385,7 +10439,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -10497,7 +10551,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -10544,7 +10598,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -10589,7 +10643,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:
@@ -10673,7 +10727,7 @@ paths:
         - name: x-ms-user-identity
           in: header
           required: false
-          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission.
+          description: Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission.
           schema:
             type: string
       responses:

--- a/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/common/models.tsp
@@ -30,13 +30,13 @@ alias AcceptJsonHeader = {
 
 /**
  * Optional request header carrying an opaque per-user identity for delegation.
- * When present and the caller has the `agents/endpoint/delegateViaUserId` RBAC permission,
+ * When present and the caller has the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission,
  * the service scopes endpoint-scoped data (responses, conversations, sessions) to the
  * supplied user identity instead of the caller's own identity.
  * If the caller has delegation RBAC but does not pass this header, the caller's own identity is used.
  */
 alias UserDelegationHeader = {
-  /** Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoint/delegateViaUserId` RBAC permission. */
+  /** Opaque per-user identity string used to scope endpoint-scoped data to a specific end user. The caller must have the `agents/endpoints/UserIdentityImpersonation/action` RBAC permission. */
   @header("x-ms-user-identity") user_identity?: string;
 };
 

--- a/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai-conversations/routes.tsp
@@ -19,7 +19,7 @@ interface Conversations {
   @post
   @operationId("createConversation")
   createConversation is OpenAIOperation<
-    OpenAI.CreateConversationBody,
+    OpenAI.CreateConversationBody & UserDelegationHeader,
     OpenAI.ConversationResource
   >;
 
@@ -36,6 +36,7 @@ interface Conversations {
       @path conversation_id: string;
 
       ...OpenAI.UpdateConversationBody;
+      ...UserDelegationHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -51,6 +52,8 @@ interface Conversations {
     {
       /** The id of the conversation to retrieve. */
       @path conversation_id: string;
+
+      ...UserDelegationHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -66,6 +69,8 @@ interface Conversations {
     {
       /** The id of the conversation to delete. */
       @path conversation_id: string;
+
+      ...UserDelegationHeader;
     },
     OpenAI.DeletedConversationResource
   >;
@@ -85,6 +90,7 @@ interface Conversations {
       ...CommonPageQueryParameters;
       ...AgentNameQueryParam;
       ...AgentIdQueryParam;
+      ...UserDelegationHeader;
     },
     AgentsPagedResult<OpenAI.ConversationResource>
   >;
@@ -111,6 +117,8 @@ interface Conversations {
       #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Auto-suppressed warnings non-applicable rules during import."
       @maxItems(20)
       items: OpenAI.Item[];
+
+      ...UserDelegationHeader;
     },
     OpenAI.ConversationItemList
   >;
@@ -129,6 +137,8 @@ interface Conversations {
 
       /** The id of the conversation item to retrieve. */
       @path item_id: string;
+
+      ...UserDelegationHeader;
     },
     OpenAI.OutputItem
   >;
@@ -147,6 +157,8 @@ interface Conversations {
 
       /** The id of the conversation item to delete. */
       @path item_id: string;
+
+      ...UserDelegationHeader;
     },
     OpenAI.ConversationResource
   >;
@@ -166,6 +178,7 @@ interface Conversations {
 
       ...CommonPageQueryParameters;
       ...ItemTypeQueryParameter;
+      ...UserDelegationHeader;
     },
     AgentsPagedResult<OpenAI.OutputItem>
   >;


### PR DESCRIPTION
## Summary

Adds `UserDelegationHeader` (`x-ms-user-identity`) to all Conversation API operations. Conversations are partitioned by user identity in Cosmos DB — delegating callers (apps/MIs with `agents/endpoints/delegateViaUserId/action` RBAC) need this header to specify which user's partition to access.

Also fixes the RBAC permission name from `agents/endpoint/delegateViaUserId` to `agents/endpoints/delegateViaUserId/action` to match the registered dataAction.

### Changes

**`openai-conversations/routes.tsp`** — Add `...UserDelegationHeader` to all 9 operations:
- createConversation, updateConversation, getConversation, deleteConversation
- listConversations
- createConversationItems, getConversationItem, deleteConversationItem, listConversationItems

**`common/models.tsp`** — Fix RBAC permission name in doc comments.

### Rationale

With the partition migration from isolation-key-based to `user_id`-based partitioning (Vienna PR #2166624), both the Responses API and Conversation API need `x-ms-user-identity` so delegating callers can target the correct user partition. Sessions do NOT need it — they use `caller_ids` document-level filtering instead of partition-based access.

### Current `x-ms-user-identity` header placement

| API | Has header | Reason |
|---|---|---|
| Invocations (3 ops) | ✅ | Endpoint-scoped entry point |
| Responses (6 ops) | ✅ | Data partitioned by user_id |
| **Conversations (9 ops)** | ✅ **NEW** | Data partitioned by user_id |
| Sessions (5 ops) | ❌ | Uses caller_ids filtering |
| Session Files (4 ops) | ❌ | Tied to session scoping |

### Design references
- Partition migration: [Vienna PR #2166624](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2166624)
- Design doc: [isolation-key-problems.md](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2120517) (Step 1 precedence + Step 2 session scoping)