### PR TITLE
[liftrmongodb] Add C# clientName renames for tier/region models

### DIFF
--- a/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
+++ b/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
@@ -56,6 +56,13 @@ using MongoDB.Atlas;
 );
 @@clientName(MongoDB.Atlas.ClusterTier, "MongoDBAtlasClusterTier", "csharp");
 
+// Emit PascalCase member names for the ClusterTier extensible enum to match the
+// JavaScript SDK convention (Free/Flex). The wire values ("FREE"/"FLEX") are
+// unchanged; this only affects the C# member identifiers. M10/M30 are already
+// PascalCase, so they need no rename.
+@@clientName(MongoDB.Atlas.ClusterTier.FREE, "Free", "csharp");
+@@clientName(MongoDB.Atlas.ClusterTier.FLEX, "Flex", "csharp");
+
 // Tier and region preview models. Apply the MongoDBAtlas* prefix for naming
 // consistency, and rename the "Response" suffix to "Result" so the public model
 // names satisfy the AZC0030 analyzer. Client-only (csharp) renames; the wire

--- a/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
+++ b/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
@@ -55,3 +55,24 @@ using MongoDB.Atlas;
   "csharp"
 );
 @@clientName(MongoDB.Atlas.ClusterTier, "MongoDBAtlasClusterTier", "csharp");
+
+// Tier and region preview models. Apply the MongoDBAtlas* prefix for naming
+// consistency, and rename the "Response" suffix to "Result" so the public model
+// names satisfy the AZC0030 analyzer. Client-only (csharp) renames; the wire
+// contract is unchanged.
+@@clientName(
+  MongoDB.Atlas.RegionsByTierResponse,
+  "MongoDBAtlasRegionsByTierResult",
+  "csharp"
+);
+@@clientName(
+  MongoDB.Atlas.TierLimitReachedResponse,
+  "MongoDBAtlasTierLimitReachedResult",
+  "csharp"
+);
+@@clientName(MongoDB.Atlas.TierRegions, "MongoDBAtlasTierRegions", "csharp");
+@@clientName(
+  MongoDB.Atlas.ProjectLimitStatus,
+  "MongoDBAtlasProjectLimitStatus",
+  "csharp"
+);

--- a/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
+++ b/specification/liftrmongodb/MongoDB.Atlas.Management/client.tsp
@@ -63,6 +63,15 @@ using MongoDB.Atlas;
 @@clientName(MongoDB.Atlas.ClusterTier.FREE, "Free", "csharp");
 @@clientName(MongoDB.Atlas.ClusterTier.FLEX, "Flex", "csharp");
 
+// Boolean property: use the .NET "Is*" assertion-style name. The wire name
+// ("backups") and nullability (bool?) are unchanged; this only renames the
+// public C# property identifier.
+@@clientName(
+  MongoDB.Atlas.ClusterProperties.backups,
+  "IsBackupsEnabled",
+  "csharp"
+);
+
 // Tier and region preview models. Apply the MongoDBAtlas* prefix for naming
 // consistency, and rename the "Response" suffix to "Result" so the public model
 // names satisfy the AZC0030 analyzer. Client-only (csharp) renames; the wire


### PR DESCRIPTION
Adds csharp-scoped `@@clientName` renames in `client.tsp` for the MongoDB Atlas tier/region preview models:

| Model / Property | New C# name | Reason |
|---|---|---|
| `RegionsByTierResponse` | `MongoDBAtlasRegionsByTierResult` | `Response` suffix trips **AZC0030**, failing the .NET SDK build |
| `TierLimitReachedResponse` | `MongoDBAtlasTierLimitReachedResult` | `Response` suffix trips **AZC0030**, failing the .NET SDK build |
| `TierRegions` | `MongoDBAtlasTierRegions` | `MongoDBAtlas*` prefix for naming consistency |
| `ProjectLimitStatus` | `MongoDBAtlasProjectLimitStatus` | `MongoDBAtlas*` prefix for naming consistency |
| `FREE/FLEX` | `Free/Flex` | Recommended for dotnet |
| `ClusterProperties.backups` | `IsBackupsEnabled` | Bool property needs `Is`/`Has`/`Can` prefix per **BOOL001** |

These are client-only (`csharp`) renames — the wire contract, JSON serialization, REST paths, and other-language SDKs are unchanged. Validated locally with `tsp compile` (compiles successfully) and `tsp format` (no formatting changes).

Unblocks the AZC0030 build failure and BOOL001 finding in Azure/azure-sdk-for-net#60084.