### PR TITLE
Revert ToolNameAndDescription move; keep browser automation

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9,30 +9,179 @@
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Insights",
+      "parent": "Evaluations"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Evalsuite",
+      "parent": "Evaluations"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Redteams",
+      "parent": "Evaluations",
+      "description": "Red Teaming"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Evaluation Taxonomies",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Evaluators",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agent Invocations",
+      "name": "Evaluation Rules",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evals",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evaluations"
+    },
+    {
+      "name": "EvaluatorGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Evaluator generation jobs"
+    },
+    {
+      "name": "AgentOptimizationJobs",
+      "parent": "Platform APIs",
+      "description": "Agent optimization jobs"
+    },
+    {
+      "name": "DataGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Data generation jobs"
+    },
+    {
+      "name": "Deployments",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Toolboxes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Skills",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Schedules",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Routines",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Videos",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Vector stores",
+      "parent": "Platform APIs",
+      "description": "Vector Stores"
+    },
+    {
+      "name": "Uploads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Threads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Realtime",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Moderations",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Images",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Files",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Embeddings",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Containers",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Completions",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Batch",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Audio",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Assistants",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Chat",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Memory Stores",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Models",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Fine-tuning",
+      "parent": "Platform APIs",
+      "description": "Fine-Tuning"
+    },
+    {
+      "name": "Scheduler",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Connections",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Indexes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Datasets",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Platform APIs"
+    },
+    {
+      "name": "Agent Containers",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Versions",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Session Files",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Sessions",
       "parent": "Agents Root"
     },
     {
@@ -41,180 +190,31 @@
       "description": "Agent Invocations (WebSocket)"
     },
     {
-      "name": "Agent Sessions",
+      "name": "Agent Invocations",
       "parent": "Agents Root"
     },
     {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
+      "name": "Agents",
+      "parent": "Agents Root",
+      "description": "Agent Management"
     },
     {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
+      "name": "Agents Root",
+      "description": "Agents"
     },
     {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
+      "name": "Conversations",
+      "parent": "Responses Root",
+      "description": "Conversations (OpenAI)"
     },
     {
-      "name": "Platform APIs"
+      "name": "Responses",
+      "parent": "Responses Root",
+      "description": "Responses (OpenAI)"
     },
     {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "Responses Root",
+      "description": "Responses"
     }
   ],
   "paths": {
@@ -12258,8 +12258,7 @@
                     },
                     "safety_identifier": {
                       "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
                       "type": "string",
@@ -12273,7 +12272,7 @@
                         {
                           "type": "string",
                           "enum": [
-                            "in_memory",
+                            "in-memory",
                             "24h"
                           ]
                         },
@@ -12310,6 +12309,16 @@
                       "anyOf": [
                         {
                           "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "max_output_tokens": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -12458,16 +12467,6 @@
                     "usage": {
                       "$ref": "#/components/schemas/OpenAI.ResponseUsage"
                     },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "parallel_tool_calls": {
                       "type": "boolean",
                       "description": "Whether to allow the model to run tool calls in parallel.",
@@ -12477,16 +12476,6 @@
                       "anyOf": [
                         {
                           "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -12612,8 +12601,7 @@
                   },
                   "safety_identifier": {
                     "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
                     "type": "string",
@@ -12627,7 +12615,7 @@
                       {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
                         ]
                       },
@@ -12664,6 +12652,16 @@
                     "anyOf": [
                       {
                         "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "max_output_tokens": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.integer"
                       },
                       {
                         "type": "null"
@@ -12762,16 +12760,6 @@
                       }
                     ]
                   },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "stream": {
                     "anyOf": [
                       {
@@ -12815,16 +12803,6 @@
                       }
                     ],
                     "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   },
                   "agent_reference": {
                     "allOf": [
@@ -16823,6 +16801,14 @@
             "type": "boolean",
             "description": "When `true`, Foundry sends its credentials when fetching the remote\nagent's Agent Card. The service defaults to `false` if a value is not\nspecified by the caller (anonymous fetch).",
             "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -16861,6 +16847,14 @@
             "type": "boolean",
             "description": "When `true`, Foundry sends its credentials when fetching the remote\nagent's Agent Card. The service defaults to `false` if a value is not\nspecified by the caller (anonymous fetch).",
             "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -18521,6 +18515,14 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -18647,6 +18649,14 @@
             "enum": [
               "azure_ai_search"
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "azure_ai_search": {
             "allOf": [
@@ -19399,6 +19409,14 @@
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -19573,6 +19591,14 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -19770,6 +19796,14 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -19798,6 +19832,14 @@
             "enum": [
               "browser_automation_preview"
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -19939,6 +19981,14 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [
@@ -20191,6 +20241,14 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -21506,9 +21564,7 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -24177,6 +24233,14 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -24226,6 +24290,14 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -24373,6 +24445,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "vector_store_ids": {
             "type": "array",
@@ -25447,8 +25527,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -25608,10 +25687,6 @@
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -25947,6 +26022,14 @@
               "memory_search_preview"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -26472,6 +26555,14 @@
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "fabric_dataagent_preview": {
             "allOf": [
               {
@@ -26956,7 +27047,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -26989,7 +27081,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -27023,7 +27116,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27051,7 +27145,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -27151,7 +27246,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -27176,7 +27272,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27209,7 +27306,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -27352,12 +27450,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -27457,7 +27549,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -27482,19 +27575,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -27567,6 +27647,14 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -27678,36 +27766,6 @@
                 "type": "null"
               }
             ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         }
       },
@@ -27727,9 +27785,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -27831,14 +27887,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -27908,8 +27956,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -27918,7 +27965,8 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
             "anyOf": [
@@ -27940,14 +27988,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -27985,29 +28025,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -28023,7 +28040,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -28070,7 +28088,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -28125,7 +28144,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -28186,7 +28206,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -28195,6 +28216,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -28215,7 +28244,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -28223,6 +28253,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -28270,7 +28326,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -28352,18 +28409,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -28375,56 +28428,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -28618,50 +28627,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -28684,9 +28656,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -28713,11 +28682,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -28733,8 +28701,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -28764,17 +28731,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -28806,18 +28812,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -28825,65 +28819,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -28985,7 +28922,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -29044,7 +28981,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -29079,67 +29016,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -29147,8 +29026,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -29190,9 +29068,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -29510,7 +29435,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -29641,16 +29573,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -29723,138 +29645,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -29871,11 +29661,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -30064,8 +29850,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -30994,7 +30779,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -31029,7 +30815,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -31053,7 +30840,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -31070,10 +30858,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -31146,8 +30930,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -31155,8 +30938,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -31165,7 +30947,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -31182,19 +30965,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31218,7 +30988,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -31226,19 +30997,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -31278,16 +31036,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -31313,9 +31061,6 @@
         ],
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
-      },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
       },
       "OpenAI.Error": {
         "type": "object",
@@ -32342,7 +32087,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -32368,13 +32114,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -32426,7 +32165,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -32460,6 +32200,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -33333,22 +33081,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -33402,7 +33142,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -33458,22 +33198,6 @@
         ]
       },
       "OpenAI.FunctionCallItemStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
         "type": "string",
         "enum": [
           "in_progress",
@@ -33798,7 +33522,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -33830,7 +33555,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -33917,14 +33643,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -33937,7 +33655,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -33960,7 +33679,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -33970,14 +33690,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -33991,7 +33703,8 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
             "anyOf": [
@@ -34002,6 +33715,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -34118,7 +33839,8 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
@@ -34154,10 +33876,6 @@
                 "type": "null"
               }
             ]
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
           }
         },
         "allOf": [
@@ -34168,62 +33886,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -34571,8 +34288,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -34595,7 +34311,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -34625,21 +34342,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -34717,6 +34427,14 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -34759,7 +34477,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -34776,7 +34494,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -34930,22 +34649,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -34999,7 +34710,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -35091,22 +34802,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -35167,14 +34870,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
           }
         },
         "description": "A file input to the model.",
@@ -35223,7 +34918,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -35301,9 +34996,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -35323,56 +35015,6 @@
           }
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
-      },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
       },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -35685,6 +35327,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -35707,9 +35350,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -35760,10 +35400,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -36108,7 +35744,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -36117,8 +35752,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -36131,10 +35765,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -36436,7 +36066,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -36559,16 +36196,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -36649,143 +36276,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -36802,9 +36292,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -36880,6 +36367,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -36887,6 +36420,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -36964,7 +36546,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -36972,9 +36554,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -36994,56 +36573,6 @@
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
       },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -37356,6 +36885,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -37378,9 +36908,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -37431,10 +36958,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -37513,17 +37036,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -37542,50 +37062,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -37823,6 +37299,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -37845,9 +37322,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -37874,11 +37348,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -37894,8 +37367,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -37925,9 +37397,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -37953,10 +37423,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -38122,7 +37588,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -38181,7 +37647,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -38219,7 +37685,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -38228,8 +37693,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -38242,10 +37706,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -38272,64 +37732,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -38600,7 +38002,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -38731,16 +38140,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -38813,138 +38212,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -38955,9 +38222,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -39316,7 +38580,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -39325,8 +38588,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -39339,10 +38601,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -39419,59 +38677,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -39697,7 +38902,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -39820,16 +39032,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -39923,7 +39125,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -39951,19 +39154,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -39975,56 +39173,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -40218,50 +39370,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -40284,9 +39399,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -40313,11 +39425,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -40333,8 +39444,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -40364,126 +39474,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -40585,7 +39576,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -40644,7 +39635,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -40679,67 +39670,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -40747,8 +39680,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -40790,9 +39722,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -40843,59 +39822,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -41116,7 +40042,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -41239,16 +40172,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -41267,200 +40190,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -41477,11 +40206,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -41494,8 +40218,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -41578,143 +40300,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -41731,9 +40316,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -41845,7 +40427,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -41977,7 +40560,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -41987,6 +40571,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -42066,7 +40666,16 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local_shell"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -42272,10 +40881,6 @@
             ],
             "default": "always"
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
@@ -42349,8 +40954,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -42384,22 +40988,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -42453,7 +41049,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -42616,14 +41212,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -42703,182 +41291,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -42893,7 +41305,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -42910,19 +41323,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -42932,57 +41332,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -43172,19 +41521,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -43192,55 +41535,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -43478,6 +41775,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -43500,9 +41798,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -43529,128 +41824,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -43669,10 +41849,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -43680,18 +41856,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -43699,7 +41863,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -43801,7 +41966,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -43860,7 +42025,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -43898,7 +42063,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -43907,8 +42071,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -43921,10 +42084,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -43951,64 +42110,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -44107,54 +42208,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -44198,54 +42251,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -44279,7 +42284,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -44402,16 +42414,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -44492,138 +42494,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -44635,19 +42505,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -44655,9 +42519,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -44878,13 +42740,6 @@
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
       },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
-      },
       "OpenAI.RankerVersionType": {
         "type": "string",
         "enum": [
@@ -44920,123 +42775,6 @@
             "description": "Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled."
           }
         }
-      },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
       },
       "OpenAI.Reasoning": {
         "type": "object",
@@ -45184,8 +42922,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -45199,7 +42936,7 @@
               {
                 "type": "string",
                 "enum": [
-                  "in_memory",
+                  "in-memory",
                   "24h"
                 ]
               },
@@ -45236,6 +42973,16 @@
             "anyOf": [
               {
                 "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -45384,16 +43131,6 @@
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
           },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "parallel_tool_calls": {
             "type": "boolean",
             "description": "Whether to allow the model to run tool calls in parallel.",
@@ -45403,16 +43140,6 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -45470,11 +43197,6 @@
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -45506,11 +43228,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -45547,11 +43264,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -45583,11 +43295,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -45638,11 +43345,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -45693,11 +43395,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -45743,11 +43440,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -45793,11 +43485,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -45843,11 +43530,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -45888,11 +43570,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -45956,11 +43633,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -46024,11 +43696,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -46069,11 +43736,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -46124,11 +43786,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -46180,11 +43837,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -46285,11 +43937,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -46330,11 +43977,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -46380,11 +44022,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -46430,11 +44067,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -46480,11 +44112,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -46637,11 +44264,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -46696,11 +44318,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -46746,11 +44363,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -46797,11 +44409,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -46848,11 +44455,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -46913,11 +44515,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -46959,11 +44556,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -47016,11 +44608,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -47052,7 +44639,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -47111,11 +44698,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -47167,11 +44749,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -47218,11 +44795,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -47269,11 +44841,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -47320,11 +44887,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -47371,11 +44933,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -47422,11 +44979,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -47473,11 +45025,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -47528,11 +45075,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -47582,11 +45124,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -47659,11 +45196,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -47728,11 +45260,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -47797,11 +45324,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -47884,11 +45406,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -47967,11 +45484,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -48031,11 +45543,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -48095,11 +45602,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -48159,11 +45661,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -48223,11 +45720,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -48287,151 +45779,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -48503,11 +45856,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -48575,11 +45923,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -48712,11 +46055,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -48762,11 +46100,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -48812,11 +46145,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -48836,7 +46164,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -48863,7 +46192,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -48896,19 +46226,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -48918,13 +46235,6 @@
         ],
         "description": "A scroll action.",
         "title": "Scroll"
-      },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
       },
       "OpenAI.SearchContextSize": {
         "type": "string",
@@ -48952,15 +46262,6 @@
         ],
         "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
-      "OpenAI.ServiceTierEnum": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "default",
-          "flex",
-          "priority"
-        ]
-      },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
         "required": [
@@ -48974,7 +46275,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -49005,7 +46307,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -49028,7 +46331,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -49052,7 +46356,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -49079,7 +46384,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -49258,10 +46564,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -49317,46 +46620,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -49555,9 +46818,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -49581,9 +46842,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -49628,64 +46887,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -49696,7 +46897,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -49705,8 +46905,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -49772,7 +46970,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -49822,7 +47021,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -49904,7 +47104,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -49977,7 +47178,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -49990,7 +47192,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -50028,8 +47230,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -50104,7 +47305,8 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
             "anyOf": [
@@ -50123,12 +47325,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -50150,7 +47346,8 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
             "anyOf": [
@@ -50181,6 +47378,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -53301,6 +50506,14 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -54334,14 +51547,6 @@
             ],
             "description": "The type of tool."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "tool_configs": {
             "type": "object",
             "unevaluatedProperties": {
@@ -55125,6 +52330,14 @@
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -55187,6 +52400,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -55212,6 +52433,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -16804,11 +16804,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -16850,11 +16852,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -18517,11 +18521,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -18652,11 +18658,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -19411,11 +19419,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -19594,11 +19604,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "bing_grounding": {
             "allOf": [
@@ -19798,11 +19810,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "browser_automation_preview": {
             "allOf": [
@@ -19835,11 +19849,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "browser_automation_preview": {
             "allOf": [
@@ -19984,11 +20000,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "outputs": {
             "allOf": [
@@ -20244,11 +20262,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -24236,11 +24256,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -24293,11 +24315,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -24448,11 +24472,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "vector_store_ids": {
             "type": "array",
@@ -26025,11 +26051,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "memory_store_name": {
             "type": "string",
@@ -26557,11 +26585,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -27650,11 +27680,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "container": {
             "anyOf": [
@@ -32203,11 +32235,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -33718,11 +33752,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -34430,11 +34466,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -40671,11 +40709,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -47381,11 +47421,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [
@@ -49400,11 +49442,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -50508,11 +50552,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -52332,11 +52378,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [
@@ -52403,11 +52451,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -52436,11 +52486,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -11067,9 +11067,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -11106,9 +11108,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
@@ -12204,9 +12208,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12291,9 +12297,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12783,9 +12791,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -12907,9 +12917,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -13033,9 +13045,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -13056,9 +13070,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -13149,9 +13165,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -13346,9 +13364,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -16302,9 +16322,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -16338,9 +16360,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A FabricIQ tool stored in a toolbox.
@@ -16434,9 +16458,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -17466,9 +17492,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -17808,9 +17836,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -18568,9 +18598,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         container:
           anyOf:
             - type: string
@@ -21653,9 +21685,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -22648,9 +22682,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -23274,9 +23310,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -27526,9 +27564,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -32699,9 +32739,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -34034,9 +34076,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -34779,9 +34823,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -35999,9 +36045,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -36047,9 +36095,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.
@@ -36069,9 +36119,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A WorkIQ tool stored in a toolbox.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -4,114 +4,114 @@ info:
   version: v1
 tags:
   - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
-  - name: Agents
+  - name: Insights
+    parent: Evaluations
+  - name: Evalsuite
+    parent: Evaluations
+  - name: Redteams
+    parent: Evaluations
+    description: Red Teaming
+  - name: Evaluation Taxonomies
+    parent: Evaluations
+  - name: Evaluators
+    parent: Evaluations
+  - name: Evaluation Rules
+    parent: Evaluations
+  - name: Evals
+    parent: Evaluations
+  - name: Evaluations
+  - name: EvaluatorGenerationJobs
+    parent: Platform APIs
+    description: Evaluator generation jobs
+  - name: AgentOptimizationJobs
+    parent: Platform APIs
+    description: Agent optimization jobs
+  - name: DataGenerationJobs
+    parent: Platform APIs
+    description: Data generation jobs
+  - name: Deployments
+    parent: Platform APIs
+  - name: Toolboxes
+    parent: Platform APIs
+  - name: Skills
+    parent: Platform APIs
+  - name: Schedules
+    parent: Platform APIs
+  - name: Routines
+    parent: Platform APIs
+  - name: Videos
+    parent: Platform APIs
+  - name: Vector stores
+    parent: Platform APIs
+    description: Vector Stores
+  - name: Uploads
+    parent: Platform APIs
+  - name: Threads
+    parent: Platform APIs
+  - name: Realtime
+    parent: Platform APIs
+  - name: Moderations
+    parent: Platform APIs
+  - name: Images
+    parent: Platform APIs
+  - name: Files
+    parent: Platform APIs
+  - name: Embeddings
+    parent: Platform APIs
+  - name: Containers
+    parent: Platform APIs
+  - name: Completions
+    parent: Platform APIs
+  - name: Batch
+    parent: Platform APIs
+  - name: Audio
+    parent: Platform APIs
+  - name: Assistants
+    parent: Platform APIs
+  - name: Chat
+    parent: Platform APIs
+  - name: Memory Stores
+    parent: Platform APIs
+  - name: Models
+    parent: Platform APIs
+  - name: Fine-tuning
+    parent: Platform APIs
+    description: Fine-Tuning
+  - name: Scheduler
+    parent: Platform APIs
+  - name: Connections
+    parent: Platform APIs
+  - name: Indexes
+    parent: Platform APIs
+  - name: Datasets
+    parent: Platform APIs
+  - name: Platform APIs
+  - name: Agent Containers
     parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
+  - name: Agent Versions
+    parent: Agents Root
+  - name: Agent Session Files
+    parent: Agents Root
+  - name: Agent Sessions
     parent: Agents Root
   - name: Agent Invocations WebSocket
     parent: Agents Root
     description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
+  - name: Agent Invocations
     parent: Agents Root
-  - name: Agent Session Files
+  - name: Agents
     parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
-  - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
-  - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
-  - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
-  - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
-  - name: Insights
-    parent: Evaluations
+    description: Agent Management
+  - name: Agents Root
+    description: Agents
+  - name: Conversations
+    parent: Responses Root
+    description: Conversations (OpenAI)
+  - name: Responses
+    parent: Responses Root
+    description: Responses (OpenAI)
+  - name: Responses Root
+    description: Responses
 paths:
   /agent_optimization_jobs:
     post:
@@ -8101,10 +8101,9 @@ paths:
                     deprecated: true
                   safety_identifier:
                     type: string
-                    maxLength: 64
                     description: |-
                       A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                        The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
                     type: string
                     description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -8114,7 +8113,7 @@ paths:
                     anyOf:
                       - type: string
                         enum:
-                          - in_memory
+                          - in-memory
                           - 24h
                       - type: 'null'
                   previous_response_id:
@@ -8131,6 +8130,10 @@ paths:
                   background:
                     anyOf:
                       - type: boolean
+                      - type: 'null'
+                  max_output_tokens:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   max_tool_calls:
                     anyOf:
@@ -8219,10 +8222,6 @@ paths:
                       - type: 'null'
                   usage:
                     $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
                   parallel_tool_calls:
                     type: boolean
                     description: Whether to allow the model to run tool calls in parallel.
@@ -8230,10 +8229,6 @@ paths:
                   conversation:
                     anyOf:
                       - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   agent_reference:
                     anyOf:
@@ -8306,10 +8301,9 @@ paths:
                   deprecated: true
                 safety_identifier:
                   type: string
-                  maxLength: 64
                   description: |-
                     A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
                   type: string
                   description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -8319,7 +8313,7 @@ paths:
                   anyOf:
                     - type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
                     - type: 'null'
                 previous_response_id:
@@ -8336,6 +8330,10 @@ paths:
                 background:
                   anyOf:
                     - type: boolean
+                    - type: 'null'
+                max_output_tokens:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.integer'
                     - type: 'null'
                 max_tool_calls:
                   anyOf:
@@ -8381,10 +8379,6 @@ paths:
                   anyOf:
                     - type: string
                     - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
                 stream:
                   anyOf:
                     - type: boolean
@@ -8404,10 +8398,6 @@ paths:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
                     - type: 'null'
                   description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
                 agent_reference:
                   allOf:
                     - $ref: '#/components/schemas/AgentReference'
@@ -11074,6 +11064,12 @@ components:
             agent's Agent Card. The service defaults to `false` if a value is not
             specified by the caller (anonymous fetch).
           default: false
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -11107,6 +11103,12 @@ components:
             agent's Agent Card. The service defaults to `false` if a value is not
             specified by the caller (anonymous fetch).
           default: false
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
@@ -12199,6 +12201,12 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12280,6 +12288,12 @@ components:
           type: string
           enum:
             - azure_ai_search
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12766,6 +12780,12 @@ components:
           enum:
             - bing_custom_search_preview
           description: The object type, which is always 'bing_custom_search_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -12884,6 +12904,12 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -13004,6 +13030,12 @@ components:
           enum:
             - browser_automation_preview
           description: The object type, which is always 'browser_automation_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -13021,6 +13053,12 @@ components:
           type: string
           enum:
             - browser_automation_preview
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -13108,6 +13146,12 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -13299,6 +13343,12 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -14192,8 +14242,7 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -16250,6 +16299,12 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -16280,6 +16335,12 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A FabricIQ tool stored in a toolbox.
@@ -16370,6 +16431,12 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         vector_store_ids:
           type: array
           items:
@@ -17067,7 +17134,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -17187,9 +17253,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -17400,6 +17463,12 @@ components:
           enum:
             - memory_search_preview
           description: The type of the tool. Always `memory_search_preview`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -17736,6 +17805,12 @@ components:
           enum:
             - fabric_dataagent_preview
           description: The object type, which is always 'fabric_dataagent_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -18068,6 +18143,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -18091,6 +18167,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -18115,6 +18192,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -18134,6 +18212,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -18199,6 +18278,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -18216,6 +18296,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -18239,6 +18320,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -18324,12 +18406,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -18424,6 +18500,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -18436,12 +18513,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -18494,6 +18565,12 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         container:
           anyOf:
             - type: string
@@ -18562,18 +18639,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -18590,8 +18655,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -18663,14 +18726,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -18716,7 +18771,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -18724,6 +18778,7 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
           anyOf:
             - type: string
@@ -18733,10 +18788,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -18763,21 +18814,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -18792,6 +18828,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -18819,6 +18856,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -18855,6 +18893,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -18895,12 +18934,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -18914,8 +18960,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -18948,6 +19015,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -18996,18 +19064,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -19019,39 +19083,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -19174,39 +19209,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -19224,8 +19233,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -19246,11 +19253,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -19264,7 +19270,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -19288,15 +19293,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -19319,60 +19351,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -19447,7 +19429,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -19485,7 +19467,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -19503,56 +19485,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -19562,7 +19497,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -19592,8 +19526,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -19816,7 +19785,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -19899,10 +19870,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -19954,87 +19921,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -20048,11 +19934,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -20188,7 +20070,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -20806,6 +20687,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -20828,6 +20710,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -20844,6 +20727,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -20854,9 +20738,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -20904,14 +20785,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -20919,6 +20798,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -20927,12 +20807,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -20949,6 +20823,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -20961,12 +20836,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -20995,10 +20864,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -21023,8 +20888,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -21718,6 +21581,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -21732,11 +21596,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -21773,6 +21632,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -21790,6 +21650,12 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -22379,17 +22245,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -22419,7 +22281,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -22453,18 +22315,6 @@ components:
             - input_image
             - input_file
     OpenAI.FunctionCallItemStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
       type: string
       enum:
         - in_progress
@@ -22675,6 +22525,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -22695,6 +22546,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -22745,12 +22597,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -22762,6 +22608,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -22777,16 +22624,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -22798,10 +22640,17 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -22879,6 +22728,7 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
@@ -22895,45 +22745,53 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-        defer_loading:
-          type: boolean
-          description: Whether this function is deferred and loaded via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -23310,7 +23168,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -23328,6 +23185,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -23349,15 +23207,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -23413,6 +23271,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -23441,7 +23305,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -23463,6 +23326,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -23565,17 +23429,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -23605,7 +23465,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -23663,17 +23523,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -23705,10 +23561,6 @@ components:
             - type: string
               format: uri
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -23736,7 +23588,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -23785,9 +23637,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -23808,38 +23657,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -24029,6 +23846,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -24046,8 +23864,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -24088,9 +23904,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -24301,7 +24114,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -24310,7 +24122,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -24320,9 +24131,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -24530,7 +24338,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -24610,10 +24420,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -24674,77 +24480,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -24758,9 +24493,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -24817,6 +24549,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -24825,6 +24595,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -24886,7 +24693,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -24894,9 +24701,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -24914,38 +24718,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -25135,6 +24907,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25152,8 +24925,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25194,9 +24965,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -25249,17 +25017,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -25276,35 +25041,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -25460,6 +25196,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -25477,8 +25214,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -25499,11 +25234,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -25517,7 +25251,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -25541,8 +25274,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -25563,9 +25294,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -25682,7 +25410,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -25720,7 +25448,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -25741,7 +25469,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -25750,7 +25477,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -25760,9 +25486,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -25784,51 +25507,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -26015,7 +25693,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -26098,10 +25778,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -26153,87 +25829,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -26241,9 +25836,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -26472,7 +26064,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -26481,7 +26072,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -26491,9 +26081,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -26548,50 +26135,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -26745,7 +26288,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -26825,10 +26370,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -26901,6 +26442,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -26918,19 +26460,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -26943,38 +26480,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -27097,39 +26603,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27147,8 +26627,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27169,11 +26647,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -27187,7 +26664,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -27211,91 +26687,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -27370,7 +26761,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -27408,7 +26799,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -27426,56 +26817,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -27485,7 +26829,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27515,8 +26858,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -27550,50 +26928,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -27747,7 +27081,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -27827,10 +27163,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27844,134 +27176,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -27985,11 +27189,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -28002,8 +27201,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -28067,77 +27264,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -28151,9 +27277,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -28245,6 +27368,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -28331,10 +27455,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -28385,6 +27522,13 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+          default: local_shell
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -28530,9 +27674,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -28592,7 +27733,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -28613,17 +27753,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -28653,7 +27789,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -28763,15 +27899,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -28829,125 +27956,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -28961,6 +27969,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -28969,50 +27978,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -29149,19 +28118,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -29169,38 +28132,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -29356,6 +28288,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -29373,8 +28306,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -29395,99 +28326,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -29501,27 +28346,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -29596,7 +28430,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -29634,7 +28468,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -29655,7 +28489,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29664,7 +28497,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29674,9 +28506,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29698,51 +28527,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -29810,37 +28594,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -29872,37 +28625,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -29929,7 +28651,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -30009,10 +28733,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30073,87 +28793,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -30162,19 +28801,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -30182,9 +28815,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -30337,11 +28968,6 @@ components:
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -30362,81 +28988,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
@@ -30542,10 +29093,9 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -30555,7 +29105,7 @@ components:
           anyOf:
             - type: string
               enum:
-                - in_memory
+                - in-memory
                 - 24h
             - type: 'null'
         previous_response_id:
@@ -30572,6 +29122,10 @@ components:
         background:
           anyOf:
             - type: boolean
+            - type: 'null'
+        max_output_tokens:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         max_tool_calls:
           anyOf:
@@ -30660,10 +29214,6 @@ components:
             - type: 'null'
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
@@ -30671,10 +29221,6 @@ components:
         conversation:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         agent_reference:
           anyOf:
@@ -30708,8 +29254,6 @@ components:
           type: string
           contentEncoding: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -30737,8 +29281,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -30769,8 +29311,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -30798,8 +29338,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -30839,8 +29377,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -30882,8 +29418,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -30921,8 +29455,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -30959,8 +29491,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -30997,8 +29527,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -31031,8 +29559,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -31127,8 +29653,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -31181,8 +29705,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -31221,8 +29743,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -31294,8 +29814,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -31337,8 +29855,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -31415,8 +29931,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -31450,8 +29964,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -31517,8 +30029,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -31555,8 +30065,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -31593,8 +30101,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -31710,8 +30216,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -31756,8 +30260,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -31796,8 +30298,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -31835,8 +30335,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -31874,8 +30372,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -31922,8 +30418,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -31959,8 +30453,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -32032,8 +30524,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -32091,7 +30581,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -32132,8 +30622,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -32176,8 +30664,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -32216,8 +30702,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -32255,8 +30739,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -32294,8 +30776,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -32333,8 +30813,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -32372,8 +30850,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -32411,8 +30887,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -32451,8 +30925,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -32496,8 +30968,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -32561,8 +31031,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -32619,8 +31087,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -32672,8 +31138,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -32738,8 +31202,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -32805,8 +31267,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -32856,8 +31316,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -32907,8 +31365,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -32956,8 +31412,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -33005,8 +31459,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -33054,8 +31506,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -33069,127 +31519,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -33244,8 +31573,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -33299,8 +31626,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -33397,8 +31722,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -33435,8 +31758,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -33473,8 +31794,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -33497,6 +31816,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -33516,6 +31836,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -33532,21 +31853,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -33570,13 +31880,6 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -33589,6 +31892,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -33610,6 +31914,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -33625,6 +31930,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -33641,6 +31947,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -33659,6 +31966,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -33801,9 +32109,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -33856,34 +32161,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -34027,8 +32304,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -34050,8 +32325,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -34080,38 +32353,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -34119,7 +32360,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -34128,8 +32368,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -34196,6 +32434,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -34230,6 +32469,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -34286,6 +32526,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -34335,6 +32576,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -34344,7 +32586,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -34373,7 +32615,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -34415,6 +32656,7 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
@@ -34423,10 +32665,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -34441,6 +32679,7 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -34457,6 +32696,12 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -36531,6 +34776,12 @@ components:
           enum:
             - sharepoint_grounding_preview
           description: The object type, which is always 'sharepoint_grounding_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -37210,12 +35461,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ToolboxToolType'
           description: The type of tool.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         tool_configs:
           type: object
           unevaluatedProperties:
@@ -37751,6 +35996,12 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -37793,6 +36044,12 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.
@@ -37809,6 +36066,12 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A WorkIQ tool stored in a toolbox.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -12,30 +12,179 @@
       "name": "Fine-Tuning"
     },
     {
-      "name": "Responses Root",
-      "description": "Responses"
+      "name": "Insights",
+      "parent": "Evaluations"
     },
     {
-      "name": "Responses",
-      "parent": "Responses Root",
-      "description": "Responses (OpenAI)"
+      "name": "Evalsuite",
+      "parent": "Evaluations"
     },
     {
-      "name": "Conversations",
-      "parent": "Responses Root",
-      "description": "Conversations (OpenAI)"
+      "name": "Redteams",
+      "parent": "Evaluations",
+      "description": "Red Teaming"
     },
     {
-      "name": "Agents Root",
-      "description": "Agents"
+      "name": "Evaluation Taxonomies",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agents",
-      "parent": "Agents Root",
-      "description": "Agent Management"
+      "name": "Evaluators",
+      "parent": "Evaluations"
     },
     {
-      "name": "Agent Invocations",
+      "name": "Evaluation Rules",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evals",
+      "parent": "Evaluations"
+    },
+    {
+      "name": "Evaluations"
+    },
+    {
+      "name": "EvaluatorGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Evaluator generation jobs"
+    },
+    {
+      "name": "AgentOptimizationJobs",
+      "parent": "Platform APIs",
+      "description": "Agent optimization jobs"
+    },
+    {
+      "name": "DataGenerationJobs",
+      "parent": "Platform APIs",
+      "description": "Data generation jobs"
+    },
+    {
+      "name": "Deployments",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Toolboxes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Skills",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Schedules",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Routines",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Videos",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Vector stores",
+      "parent": "Platform APIs",
+      "description": "Vector Stores"
+    },
+    {
+      "name": "Uploads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Threads",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Realtime",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Moderations",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Images",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Files",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Embeddings",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Containers",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Completions",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Batch",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Audio",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Assistants",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Chat",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Memory Stores",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Models",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Fine-tuning",
+      "parent": "Platform APIs",
+      "description": "Fine-Tuning"
+    },
+    {
+      "name": "Scheduler",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Connections",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Indexes",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Datasets",
+      "parent": "Platform APIs"
+    },
+    {
+      "name": "Platform APIs"
+    },
+    {
+      "name": "Agent Containers",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Versions",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Session Files",
+      "parent": "Agents Root"
+    },
+    {
+      "name": "Agent Sessions",
       "parent": "Agents Root"
     },
     {
@@ -44,180 +193,31 @@
       "description": "Agent Invocations (WebSocket)"
     },
     {
-      "name": "Agent Sessions",
+      "name": "Agent Invocations",
       "parent": "Agents Root"
     },
     {
-      "name": "Agent Session Files",
-      "parent": "Agents Root"
+      "name": "Agents",
+      "parent": "Agents Root",
+      "description": "Agent Management"
     },
     {
-      "name": "Agent Versions",
-      "parent": "Agents Root"
+      "name": "Agents Root",
+      "description": "Agents"
     },
     {
-      "name": "Agent Containers",
-      "parent": "Agents Root"
+      "name": "Conversations",
+      "parent": "Responses Root",
+      "description": "Conversations (OpenAI)"
     },
     {
-      "name": "Platform APIs"
+      "name": "Responses",
+      "parent": "Responses Root",
+      "description": "Responses (OpenAI)"
     },
     {
-      "name": "Datasets",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Indexes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Connections",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Scheduler",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Fine-tuning",
-      "parent": "Platform APIs",
-      "summary": "Fine-Tuning"
-    },
-    {
-      "name": "Models",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Memory Stores",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Chat",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Assistants",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Audio",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Batch",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Completions",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Containers",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Embeddings",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Files",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Images",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Moderations",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Realtime",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Threads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Uploads",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Vector stores",
-      "parent": "Platform APIs",
-      "summary": "Vector Stores"
-    },
-    {
-      "name": "Videos",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Routines",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Schedules",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Skills",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Toolboxes",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "Deployments",
-      "parent": "Platform APIs"
-    },
-    {
-      "name": "DataGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Data generation jobs"
-    },
-    {
-      "name": "AgentOptimizationJobs",
-      "parent": "Platform APIs",
-      "summary": "Agent optimization jobs"
-    },
-    {
-      "name": "EvaluatorGenerationJobs",
-      "parent": "Platform APIs",
-      "summary": "Evaluator generation jobs"
-    },
-    {
-      "name": "Evaluations"
-    },
-    {
-      "name": "Evals",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Rules",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluators",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Evaluation Taxonomies",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Redteams",
-      "parent": "Evaluations",
-      "summary": "Red Teaming"
-    },
-    {
-      "name": "Evalsuite",
-      "parent": "Evaluations"
-    },
-    {
-      "name": "Insights",
-      "parent": "Evaluations"
+      "name": "Responses Root",
+      "description": "Responses"
     }
   ],
   "paths": {
@@ -15176,8 +15176,7 @@
                     },
                     "safety_identifier": {
                       "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
                       "type": "string",
@@ -15191,7 +15190,7 @@
                         {
                           "type": "string",
                           "enum": [
-                            "in_memory",
+                            "in-memory",
                             "24h"
                           ]
                         },
@@ -15228,6 +15227,16 @@
                       "anyOf": [
                         {
                           "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "max_output_tokens": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -15376,16 +15385,6 @@
                     "usage": {
                       "$ref": "#/components/schemas/OpenAI.ResponseUsage"
                     },
-                    "moderation": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.Moderation"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
                     "parallel_tool_calls": {
                       "type": "boolean",
                       "description": "Whether to allow the model to run tool calls in parallel.",
@@ -15395,16 +15394,6 @@
                       "anyOf": [
                         {
                           "$ref": "#/components/schemas/OpenAI.ConversationReference"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "max_output_tokens": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/OpenAI.integer"
                         },
                         {
                           "type": "null"
@@ -15542,8 +15531,7 @@
                   },
                   "safety_identifier": {
                     "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
                     "type": "string",
@@ -15557,7 +15545,7 @@
                       {
                         "type": "string",
                         "enum": [
-                          "in_memory",
+                          "in-memory",
                           "24h"
                         ]
                       },
@@ -15594,6 +15582,16 @@
                     "anyOf": [
                       {
                         "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "max_output_tokens": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/OpenAI.integer"
                       },
                       {
                         "type": "null"
@@ -15692,16 +15690,6 @@
                       }
                     ]
                   },
-                  "moderation": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.ModerationParam"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "stream": {
                     "anyOf": [
                       {
@@ -15745,16 +15733,6 @@
                       }
                     ],
                     "description": "Context management configuration for this request."
-                  },
-                  "max_output_tokens": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/OpenAI.integer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   },
                   "agent": {
                     "allOf": [
@@ -19765,6 +19743,14 @@
             "type": "boolean",
             "description": "When `true`, Foundry sends its credentials when fetching the remote\nagent's Agent Card. The service defaults to `false` if a value is not\nspecified by the caller (anonymous fetch).",
             "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -19803,6 +19789,14 @@
             "type": "boolean",
             "description": "When `true`, Foundry sends its credentials when fetching the remote\nagent's Agent Card. The service defaults to `false` if a value is not\nspecified by the caller (anonymous fetch).",
             "default": false
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -21944,6 +21938,14 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -22070,6 +22072,14 @@
             "enum": [
               "azure_ai_search"
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "azure_ai_search": {
             "allOf": [
@@ -22822,6 +22832,14 @@
             ],
             "description": "The object type, which is always 'bing_custom_search_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "bing_custom_search_preview": {
             "allOf": [
               {
@@ -22996,6 +23014,14 @@
               "bing_grounding"
             ],
             "description": "The object type, which is always 'bing_grounding'."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "bing_grounding": {
             "allOf": [
@@ -23193,6 +23219,14 @@
             ],
             "description": "The object type, which is always 'browser_automation_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "browser_automation_preview": {
             "allOf": [
               {
@@ -23221,6 +23255,14 @@
             "enum": [
               "browser_automation_preview"
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "browser_automation_preview": {
             "allOf": [
@@ -23362,6 +23404,14 @@
               "capture_structured_outputs"
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "outputs": {
             "allOf": [
@@ -23614,6 +23664,14 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -25106,9 +25164,7 @@
         },
         "discriminator": {
           "propertyName": "type",
-          "mapping": {
-            "azure_ai_source": "#/components/schemas/AzureAIDataSourceConfig"
-          }
+          "mapping": {}
         },
         "description": "Base class for run data sources with discriminator support."
       },
@@ -28658,6 +28714,14 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -28707,6 +28771,14 @@
             ],
             "description": "(Optional) Whether the agent requires approval before executing actions. Default is always.",
             "default": "always"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -28854,6 +28926,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "vector_store_ids": {
             "type": "array",
@@ -30001,8 +30081,7 @@
             "red_team_seed_prompts": "#/components/schemas/RedTeamSeedPromptsItemGenerationParams",
             "red_team_taxonomy": "#/components/schemas/RedTeamTaxonomyItemGenerationParams",
             "response_retrieval": "#/components/schemas/ResponseRetrievalItemGenerationParams",
-            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams",
-            "synthetic_data_gen_preview": "#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams"
+            "conversation_gen_preview": "#/components/schemas/ConversationGenPreviewItemGenerationParams"
           }
         },
         "description": "Represents the set of parameters used to control item generation operations."
@@ -30162,10 +30241,6 @@
               }
             ],
             "default": "always"
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
           },
           "project_connection_id": {
             "type": "string",
@@ -30514,6 +30589,14 @@
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "memory_store_name": {
             "type": "string",
             "description": "The name of the memory store to use."
@@ -30558,6 +30641,14 @@
               "memory_search"
             ],
             "description": "The type of the tool. Always `memory_search_preview`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "memory_store_name": {
             "type": "string",
@@ -31118,6 +31209,14 @@
             ],
             "description": "The object type, which is always 'fabric_dataagent_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "fabric_dataagent_preview": {
             "allOf": [
               {
@@ -31602,7 +31701,8 @@
               "create_file"
             ],
             "description": "Create a new file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -31635,7 +31735,8 @@
               "create_file"
             ],
             "description": "The operation type. Always `create_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "create_file"
           },
           "path": {
             "type": "string",
@@ -31669,7 +31770,8 @@
               "delete_file"
             ],
             "description": "Delete the specified file.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -31697,7 +31799,8 @@
               "delete_file"
             ],
             "description": "The operation type. Always `delete_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "delete_file"
           },
           "path": {
             "type": "string",
@@ -31797,7 +31900,8 @@
               "apply_patch"
             ],
             "description": "The type of the tool. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -31822,7 +31926,8 @@
               "update_file"
             ],
             "description": "Update an existing file with the provided diff.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -31855,7 +31960,8 @@
               "update_file"
             ],
             "description": "The operation type. Always `update_file`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "update_file"
           },
           "path": {
             "type": "string",
@@ -31998,12 +32104,6 @@
       "OpenAI.ChatModel": {
         "type": "string",
         "enum": [
-          "gpt-5.4",
-          "gpt-5.4-mini",
-          "gpt-5.4-nano",
-          "gpt-5.4-mini-2026-03-17",
-          "gpt-5.4-nano-2026-03-17",
-          "gpt-5.3-chat-latest",
           "gpt-5.2",
           "gpt-5.2-2025-12-11",
           "gpt-5.2-chat-latest",
@@ -32103,7 +32203,8 @@
               "click"
             ],
             "description": "Specifies the event type. For a click action, this property is always `click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "click"
           },
           "button": {
             "allOf": [
@@ -32128,19 +32229,6 @@
               }
             ],
             "description": "The y-coordinate where the click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -32213,6 +32301,14 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "container": {
             "anyOf": [
@@ -32324,36 +32420,6 @@
                 "type": "null"
               }
             ]
-          },
-          "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "prompt_cache_retention": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.PromptCacheRetentionEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "service_tier": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ServiceTierEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         }
       },
@@ -32373,9 +32439,7 @@
               "gt",
               "gte",
               "lt",
-              "lte",
-              "in",
-              "nin"
+              "lte"
             ],
             "description": "Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.\n  - `eq`: equals\n  - `ne`: not equal\n  - `gt`: greater than\n  - `gte`: greater than or equal\n  - `lt`: less than\n  - `lte`: less than or equal\n  - `in`: in\n  - `nin`: not in",
             "default": "eq"
@@ -32477,14 +32541,6 @@
           }
         }
       },
-      "OpenAI.ComputerActionList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OpenAI.ComputerAction"
-        },
-        "description": "Flattened batched actions for `computer_use`. Each action includes an\n`type` discriminator and action-specific fields.",
-        "title": "Computer Action List"
-      },
       "OpenAI.ComputerActionType": {
         "anyOf": [
           {
@@ -32554,8 +32610,7 @@
         "required": [
           "type",
           "image_url",
-          "file_id",
-          "detail"
+          "file_id"
         ],
         "properties": {
           "type": {
@@ -32564,7 +32619,8 @@
               "computer_screenshot"
             ],
             "description": "Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_screenshot"
           },
           "image_url": {
             "anyOf": [
@@ -32586,14 +32642,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ImageDetail"
-              }
-            ],
-            "description": "The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -32631,29 +32679,6 @@
         },
         "description": "A computer screenshot image used with the computer use tool."
       },
-      "OpenAI.ComputerTool": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ],
-            "description": "The type of the computer tool. Always `computer`.",
-            "x-stainless-const": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).",
-        "title": "Computer"
-      },
       "OpenAI.ComputerUsePreviewTool": {
         "type": "object",
         "required": [
@@ -32669,7 +32694,8 @@
               "computer_use_preview"
             ],
             "description": "The type of the computer use tool. Always `computer_use_preview`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "computer_use_preview"
           },
           "environment": {
             "allOf": [
@@ -32716,7 +32742,8 @@
               "container_auto"
             ],
             "description": "Automatically creates a container for this request",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_auto"
           },
           "file_ids": {
             "type": "array",
@@ -32771,7 +32798,8 @@
               "container_file_citation"
             ],
             "description": "The type of the container file citation. Always `container_file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_file_citation"
           },
           "container_id": {
             "type": "string",
@@ -32832,7 +32860,8 @@
               "allowlist"
             ],
             "description": "Allow outbound network access only to specified domains. Always `allowlist`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "allowlist"
           },
           "allowed_domains": {
             "type": "array",
@@ -32841,6 +32870,14 @@
             },
             "minItems": 1,
             "description": "A list of allowed domains when type is `allowlist`."
+          },
+          "domain_secrets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam"
+            },
+            "minItems": 1,
+            "description": "Optional domain-scoped secrets for allowlisted domains."
           }
         },
         "allOf": [
@@ -32861,7 +32898,8 @@
               "disabled"
             ],
             "description": "Disable outbound network access. Always `disabled`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "disabled"
           }
         },
         "allOf": [
@@ -32869,6 +32907,32 @@
             "$ref": "#/components/schemas/OpenAI.ContainerNetworkPolicyParam"
           }
         ]
+      },
+      "OpenAI.ContainerNetworkPolicyDomainSecretParam": {
+        "type": "object",
+        "required": [
+          "domain",
+          "name",
+          "value"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The domain associated with the secret."
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the secret to inject for the domain."
+          },
+          "value": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10485760,
+            "description": "The secret value to inject for the domain."
+          }
+        }
       },
       "OpenAI.ContainerNetworkPolicyParam": {
         "type": "object",
@@ -32916,7 +32980,8 @@
               "container_reference"
             ],
             "description": "The environment type. Always `container_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "container_reference"
           },
           "container_id": {
             "type": "string"
@@ -32998,18 +33063,14 @@
           "propertyName": "type",
           "mapping": {
             "message": "#/components/schemas/OpenAI.ConversationItemMessage",
-            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput",
+            "function_call": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource",
             "file_search_call": "#/components/schemas/OpenAI.ConversationItemFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ConversationItemWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ConversationItemImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ConversationItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ConversationItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ConversationItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ConversationItemAdditionalTools",
+            "computer_call_output": "#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ConversationItemReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ConversationItemCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCall",
             "local_shell_call_output": "#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput",
@@ -33021,56 +33082,12 @@
             "mcp_approval_request": "#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource",
             "mcp_call": "#/components/schemas/OpenAI.ConversationItemMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.ConversationItemCustomToolCall",
+            "custom_tool_call_output": "#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput"
           }
         },
         "description": "A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).",
         "title": "Conversation item"
-      },
-      "OpenAI.ConversationItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
       },
       "OpenAI.ConversationItemApplyPatchToolCall": {
         "type": "object",
@@ -33264,50 +33281,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ConversationItemCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ConversationItemComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -33330,9 +33310,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -33359,11 +33336,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ConversationItemComputerToolCallOutput": {
+      "OpenAI.ConversationItemComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -33379,8 +33355,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -33410,17 +33385,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
-      "OpenAI.ConversationItemCustomToolCallOutputResource": {
+      "OpenAI.ConversationItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
-          "output",
-          "status"
+          "name",
+          "input"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "custom_tool_call"
+            ],
+            "description": "The type of the custom tool call. Always `custom_tool_call`.",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the custom tool call in the OpenAI platform."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "An identifier used to map this custom tool call to a tool call output."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the custom tool being called."
+          },
+          "input": {
+            "type": "string",
+            "description": "The input for the custom tool call generated by the model."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ],
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
+      },
+      "OpenAI.ConversationItemCustomToolCallOutput": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
           "type": {
@@ -33452,18 +33466,6 @@
               }
             ],
             "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -33471,65 +33473,8 @@
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
         ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ConversationItemCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "The output of a custom tool call from your code, being sent back to the model.",
+        "title": "Custom tool call output"
       },
       "OpenAI.ConversationItemFileSearchToolCall": {
         "type": "object",
@@ -33631,7 +33576,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -33690,7 +33635,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -33725,67 +33670,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ConversationItemFunctionToolCall": {
+      "OpenAI.ConversationItemFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ConversationItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -33793,8 +33680,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -33836,9 +33722,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ConversationItem"
           }
+        ]
+      },
+      "OpenAI.ConversationItemFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ConversationItem"
+          }
+        ]
       },
       "OpenAI.ConversationItemImageGenToolCall": {
         "type": "object",
@@ -34156,7 +34089,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -34287,16 +34227,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -34369,138 +34299,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ConversationItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
-      "OpenAI.ConversationItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ConversationItem"
-          }
-        ]
-      },
       "OpenAI.ConversationItemType": {
         "anyOf": [
           {
@@ -34517,11 +34315,7 @@
               "image_generation_call",
               "computer_call",
               "computer_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
-              "compaction",
               "code_interpreter_call",
               "local_shell_call",
               "local_shell_call_output",
@@ -34710,8 +34504,7 @@
           "propertyName": "type",
           "mapping": {
             "text": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText",
-            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject",
-            "json_schema": "#/components/schemas/OpenAI.ResponseFormatJsonSchema"
+            "json_object": "#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject"
           }
         },
         "description": "An object specifying the format that the model must output.\nSetting to `{ \"type\": \"json_schema\", \"json_schema\": {...} }` enables\nStructured Outputs which ensures the model will match your supplied JSON\nschema. Learn more in the [Structured Outputs\nguide](/docs/guides/structured-outputs).\nSetting to `{ \"type\": \"json_object\" }` enables the older JSON mode, which\nensures the message the model generates is valid JSON. Using `json_schema`\nis preferred for models that support it."
@@ -35640,7 +35433,8 @@
               "grammar"
             ],
             "description": "Grammar format. Always `grammar`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "grammar"
           },
           "syntax": {
             "allOf": [
@@ -35675,7 +35469,8 @@
               "text"
             ],
             "description": "Unconstrained text format. Always `text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           }
         },
         "allOf": [
@@ -35699,7 +35494,8 @@
               "custom"
             ],
             "description": "The type of the custom tool. Always `custom`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "custom"
           },
           "name": {
             "type": "string",
@@ -35716,10 +35512,6 @@
               }
             ],
             "description": "The input format for the custom tool. Default is unconstrained text."
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this tool should be deferred and discovered via tool search."
           }
         },
         "allOf": [
@@ -35792,8 +35584,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.DoubleClickAction": {
@@ -35801,8 +35592,7 @@
         "required": [
           "type",
           "x",
-          "y",
-          "keys"
+          "y"
         ],
         "properties": {
           "type": {
@@ -35811,7 +35601,8 @@
               "double_click"
             ],
             "description": "Specifies the event type. For a double click action, this property is always set to `double_click`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "double_click"
           },
           "x": {
             "allOf": [
@@ -35828,19 +35619,6 @@
               }
             ],
             "description": "The y-coordinate where the double click occurred."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -35864,7 +35642,8 @@
               "drag"
             ],
             "description": "Specifies the event type. For a drag action, this property is always set to `drag`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "drag"
           },
           "path": {
             "type": "array",
@@ -35872,19 +35651,6 @@
               "$ref": "#/components/schemas/OpenAI.CoordParam"
             },
             "description": "An array of coordinates representing the path of the drag action. Coordinates will appear as an array of objects, eg\n  ```\n  [\n    { x: 100, y: 200 },\n    { x: 200, y: 300 }\n  ]\n  ```"
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -35924,16 +35690,6 @@
             ],
             "description": "Text, image, or audio input to the model, used to generate a response.\n  Can also contain previous assistant responses."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "type": {
             "type": "string",
             "enum": [
@@ -35959,9 +35715,6 @@
         ],
         "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role. Messages with the\n`assistant` role are presumed to have been generated by the model in previous\ninteractions.",
         "title": "Input message"
-      },
-      "OpenAI.EmptyModelParam": {
-        "type": "object"
       },
       "OpenAI.Error": {
         "type": "object",
@@ -36988,7 +36741,8 @@
               "file_citation"
             ],
             "description": "The type of the file citation. Always `file_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_citation"
           },
           "file_id": {
             "type": "string",
@@ -37014,13 +36768,6 @@
         ],
         "description": "A citation to a file.",
         "title": "File citation"
-      },
-      "OpenAI.FileInputDetail": {
-        "type": "string",
-        "enum": [
-          "low",
-          "high"
-        ]
       },
       "OpenAI.FilePath": {
         "type": "object",
@@ -37072,7 +36819,8 @@
               "file_search"
             ],
             "description": "The type of the file search tool. Always `file_search`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "file_search"
           },
           "vector_store_ids": {
             "type": "array",
@@ -37106,6 +36854,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -37979,22 +37735,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -38048,7 +37796,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -38104,22 +37852,6 @@
         ]
       },
       "OpenAI.FunctionCallItemStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
-      "OpenAI.FunctionCallStatus": {
         "type": "string",
         "enum": [
           "in_progress",
@@ -38444,7 +38176,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -38476,7 +38209,8 @@
               "exit"
             ],
             "description": "The outcome type. Always `exit`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "exit"
           },
           "exit_code": {
             "allOf": [
@@ -38563,14 +38297,6 @@
           }
         ]
       },
-      "OpenAI.FunctionShellCallOutputStatusEnum": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
-      },
       "OpenAI.FunctionShellCallOutputTimeoutOutcome": {
         "type": "object",
         "required": [
@@ -38583,7 +38309,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -38606,7 +38333,8 @@
               "timeout"
             ],
             "description": "The outcome type. Always `timeout`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "timeout"
           }
         },
         "allOf": [
@@ -38616,14 +38344,6 @@
         ],
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "title": "Shell call timeout outcome"
-      },
-      "OpenAI.FunctionShellCallStatus": {
-        "type": "string",
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ]
       },
       "OpenAI.FunctionShellToolParam": {
         "type": "object",
@@ -38637,7 +38357,8 @@
               "shell"
             ],
             "description": "The type of the shell tool. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           },
           "environment": {
             "anyOf": [
@@ -38648,6 +38369,14 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -38764,7 +38493,8 @@
               "function"
             ],
             "description": "The type of the function tool. Always `function`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "function"
           },
           "name": {
             "type": "string",
@@ -38800,10 +38530,6 @@
                 "type": "null"
               }
             ]
-          },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function is deferred and loaded via tool search."
           }
         },
         "allOf": [
@@ -38814,62 +38540,61 @@
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).",
         "title": "Function"
       },
-      "OpenAI.FunctionToolParam": {
+      "OpenAI.FunctionToolCallOutput": {
         "type": "object",
         "required": [
-          "name",
-          "type"
+          "type",
+          "call_id",
+          "output"
         ],
         "properties": {
-          "name": {
+          "id": {
             "type": "string",
-            "minLength": 1,
-            "maxLength": 128,
-            "pattern": "^[a-zA-Z0-9_-]+$"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "strict": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
             "enum": [
-              "function"
+              "function_call_output"
             ],
-            "x-stainless-const": true,
-            "default": "function"
+            "description": "The type of the function tool call output. Always `function_call_output`.",
+            "x-stainless-const": true
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this function should be deferred and discovered via tool search."
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
+                }
+              }
+            ],
+            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
           }
-        }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemField"
+          }
+        ],
+        "description": "The output of a function tool call.",
+        "title": "Function tool call output"
       },
       "OpenAI.GraderLabelModel": {
         "type": "object",
@@ -39217,8 +38942,7 @@
         "enum": [
           "low",
           "high",
-          "auto",
-          "original"
+          "auto"
         ]
       },
       "OpenAI.ImageGenActionEnum": {
@@ -39241,7 +38965,8 @@
               "image_generation"
             ],
             "description": "The type of the image generation tool. Always `image_generation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "image_generation"
           },
           "model": {
             "anyOf": [
@@ -39271,21 +38996,14 @@
             "default": "auto"
           },
           "size": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "1024x1024",
-                  "1024x1536",
-                  "1536x1024",
-                  "auto"
-                ]
-              }
+            "type": "string",
+            "enum": [
+              "1024x1024",
+              "1024x1536",
+              "1536x1024",
+              "auto"
             ],
-            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n  `1536x1024`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "output_format": {
@@ -39363,6 +39081,14 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -39405,7 +39131,7 @@
             ]
           }
         ],
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
       },
       "OpenAI.InlineSkillParam": {
         "type": "object",
@@ -39422,7 +39148,8 @@
               "inline"
             ],
             "description": "Defines an inline skill for this request.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "inline"
           },
           "name": {
             "type": "string",
@@ -39576,22 +39303,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -39645,7 +39364,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -39737,22 +39456,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "description": "A file input to the model.",
@@ -39813,14 +39524,6 @@
                 "type": "null"
               }
             ]
-          },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
           }
         },
         "description": "A file input to the model.",
@@ -39869,7 +39572,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision).",
@@ -39947,9 +39650,6 @@
             "web_search_call": "#/components/schemas/OpenAI.InputItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.InputItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.InputItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.InputItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.InputItemImageGenToolCall",
@@ -39969,56 +39669,6 @@
           }
         },
         "description": "An item representing part of the context for the response to be\ngenerated by the model. Can contain text, images, and audio inputs,\nas well as previous assistant responses and tool call outputs."
-      },
-      "OpenAI.InputItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
       },
       "OpenAI.InputItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -40331,6 +39981,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -40353,9 +40004,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -40406,10 +40054,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -40754,7 +40398,6 @@
       "OpenAI.InputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -40763,8 +40406,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -40777,10 +40419,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -41082,7 +40720,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -41205,16 +40850,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -41295,143 +40930,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.InputItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
-      "OpenAI.InputItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.InputItem"
-          }
-        ]
-      },
       "OpenAI.InputItemType": {
         "anyOf": [
           {
@@ -41448,9 +40946,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -41526,6 +41021,52 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
+      "OpenAI.InputMessage": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.Item"
+          }
+        ],
+        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
+        "title": "Input message"
+      },
       "OpenAI.InputMessageContentList": {
         "type": "array",
         "items": {
@@ -41533,6 +41074,55 @@
         },
         "description": "A list of one or many input items to the model, containing different content\ntypes.",
         "title": "Input item content list"
+      },
+      "OpenAI.InputMessageResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the message input. Always set to `message`.",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "system",
+              "developer"
+            ],
+            "description": "The role of the message input. One of `user`, `system`, or `developer`."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          },
+          "content": {
+            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the message input."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.InputParam": {
         "oneOf": [
@@ -41610,7 +41200,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessage",
             "output_message": "#/components/schemas/OpenAI.ItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemComputerToolCall",
@@ -41618,9 +41208,6 @@
             "web_search_call": "#/components/schemas/OpenAI.ItemWebSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.ItemFunctionToolCall",
             "function_call_output": "#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemToolSearchCallItemParam",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemToolSearchOutputItemParam",
-            "additional_tools": "#/components/schemas/OpenAI.ItemAdditionalToolsItemParam",
             "reasoning": "#/components/schemas/OpenAI.ItemReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemCompactionSummaryItemParam",
             "image_generation_call": "#/components/schemas/OpenAI.ItemImageGenToolCall",
@@ -41640,56 +41227,6 @@
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemAdditionalToolsItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The item type. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "developer"
-            ],
-            "description": "The role that provided the additional tools. Only `developer` is supported.",
-            "x-stainless-const": true,
-            "default": "developer"
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "A list of additional tools made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
       },
       "OpenAI.ItemApplyPatchToolCallItemParam": {
         "type": "object",
@@ -42002,6 +41539,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -42024,9 +41562,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -42077,10 +41612,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -42159,17 +41690,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "function_call_output": "#/components/schemas/OpenAI.FunctionToolCallOutput",
             "message": "#/components/schemas/OpenAI.ItemFieldMessage",
             "function_call": "#/components/schemas/OpenAI.ItemFieldFunctionToolCall",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemFieldToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemFieldToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemFieldAdditionalTools",
-            "function_call_output": "#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput",
             "file_search_call": "#/components/schemas/OpenAI.ItemFieldFileSearchToolCall",
             "web_search_call": "#/components/schemas/OpenAI.ItemFieldWebSearchToolCall",
             "image_generation_call": "#/components/schemas/OpenAI.ItemFieldImageGenToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemFieldComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource",
             "reasoning": "#/components/schemas/OpenAI.ItemFieldReasoningItem",
             "compaction": "#/components/schemas/OpenAI.ItemFieldCompactionBody",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall",
@@ -42188,50 +41716,6 @@
           }
         },
         "description": "An item representing a message, tool call, tool output, reasoning, or other response element."
-      },
-      "OpenAI.ItemFieldAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
       },
       "OpenAI.ItemFieldApplyPatchToolCall": {
         "type": "object",
@@ -42469,6 +41953,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -42491,9 +41976,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -42520,11 +42002,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemFieldComputerToolCallOutput": {
+      "OpenAI.ItemFieldComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -42540,8 +42021,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -42571,9 +42051,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemField"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
+        ]
       },
       "OpenAI.ItemFieldCustomToolCall": {
         "type": "object",
@@ -42599,10 +42077,6 @@
           "call_id": {
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
           },
           "name": {
             "type": "string",
@@ -42768,7 +42242,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -42827,7 +42301,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -42865,7 +42339,6 @@
       "OpenAI.ItemFieldFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -42874,8 +42347,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -42888,10 +42360,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -42918,64 +42386,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.ItemFieldFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.ItemFieldImageGenToolCall": {
         "type": "object",
@@ -43246,7 +42656,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -43377,16 +42794,6 @@
               "$ref": "#/components/schemas/OpenAI.MessageContent"
             },
             "description": "The content of the message"
-          },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -43459,138 +42866,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.ItemFieldToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
-      "OpenAI.ItemFieldToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemField"
-          }
-        ]
-      },
       "OpenAI.ItemFieldType": {
         "anyOf": [
           {
@@ -43601,9 +42876,6 @@
             "enum": [
               "message",
               "function_call",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "function_call_output",
               "file_search_call",
               "web_search_call",
@@ -43962,7 +43234,6 @@
       "OpenAI.ItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -43971,8 +43242,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -43985,10 +43255,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -44065,59 +43331,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemLocalShellToolCall": {
         "type": "object",
@@ -44343,7 +43556,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -44466,16 +43686,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -44569,7 +43779,8 @@
               "item_reference"
             ],
             "description": "The type of item to reference. Always `item_reference`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "item_reference"
           },
           "id": {
             "type": "string",
@@ -44597,19 +43808,14 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.ItemResourceInputMessage",
+            "message": "#/components/schemas/OpenAI.InputMessageResource",
             "output_message": "#/components/schemas/OpenAI.ItemResourceOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.ItemResourceFileSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.ItemResourceComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput",
+            "computer_call_output": "#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource",
             "web_search_call": "#/components/schemas/OpenAI.ItemResourceWebSearchToolCall",
-            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput",
-            "tool_search_call": "#/components/schemas/OpenAI.ItemResourceToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.ItemResourceToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.ItemResourceAdditionalTools",
-            "reasoning": "#/components/schemas/OpenAI.ItemResourceReasoningItem",
-            "compaction": "#/components/schemas/OpenAI.ItemResourceCompactionBody",
+            "function_call": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource",
+            "function_call_output": "#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource",
             "image_generation_call": "#/components/schemas/OpenAI.ItemResourceImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.ItemResourceLocalShellToolCall",
@@ -44621,56 +43827,10 @@
             "mcp_list_tools": "#/components/schemas/OpenAI.ItemResourceMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest",
             "mcp_approval_response": "#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource",
-            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall",
-            "custom_tool_call": "#/components/schemas/OpenAI.ItemResourceCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource"
+            "mcp_call": "#/components/schemas/OpenAI.ItemResourceMcpToolCall"
           }
         },
         "description": "Content item used to generate a response."
-      },
-      "OpenAI.ItemResourceAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
       },
       "OpenAI.ItemResourceApplyPatchToolCall": {
         "type": "object",
@@ -44864,50 +44024,13 @@
         "description": "A tool call to run code.",
         "title": "Code interpreter tool call"
       },
-      "OpenAI.ItemResourceCompactionBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "encrypted_content"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "compaction"
-            ],
-            "description": "The type of the item. Always `compaction`.",
-            "x-stainless-const": true,
-            "default": "compaction"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the compaction item."
-          },
-          "encrypted_content": {
-            "type": "string",
-            "description": "The encrypted content that was produced by compaction."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
-        "title": "Compaction item"
-      },
       "OpenAI.ItemResourceComputerToolCall": {
         "type": "object",
         "required": [
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -44930,9 +44053,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -44959,11 +44079,10 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.ItemResourceComputerToolCallOutput": {
+      "OpenAI.ItemResourceComputerToolCallOutputResource": {
         "type": "object",
         "required": [
           "type",
-          "id",
           "call_id",
           "output"
         ],
@@ -44979,8 +44098,7 @@
           },
           "id": {
             "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
+            "description": "The ID of the computer tool call output."
           },
           "call_id": {
             "type": "string",
@@ -45010,126 +44128,7 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.ItemResourceCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.ItemResourceCustomToolCallResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "name",
-          "input",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call"
-            ],
-            "description": "The type of the custom tool call. Always `custom_tool_call`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "An identifier used to map this custom tool call to a tool call output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the custom tool being called."
-          },
-          "input": {
-            "type": "string",
-            "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "title": "ResponseCustomToolCallItem"
+        ]
       },
       "OpenAI.ItemResourceFileSearchToolCall": {
         "type": "object",
@@ -45231,7 +44230,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -45290,7 +44289,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -45325,67 +44324,9 @@
         "description": "The output of a shell tool call that was emitted.",
         "title": "Shell call output"
       },
-      "OpenAI.ItemResourceFunctionToolCall": {
+      "OpenAI.ItemResourceFunctionToolCallOutputResource": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "call_id",
-          "name",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call"
-            ],
-            "description": "The type of the function tool call. Always `function_call`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the function to run."
-          },
-          "arguments": {
-            "type": "string",
-            "description": "A JSON string of the arguments to pass to the function."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
-        "title": "Function tool call"
-      },
-      "OpenAI.ItemResourceFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
           "type",
           "call_id",
           "output"
@@ -45393,8 +44334,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API."
           },
           "type": {
             "type": "string",
@@ -45436,9 +44376,56 @@
           {
             "$ref": "#/components/schemas/OpenAI.ItemResource"
           }
+        ]
+      },
+      "OpenAI.ItemResourceFunctionToolCallResource": {
+        "type": "object",
+        "required": [
+          "type",
+          "call_id",
+          "name",
+          "arguments"
         ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "function_call"
+            ],
+            "description": "The type of the function tool call. Always `function_call`.",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the function to run."
+          },
+          "arguments": {
+            "type": "string",
+            "description": "A JSON string of the arguments to pass to the function."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "in_progress",
+              "completed",
+              "incomplete"
+            ],
+            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ItemResource"
+          }
+        ]
       },
       "OpenAI.ItemResourceImageGenToolCall": {
         "type": "object",
@@ -45489,59 +44476,6 @@
         ],
         "description": "An image generation request made by the model.",
         "title": "Image generation call"
-      },
-      "OpenAI.ItemResourceInputMessage": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content",
-          "id"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the message input. Always set to `message`.",
-            "x-stainless-const": true,
-            "default": "message"
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user",
-              "system",
-              "developer"
-            ],
-            "description": "The role of the message input. One of `user`, `system`, or `developer`."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "content": {
-            "$ref": "#/components/schemas/OpenAI.InputMessageContentList"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the message input.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A message input to the model with a role indicating instruction following\nhierarchy. Instructions given with the `developer` or `system` role take\nprecedence over instructions given with the `user` role.",
-        "title": "Input message"
       },
       "OpenAI.ItemResourceLocalShellToolCall": {
         "type": "object",
@@ -45762,7 +44696,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -45885,16 +44826,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -45913,200 +44844,6 @@
         "description": "An output message from the model.",
         "title": "Output message"
       },
-      "OpenAI.ItemResourceReasoningItem": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "summary"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "reasoning"
-            ],
-            "description": "The type of the object. Always `reasoning`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the reasoning content."
-          },
-          "encrypted_content": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "summary": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SummaryTextContent"
-            },
-            "description": "Reasoning summary content."
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ReasoningTextContent"
-            },
-            "description": "Reasoning text content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ],
-        "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
-        "title": "Reasoning"
-      },
-      "OpenAI.ItemResourceToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
-      "OpenAI.ItemResourceToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ItemResource"
-          }
-        ]
-      },
       "OpenAI.ItemResourceType": {
         "anyOf": [
           {
@@ -46123,11 +44860,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
-              "reasoning",
-              "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
@@ -46140,8 +44872,6 @@
               "mcp_approval_request",
               "mcp_approval_response",
               "mcp_call",
-              "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -46224,143 +44954,6 @@
         "description": "The results of a web search tool call. See the\n[web search guide](/docs/guides/tools-web-search) for more information.",
         "title": "Web search tool call"
       },
-      "OpenAI.ItemToolSearchCallItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "arguments"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The item type. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              }
-            ],
-            "description": "The arguments supplied to the tool search call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
-      "OpenAI.ItemToolSearchOutputItemParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "tools"
-        ],
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The item type. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by the tool search output."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallItemStatus"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Item"
-          }
-        ]
-      },
       "OpenAI.ItemType": {
         "anyOf": [
           {
@@ -46377,9 +44970,6 @@
               "web_search_call",
               "function_call",
               "function_call_output",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "reasoning",
               "compaction",
               "image_generation_call",
@@ -46491,7 +45081,8 @@
               "keypress"
             ],
             "description": "Specifies the event type. For a keypress action, this property is always set to `keypress`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "keypress"
           },
           "keys": {
             "type": "array",
@@ -46623,7 +45214,8 @@
               "local"
             ],
             "description": "The environment type. Always `local`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local"
           }
         },
         "allOf": [
@@ -46633,6 +45225,22 @@
         ],
         "description": "Represents the use of a local environment to perform shell actions.",
         "title": "Local Environment"
+      },
+      "OpenAI.LocalShellCallOutputStatusEnum": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
+      },
+      "OpenAI.LocalShellCallStatus": {
+        "type": "string",
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "OpenAI.LocalShellExecAction": {
         "type": "object",
@@ -46712,7 +45320,16 @@
               "local_shell"
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "local_shell"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -46918,10 +45535,6 @@
             ],
             "default": "always"
           },
-          "defer_loading": {
-            "type": "boolean",
-            "description": "Whether this MCP tool is deferred and discovered via tool search."
-          },
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
@@ -46995,8 +45608,7 @@
             "reasoning_text": "#/components/schemas/OpenAI.MessageContentReasoningTextContent",
             "refusal": "#/components/schemas/OpenAI.MessageContentRefusalContent",
             "input_image": "#/components/schemas/OpenAI.MessageContentInputImageContent",
-            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent",
-            "summary_text": "#/components/schemas/OpenAI.SummaryTextContent"
+            "input_file": "#/components/schemas/OpenAI.MessageContentInputFileContent"
           }
         },
         "description": "A content part that makes up an input or output item."
@@ -47030,22 +45642,14 @@
             "type": "string",
             "description": "The name of the file to be sent to the model."
           },
-          "file_data": {
-            "type": "string",
-            "description": "The content of the file to be sent to the model."
-          },
           "file_url": {
             "type": "string",
             "format": "uri",
             "description": "The URL of the file to be sent to the model."
           },
-          "detail": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FileInputDetail"
-              }
-            ],
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          "file_data": {
+            "type": "string",
+            "description": "The content of the file to be sent to the model."
           }
         },
         "allOf": [
@@ -47099,7 +45703,7 @@
                 "$ref": "#/components/schemas/OpenAI.ImageDetail"
               }
             ],
-            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+            "description": "The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`."
           }
         },
         "allOf": [
@@ -47262,14 +45866,6 @@
           }
         ]
       },
-      "OpenAI.MessagePhase": {
-        "type": "string",
-        "enum": [
-          "commentary",
-          "final_answer"
-        ],
-        "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).\nFor models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend\nphase on all assistant messages — dropping it can degrade performance. Not used for user messages."
-      },
       "OpenAI.MessageRole": {
         "type": "string",
         "enum": [
@@ -47349,182 +45945,6 @@
           }
         ]
       },
-      "OpenAI.Moderation": {
-        "type": "object",
-        "required": [
-          "input",
-          "output"
-        ],
-        "properties": {
-          "input": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response input."
-          },
-          "output": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-              }
-            ],
-            "description": "Moderation for the response output."
-          }
-        },
-        "description": "Moderation results or errors for the response input and output.",
-        "title": "Moderation"
-      },
-      "OpenAI.ModerationEntry": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntryType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "moderation_result": "#/components/schemas/OpenAI.ModerationResultBody",
-            "error": "#/components/schemas/OpenAI.ModerationErrorBody"
-          }
-        },
-        "description": "Moderation results or an error for a response moderation check."
-      },
-      "OpenAI.ModerationEntryType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "moderation_result",
-              "error"
-            ]
-          }
-        ]
-      },
-      "OpenAI.ModerationErrorBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "error"
-            ],
-            "description": "The object type, which was always `error` for moderation failures.",
-            "x-stainless-const": true
-          },
-          "code": {
-            "type": "string",
-            "description": "The error code."
-          },
-          "message": {
-            "type": "string",
-            "description": "The error message."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "An error produced while attempting moderation for the response input or output.",
-        "title": "Moderation error"
-      },
-      "OpenAI.ModerationInputType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
-      },
-      "OpenAI.ModerationParam": {
-        "type": "object",
-        "required": [
-          "model"
-        ],
-        "properties": {
-          "model": {
-            "type": "string",
-            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
-          }
-        },
-        "description": "Configuration for running moderation on the input and output of this response."
-      },
-      "OpenAI.ModerationResultBody": {
-        "type": "object",
-        "required": [
-          "type",
-          "model",
-          "flagged",
-          "categories",
-          "category_scores",
-          "category_applied_input_types"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "moderation_result"
-            ],
-            "description": "The object type, which was always `moderation_result` for successful moderation results.",
-            "x-stainless-const": true
-          },
-          "model": {
-            "type": "string",
-            "description": "The moderation model that produced this result."
-          },
-          "flagged": {
-            "type": "boolean",
-            "description": "A boolean indicating whether the content was flagged by any category."
-          },
-          "categories": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "boolean"
-            },
-            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_scores": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "$ref": "#/components/schemas/OpenAI.numeric"
-            },
-            "description": "A dictionary of moderation categories to scores.",
-            "x-oaiTypeLabel": "map"
-          },
-          "category_applied_input_types": {
-            "type": "object",
-            "unevaluatedProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OpenAI.ModerationInputType"
-              }
-            },
-            "description": "Which modalities of input are reflected by the score for each category.",
-            "x-oaiTypeLabel": "map"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ModerationEntry"
-          }
-        ],
-        "description": "A moderation result produced for the response input or output.",
-        "title": "Moderation result"
-      },
       "OpenAI.MoveParam": {
         "type": "object",
         "required": [
@@ -47539,7 +45959,8 @@
               "move"
             ],
             "description": "Specifies the event type. For a move action, this property is always set to `move`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "move"
           },
           "x": {
             "allOf": [
@@ -47556,19 +45977,6 @@
               }
             ],
             "description": "The y-coordinate to move to."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -47578,57 +45986,6 @@
         ],
         "description": "A mouse move action.",
         "title": "Move"
-      },
-      "OpenAI.NamespaceToolParam": {
-        "type": "object",
-        "required": [
-          "type",
-          "name",
-          "description",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "namespace"
-            ],
-            "description": "The type of the tool. Always `namespace`.",
-            "x-stainless-const": true
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1,
-            "description": "The namespace name used in tool calls (for example, `crm`)."
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "description": "A description of the namespace shown to the model."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OpenAI.FunctionToolParam"
-                },
-                {
-                  "$ref": "#/components/schemas/OpenAI.CustomToolParam"
-                }
-              ]
-            },
-            "minItems": 1,
-            "description": "The function/custom tools available inside this namespace."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Groups function/custom tools under a shared namespace.",
-        "title": "Namespace"
       },
       "OpenAI.OutputContent": {
         "type": "object",
@@ -47829,19 +46186,13 @@
             "output_message": "#/components/schemas/OpenAI.OutputItemOutputMessage",
             "file_search_call": "#/components/schemas/OpenAI.OutputItemFileSearchToolCall",
             "function_call": "#/components/schemas/OpenAI.OutputItemFunctionToolCall",
-            "function_call_output": "#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput",
             "web_search_call": "#/components/schemas/OpenAI.OutputItemWebSearchToolCall",
             "computer_call": "#/components/schemas/OpenAI.OutputItemComputerToolCall",
-            "computer_call_output": "#/components/schemas/OpenAI.OutputItemComputerToolCallOutput",
             "reasoning": "#/components/schemas/OpenAI.OutputItemReasoningItem",
-            "tool_search_call": "#/components/schemas/OpenAI.OutputItemToolSearchCall",
-            "tool_search_output": "#/components/schemas/OpenAI.OutputItemToolSearchOutput",
-            "additional_tools": "#/components/schemas/OpenAI.OutputItemAdditionalTools",
             "compaction": "#/components/schemas/OpenAI.OutputItemCompactionBody",
             "image_generation_call": "#/components/schemas/OpenAI.OutputItemImageGenToolCall",
             "code_interpreter_call": "#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall",
             "local_shell_call": "#/components/schemas/OpenAI.OutputItemLocalShellToolCall",
-            "local_shell_call_output": "#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput",
             "shell_call": "#/components/schemas/OpenAI.OutputItemFunctionShellCall",
             "shell_call_output": "#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput",
             "apply_patch_call": "#/components/schemas/OpenAI.OutputItemApplyPatchToolCall",
@@ -47849,55 +46200,9 @@
             "mcp_call": "#/components/schemas/OpenAI.OutputItemMcpToolCall",
             "mcp_list_tools": "#/components/schemas/OpenAI.OutputItemMcpListTools",
             "mcp_approval_request": "#/components/schemas/OpenAI.OutputItemMcpApprovalRequest",
-            "mcp_approval_response": "#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource",
-            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCallResource",
-            "custom_tool_call_output": "#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource"
+            "custom_tool_call": "#/components/schemas/OpenAI.OutputItemCustomToolCall"
           }
         }
-      },
-      "OpenAI.OutputItemAdditionalTools": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "role",
-          "tools"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "additional_tools"
-            ],
-            "description": "The type of the item. Always `additional_tools`.",
-            "x-stainless-const": true,
-            "default": "additional_tools"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the additional tools item."
-          },
-          "role": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessageRole"
-              }
-            ],
-            "description": "The role that provided the additional tools."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The additional tool definitions made available at this item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
       },
       "OpenAI.OutputItemApplyPatchToolCall": {
         "type": "object",
@@ -48135,6 +46440,7 @@
           "type",
           "id",
           "call_id",
+          "action",
           "pending_safety_checks",
           "status"
         ],
@@ -48157,9 +46463,6 @@
           },
           "action": {
             "$ref": "#/components/schemas/OpenAI.ComputerAction"
-          },
-          "actions": {
-            "$ref": "#/components/schemas/OpenAI.ComputerActionList"
           },
           "pending_safety_checks": {
             "type": "array",
@@ -48186,128 +46489,13 @@
         "description": "A tool call to a computer use tool. See the\n[computer use guide](/docs/guides/tools-computer-use) for more information.",
         "title": "Computer tool call"
       },
-      "OpenAI.OutputItemComputerToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_call_output"
-            ],
-            "description": "The type of the computer tool call output. Always `computer_call_output`.",
-            "x-stainless-const": true,
-            "default": "computer_call_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The ID of the computer tool call output.",
-            "readOnly": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The ID of the computer tool call that produced the output."
-          },
-          "acknowledged_safety_checks": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.ComputerCallSafetyCheckParam"
-            },
-            "description": "The safety checks reported by the API that have been acknowledged by the\n  developer."
-          },
-          "output": {
-            "$ref": "#/components/schemas/OpenAI.ComputerScreenshotImage"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the message input. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when input items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a computer tool call.",
-        "title": "Computer tool call output"
-      },
-      "OpenAI.OutputItemCustomToolCallOutputResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "call_id",
-          "output",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "custom_tool_call_output"
-            ],
-            "description": "The type of the custom tool call output. Always `custom_tool_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the custom tool call output in the OpenAI platform."
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The call ID, used to map this custom tool call output to a custom tool call."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the custom tool call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "title": "ResponseCustomToolCallOutputItem"
-      },
-      "OpenAI.OutputItemCustomToolCallResource": {
+      "OpenAI.OutputItemCustomToolCall": {
         "type": "object",
         "required": [
           "type",
           "call_id",
           "name",
-          "input",
-          "status"
+          "input"
         ],
         "properties": {
           "type": {
@@ -48326,10 +46514,6 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output."
           },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the custom tool being called."
-          },
           "name": {
             "type": "string",
             "description": "The name of the custom tool being called."
@@ -48337,18 +46521,6 @@
           "input": {
             "type": "string",
             "description": "The input for the custom tool call generated by the model."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
           }
         },
         "allOf": [
@@ -48356,7 +46528,8 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "title": "ResponseCustomToolCallItem"
+        "description": "A call to a custom tool created by the model.",
+        "title": "Custom tool call"
       },
       "OpenAI.OutputItemFileSearchToolCall": {
         "type": "object",
@@ -48458,7 +46631,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallStatus"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallStatus"
               }
             ],
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
@@ -48517,7 +46690,7 @@
           "status": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum"
+                "$ref": "#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum"
               }
             ],
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -48555,7 +46728,6 @@
       "OpenAI.OutputItemFunctionToolCall": {
         "type": "object",
         "required": [
-          "id",
           "type",
           "call_id",
           "name",
@@ -48564,8 +46736,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The unique ID of the function tool call.",
-            "readOnly": true
+            "description": "The unique ID of the function tool call."
           },
           "type": {
             "type": "string",
@@ -48578,10 +46749,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the function to run."
           },
           "name": {
             "type": "string",
@@ -48608,64 +46775,6 @@
         ],
         "description": "A tool call to run a function. See the\n[function calling guide](/docs/guides/function-calling) for more information.",
         "title": "Function tool call"
-      },
-      "OpenAI.OutputItemFunctionToolCallOutput": {
-        "type": "object",
-        "required": [
-          "id",
-          "type",
-          "call_id",
-          "output"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call output. Populated when this item\n  is returned via API.",
-            "readOnly": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "function_call_output"
-            ],
-            "description": "The type of the function tool call output. Always `function_call_output`.",
-            "x-stainless-const": true
-          },
-          "call_id": {
-            "type": "string",
-            "description": "The unique ID of the function tool call generated by the model."
-          },
-          "output": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput"
-                }
-              }
-            ],
-            "description": "The output from the function call generated by your code.\n  Can be a string or an list of output content."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "in_progress",
-              "completed",
-              "incomplete"
-            ],
-            "description": "The status of the item. One of `in_progress`, `completed`, or\n  `incomplete`. Populated when items are returned via API."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a function tool call.",
-        "title": "Function tool call output"
       },
       "OpenAI.OutputItemImageGenToolCall": {
         "type": "object",
@@ -48764,54 +46873,6 @@
         "description": "A tool call to run a command on the local shell.",
         "title": "Local shell call"
       },
-      "OpenAI.OutputItemLocalShellToolCallOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "local_shell_call_output"
-            ],
-            "description": "The type of the local shell tool call output. Always `local_shell_call_output`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the local shell tool call generated by the model."
-          },
-          "output": {
-            "type": "string",
-            "description": "A JSON string of the output of the local shell tool call."
-          },
-          "status": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "in_progress",
-                  "completed",
-                  "incomplete"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "The output of a local shell tool call.",
-        "title": "Local shell call output"
-      },
       "OpenAI.OutputItemMcpApprovalRequest": {
         "type": "object",
         "required": [
@@ -48855,54 +46916,6 @@
         "description": "A request for human approval of a tool invocation.",
         "title": "MCP approval request"
       },
-      "OpenAI.OutputItemMcpApprovalResponseResource": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "approval_request_id",
-          "approve"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "mcp_approval_response"
-            ],
-            "description": "The type of the item. Always `mcp_approval_response`.",
-            "x-stainless-const": true
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the approval response"
-          },
-          "approval_request_id": {
-            "type": "string",
-            "description": "The ID of the approval request being answered."
-          },
-          "approve": {
-            "type": "boolean",
-            "description": "Whether the request was approved."
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ],
-        "description": "A response to an MCP approval request.",
-        "title": "MCP approval response"
-      },
       "OpenAI.OutputItemMcpListTools": {
         "type": "object",
         "required": [
@@ -48936,7 +46949,14 @@
             "description": "The tools available on the server."
           },
           "error": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "allOf": [
@@ -49059,16 +47079,6 @@
             },
             "description": "The content of the output message."
           },
-          "phase": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.MessagePhase"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "status": {
             "type": "string",
             "enum": [
@@ -49149,138 +47159,6 @@
         "description": "A description of the chain of thought used by a reasoning model while generating\na response. Be sure to include these items in your `input` to the Responses API\nfor subsequent turns of a conversation if you are manually\n[managing context](/docs/guides/conversation-state).",
         "title": "Reasoning"
       },
-      "OpenAI.OutputItemToolSearchCall": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "arguments",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_call"
-            ],
-            "description": "The type of the item. Always `tool_search_call`.",
-            "x-stainless-const": true,
-            "default": "tool_search_call"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search call item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "arguments": {
-            "description": "Arguments used for the tool search call."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallStatus"
-              }
-            ],
-            "description": "The status of the tool search call item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
-      "OpenAI.OutputItemToolSearchOutput": {
-        "type": "object",
-        "required": [
-          "type",
-          "id",
-          "call_id",
-          "execution",
-          "tools",
-          "status"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search_output"
-            ],
-            "description": "The type of the item. Always `tool_search_output`.",
-            "x-stainless-const": true,
-            "default": "tool_search_output"
-          },
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the tool search output item."
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search was executed by the server or by the client."
-          },
-          "tools": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.Tool"
-            },
-            "description": "The loaded tool definitions returned by tool search."
-          },
-          "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.FunctionCallOutputStatusEnum"
-              }
-            ],
-            "description": "The status of the tool search output item that was recorded."
-          },
-          "created_by": {
-            "type": "string",
-            "description": "The identifier of the actor that created the item."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.OutputItem"
-          }
-        ]
-      },
       "OpenAI.OutputItemType": {
         "anyOf": [
           {
@@ -49292,19 +47170,13 @@
               "output_message",
               "file_search_call",
               "function_call",
-              "function_call_output",
               "web_search_call",
               "computer_call",
-              "computer_call_output",
               "reasoning",
-              "tool_search_call",
-              "tool_search_output",
-              "additional_tools",
               "compaction",
               "image_generation_call",
               "code_interpreter_call",
               "local_shell_call",
-              "local_shell_call_output",
               "shell_call",
               "shell_call_output",
               "apply_patch_call",
@@ -49312,9 +47184,7 @@
               "mcp_call",
               "mcp_list_tools",
               "mcp_approval_request",
-              "mcp_approval_response",
               "custom_tool_call",
-              "custom_tool_call_output",
               "structured_outputs",
               "oauth_consent_request",
               "memory_search_call",
@@ -49535,13 +47405,6 @@
         },
         "description": "Reference to a prompt template and its variables.\n[Learn more](/docs/guides/text?api-mode=responses#reusable-prompts)."
       },
-      "OpenAI.PromptCacheRetentionEnum": {
-        "type": "string",
-        "enum": [
-          "in_memory",
-          "24h"
-        ]
-      },
       "OpenAI.RankerVersionType": {
         "type": "string",
         "enum": [
@@ -49577,123 +47440,6 @@
             "description": "Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled."
           }
         }
-      },
-      "OpenAI.RealtimeMCPError": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMcpErrorType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "protocol_error": "#/components/schemas/OpenAI.RealtimeMCPProtocolError",
-            "tool_execution_error": "#/components/schemas/OpenAI.RealtimeMCPToolExecutionError",
-            "http_error": "#/components/schemas/OpenAI.RealtimeMCPHTTPError"
-          }
-        }
-      },
-      "OpenAI.RealtimeMCPHTTPError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "http_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP HTTP error"
-      },
-      "OpenAI.RealtimeMCPProtocolError": {
-        "type": "object",
-        "required": [
-          "type",
-          "code",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "protocol_error"
-            ],
-            "x-stainless-const": true
-          },
-          "code": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP protocol error"
-      },
-      "OpenAI.RealtimeMCPToolExecutionError": {
-        "type": "object",
-        "required": [
-          "type",
-          "message"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_execution_error"
-            ],
-            "x-stainless-const": true
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeMCPError"
-          }
-        ],
-        "title": "Realtime MCP tool execution error"
-      },
-      "OpenAI.RealtimeMcpErrorType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "protocol_error",
-              "tool_execution_error",
-              "http_error"
-            ]
-          }
-        ]
       },
       "OpenAI.Reasoning": {
         "type": "object",
@@ -49841,8 +47587,7 @@
           },
           "safety_identifier": {
             "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
             "type": "string",
@@ -49856,7 +47601,7 @@
               {
                 "type": "string",
                 "enum": [
-                  "in_memory",
+                  "in-memory",
                   "24h"
                 ]
               },
@@ -49893,6 +47638,16 @@
             "anyOf": [
               {
                 "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_output_tokens": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -50041,16 +47796,6 @@
           "usage": {
             "$ref": "#/components/schemas/OpenAI.ResponseUsage"
           },
-          "moderation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Moderation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "parallel_tool_calls": {
             "type": "boolean",
             "description": "Whether to allow the model to run tool calls in parallel.",
@@ -50060,16 +47805,6 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/OpenAI.ConversationReference"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.integer"
               },
               {
                 "type": "null"
@@ -50139,11 +47874,6 @@
             "description": "A chunk of Base64 encoded response audio bytes."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial audio response.",
         "x-oaiMeta": {
           "name": "response.audio.delta",
@@ -50175,11 +47905,6 @@
             "description": "The sequence number of the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the audio response is complete.",
         "x-oaiMeta": {
           "name": "response.audio.done",
@@ -50216,11 +47941,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial transcript of audio.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.delta",
@@ -50252,11 +47972,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the full audio transcript is completed.",
         "x-oaiMeta": {
           "name": "response.audio.transcript.done",
@@ -50307,11 +48022,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial code snippet is streamed by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.delta",
@@ -50362,11 +48072,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code snippet is finalized by the code interpreter.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call_code.done",
@@ -50412,11 +48117,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter call is completed.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.completed",
@@ -50462,11 +48162,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a code interpreter call is in progress.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.in_progress",
@@ -50512,11 +48207,6 @@
             "description": "The sequence number of this event, used to order streaming events."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the code interpreter is actively interpreting the code snippet.",
         "x-oaiMeta": {
           "name": "response.code_interpreter_call.interpreting",
@@ -50557,11 +48247,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the model response is complete.",
         "x-oaiMeta": {
           "name": "response.completed",
@@ -50625,11 +48310,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new content part is added.",
         "x-oaiMeta": {
           "name": "response.content_part.added",
@@ -50693,11 +48373,6 @@
             "description": "The content part that is done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a content part is done.",
         "x-oaiMeta": {
           "name": "response.content_part.done",
@@ -50738,11 +48413,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response is created.",
         "x-oaiMeta": {
           "name": "response.created",
@@ -50793,11 +48463,6 @@
             "description": "The incremental input data (delta) for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event representing a delta (partial update) to the input of a custom tool call.",
         "title": "ResponseCustomToolCallInputDelta",
         "x-oaiMeta": {
@@ -50849,11 +48514,6 @@
             "description": "The complete input data for the custom tool call."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Event indicating that input for a custom tool call is complete.",
         "title": "ResponseCustomToolCallInputDone",
         "x-oaiMeta": {
@@ -50954,11 +48614,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an error occurs.",
         "x-oaiMeta": {
           "name": "error",
@@ -50999,11 +48654,6 @@
             "description": "The response that failed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response fails.",
         "x-oaiMeta": {
           "name": "response.failed",
@@ -51049,11 +48699,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is completed (results found).",
         "x-oaiMeta": {
           "name": "response.file_search_call.completed",
@@ -51099,11 +48744,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search call is initiated.",
         "x-oaiMeta": {
           "name": "response.file_search_call.in_progress",
@@ -51149,11 +48789,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a file search is currently searching.",
         "x-oaiMeta": {
           "name": "response.file_search_call.searching",
@@ -51306,11 +48941,6 @@
             "description": "The function-call arguments delta that is added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial function-call arguments delta.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.delta",
@@ -51365,11 +48995,6 @@
             "description": "The function-call arguments."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when function-call arguments are finalized.",
         "x-oaiMeta": {
           "name": "response.function_call_arguments.done",
@@ -51415,11 +49040,6 @@
             "description": "The unique identifier of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call has completed and the final image is available.",
         "title": "ResponseImageGenCallCompletedEvent",
         "x-oaiMeta": {
@@ -51466,11 +49086,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is actively generating an image (intermediate state).",
         "title": "ResponseImageGenCallGeneratingEvent",
         "x-oaiMeta": {
@@ -51517,11 +49132,6 @@
             "description": "The sequence number of the image generation item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an image generation tool call is in progress.",
         "title": "ResponseImageGenCallInProgressEvent",
         "x-oaiMeta": {
@@ -51582,11 +49192,6 @@
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a partial image is available during image generation streaming.",
         "title": "ResponseImageGenCallPartialImageEvent",
         "x-oaiMeta": {
@@ -51628,11 +49233,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the response is in progress.",
         "x-oaiMeta": {
           "name": "response.in_progress",
@@ -51685,11 +49285,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "An event that is emitted when a response finishes as incomplete.",
         "x-oaiMeta": {
           "name": "response.incomplete",
@@ -51721,7 +49316,7 @@
             "items": {
               "$ref": "#/components/schemas/OpenAI.ResponseLogProbTopLogprobs"
             },
-            "description": "The log probabilities of up to 20 of the most likely tokens."
+            "description": "The log probability of the top 20 most likely tokens."
           }
         },
         "description": "A logprob is the logarithmic probability that the model assigns to producing\na particular token at a given position in the sequence. Less-negative (higher)\nlogprob values indicate greater model confidence in that token choice."
@@ -51780,11 +49375,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a delta (partial update) to the arguments of an MCP tool call.",
         "title": "ResponseMCPCallArgumentsDeltaEvent",
         "x-oaiMeta": {
@@ -51836,11 +49426,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the arguments for an MCP tool call are finalized.",
         "title": "ResponseMCPCallArgumentsDoneEvent",
         "x-oaiMeta": {
@@ -51887,11 +49472,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has completed successfully.",
         "title": "ResponseMCPCallCompletedEvent",
         "x-oaiMeta": {
@@ -51938,11 +49518,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call has failed.",
         "title": "ResponseMCPCallFailedEvent",
         "x-oaiMeta": {
@@ -51989,11 +49564,6 @@
             "description": "The unique identifier of the MCP tool call item being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an MCP  tool call is in progress.",
         "title": "ResponseMCPCallInProgressEvent",
         "x-oaiMeta": {
@@ -52040,11 +49610,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the list of available MCP tools has been successfully retrieved.",
         "title": "ResponseMCPListToolsCompletedEvent",
         "x-oaiMeta": {
@@ -52091,11 +49656,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the attempt to list available MCP tools has failed.",
         "title": "ResponseMCPListToolsFailedEvent",
         "x-oaiMeta": {
@@ -52142,11 +49702,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when the system is in the process of retrieving the list of available MCP tools.",
         "title": "ResponseMCPListToolsInProgressEvent",
         "x-oaiMeta": {
@@ -52197,11 +49752,6 @@
             "description": "The output item that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new output item is added.",
         "x-oaiMeta": {
           "name": "response.output_item.added",
@@ -52251,11 +49801,6 @@
             "description": "The output item that was marked done."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an output item is marked done.",
         "x-oaiMeta": {
           "name": "response.output_item.done",
@@ -52328,11 +49873,6 @@
             "description": "The annotation object being added. (See annotation schema for details.)"
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when an annotation is added to output text content.",
         "title": "ResponseOutputTextAnnotationAddedEvent",
         "x-oaiMeta": {
@@ -52397,11 +49937,6 @@
             "description": "The sequence number for this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a response is queued and waiting to be processed.",
         "title": "ResponseQueuedEvent",
         "x-oaiMeta": {
@@ -52466,11 +50001,6 @@
             "description": "The summary part that was added."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a new reasoning summary part is added.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.added",
@@ -52553,11 +50083,6 @@
             "description": "The completed summary part."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary part is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_part.done",
@@ -52636,11 +50161,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning summary text.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.delta",
@@ -52700,11 +50220,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning summary text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_summary_text.done",
@@ -52764,11 +50279,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a delta is added to a reasoning text.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.delta",
@@ -52828,11 +50338,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a reasoning text is completed.",
         "x-oaiMeta": {
           "name": "response.reasoning_text.done",
@@ -52892,11 +50397,6 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is a partial refusal text.",
         "x-oaiMeta": {
           "name": "response.refusal.delta",
@@ -52956,151 +50456,12 @@
             "description": "The sequence number of this event."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when refusal text is finalized.",
         "x-oaiMeta": {
           "name": "response.refusal.done",
           "group": "responses",
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
-      },
-      "OpenAI.ResponseStreamEvent": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEventType"
-          }
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "response.audio.transcript.delta": "#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent",
-            "response.code_interpreter_call_code.delta": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent",
-            "response.code_interpreter_call.in_progress": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent",
-            "response.code_interpreter_call.interpreting": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent",
-            "response.content_part.added": "#/components/schemas/OpenAI.ResponseContentPartAddedEvent",
-            "response.created": "#/components/schemas/OpenAI.ResponseCreatedEvent",
-            "error": "#/components/schemas/OpenAI.ResponseErrorEvent",
-            "response.file_search_call.in_progress": "#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent",
-            "response.file_search_call.searching": "#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent",
-            "response.function_call_arguments.delta": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent",
-            "response.in_progress": "#/components/schemas/OpenAI.ResponseInProgressEvent",
-            "response.failed": "#/components/schemas/OpenAI.ResponseFailedEvent",
-            "response.incomplete": "#/components/schemas/OpenAI.ResponseIncompleteEvent",
-            "response.output_item.added": "#/components/schemas/OpenAI.ResponseOutputItemAddedEvent",
-            "response.reasoning_summary_part.added": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent",
-            "response.reasoning_summary_text.delta": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent",
-            "response.reasoning_text.delta": "#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent",
-            "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
-            "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
-            "response.web_search_call.in_progress": "#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent",
-            "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
-            "response.image_generation_call.generating": "#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent",
-            "response.image_generation_call.in_progress": "#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent",
-            "response.image_generation_call.partial_image": "#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent",
-            "response.mcp_call_arguments.delta": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent",
-            "response.mcp_call.failed": "#/components/schemas/OpenAI.ResponseMCPCallFailedEvent",
-            "response.mcp_call.in_progress": "#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent",
-            "response.mcp_list_tools.failed": "#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent",
-            "response.mcp_list_tools.in_progress": "#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent",
-            "response.output_text.annotation.added": "#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent",
-            "response.queued": "#/components/schemas/OpenAI.ResponseQueuedEvent",
-            "response.custom_tool_call_input.delta": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent",
-            "response.audio.done": "#/components/schemas/OpenAI.ResponseAudioDoneEvent",
-            "response.audio.transcript.done": "#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent",
-            "response.code_interpreter_call_code.done": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent",
-            "response.code_interpreter_call.completed": "#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent",
-            "response.completed": "#/components/schemas/OpenAI.ResponseCompletedEvent",
-            "response.content_part.done": "#/components/schemas/OpenAI.ResponseContentPartDoneEvent",
-            "response.file_search_call.completed": "#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent",
-            "response.function_call_arguments.done": "#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent",
-            "response.output_item.done": "#/components/schemas/OpenAI.ResponseOutputItemDoneEvent",
-            "response.reasoning_summary_part.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent",
-            "response.reasoning_summary_text.done": "#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent",
-            "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
-            "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
-            "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
-            "response.image_generation_call.completed": "#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent",
-            "response.mcp_call_arguments.done": "#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent",
-            "response.mcp_call.completed": "#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent",
-            "response.mcp_list_tools.completed": "#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent",
-            "response.custom_tool_call_input.done": "#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent",
-            "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
-          }
-        }
-      },
-      "OpenAI.ResponseStreamEventType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "response.audio.delta",
-              "response.audio.done",
-              "response.audio.transcript.delta",
-              "response.audio.transcript.done",
-              "response.code_interpreter_call_code.delta",
-              "response.code_interpreter_call_code.done",
-              "response.code_interpreter_call.completed",
-              "response.code_interpreter_call.in_progress",
-              "response.code_interpreter_call.interpreting",
-              "response.completed",
-              "response.content_part.added",
-              "response.content_part.done",
-              "response.created",
-              "error",
-              "response.file_search_call.completed",
-              "response.file_search_call.in_progress",
-              "response.file_search_call.searching",
-              "response.function_call_arguments.delta",
-              "response.function_call_arguments.done",
-              "response.in_progress",
-              "response.failed",
-              "response.incomplete",
-              "response.output_item.added",
-              "response.output_item.done",
-              "response.reasoning_summary_part.added",
-              "response.reasoning_summary_part.done",
-              "response.reasoning_summary_text.delta",
-              "response.reasoning_summary_text.done",
-              "response.reasoning_text.delta",
-              "response.reasoning_text.done",
-              "response.refusal.delta",
-              "response.refusal.done",
-              "response.output_text.delta",
-              "response.output_text.done",
-              "response.web_search_call.completed",
-              "response.web_search_call.in_progress",
-              "response.web_search_call.searching",
-              "response.image_generation_call.completed",
-              "response.image_generation_call.generating",
-              "response.image_generation_call.in_progress",
-              "response.image_generation_call.partial_image",
-              "response.mcp_call_arguments.delta",
-              "response.mcp_call_arguments.done",
-              "response.mcp_call.completed",
-              "response.mcp_call.failed",
-              "response.mcp_call.in_progress",
-              "response.mcp_list_tools.completed",
-              "response.mcp_list_tools.failed",
-              "response.mcp_list_tools.in_progress",
-              "response.output_text.annotation.added",
-              "response.queued",
-              "response.custom_tool_call_input.delta",
-              "response.custom_tool_call_input.done"
-            ]
-          }
-        ]
       },
       "OpenAI.ResponseStreamOptions": {
         "type": "object",
@@ -53172,11 +50533,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when there is an additional text delta.",
         "x-oaiMeta": {
           "name": "response.output_text.delta",
@@ -53244,11 +50600,6 @@
             "description": "The log probabilities of the tokens in the delta."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when text content is finalized.",
         "x-oaiMeta": {
           "name": "response.output_text.done",
@@ -53381,11 +50732,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is completed.",
         "x-oaiMeta": {
           "name": "response.web_search_call.completed",
@@ -53431,11 +50777,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is initiated.",
         "x-oaiMeta": {
           "name": "response.web_search_call.in_progress",
@@ -53481,11 +50822,6 @@
             "description": "The sequence number of the web search call being processed."
           }
         },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
         "description": "Emitted when a web search call is executing.",
         "x-oaiMeta": {
           "name": "response.web_search_call.searching",
@@ -53505,7 +50841,8 @@
               "screenshot"
             ],
             "description": "Specifies the event type. For a screenshot action, this property is always set to `screenshot`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "screenshot"
           }
         },
         "allOf": [
@@ -53532,7 +50869,8 @@
               "scroll"
             ],
             "description": "Specifies the event type. For a scroll action, this property is always set to `scroll`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "scroll"
           },
           "x": {
             "allOf": [
@@ -53565,19 +50903,6 @@
               }
             ],
             "description": "The vertical scroll distance."
-          },
-          "keys": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "allOf": [
@@ -53587,13 +50912,6 @@
         ],
         "description": "A scroll action.",
         "title": "Scroll"
-      },
-      "OpenAI.SearchContentType": {
-        "type": "string",
-        "enum": [
-          "text",
-          "image"
-        ]
       },
       "OpenAI.SearchContextSize": {
         "type": "string",
@@ -53621,15 +50939,6 @@
         ],
         "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
-      "OpenAI.ServiceTierEnum": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "default",
-          "flex",
-          "priority"
-        ]
-      },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
         "required": [
@@ -53643,7 +50952,8 @@
               "skill_reference"
             ],
             "description": "References a skill created with the /v1/skills endpoint.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "skill_reference"
           },
           "skill_id": {
             "type": "string",
@@ -53674,7 +50984,8 @@
               "apply_patch"
             ],
             "description": "The tool to call. Always `apply_patch`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "apply_patch"
           }
         },
         "allOf": [
@@ -53697,7 +51008,8 @@
               "shell"
             ],
             "description": "The tool to call. Always `shell`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "shell"
           }
         },
         "allOf": [
@@ -53721,7 +51033,8 @@
               "summary_text"
             ],
             "description": "The type of the object. Always `summary_text`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "summary_text"
           },
           "text": {
             "type": "string",
@@ -53748,7 +51061,8 @@
             "enum": [
               "text"
             ],
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "text"
           },
           "text": {
             "type": "string"
@@ -53928,10 +51242,7 @@
             "shell": "#/components/schemas/OpenAI.FunctionShellToolParam",
             "custom": "#/components/schemas/OpenAI.CustomToolParam",
             "web_search_preview": "#/components/schemas/OpenAI.WebSearchPreviewTool",
-            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam",
-            "computer": "#/components/schemas/OpenAI.ComputerTool",
-            "namespace": "#/components/schemas/OpenAI.NamespaceToolParam",
-            "tool_search": "#/components/schemas/OpenAI.ToolSearchToolParam"
+            "apply_patch": "#/components/schemas/OpenAI.ApplyPatchToolParam"
           }
         },
         "description": "A tool that can be used to generate a response."
@@ -53987,46 +51298,6 @@
             "type": "string",
             "enum": [
               "code_interpreter"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputer": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer"
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
-          }
-        ],
-        "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
-      },
-      "OpenAI.ToolChoiceComputerUse": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "computer_use"
             ]
           }
         },
@@ -54225,9 +51496,7 @@
             "computer_use_preview": "#/components/schemas/OpenAI.ToolChoiceComputerUsePreview",
             "web_search_preview_2025_03_11": "#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311",
             "image_generation": "#/components/schemas/OpenAI.ToolChoiceImageGeneration",
-            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter",
-            "computer": "#/components/schemas/OpenAI.ToolChoiceComputer",
-            "computer_use": "#/components/schemas/OpenAI.ToolChoiceComputerUse"
+            "code_interpreter": "#/components/schemas/OpenAI.ToolChoiceCodeInterpreter"
           }
         },
         "description": "How the model should select which tool (or tools) to use when generating\na response. See the `tools` parameter to see how to specify which tools\nthe model can call."
@@ -54251,9 +51520,7 @@
               "computer_use_preview",
               "web_search_preview_2025_03_11",
               "image_generation",
-              "code_interpreter",
-              "computer",
-              "computer_use"
+              "code_interpreter"
             ]
           }
         ]
@@ -54298,64 +51565,6 @@
         ],
         "description": "Indicates that the model should use a built-in tool to generate a response.\n[Learn more about built-in tools](https://platform.openai.com/docs/guides/tools)."
       },
-      "OpenAI.ToolSearchExecutionType": {
-        "type": "string",
-        "enum": [
-          "server",
-          "client"
-        ]
-      },
-      "OpenAI.ToolSearchToolParam": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "tool_search"
-            ],
-            "description": "The type of the tool. Always `tool_search`.",
-            "x-stainless-const": true
-          },
-          "execution": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.ToolSearchExecutionType"
-              }
-            ],
-            "description": "Whether tool search is executed by the server or by the client."
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "parameters": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.EmptyModelParam"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.Tool"
-          }
-        ],
-        "description": "Hosted or BYOT tool search configuration for deferred tools.",
-        "title": "Tool search tool"
-      },
       "OpenAI.ToolType": {
         "anyOf": [
           {
@@ -54366,7 +51575,6 @@
             "enum": [
               "function",
               "file_search",
-              "computer",
               "computer_use_preview",
               "web_search",
               "mcp",
@@ -54375,8 +51583,6 @@
               "local_shell",
               "shell",
               "custom",
-              "namespace",
-              "tool_search",
               "web_search_preview",
               "apply_patch",
               "a2a_preview",
@@ -54443,7 +51649,8 @@
               "type"
             ],
             "description": "Specifies the event type. For a type action, this property is always set to `type`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "type"
           },
           "text": {
             "type": "string",
@@ -54493,7 +51700,8 @@
               "url_citation"
             ],
             "description": "The type of the URL citation. Always `url_citation`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "url_citation"
           },
           "url": {
             "type": "string",
@@ -54575,7 +51783,8 @@
               "wait"
             ],
             "description": "Specifies the event type. For a wait action, this property is always set to `wait`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "wait"
           }
         },
         "allOf": [
@@ -54648,7 +51857,8 @@
       "OpenAI.WebSearchActionSearch": {
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "query"
         ],
         "properties": {
           "type": {
@@ -54661,7 +51871,7 @@
           },
           "query": {
             "type": "string",
-            "description": "The search query.",
+            "description": "[DEPRECATED] The search query.",
             "deprecated": true
           },
           "queries": {
@@ -54699,8 +51909,7 @@
             "x-stainless-const": true
           },
           "url": {
-            "type": "string",
-            "format": "uri"
+            "type": "string"
           }
         }
       },
@@ -54775,7 +51984,8 @@
               "web_search_preview"
             ],
             "description": "The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.",
-            "x-stainless-const": true
+            "x-stainless-const": true,
+            "default": "web_search_preview"
           },
           "user_location": {
             "anyOf": [
@@ -54794,12 +52004,6 @@
               }
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default."
-          },
-          "search_content_types": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.SearchContentType"
-            }
           }
         },
         "allOf": [
@@ -54821,7 +52025,8 @@
             "enum": [
               "web_search"
             ],
-            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+            "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.",
+            "default": "web_search"
           },
           "filters": {
             "anyOf": [
@@ -54852,6 +52057,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           },
           "custom_search_configuration": {
             "allOf": [
@@ -58065,6 +55278,14 @@
             ],
             "description": "The object type, which is always 'sharepoint_grounding_preview'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "sharepoint_grounding_preview": {
             "allOf": [
               {
@@ -59124,14 +56345,6 @@
             ],
             "description": "The type of tool."
           },
-          "name": {
-            "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
-          },
-          "description": {
-            "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
-          },
           "tool_configs": {
             "type": "object",
             "unevaluatedProperties": {
@@ -59995,6 +57208,14 @@
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -60057,6 +57278,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [
@@ -60082,6 +57311,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The ID of the WorkIQ project connection."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -19746,11 +19746,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -19792,11 +19794,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -21940,11 +21944,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -22075,11 +22081,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -22834,11 +22842,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "bing_custom_search_preview": {
             "allOf": [
@@ -23017,11 +23027,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "bing_grounding": {
             "allOf": [
@@ -23221,11 +23233,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "browser_automation_preview": {
             "allOf": [
@@ -23258,11 +23272,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "browser_automation_preview": {
             "allOf": [
@@ -23407,11 +23423,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "outputs": {
             "allOf": [
@@ -23667,11 +23685,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -28717,11 +28737,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -28774,11 +28796,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -28929,11 +28953,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "vector_store_ids": {
             "type": "array",
@@ -30591,11 +30617,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "memory_store_name": {
             "type": "string",
@@ -30644,11 +30672,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "memory_store_name": {
             "type": "string",
@@ -31211,11 +31241,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "fabric_dataagent_preview": {
             "allOf": [
@@ -32304,11 +32336,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "container": {
             "anyOf": [
@@ -36857,11 +36891,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -38372,11 +38408,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -39084,11 +39122,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -45325,11 +45365,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -52060,11 +52102,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [
@@ -54172,11 +54216,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -55280,11 +55326,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "sharepoint_grounding_preview": {
             "allOf": [
@@ -57210,11 +57258,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [
@@ -57281,11 +57331,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -57314,11 +57366,13 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration."
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration."
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -5,114 +5,114 @@ info:
 tags:
   - name: EvaluationSuiteGenerationJobs
   - name: Fine-Tuning
-  - name: Responses Root
-    description: Responses
-  - name: Responses
-    parent: Responses Root
-    description: Responses (OpenAI)
-  - name: Conversations
-    parent: Responses Root
-    description: Conversations (OpenAI)
-  - name: Agents Root
-    description: Agents
-  - name: Agents
+  - name: Insights
+    parent: Evaluations
+  - name: Evalsuite
+    parent: Evaluations
+  - name: Redteams
+    parent: Evaluations
+    description: Red Teaming
+  - name: Evaluation Taxonomies
+    parent: Evaluations
+  - name: Evaluators
+    parent: Evaluations
+  - name: Evaluation Rules
+    parent: Evaluations
+  - name: Evals
+    parent: Evaluations
+  - name: Evaluations
+  - name: EvaluatorGenerationJobs
+    parent: Platform APIs
+    description: Evaluator generation jobs
+  - name: AgentOptimizationJobs
+    parent: Platform APIs
+    description: Agent optimization jobs
+  - name: DataGenerationJobs
+    parent: Platform APIs
+    description: Data generation jobs
+  - name: Deployments
+    parent: Platform APIs
+  - name: Toolboxes
+    parent: Platform APIs
+  - name: Skills
+    parent: Platform APIs
+  - name: Schedules
+    parent: Platform APIs
+  - name: Routines
+    parent: Platform APIs
+  - name: Videos
+    parent: Platform APIs
+  - name: Vector stores
+    parent: Platform APIs
+    description: Vector Stores
+  - name: Uploads
+    parent: Platform APIs
+  - name: Threads
+    parent: Platform APIs
+  - name: Realtime
+    parent: Platform APIs
+  - name: Moderations
+    parent: Platform APIs
+  - name: Images
+    parent: Platform APIs
+  - name: Files
+    parent: Platform APIs
+  - name: Embeddings
+    parent: Platform APIs
+  - name: Containers
+    parent: Platform APIs
+  - name: Completions
+    parent: Platform APIs
+  - name: Batch
+    parent: Platform APIs
+  - name: Audio
+    parent: Platform APIs
+  - name: Assistants
+    parent: Platform APIs
+  - name: Chat
+    parent: Platform APIs
+  - name: Memory Stores
+    parent: Platform APIs
+  - name: Models
+    parent: Platform APIs
+  - name: Fine-tuning
+    parent: Platform APIs
+    description: Fine-Tuning
+  - name: Scheduler
+    parent: Platform APIs
+  - name: Connections
+    parent: Platform APIs
+  - name: Indexes
+    parent: Platform APIs
+  - name: Datasets
+    parent: Platform APIs
+  - name: Platform APIs
+  - name: Agent Containers
     parent: Agents Root
-    description: Agent Management
-  - name: Agent Invocations
+  - name: Agent Versions
+    parent: Agents Root
+  - name: Agent Session Files
+    parent: Agents Root
+  - name: Agent Sessions
     parent: Agents Root
   - name: Agent Invocations WebSocket
     parent: Agents Root
     description: Agent Invocations (WebSocket)
-  - name: Agent Sessions
+  - name: Agent Invocations
     parent: Agents Root
-  - name: Agent Session Files
+  - name: Agents
     parent: Agents Root
-  - name: Agent Versions
-    parent: Agents Root
-  - name: Agent Containers
-    parent: Agents Root
-  - name: Platform APIs
-  - name: Datasets
-    parent: Platform APIs
-  - name: Indexes
-    parent: Platform APIs
-  - name: Connections
-    parent: Platform APIs
-  - name: Scheduler
-    parent: Platform APIs
-  - name: Fine-tuning
-    parent: Platform APIs
-    summary: Fine-Tuning
-  - name: Models
-    parent: Platform APIs
-  - name: Memory Stores
-    parent: Platform APIs
-  - name: Chat
-    parent: Platform APIs
-  - name: Assistants
-    parent: Platform APIs
-  - name: Audio
-    parent: Platform APIs
-  - name: Batch
-    parent: Platform APIs
-  - name: Completions
-    parent: Platform APIs
-  - name: Containers
-    parent: Platform APIs
-  - name: Embeddings
-    parent: Platform APIs
-  - name: Files
-    parent: Platform APIs
-  - name: Images
-    parent: Platform APIs
-  - name: Moderations
-    parent: Platform APIs
-  - name: Realtime
-    parent: Platform APIs
-  - name: Threads
-    parent: Platform APIs
-  - name: Uploads
-    parent: Platform APIs
-  - name: Vector stores
-    parent: Platform APIs
-    summary: Vector Stores
-  - name: Videos
-    parent: Platform APIs
-  - name: Routines
-    parent: Platform APIs
-  - name: Schedules
-    parent: Platform APIs
-  - name: Skills
-    parent: Platform APIs
-  - name: Toolboxes
-    parent: Platform APIs
-  - name: Deployments
-    parent: Platform APIs
-  - name: DataGenerationJobs
-    parent: Platform APIs
-    summary: Data generation jobs
-  - name: AgentOptimizationJobs
-    parent: Platform APIs
-    summary: Agent optimization jobs
-  - name: EvaluatorGenerationJobs
-    parent: Platform APIs
-    summary: Evaluator generation jobs
-  - name: Evaluations
-  - name: Evals
-    parent: Evaluations
-  - name: Evaluation Rules
-    parent: Evaluations
-  - name: Evaluators
-    parent: Evaluations
-  - name: Evaluation Taxonomies
-    parent: Evaluations
-  - name: Redteams
-    parent: Evaluations
-    summary: Red Teaming
-  - name: Evalsuite
-    parent: Evaluations
-  - name: Insights
-    parent: Evaluations
+    description: Agent Management
+  - name: Agents Root
+    description: Agents
+  - name: Conversations
+    parent: Responses Root
+    description: Conversations (OpenAI)
+  - name: Responses
+    parent: Responses Root
+    description: Responses (OpenAI)
+  - name: Responses Root
+    description: Responses
 paths:
   /agent_optimization_jobs:
     post:
@@ -10030,10 +10030,9 @@ paths:
                     deprecated: true
                   safety_identifier:
                     type: string
-                    maxLength: 64
                     description: |-
                       A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                        The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
                     type: string
                     description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -10043,7 +10042,7 @@ paths:
                     anyOf:
                       - type: string
                         enum:
-                          - in_memory
+                          - in-memory
                           - 24h
                       - type: 'null'
                   previous_response_id:
@@ -10060,6 +10059,10 @@ paths:
                   background:
                     anyOf:
                       - type: boolean
+                      - type: 'null'
+                  max_output_tokens:
+                    anyOf:
+                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   max_tool_calls:
                     anyOf:
@@ -10148,10 +10151,6 @@ paths:
                       - type: 'null'
                   usage:
                     $ref: '#/components/schemas/OpenAI.ResponseUsage'
-                  moderation:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.Moderation'
-                      - type: 'null'
                   parallel_tool_calls:
                     type: boolean
                     description: Whether to allow the model to run tool calls in parallel.
@@ -10159,10 +10158,6 @@ paths:
                   conversation:
                     anyOf:
                       - $ref: '#/components/schemas/OpenAI.ConversationReference'
-                      - type: 'null'
-                  max_output_tokens:
-                    anyOf:
-                      - $ref: '#/components/schemas/OpenAI.integer'
                       - type: 'null'
                   agent:
                     allOf:
@@ -10248,10 +10243,9 @@ paths:
                   deprecated: true
                 safety_identifier:
                   type: string
-                  maxLength: 64
                   description: |-
                     A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                      The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
                   type: string
                   description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -10261,7 +10255,7 @@ paths:
                   anyOf:
                     - type: string
                       enum:
-                        - in_memory
+                        - in-memory
                         - 24h
                     - type: 'null'
                 previous_response_id:
@@ -10278,6 +10272,10 @@ paths:
                 background:
                   anyOf:
                     - type: boolean
+                    - type: 'null'
+                max_output_tokens:
+                  anyOf:
+                    - $ref: '#/components/schemas/OpenAI.integer'
                     - type: 'null'
                 max_tool_calls:
                   anyOf:
@@ -10323,10 +10321,6 @@ paths:
                   anyOf:
                     - type: string
                     - type: 'null'
-                moderation:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.ModerationParam'
-                    - type: 'null'
                 stream:
                   anyOf:
                     - type: boolean
@@ -10346,10 +10340,6 @@ paths:
                         $ref: '#/components/schemas/OpenAI.ContextManagementParam'
                     - type: 'null'
                   description: Context management configuration for this request.
-                max_output_tokens:
-                  anyOf:
-                    - $ref: '#/components/schemas/OpenAI.integer'
-                    - type: 'null'
                 agent:
                   allOf:
                     - $ref: '#/components/schemas/AgentReference'
@@ -13028,6 +13018,12 @@ components:
             agent's Agent Card. The service defaults to `false` if a value is not
             specified by the caller (anonymous fetch).
           default: false
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -13061,6 +13057,12 @@ components:
             agent's Agent Card. The service defaults to `false` if a value is not
             specified by the caller (anonymous fetch).
           default: false
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
@@ -14488,6 +14490,12 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -14569,6 +14577,12 @@ components:
           type: string
           enum:
             - azure_ai_search
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -15055,6 +15069,12 @@ components:
           enum:
             - bing_custom_search_preview
           description: The object type, which is always 'bing_custom_search_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -15173,6 +15193,12 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -15293,6 +15319,12 @@ components:
           enum:
             - browser_automation_preview
           description: The object type, which is always 'browser_automation_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -15310,6 +15342,12 @@ components:
           type: string
           enum:
             - browser_automation_preview
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -15397,6 +15435,12 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -15588,6 +15632,12 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -16606,8 +16656,7 @@ components:
           description: The overall object JSON schema for the run data source items.
       discriminator:
         propertyName: type
-        mapping:
-          azure_ai_source: '#/components/schemas/AzureAIDataSourceConfig'
+        mapping: {}
       description: Base class for run data sources with discriminator support.
     DatasetDataGenerationJobOutput:
       type: object
@@ -19270,6 +19319,12 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -19300,6 +19355,12 @@ components:
             - type: 'null'
           description: (Optional) Whether the agent requires approval before executing actions. Default is always.
           default: always
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A FabricIQ tool stored in a toolbox.
@@ -19390,6 +19451,12 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         vector_store_ids:
           type: array
           items:
@@ -20133,7 +20200,6 @@ components:
           red_team_taxonomy: '#/components/schemas/RedTeamTaxonomyItemGenerationParams'
           response_retrieval: '#/components/schemas/ResponseRetrievalItemGenerationParams'
           conversation_gen_preview: '#/components/schemas/ConversationGenPreviewItemGenerationParams'
-          synthetic_data_gen_preview: '#/components/schemas/SyntheticDataGenerationPreviewItemGenerationParams'
       description: Represents the set of parameters used to control item generation operations.
     ItemGenerationParamsType:
       anyOf:
@@ -20253,9 +20319,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -20474,6 +20537,12 @@ components:
           enum:
             - memory_search_preview
           description: The type of the tool. Always `memory_search_preview`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20507,6 +20576,12 @@ components:
           enum:
             - memory_search
           description: The type of the tool. Always `memory_search_preview`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20866,6 +20941,12 @@ components:
           enum:
             - fabric_dataagent_preview
           description: The object type, which is always 'fabric_dataagent_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -21198,6 +21279,7 @@ components:
             - create_file
           description: Create a new file with the provided diff.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           description: Path of the file to create.
@@ -21221,6 +21303,7 @@ components:
             - create_file
           description: The operation type. Always `create_file`.
           x-stainless-const: true
+          default: create_file
         path:
           type: string
           minLength: 1
@@ -21245,6 +21328,7 @@ components:
             - delete_file
           description: Delete the specified file.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           description: Path of the file to delete.
@@ -21264,6 +21348,7 @@ components:
             - delete_file
           description: The operation type. Always `delete_file`.
           x-stainless-const: true
+          default: delete_file
         path:
           type: string
           minLength: 1
@@ -21329,6 +21414,7 @@ components:
             - apply_patch
           description: The type of the tool. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Allows the assistant to create, delete, or update files using unified diffs.
@@ -21346,6 +21432,7 @@ components:
             - update_file
           description: Update an existing file with the provided diff.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           description: Path of the file to update.
@@ -21369,6 +21456,7 @@ components:
             - update_file
           description: The operation type. Always `update_file`.
           x-stainless-const: true
+          default: update_file
         path:
           type: string
           minLength: 1
@@ -21454,12 +21542,6 @@ components:
     OpenAI.ChatModel:
       type: string
       enum:
-        - gpt-5.4
-        - gpt-5.4-mini
-        - gpt-5.4-nano
-        - gpt-5.4-mini-2026-03-17
-        - gpt-5.4-nano-2026-03-17
-        - gpt-5.3-chat-latest
         - gpt-5.2
         - gpt-5.2-2025-12-11
         - gpt-5.2-chat-latest
@@ -21554,6 +21636,7 @@ components:
             - click
           description: Specifies the event type. For a click action, this property is always `click`.
           x-stainless-const: true
+          default: click
         button:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ClickButtonType'
@@ -21566,12 +21649,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A click action.
@@ -21624,6 +21701,12 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         container:
           anyOf:
             - type: string
@@ -21692,18 +21775,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
-        prompt_cache_retention:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.PromptCacheRetentionEnum'
-            - type: 'null'
-        service_tier:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.ServiceTierEnum'
-            - type: 'null'
     OpenAI.ComparisonFilter:
       type: object
       required:
@@ -21720,8 +21791,6 @@ components:
             - gte
             - lt
             - lte
-            - in
-            - nin
           description: |-
             Specifies the comparison operator: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `nin`.
               - `eq`: equals
@@ -21793,14 +21862,6 @@ components:
           scroll: '#/components/schemas/OpenAI.ScrollParam'
           type: '#/components/schemas/OpenAI.TypeParam'
           wait: '#/components/schemas/OpenAI.WaitParam'
-    OpenAI.ComputerActionList:
-      type: array
-      items:
-        $ref: '#/components/schemas/OpenAI.ComputerAction'
-      description: |-
-        Flattened batched actions for `computer_use`. Each action includes an
-        `type` discriminator and action-specific fields.
-      title: Computer Action List
     OpenAI.ComputerActionType:
       anyOf:
         - type: string
@@ -21846,7 +21907,6 @@ components:
         - type
         - image_url
         - file_id
-        - detail
       properties:
         type:
           type: string
@@ -21854,6 +21914,7 @@ components:
             - computer_screenshot
           description: Specifies the event type. For a computer screenshot, this property is always set to `computer_screenshot`.
           x-stainless-const: true
+          default: computer_screenshot
         image_url:
           anyOf:
             - type: string
@@ -21863,10 +21924,6 @@ components:
           anyOf:
             - type: string
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the screenshot image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A screenshot of a computer.
@@ -21893,21 +21950,6 @@ components:
           type: string
           description: The identifier of an uploaded file that contains the screenshot.
       description: A computer screenshot image used with the computer use tool.
-    OpenAI.ComputerTool:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-          description: The type of the computer tool. Always `computer`.
-          x-stainless-const: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: A tool that controls a virtual computer. Learn more about the [computer tool](https://platform.openai.com/docs/guides/tools-computer-use).
-      title: Computer
     OpenAI.ComputerUsePreviewTool:
       type: object
       required:
@@ -21922,6 +21964,7 @@ components:
             - computer_use_preview
           description: The type of the computer use tool. Always `computer_use_preview`.
           x-stainless-const: true
+          default: computer_use_preview
         environment:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ComputerEnvironment'
@@ -21949,6 +21992,7 @@ components:
             - container_auto
           description: Automatically creates a container for this request
           x-stainless-const: true
+          default: container_auto
         file_ids:
           type: array
           items:
@@ -21985,6 +22029,7 @@ components:
             - container_file_citation
           description: The type of the container file citation. Always `container_file_citation`.
           x-stainless-const: true
+          default: container_file_citation
         container_id:
           type: string
           description: The ID of the container file.
@@ -22025,12 +22070,19 @@ components:
             - allowlist
           description: Allow outbound network access only to specified domains. Always `allowlist`.
           x-stainless-const: true
+          default: allowlist
         allowed_domains:
           type: array
           items:
             type: string
           minItems: 1
           description: A list of allowed domains when type is `allowlist`.
+        domain_secrets:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyDomainSecretParam'
+          minItems: 1
+          description: Optional domain-scoped secrets for allowlisted domains.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
     OpenAI.ContainerNetworkPolicyDisabledParam:
@@ -22044,8 +22096,29 @@ components:
             - disabled
           description: Disable outbound network access. Always `disabled`.
           x-stainless-const: true
+          default: disabled
       allOf:
         - $ref: '#/components/schemas/OpenAI.ContainerNetworkPolicyParam'
+    OpenAI.ContainerNetworkPolicyDomainSecretParam:
+      type: object
+      required:
+        - domain
+        - name
+        - value
+      properties:
+        domain:
+          type: string
+          minLength: 1
+          description: The domain associated with the secret.
+        name:
+          type: string
+          minLength: 1
+          description: The name of the secret to inject for the domain.
+        value:
+          type: string
+          minLength: 1
+          maxLength: 10485760
+          description: The secret value to inject for the domain.
     OpenAI.ContainerNetworkPolicyParam:
       type: object
       required:
@@ -22078,6 +22151,7 @@ components:
             - container_reference
           description: The environment type. Always `container_reference`.
           x-stainless-const: true
+          default: container_reference
         container_id:
           type: string
       allOf:
@@ -22126,18 +22200,14 @@ components:
         propertyName: type
         mapping:
           message: '#/components/schemas/OpenAI.ConversationItemMessage'
-          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutput'
+          function_call: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ConversationItemFunctionToolCallOutputResource'
           file_search_call: '#/components/schemas/OpenAI.ConversationItemFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ConversationItemWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ConversationItemImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ConversationItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ConversationItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ConversationItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ConversationItemAdditionalTools'
+          computer_call_output: '#/components/schemas/OpenAI.ConversationItemComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ConversationItemReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ConversationItemCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ConversationItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCall'
           local_shell_call_output: '#/components/schemas/OpenAI.ConversationItemLocalShellToolCallOutput'
@@ -22149,39 +22219,10 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ConversationItemMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ConversationItemMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ConversationItemMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutputResource'
+          custom_tool_call: '#/components/schemas/OpenAI.ConversationItemCustomToolCall'
+          custom_tool_call_output: '#/components/schemas/OpenAI.ConversationItemCustomToolCallOutput'
       description: A single item within a conversation. The set of possible types are the same as the `output` type of a [Response object](/docs/api-reference/responses/object#responses/object-output).
       title: Conversation item
-    OpenAI.ConversationItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemApplyPatchToolCall:
       type: object
       required:
@@ -22304,39 +22345,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ConversationItemCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ConversationItemComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -22354,8 +22369,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -22376,11 +22389,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ConversationItemComputerToolCallOutput:
+    OpenAI.ConversationItemComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -22394,7 +22406,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -22418,15 +22429,42 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ConversationItemCustomToolCallOutputResource:
+    OpenAI.ConversationItemCustomToolCall:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - input
+      properties:
+        type:
+          type: string
+          enum:
+            - custom_tool_call
+          description: The type of the custom tool call. Always `custom_tool_call`.
+          x-stainless-const: true
+        id:
+          type: string
+          description: The unique ID of the custom tool call in the OpenAI platform.
+        call_id:
+          type: string
+          description: An identifier used to map this custom tool call to a tool call output.
+        name:
+          type: string
+          description: The name of the custom tool being called.
+        input:
+          type: string
+          description: The input for the custom tool call generated by the model.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
+    OpenAI.ConversationItemCustomToolCallOutput:
       type: object
       required:
         - type
         - call_id
         - output
-        - status
       properties:
         type:
           type: string
@@ -22449,60 +22487,10 @@ components:
           description: |-
             The output from the custom tool call generated by your code.
               Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ConversationItemCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      title: ResponseCustomToolCallItem
+      description: The output of a custom tool call from your code, being sent back to the model.
+      title: Custom tool call output
     OpenAI.ConversationItemFileSearchToolCall:
       type: object
       required:
@@ -22577,7 +22565,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -22615,7 +22603,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -22633,56 +22621,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ConversationItemFunctionToolCall:
+    OpenAI.ConversationItemFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ConversationItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -22692,7 +22633,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -22722,8 +22662,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ConversationItemFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemImageGenToolCall:
       type: object
       required:
@@ -22946,7 +22921,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A list of tools available on an MCP server.
@@ -23029,10 +23006,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ConversationItem'
       description: A message to or from the model.
@@ -23084,87 +23057,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ConversationItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
-    OpenAI.ConversationItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ConversationItem'
     OpenAI.ConversationItemType:
       anyOf:
         - type: string
@@ -23178,11 +23070,7 @@ components:
             - image_generation_call
             - computer_call
             - computer_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
-            - compaction
             - code_interpreter_call
             - local_shell_call
             - local_shell_call_output
@@ -23318,7 +23206,6 @@ components:
         mapping:
           text: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatText'
           json_object: '#/components/schemas/OpenAI.CreateChatCompletionRequestResponseFormatResponseFormatJsonObject'
-          json_schema: '#/components/schemas/OpenAI.ResponseFormatJsonSchema'
       description: |-
         An object specifying the format that the model must output.
         Setting to `{ "type": "json_schema", "json_schema": {...} }` enables
@@ -23936,6 +23823,7 @@ components:
             - grammar
           description: Grammar format. Always `grammar`.
           x-stainless-const: true
+          default: grammar
         syntax:
           allOf:
             - $ref: '#/components/schemas/OpenAI.GrammarSyntax1'
@@ -23958,6 +23846,7 @@ components:
             - text
           description: Unconstrained text format. Always `text`.
           x-stainless-const: true
+          default: text
       allOf:
         - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
       description: Unconstrained free-form text.
@@ -23974,6 +23863,7 @@ components:
             - custom
           description: The type of the custom tool. Always `custom`.
           x-stainless-const: true
+          default: custom
         name:
           type: string
           description: The name of the custom tool, used to identify it in tool calls.
@@ -23984,9 +23874,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.CustomToolParamFormat'
           description: The input format for the custom tool. Default is unconstrained text.
-        defer_loading:
-          type: boolean
-          description: Whether this tool should be deferred and discovered via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A custom tool that processes input using a specified format. Learn more about   [custom tools](/docs/guides/function-calling#custom-tools)
@@ -24034,14 +23921,12 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.DoubleClickAction:
       type: object
       required:
         - type
         - x
         - 'y'
-        - keys
       properties:
         type:
           type: string
@@ -24049,6 +23934,7 @@ components:
             - double_click
           description: Specifies the event type. For a double click action, this property is always set to `double_click`.
           x-stainless-const: true
+          default: double_click
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -24057,12 +23943,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate where the double click occurred.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A double click action.
@@ -24079,6 +23959,7 @@ components:
             - drag
           description: Specifies the event type. For a drag action, this property is always set to `drag`.
           x-stainless-const: true
+          default: drag
         path:
           type: array
           items:
@@ -24091,12 +23972,6 @@ components:
                 { x: 200, y: 300 }
               ]
               ```
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A drag action.
@@ -24125,10 +24000,6 @@ components:
           description: |-
             Text, image, or audio input to the model, used to generate a response.
               Can also contain previous assistant responses.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         type:
           type: string
           enum:
@@ -24153,8 +24024,6 @@ components:
         `assistant` role are presumed to have been generated by the model in previous
         interactions.
       title: Input message
-    OpenAI.EmptyModelParam:
-      type: object
     OpenAI.Error:
       type: object
       required:
@@ -24848,6 +24717,7 @@ components:
             - file_citation
           description: The type of the file citation. Always `file_citation`.
           x-stainless-const: true
+          default: file_citation
         file_id:
           type: string
           description: The ID of the file.
@@ -24862,11 +24732,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Annotation'
       description: A citation to a file.
       title: File citation
-    OpenAI.FileInputDetail:
-      type: string
-      enum:
-        - low
-        - high
     OpenAI.FilePath:
       type: object
       required:
@@ -24903,6 +24768,7 @@ components:
             - file_search
           description: The type of the file search tool. Always `file_search`.
           x-stainless-const: true
+          default: file_search
         vector_store_ids:
           type: array
           items:
@@ -24920,6 +24786,12 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -25509,17 +25381,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: A file input to the model.
@@ -25549,7 +25417,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -25583,18 +25451,6 @@ components:
             - input_image
             - input_file
     OpenAI.FunctionCallItemStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
-    OpenAI.FunctionCallStatus:
       type: string
       enum:
         - in_progress
@@ -25805,6 +25661,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -25825,6 +25682,7 @@ components:
             - exit
           description: The outcome type. Always `exit`.
           x-stainless-const: true
+          default: exit
         exit_code:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -25875,12 +25733,6 @@ components:
           enum:
             - timeout
             - exit
-    OpenAI.FunctionShellCallOutputStatusEnum:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellCallOutputTimeoutOutcome:
       type: object
       required:
@@ -25892,6 +25744,7 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcome'
       description: Indicates that the shell call exceeded its configured time limit.
@@ -25907,16 +25760,11 @@ components:
             - timeout
           description: The outcome type. Always `timeout`.
           x-stainless-const: true
+          default: timeout
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputOutcomeParam'
       description: Indicates that the shell call exceeded its configured time limit.
       title: Shell call timeout outcome
-    OpenAI.FunctionShellCallStatus:
-      type: string
-      enum:
-        - in_progress
-        - completed
-        - incomplete
     OpenAI.FunctionShellToolParam:
       type: object
       required:
@@ -25928,10 +25776,17 @@ components:
             - shell
           description: The type of the shell tool. Always `shell`.
           x-stainless-const: true
+          default: shell
         environment:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -26009,6 +25864,7 @@ components:
             - function
           description: The type of the function tool. Always `function`.
           x-stainless-const: true
+          default: function
         name:
           type: string
           description: The name of the function to call.
@@ -26025,45 +25881,53 @@ components:
           anyOf:
             - type: boolean
             - type: 'null'
-        defer_loading:
-          type: boolean
-          description: Whether this function is deferred and loaded via tool search.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling).
       title: Function
-    OpenAI.FunctionToolParam:
+    OpenAI.FunctionToolCallOutput:
       type: object
       required:
-        - name
         - type
+        - call_id
+        - output
       properties:
-        name:
+        id:
           type: string
-          minLength: 1
-          maxLength: 128
-          pattern: ^[a-zA-Z0-9_-]+$
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-        strict:
-          anyOf:
-            - type: boolean
-            - type: 'null'
+          description: |-
+            The unique ID of the function tool call output. Populated when this item
+              is returned via API.
         type:
           type: string
           enum:
-            - function
+            - function_call_output
+          description: The type of the function tool call output. Always `function_call_output`.
           x-stainless-const: true
-          default: function
-        defer_loading:
-          type: boolean
-          description: Whether this function should be deferred and discovered via tool search.
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        output:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
+          description: |-
+            The output from the function call generated by your code.
+              Can be a string or an list of output content.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemField'
+      description: The output of a function tool call.
+      title: Function tool call output
     OpenAI.GraderLabelModel:
       type: object
       required:
@@ -26440,7 +26304,6 @@ components:
         - low
         - high
         - auto
-        - original
     OpenAI.ImageGenActionEnum:
       type: string
       enum:
@@ -26458,6 +26321,7 @@ components:
             - image_generation
           description: The type of the image generation tool. Always `image_generation`.
           x-stainless-const: true
+          default: image_generation
         model:
           anyOf:
             - type: string
@@ -26479,15 +26343,15 @@ components:
               or `auto`. Default: `auto`.
           default: auto
         size:
-          anyOf:
-            - type: string
-            - type: string
-              enum:
-                - 1024x1024
-                - 1024x1536
-                - 1536x1024
-                - auto
-          description: The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.
+          type: string
+          enum:
+            - 1024x1024
+            - 1024x1536
+            - 1536x1024
+            - auto
+          description: |-
+            The size of the generated image. One of `1024x1024`, `1024x1536`,
+              `1536x1024`, or `auto`. Default: `auto`.
           default: auto
         output_format:
           type: string
@@ -26543,6 +26407,12 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -26571,7 +26441,6 @@ components:
             - memory_search_call.results
       description: |-
         Specify additional output data to include in the model response. Currently supported values are:
-        - `web_search_call.results`: Include the search results of the web search tool call.
         - `web_search_call.action.sources`: Include the sources of the web search tool call.
         - `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.
         - `computer_call_output.output.image_url`: Include image urls from the computer call output.
@@ -26593,6 +26462,7 @@ components:
             - inline
           description: Defines an inline skill for this request.
           x-stainless-const: true
+          default: inline
         name:
           type: string
           description: The name of the skill.
@@ -26695,17 +26565,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: A file input to the model.
@@ -26735,7 +26601,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -26793,17 +26659,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       description: A file input to the model.
       title: Input file
     OpenAI.InputFileContentParam:
@@ -26835,10 +26697,6 @@ components:
             - type: string
               format: uri
             - type: 'null'
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
       description: A file input to the model.
       title: Input file
     OpenAI.InputImageContent:
@@ -26866,7 +26724,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
       title: Input image
     OpenAI.InputImageContentParamAutoParam:
@@ -26915,9 +26773,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.InputItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.InputItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.InputItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.InputItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.InputItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.InputItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.InputItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.InputItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.InputItemImageGenToolCall'
@@ -26938,38 +26793,6 @@ components:
         An item representing part of the context for the response to be
         generated by the model. Can contain text, images, and audio inputs,
         as well as previous assistant responses and tool call outputs.
-    OpenAI.InputItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -27159,6 +26982,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -27176,8 +27000,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -27218,9 +27040,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -27431,7 +27250,6 @@ components:
     OpenAI.InputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -27440,7 +27258,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -27450,9 +27267,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -27660,7 +27474,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
       description: A list of tools available on an MCP server.
@@ -27740,10 +27556,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -27804,77 +27616,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.InputItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
-    OpenAI.InputItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.InputItem'
     OpenAI.InputItemType:
       anyOf:
         - type: string
@@ -27888,9 +27629,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -27947,6 +27685,44 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
+    OpenAI.InputMessage:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.Item'
+      description: |-
+        A message input to the model with a role indicating instruction following
+        hierarchy. Instructions given with the `developer` or `system` role take
+        precedence over instructions given with the `user` role.
+      title: Input message
     OpenAI.InputMessageContentList:
       type: array
       items:
@@ -27955,6 +27731,43 @@ components:
         A list of one or many input items to the model, containing different content
         types.
       title: Input item content list
+    OpenAI.InputMessageResource:
+      type: object
+      required:
+        - type
+        - role
+        - content
+        - id
+      properties:
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the message input. Always set to `message`.
+          x-stainless-const: true
+        role:
+          type: string
+          enum:
+            - user
+            - system
+            - developer
+          description: The role of the message input. One of `user`, `system`, or `developer`.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+        content:
+          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
+        id:
+          type: string
+          description: The unique ID of the message input.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.InputParam:
       oneOf:
         - type: string
@@ -28016,7 +27829,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessage'
           output_message: '#/components/schemas/OpenAI.ItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemComputerToolCall'
@@ -28024,9 +27837,6 @@ components:
           web_search_call: '#/components/schemas/OpenAI.ItemWebSearchToolCall'
           function_call: '#/components/schemas/OpenAI.ItemFunctionToolCall'
           function_call_output: '#/components/schemas/OpenAI.ItemFunctionCallOutputItemParam'
-          tool_search_call: '#/components/schemas/OpenAI.ItemToolSearchCallItemParam'
-          tool_search_output: '#/components/schemas/OpenAI.ItemToolSearchOutputItemParam'
-          additional_tools: '#/components/schemas/OpenAI.ItemAdditionalToolsItemParam'
           reasoning: '#/components/schemas/OpenAI.ItemReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemCompactionSummaryItemParam'
           image_generation_call: '#/components/schemas/OpenAI.ItemImageGenToolCall'
@@ -28044,38 +27854,6 @@ components:
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemCustomToolCallOutput'
           custom_tool_call: '#/components/schemas/OpenAI.ItemCustomToolCall'
       description: Content item used to generate a response.
-    OpenAI.ItemAdditionalToolsItemParam:
-      type: object
-      required:
-        - type
-        - role
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The item type. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        role:
-          type: string
-          enum:
-            - developer
-          description: The role that provided the additional tools. Only `developer` is supported.
-          x-stainless-const: true
-          default: developer
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: A list of additional tools made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemApplyPatchToolCallItemParam:
       type: object
       required:
@@ -28265,6 +28043,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -28282,8 +28061,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -28324,9 +28101,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -28379,17 +28153,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          function_call_output: '#/components/schemas/OpenAI.FunctionToolCallOutput'
           message: '#/components/schemas/OpenAI.ItemFieldMessage'
           function_call: '#/components/schemas/OpenAI.ItemFieldFunctionToolCall'
-          tool_search_call: '#/components/schemas/OpenAI.ItemFieldToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemFieldToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemFieldAdditionalTools'
-          function_call_output: '#/components/schemas/OpenAI.ItemFieldFunctionToolCallOutput'
           file_search_call: '#/components/schemas/OpenAI.ItemFieldFileSearchToolCall'
           web_search_call: '#/components/schemas/OpenAI.ItemFieldWebSearchToolCall'
           image_generation_call: '#/components/schemas/OpenAI.ItemFieldImageGenToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemFieldComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemFieldComputerToolCallOutputResource'
           reasoning: '#/components/schemas/OpenAI.ItemFieldReasoningItem'
           compaction: '#/components/schemas/OpenAI.ItemFieldCompactionBody'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemFieldCodeInterpreterToolCall'
@@ -28406,35 +28177,6 @@ components:
           custom_tool_call: '#/components/schemas/OpenAI.ItemFieldCustomToolCall'
           custom_tool_call_output: '#/components/schemas/OpenAI.ItemFieldCustomToolCallOutput'
       description: An item representing a message, tool call, tool output, reasoning, or other response element.
-    OpenAI.ItemFieldAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldApplyPatchToolCall:
       type: object
       required:
@@ -28590,6 +28332,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -28607,8 +28350,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -28629,11 +28370,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemFieldComputerToolCallOutput:
+    OpenAI.ItemFieldComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -28647,7 +28387,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -28671,8 +28410,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a computer tool call.
-      title: Computer tool call output
     OpenAI.ItemFieldCustomToolCall:
       type: object
       required:
@@ -28693,9 +28430,6 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
@@ -28812,7 +28546,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -28850,7 +28584,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -28871,7 +28605,6 @@ components:
     OpenAI.ItemFieldFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -28880,7 +28613,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -28890,9 +28622,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -28914,51 +28643,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.ItemFieldFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.ItemFieldImageGenToolCall:
       type: object
       required:
@@ -29145,7 +28829,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A list of tools available on an MCP server.
@@ -29228,10 +28914,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.MessageContent'
           description: The content of the message
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemField'
       description: A message to or from the model.
@@ -29283,87 +28965,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.ItemFieldToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
-    OpenAI.ItemFieldToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemField'
     OpenAI.ItemFieldType:
       anyOf:
         - type: string
@@ -29371,9 +28972,6 @@ components:
           enum:
             - message
             - function_call
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - function_call_output
             - file_search_call
             - web_search_call
@@ -29602,7 +29200,6 @@ components:
     OpenAI.ItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -29611,7 +29208,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -29621,9 +29217,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -29678,50 +29271,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemLocalShellToolCall:
       type: object
       required:
@@ -29875,7 +29424,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
       description: A list of tools available on an MCP server.
@@ -29955,10 +29506,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30031,6 +29578,7 @@ components:
             - item_reference
           description: The type of item to reference. Always `item_reference`.
           x-stainless-const: true
+          default: item_reference
         id:
           type: string
           description: The ID of the item to reference.
@@ -30048,19 +29596,14 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.ItemResourceInputMessage'
+          message: '#/components/schemas/OpenAI.InputMessageResource'
           output_message: '#/components/schemas/OpenAI.ItemResourceOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.ItemResourceFileSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.ItemResourceComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutput'
+          computer_call_output: '#/components/schemas/OpenAI.ItemResourceComputerToolCallOutputResource'
           web_search_call: '#/components/schemas/OpenAI.ItemResourceWebSearchToolCall'
-          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutput'
-          tool_search_call: '#/components/schemas/OpenAI.ItemResourceToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.ItemResourceToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.ItemResourceAdditionalTools'
-          reasoning: '#/components/schemas/OpenAI.ItemResourceReasoningItem'
-          compaction: '#/components/schemas/OpenAI.ItemResourceCompactionBody'
+          function_call: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallResource'
+          function_call_output: '#/components/schemas/OpenAI.ItemResourceFunctionToolCallOutputResource'
           image_generation_call: '#/components/schemas/OpenAI.ItemResourceImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.ItemResourceCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.ItemResourceLocalShellToolCall'
@@ -30073,38 +29616,7 @@ components:
           mcp_approval_request: '#/components/schemas/OpenAI.ItemResourceMcpApprovalRequest'
           mcp_approval_response: '#/components/schemas/OpenAI.ItemResourceMcpApprovalResponseResource'
           mcp_call: '#/components/schemas/OpenAI.ItemResourceMcpToolCall'
-          custom_tool_call: '#/components/schemas/OpenAI.ItemResourceCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.ItemResourceCustomToolCallOutputResource'
       description: Content item used to generate a response.
-    OpenAI.ItemResourceAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceApplyPatchToolCall:
       type: object
       required:
@@ -30227,39 +29739,13 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A tool call to run code.
       title: Code interpreter tool call
-    OpenAI.ItemResourceCompactionBody:
-      type: object
-      required:
-        - type
-        - id
-        - encrypted_content
-      properties:
-        type:
-          type: string
-          enum:
-            - compaction
-          description: The type of the item. Always `compaction`.
-          x-stainless-const: true
-          default: compaction
-        id:
-          type: string
-          description: The unique ID of the compaction item.
-        encrypted_content:
-          type: string
-          description: The encrypted content that was produced by compaction.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).
-      title: Compaction item
     OpenAI.ItemResourceComputerToolCall:
       type: object
       required:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -30277,8 +29763,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -30299,11 +29783,10 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.ItemResourceComputerToolCallOutput:
+    OpenAI.ItemResourceComputerToolCallOutputResource:
       type: object
       required:
         - type
-        - id
         - call_id
         - output
       properties:
@@ -30317,7 +29800,6 @@ components:
         id:
           type: string
           description: The ID of the computer tool call output.
-          readOnly: true
         call_id:
           type: string
           description: The ID of the computer tool call that produced the output.
@@ -30341,91 +29823,6 @@ components:
               `incomplete`. Populated when input items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.ItemResourceCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.ItemResourceCustomToolCallResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - name
-        - input
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call
-          description: The type of the custom tool call. Always `custom_tool_call`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call in the OpenAI platform.
-        call_id:
-          type: string
-          description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
-        name:
-          type: string
-          description: The name of the custom tool being called.
-        input:
-          type: string
-          description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      title: ResponseCustomToolCallItem
     OpenAI.ItemResourceFileSearchToolCall:
       type: object
       required:
@@ -30500,7 +29897,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -30538,7 +29935,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -30556,56 +29953,9 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: The output of a shell tool call that was emitted.
       title: Shell call output
-    OpenAI.ItemResourceFunctionToolCall:
+    OpenAI.ItemResourceFunctionToolCallOutputResource:
       type: object
       required:
-        - id
-        - type
-        - call_id
-        - name
-        - arguments
-      properties:
-        id:
-          type: string
-          description: The unique ID of the function tool call.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call
-          description: The type of the function tool call. Always `function_call`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
-        name:
-          type: string
-          description: The name of the function to run.
-        arguments:
-          type: string
-          description: A JSON string of the arguments to pass to the function.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A tool call to run a function. See the
-        [function calling guide](/docs/guides/function-calling) for more information.
-      title: Function tool call
-    OpenAI.ItemResourceFunctionToolCallOutput:
-      type: object
-      required:
-        - id
         - type
         - call_id
         - output
@@ -30615,7 +29965,6 @@ components:
           description: |-
             The unique ID of the function tool call output. Populated when this item
               is returned via API.
-          readOnly: true
         type:
           type: string
           enum:
@@ -30645,8 +29994,43 @@ components:
               `incomplete`. Populated when items are returned via API.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: The output of a function tool call.
-      title: Function tool call output
+    OpenAI.ItemResourceFunctionToolCallResource:
+      type: object
+      required:
+        - type
+        - call_id
+        - name
+        - arguments
+      properties:
+        id:
+          type: string
+          description: The unique ID of the function tool call.
+        type:
+          type: string
+          enum:
+            - function_call
+          description: The type of the function tool call. Always `function_call`.
+          x-stainless-const: true
+        call_id:
+          type: string
+          description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the function to run.
+        arguments:
+          type: string
+          description: A JSON string of the arguments to pass to the function.
+        status:
+          type: string
+          enum:
+            - in_progress
+            - completed
+            - incomplete
+          description: |-
+            The status of the item. One of `in_progress`, `completed`, or
+              `incomplete`. Populated when items are returned via API.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceImageGenToolCall:
       type: object
       required:
@@ -30680,50 +30064,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An image generation request made by the model.
       title: Image generation call
-    OpenAI.ItemResourceInputMessage:
-      type: object
-      required:
-        - type
-        - role
-        - content
-        - id
-      properties:
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the message input. Always set to `message`.
-          x-stainless-const: true
-          default: message
-        role:
-          type: string
-          enum:
-            - user
-            - system
-            - developer
-          description: The role of the message input. One of `user`, `system`, or `developer`.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        content:
-          $ref: '#/components/schemas/OpenAI.InputMessageContentList'
-        id:
-          type: string
-          description: The unique ID of the message input.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A message input to the model with a role indicating instruction following
-        hierarchy. Instructions given with the `developer` or `system` role take
-        precedence over instructions given with the `user` role.
-      title: Input message
     OpenAI.ItemResourceLocalShellToolCall:
       type: object
       required:
@@ -30877,7 +30217,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: A list of tools available on an MCP server.
@@ -30957,10 +30299,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -30974,134 +30312,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.ItemResource'
       description: An output message from the model.
       title: Output message
-    OpenAI.ItemResourceReasoningItem:
-      type: object
-      required:
-        - type
-        - id
-        - summary
-      properties:
-        type:
-          type: string
-          enum:
-            - reasoning
-          description: The type of the object. Always `reasoning`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique identifier of the reasoning content.
-        encrypted_content:
-          anyOf:
-            - type: string
-            - type: 'null'
-        summary:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SummaryTextContent'
-          description: Reasoning summary content.
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ReasoningTextContent'
-          description: Reasoning text content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-      description: |-
-        A description of the chain of thought used by a reasoning model while generating
-        a response. Be sure to include these items in your `input` to the Responses API
-        for subsequent turns of a conversation if you are manually
-        [managing context](/docs/guides/conversation-state).
-      title: Reasoning
-    OpenAI.ItemResourceToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
-    OpenAI.ItemResourceToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ItemResource'
     OpenAI.ItemResourceType:
       anyOf:
         - type: string
@@ -31115,11 +30325,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
-            - reasoning
-            - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
@@ -31132,8 +30337,6 @@ components:
             - mcp_approval_request
             - mcp_approval_response
             - mcp_call
-            - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -31197,77 +30400,6 @@ components:
         The results of a web search tool call. See the
         [web search guide](/docs/guides/tools-web-search) for more information.
       title: Web search tool call
-    OpenAI.ItemToolSearchCallItemParam:
-      type: object
-      required:
-        - type
-        - arguments
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The item type. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-          description: The arguments supplied to the tool search call.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
-    OpenAI.ItemToolSearchOutputItemParam:
-      type: object
-      required:
-        - type
-        - tools
-      properties:
-        id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The item type. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by the tool search output.
-        status:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallItemStatus'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Item'
     OpenAI.ItemType:
       anyOf:
         - type: string
@@ -31281,9 +30413,6 @@ components:
             - web_search_call
             - function_call
             - function_call_output
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - reasoning
             - compaction
             - image_generation_call
@@ -31375,6 +30504,7 @@ components:
             - keypress
           description: Specifies the event type. For a keypress action, this property is always set to `keypress`.
           x-stainless-const: true
+          default: keypress
         keys:
           type: array
           items:
@@ -31461,10 +30591,23 @@ components:
             - local
           description: The environment type. Always `local`.
           x-stainless-const: true
+          default: local
       allOf:
         - $ref: '#/components/schemas/OpenAI.FunctionShellCallEnvironment'
       description: Represents the use of a local environment to perform shell actions.
       title: Local Environment
+    OpenAI.LocalShellCallOutputStatusEnum:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
+    OpenAI.LocalShellCallStatus:
+      type: string
+      enum:
+        - in_progress
+        - completed
+        - incomplete
     OpenAI.LocalShellExecAction:
       type: object
       required:
@@ -31515,6 +30658,13 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+          default: local_shell
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -31660,9 +30810,6 @@ components:
                 - never
             - type: 'null'
           default: always
-        defer_loading:
-          type: boolean
-          description: Whether this MCP tool is deferred and discovered via tool search.
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
@@ -31722,7 +30869,6 @@ components:
           refusal: '#/components/schemas/OpenAI.MessageContentRefusalContent'
           input_image: '#/components/schemas/OpenAI.MessageContentInputImageContent'
           input_file: '#/components/schemas/OpenAI.MessageContentInputFileContent'
-          summary_text: '#/components/schemas/OpenAI.SummaryTextContent'
       description: A content part that makes up an input or output item.
     OpenAI.MessageContentInputFileContent:
       type: object
@@ -31743,17 +30889,13 @@ components:
         filename:
           type: string
           description: The name of the file to be sent to the model.
-        file_data:
-          type: string
-          description: The content of the file to be sent to the model.
         file_url:
           type: string
           format: uri
           description: The URL of the file to be sent to the model.
-        detail:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FileInputDetail'
-          description: The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`.
+        file_data:
+          type: string
+          description: The content of the file to be sent to the model.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: A file input to the model.
@@ -31783,7 +30925,7 @@ components:
         detail:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageDetail'
-          description: The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`.
+          description: The detail level of the image to be sent to the model. One of `high`, `low`, or `auto`. Defaults to `auto`.
       allOf:
         - $ref: '#/components/schemas/OpenAI.MessageContent'
       description: An image input to the model. Learn about [image inputs](/docs/guides/vision).
@@ -31893,15 +31035,6 @@ components:
             - input_image
             - computer_screenshot
             - input_file
-    OpenAI.MessagePhase:
-      type: string
-      enum:
-        - commentary
-        - final_answer
-      description: |-
-        Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`).
-        For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend
-        phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
     OpenAI.MessageRole:
       type: string
       enum:
@@ -31959,125 +31092,6 @@ components:
       anyOf:
         - type: string
         - $ref: '#/components/schemas/OpenAI.ChatModel'
-    OpenAI.Moderation:
-      type: object
-      required:
-        - input
-        - output
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response input.
-        output:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-          description: Moderation for the response output.
-      description: Moderation results or errors for the response input and output.
-      title: Moderation
-    OpenAI.ModerationEntry:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ModerationEntryType'
-      discriminator:
-        propertyName: type
-        mapping:
-          moderation_result: '#/components/schemas/OpenAI.ModerationResultBody'
-          error: '#/components/schemas/OpenAI.ModerationErrorBody'
-      description: Moderation results or an error for a response moderation check.
-    OpenAI.ModerationEntryType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - moderation_result
-            - error
-    OpenAI.ModerationErrorBody:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - error
-          description: The object type, which was always `error` for moderation failures.
-          x-stainless-const: true
-        code:
-          type: string
-          description: The error code.
-        message:
-          type: string
-          description: The error message.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: An error produced while attempting moderation for the response input or output.
-      title: Moderation error
-    OpenAI.ModerationInputType:
-      type: string
-      enum:
-        - text
-        - image
-    OpenAI.ModerationParam:
-      type: object
-      required:
-        - model
-      properties:
-        model:
-          type: string
-          description: The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.
-      description: Configuration for running moderation on the input and output of this response.
-    OpenAI.ModerationResultBody:
-      type: object
-      required:
-        - type
-        - model
-        - flagged
-        - categories
-        - category_scores
-        - category_applied_input_types
-      properties:
-        type:
-          type: string
-          enum:
-            - moderation_result
-          description: The object type, which was always `moderation_result` for successful moderation results.
-          x-stainless-const: true
-        model:
-          type: string
-          description: The moderation model that produced this result.
-        flagged:
-          type: boolean
-          description: A boolean indicating whether the content was flagged by any category.
-        categories:
-          type: object
-          unevaluatedProperties:
-            type: boolean
-          description: A dictionary of moderation categories to booleans, True if the input is flagged under this category.
-          x-oaiTypeLabel: map
-        category_scores:
-          type: object
-          unevaluatedProperties:
-            $ref: '#/components/schemas/OpenAI.numeric'
-          description: A dictionary of moderation categories to scores.
-          x-oaiTypeLabel: map
-        category_applied_input_types:
-          type: object
-          unevaluatedProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/OpenAI.ModerationInputType'
-          description: Which modalities of input are reflected by the score for each category.
-          x-oaiTypeLabel: map
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ModerationEntry'
-      description: A moderation result produced for the response input or output.
-      title: Moderation result
     OpenAI.MoveParam:
       type: object
       required:
@@ -32091,6 +31105,7 @@ components:
             - move
           description: Specifies the event type. For a move action, this property is always set to `move`.
           x-stainless-const: true
+          default: move
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -32099,50 +31114,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The y-coordinate to move to.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A mouse move action.
       title: Move
-    OpenAI.NamespaceToolParam:
-      type: object
-      required:
-        - type
-        - name
-        - description
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - namespace
-          description: The type of the tool. Always `namespace`.
-          x-stainless-const: true
-        name:
-          type: string
-          minLength: 1
-          description: The namespace name used in tool calls (for example, `crm`).
-        description:
-          type: string
-          minLength: 1
-          description: A description of the namespace shown to the model.
-        tools:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/OpenAI.FunctionToolParam'
-              - $ref: '#/components/schemas/OpenAI.CustomToolParam'
-          minItems: 1
-          description: The function/custom tools available inside this namespace.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Groups function/custom tools under a shared namespace.
-      title: Namespace
     OpenAI.OutputContent:
       type: object
       required:
@@ -32284,19 +31259,13 @@ components:
           output_message: '#/components/schemas/OpenAI.OutputItemOutputMessage'
           file_search_call: '#/components/schemas/OpenAI.OutputItemFileSearchToolCall'
           function_call: '#/components/schemas/OpenAI.OutputItemFunctionToolCall'
-          function_call_output: '#/components/schemas/OpenAI.OutputItemFunctionToolCallOutput'
           web_search_call: '#/components/schemas/OpenAI.OutputItemWebSearchToolCall'
           computer_call: '#/components/schemas/OpenAI.OutputItemComputerToolCall'
-          computer_call_output: '#/components/schemas/OpenAI.OutputItemComputerToolCallOutput'
           reasoning: '#/components/schemas/OpenAI.OutputItemReasoningItem'
-          tool_search_call: '#/components/schemas/OpenAI.OutputItemToolSearchCall'
-          tool_search_output: '#/components/schemas/OpenAI.OutputItemToolSearchOutput'
-          additional_tools: '#/components/schemas/OpenAI.OutputItemAdditionalTools'
           compaction: '#/components/schemas/OpenAI.OutputItemCompactionBody'
           image_generation_call: '#/components/schemas/OpenAI.OutputItemImageGenToolCall'
           code_interpreter_call: '#/components/schemas/OpenAI.OutputItemCodeInterpreterToolCall'
           local_shell_call: '#/components/schemas/OpenAI.OutputItemLocalShellToolCall'
-          local_shell_call_output: '#/components/schemas/OpenAI.OutputItemLocalShellToolCallOutput'
           shell_call: '#/components/schemas/OpenAI.OutputItemFunctionShellCall'
           shell_call_output: '#/components/schemas/OpenAI.OutputItemFunctionShellCallOutput'
           apply_patch_call: '#/components/schemas/OpenAI.OutputItemApplyPatchToolCall'
@@ -32304,38 +31273,7 @@ components:
           mcp_call: '#/components/schemas/OpenAI.OutputItemMcpToolCall'
           mcp_list_tools: '#/components/schemas/OpenAI.OutputItemMcpListTools'
           mcp_approval_request: '#/components/schemas/OpenAI.OutputItemMcpApprovalRequest'
-          mcp_approval_response: '#/components/schemas/OpenAI.OutputItemMcpApprovalResponseResource'
-          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCallResource'
-          custom_tool_call_output: '#/components/schemas/OpenAI.OutputItemCustomToolCallOutputResource'
-    OpenAI.OutputItemAdditionalTools:
-      type: object
-      required:
-        - type
-        - id
-        - role
-        - tools
-      properties:
-        type:
-          type: string
-          enum:
-            - additional_tools
-          description: The type of the item. Always `additional_tools`.
-          x-stainless-const: true
-          default: additional_tools
-        id:
-          type: string
-          description: The unique ID of the additional tools item.
-        role:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.MessageRole'
-          description: The role that provided the additional tools.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The additional tool definitions made available at this item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
+          custom_tool_call: '#/components/schemas/OpenAI.OutputItemCustomToolCall'
     OpenAI.OutputItemApplyPatchToolCall:
       type: object
       required:
@@ -32491,6 +31429,7 @@ components:
         - type
         - id
         - call_id
+        - action
         - pending_safety_checks
         - status
       properties:
@@ -32508,8 +31447,6 @@ components:
           description: An identifier used when responding to the tool call with output.
         action:
           $ref: '#/components/schemas/OpenAI.ComputerAction'
-        actions:
-          $ref: '#/components/schemas/OpenAI.ComputerActionList'
         pending_safety_checks:
           type: array
           items:
@@ -32530,99 +31467,13 @@ components:
         A tool call to a computer use tool. See the
         [computer use guide](/docs/guides/tools-computer-use) for more information.
       title: Computer tool call
-    OpenAI.OutputItemComputerToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_call_output
-          description: The type of the computer tool call output. Always `computer_call_output`.
-          x-stainless-const: true
-          default: computer_call_output
-        id:
-          type: string
-          description: The ID of the computer tool call output.
-          readOnly: true
-        call_id:
-          type: string
-          description: The ID of the computer tool call that produced the output.
-        acknowledged_safety_checks:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.ComputerCallSafetyCheckParam'
-          description: |-
-            The safety checks reported by the API that have been acknowledged by the
-              developer.
-        output:
-          $ref: '#/components/schemas/OpenAI.ComputerScreenshotImage'
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the message input. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when input items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a computer tool call.
-      title: Computer tool call output
-    OpenAI.OutputItemCustomToolCallOutputResource:
-      type: object
-      required:
-        - type
-        - call_id
-        - output
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - custom_tool_call_output
-          description: The type of the custom tool call output. Always `custom_tool_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the custom tool call output in the OpenAI platform.
-        call_id:
-          type: string
-          description: The call ID, used to map this custom tool call output to a custom tool call.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the custom tool call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallOutputItem
-    OpenAI.OutputItemCustomToolCallResource:
+    OpenAI.OutputItemCustomToolCall:
       type: object
       required:
         - type
         - call_id
         - name
         - input
-        - status
       properties:
         type:
           type: string
@@ -32636,27 +31487,16 @@ components:
         call_id:
           type: string
           description: An identifier used to map this custom tool call to a tool call output.
-        namespace:
-          type: string
-          description: The namespace of the custom tool being called.
         name:
           type: string
           description: The name of the custom tool being called.
         input:
           type: string
           description: The input for the custom tool call generated by the model.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-      title: ResponseCustomToolCallItem
+      description: A call to a custom tool created by the model.
+      title: Custom tool call
     OpenAI.OutputItemFileSearchToolCall:
       type: object
       required:
@@ -32731,7 +31571,7 @@ components:
           description: The shell commands and limits that describe how to run the tool call.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallStatus'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallStatus'
           description: The status of the shell call. One of `in_progress`, `completed`, or `incomplete`.
         environment:
           anyOf:
@@ -32769,7 +31609,7 @@ components:
           description: The unique ID of the shell tool call generated by the model.
         status:
           allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputStatusEnum'
+            - $ref: '#/components/schemas/OpenAI.LocalShellCallOutputStatusEnum'
           description: The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`.
         output:
           type: array
@@ -32790,7 +31630,6 @@ components:
     OpenAI.OutputItemFunctionToolCall:
       type: object
       required:
-        - id
         - type
         - call_id
         - name
@@ -32799,7 +31638,6 @@ components:
         id:
           type: string
           description: The unique ID of the function tool call.
-          readOnly: true
         type:
           type: string
           enum:
@@ -32809,9 +31647,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        namespace:
-          type: string
-          description: The namespace of the function to run.
         name:
           type: string
           description: The name of the function to run.
@@ -32833,51 +31668,6 @@ components:
         A tool call to run a function. See the
         [function calling guide](/docs/guides/function-calling) for more information.
       title: Function tool call
-    OpenAI.OutputItemFunctionToolCallOutput:
-      type: object
-      required:
-        - id
-        - type
-        - call_id
-        - output
-      properties:
-        id:
-          type: string
-          description: |-
-            The unique ID of the function tool call output. Populated when this item
-              is returned via API.
-          readOnly: true
-        type:
-          type: string
-          enum:
-            - function_call_output
-          description: The type of the function tool call output. Always `function_call_output`.
-          x-stainless-const: true
-        call_id:
-          type: string
-          description: The unique ID of the function tool call generated by the model.
-        output:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                $ref: '#/components/schemas/OpenAI.FunctionAndCustomToolCallOutput'
-          description: |-
-            The output from the function call generated by your code.
-              Can be a string or an list of output content.
-        status:
-          type: string
-          enum:
-            - in_progress
-            - completed
-            - incomplete
-          description: |-
-            The status of the item. One of `in_progress`, `completed`, or
-              `incomplete`. Populated when items are returned via API.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a function tool call.
-      title: Function tool call output
     OpenAI.OutputItemImageGenToolCall:
       type: object
       required:
@@ -32945,37 +31735,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A tool call to run a command on the local shell.
       title: Local shell call
-    OpenAI.OutputItemLocalShellToolCallOutput:
-      type: object
-      required:
-        - type
-        - id
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - local_shell_call_output
-          description: The type of the local shell tool call output. Always `local_shell_call_output`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the local shell tool call generated by the model.
-        output:
-          type: string
-          description: A JSON string of the output of the local shell tool call.
-        status:
-          anyOf:
-            - type: string
-              enum:
-                - in_progress
-                - completed
-                - incomplete
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: The output of a local shell tool call.
-      title: Local shell call output
     OpenAI.OutputItemMcpApprovalRequest:
       type: object
       required:
@@ -33007,37 +31766,6 @@ components:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A request for human approval of a tool invocation.
       title: MCP approval request
-    OpenAI.OutputItemMcpApprovalResponseResource:
-      type: object
-      required:
-        - type
-        - id
-        - approval_request_id
-        - approve
-      properties:
-        type:
-          type: string
-          enum:
-            - mcp_approval_response
-          description: The type of the item. Always `mcp_approval_response`.
-          x-stainless-const: true
-        id:
-          type: string
-          description: The unique ID of the approval response
-        approval_request_id:
-          type: string
-          description: The ID of the approval request being answered.
-        approve:
-          type: boolean
-          description: Whether the request was approved.
-        reason:
-          anyOf:
-            - type: string
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-      description: A response to an MCP approval request.
-      title: MCP approval response
     OpenAI.OutputItemMcpListTools:
       type: object
       required:
@@ -33064,7 +31792,9 @@ components:
             $ref: '#/components/schemas/OpenAI.MCPListToolsTool'
           description: The tools available on the server.
         error:
-          $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
+          anyOf:
+            - type: string
+            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: A list of tools available on an MCP server.
@@ -33144,10 +31874,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.OutputMessageContent'
           description: The content of the output message.
-        phase:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.MessagePhase'
-            - type: 'null'
         status:
           type: string
           enum:
@@ -33208,87 +31934,6 @@ components:
         for subsequent turns of a conversation if you are manually
         [managing context](/docs/guides/conversation-state).
       title: Reasoning
-    OpenAI.OutputItemToolSearchCall:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - arguments
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_call
-          description: The type of the item. Always `tool_search_call`.
-          x-stainless-const: true
-          default: tool_search_call
-        id:
-          type: string
-          description: The unique ID of the tool search call item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        arguments:
-          description: Arguments used for the tool search call.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallStatus'
-          description: The status of the tool search call item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
-    OpenAI.OutputItemToolSearchOutput:
-      type: object
-      required:
-        - type
-        - id
-        - call_id
-        - execution
-        - tools
-        - status
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search_output
-          description: The type of the item. Always `tool_search_output`.
-          x-stainless-const: true
-          default: tool_search_output
-        id:
-          type: string
-          description: The unique ID of the tool search output item.
-        call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search was executed by the server or by the client.
-        tools:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.Tool'
-          description: The loaded tool definitions returned by tool search.
-        status:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.FunctionCallOutputStatusEnum'
-          description: The status of the tool search output item that was recorded.
-        created_by:
-          type: string
-          description: The identifier of the actor that created the item.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.OutputItem'
     OpenAI.OutputItemType:
       anyOf:
         - type: string
@@ -33297,19 +31942,13 @@ components:
             - output_message
             - file_search_call
             - function_call
-            - function_call_output
             - web_search_call
             - computer_call
-            - computer_call_output
             - reasoning
-            - tool_search_call
-            - tool_search_output
-            - additional_tools
             - compaction
             - image_generation_call
             - code_interpreter_call
             - local_shell_call
-            - local_shell_call_output
             - shell_call
             - shell_call_output
             - apply_patch_call
@@ -33317,9 +31956,7 @@ components:
             - mcp_call
             - mcp_list_tools
             - mcp_approval_request
-            - mcp_approval_response
             - custom_tool_call
-            - custom_tool_call_output
             - structured_outputs
             - oauth_consent_request
             - memory_search_call
@@ -33472,11 +32109,6 @@ components:
       description: |-
         Reference to a prompt template and its variables.
         [Learn more](/docs/guides/text?api-mode=responses#reusable-prompts).
-    OpenAI.PromptCacheRetentionEnum:
-      type: string
-      enum:
-        - in_memory
-        - 24h
     OpenAI.RankerVersionType:
       type: string
       enum:
@@ -33497,81 +32129,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.HybridSearchOptions'
           description: Weights that control how reciprocal rank fusion balances semantic embedding matches versus sparse keyword matches when hybrid search is enabled.
-    OpenAI.RealtimeMCPError:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.RealtimeMcpErrorType'
-      discriminator:
-        propertyName: type
-        mapping:
-          protocol_error: '#/components/schemas/OpenAI.RealtimeMCPProtocolError'
-          tool_execution_error: '#/components/schemas/OpenAI.RealtimeMCPToolExecutionError'
-          http_error: '#/components/schemas/OpenAI.RealtimeMCPHTTPError'
-    OpenAI.RealtimeMCPHTTPError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - http_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP HTTP error
-    OpenAI.RealtimeMCPProtocolError:
-      type: object
-      required:
-        - type
-        - code
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - protocol_error
-          x-stainless-const: true
-        code:
-          $ref: '#/components/schemas/OpenAI.integer'
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP protocol error
-    OpenAI.RealtimeMCPToolExecutionError:
-      type: object
-      required:
-        - type
-        - message
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_execution_error
-          x-stainless-const: true
-        message:
-          type: string
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeMCPError'
-      title: Realtime MCP tool execution error
-    OpenAI.RealtimeMcpErrorType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - protocol_error
-            - tool_execution_error
-            - http_error
     OpenAI.Reasoning:
       type: object
       properties:
@@ -33677,10 +32234,9 @@ components:
           deprecated: true
         safety_identifier:
           type: string
-          maxLength: 64
           description: |-
             A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+              The IDs should be a string that uniquely identifies each user. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
           type: string
           description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
@@ -33690,7 +32246,7 @@ components:
           anyOf:
             - type: string
               enum:
-                - in_memory
+                - in-memory
                 - 24h
             - type: 'null'
         previous_response_id:
@@ -33707,6 +32263,10 @@ components:
         background:
           anyOf:
             - type: boolean
+            - type: 'null'
+        max_output_tokens:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         max_tool_calls:
           anyOf:
@@ -33795,10 +32355,6 @@ components:
             - type: 'null'
         usage:
           $ref: '#/components/schemas/OpenAI.ResponseUsage'
-        moderation:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Moderation'
-            - type: 'null'
         parallel_tool_calls:
           type: boolean
           description: Whether to allow the model to run tool calls in parallel.
@@ -33806,10 +32362,6 @@ components:
         conversation:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ConversationReference'
-            - type: 'null'
-        max_output_tokens:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.integer'
             - type: 'null'
         agent:
           allOf:
@@ -33856,8 +32408,6 @@ components:
           type: string
           contentEncoding: base64
           description: A chunk of Base64 encoded response audio bytes.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial audio response.
       x-oaiMeta:
         name: response.audio.delta
@@ -33885,8 +32435,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the audio response is complete.
       x-oaiMeta:
         name: response.audio.done
@@ -33917,8 +32465,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial transcript of audio.
       x-oaiMeta:
         name: response.audio.transcript.delta
@@ -33946,8 +32492,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the full audio transcript is completed.
       x-oaiMeta:
         name: response.audio.transcript.done
@@ -33987,8 +32531,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial code snippet is streamed by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.delta
@@ -34030,8 +32572,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code snippet is finalized by the code interpreter.
       x-oaiMeta:
         name: response.code_interpreter_call_code.done
@@ -34069,8 +32609,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter call is completed.
       x-oaiMeta:
         name: response.code_interpreter_call.completed
@@ -34107,8 +32645,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a code interpreter call is in progress.
       x-oaiMeta:
         name: response.code_interpreter_call.in_progress
@@ -34145,8 +32681,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event, used to order streaming events.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the code interpreter is actively interpreting the code snippet.
       x-oaiMeta:
         name: response.code_interpreter_call.interpreting
@@ -34179,8 +32713,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the model response is complete.
       x-oaiMeta:
         name: response.completed
@@ -34275,8 +32807,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new content part is added.
       x-oaiMeta:
         name: response.content_part.added
@@ -34329,8 +32859,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputContent'
           description: The content part that is done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a content part is done.
       x-oaiMeta:
         name: response.content_part.done
@@ -34369,8 +32897,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response is created.
       x-oaiMeta:
         name: response.created
@@ -34442,8 +32968,6 @@ components:
         delta:
           type: string
           description: The incremental input data (delta) for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event representing a delta (partial update) to the input of a custom tool call.
       title: ResponseCustomToolCallInputDelta
       x-oaiMeta:
@@ -34485,8 +33009,6 @@ components:
         input:
           type: string
           description: The complete input data for the custom tool call.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Event indicating that input for a custom tool call is complete.
       title: ResponseCustomToolCallInputDone
       x-oaiMeta:
@@ -34563,8 +33085,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an error occurs.
       x-oaiMeta:
         name: error
@@ -34598,8 +33118,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Response'
           description: The response that failed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response fails.
       x-oaiMeta:
         name: response.failed
@@ -34665,8 +33183,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is completed (results found).
       x-oaiMeta:
         name: response.file_search_call.completed
@@ -34703,8 +33219,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search call is initiated.
       x-oaiMeta:
         name: response.file_search_call.in_progress
@@ -34741,8 +33255,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a file search is currently searching.
       x-oaiMeta:
         name: response.file_search_call.searching
@@ -34858,8 +33370,6 @@ components:
         delta:
           type: string
           description: The function-call arguments delta that is added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial function-call arguments delta.
       x-oaiMeta:
         name: response.function_call_arguments.delta
@@ -34904,8 +33414,6 @@ components:
         arguments:
           type: string
           description: The function-call arguments.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when function-call arguments are finalized.
       x-oaiMeta:
         name: response.function_call_arguments.done
@@ -34944,8 +33452,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call has completed and the final image is available.
       title: ResponseImageGenCallCompletedEvent
       x-oaiMeta:
@@ -34983,8 +33489,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is actively generating an image (intermediate state).
       title: ResponseImageGenCallGeneratingEvent
       x-oaiMeta:
@@ -35022,8 +33526,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the image generation item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an image generation tool call is in progress.
       title: ResponseImageGenCallInProgressEvent
       x-oaiMeta:
@@ -35070,8 +33572,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
       title: ResponseImageGenCallPartialImageEvent
       x-oaiMeta:
@@ -35107,8 +33607,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the response is in progress.
       x-oaiMeta:
         name: response.in_progress
@@ -35180,8 +33678,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: An event that is emitted when a response finishes as incomplete.
       x-oaiMeta:
         name: response.incomplete
@@ -35239,7 +33735,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProbTopLogprobs'
-          description: The log probabilities of up to 20 of the most likely tokens.
+          description: The log probability of the top 20 most likely tokens.
       description: |-
         A logprob is the logarithmic probability that the model assigns to producing
         a particular token at a given position in the sequence. Less-negative (higher)
@@ -35280,8 +33776,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
       title: ResponseMCPCallArgumentsDeltaEvent
       x-oaiMeta:
@@ -35324,8 +33818,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the arguments for an MCP tool call are finalized.
       title: ResponseMCPCallArgumentsDoneEvent
       x-oaiMeta:
@@ -35364,8 +33856,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has completed successfully.
       title: ResponseMCPCallCompletedEvent
       x-oaiMeta:
@@ -35403,8 +33893,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call has failed.
       title: ResponseMCPCallFailedEvent
       x-oaiMeta:
@@ -35442,8 +33930,6 @@ components:
         item_id:
           type: string
           description: The unique identifier of the MCP tool call item being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an MCP  tool call is in progress.
       title: ResponseMCPCallInProgressEvent
       x-oaiMeta:
@@ -35481,8 +33967,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the list of available MCP tools has been successfully retrieved.
       title: ResponseMCPListToolsCompletedEvent
       x-oaiMeta:
@@ -35520,8 +34004,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the attempt to list available MCP tools has failed.
       title: ResponseMCPListToolsFailedEvent
       x-oaiMeta:
@@ -35559,8 +34041,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when the system is in the process of retrieving the list of available MCP tools.
       title: ResponseMCPListToolsInProgressEvent
       x-oaiMeta:
@@ -35599,8 +34079,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
       x-oaiMeta:
         name: response.output_item.added
@@ -35644,8 +34122,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.OutputItem'
           description: The output item that was marked done.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an output item is marked done.
       x-oaiMeta:
         name: response.output_item.done
@@ -35709,8 +34185,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.Annotation'
           description: The annotation object being added. (See annotation schema for details.)
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when an annotation is added to output text content.
       title: ResponseOutputTextAnnotationAddedEvent
       x-oaiMeta:
@@ -35767,8 +34241,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number for this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a response is queued and waiting to be processed.
       title: ResponseQueuedEvent
       x-oaiMeta:
@@ -35820,8 +34292,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEventPart'
           description: The summary part that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new reasoning summary part is added.
       x-oaiMeta:
         name: response.reasoning_summary_part.added
@@ -35886,8 +34356,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEventPart'
           description: The completed summary part.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary part is completed.
       x-oaiMeta:
         name: response.reasoning_summary_part.done
@@ -35953,8 +34421,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning summary text.
       x-oaiMeta:
         name: response.reasoning_summary_text.delta
@@ -36004,8 +34470,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning summary text is completed.
       x-oaiMeta:
         name: response.reasoning_summary_text.done
@@ -36055,8 +34519,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a delta is added to a reasoning text.
       x-oaiMeta:
         name: response.reasoning_text.delta
@@ -36104,8 +34566,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a reasoning text is completed.
       x-oaiMeta:
         name: response.reasoning_text.done
@@ -36153,8 +34613,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is a partial refusal text.
       x-oaiMeta:
         name: response.refusal.delta
@@ -36202,8 +34660,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of this event.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when refusal text is finalized.
       x-oaiMeta:
         name: response.refusal.done
@@ -36217,127 +34673,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseStreamEvent:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/OpenAI.ResponseStreamEventType'
-      discriminator:
-        propertyName: type
-        mapping:
-          response.audio.transcript.delta: '#/components/schemas/OpenAI.ResponseAudioTranscriptDeltaEvent'
-          response.code_interpreter_call_code.delta: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDeltaEvent'
-          response.code_interpreter_call.in_progress: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInProgressEvent'
-          response.code_interpreter_call.interpreting: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallInterpretingEvent'
-          response.content_part.added: '#/components/schemas/OpenAI.ResponseContentPartAddedEvent'
-          response.created: '#/components/schemas/OpenAI.ResponseCreatedEvent'
-          error: '#/components/schemas/OpenAI.ResponseErrorEvent'
-          response.file_search_call.in_progress: '#/components/schemas/OpenAI.ResponseFileSearchCallInProgressEvent'
-          response.file_search_call.searching: '#/components/schemas/OpenAI.ResponseFileSearchCallSearchingEvent'
-          response.function_call_arguments.delta: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDeltaEvent'
-          response.in_progress: '#/components/schemas/OpenAI.ResponseInProgressEvent'
-          response.failed: '#/components/schemas/OpenAI.ResponseFailedEvent'
-          response.incomplete: '#/components/schemas/OpenAI.ResponseIncompleteEvent'
-          response.output_item.added: '#/components/schemas/OpenAI.ResponseOutputItemAddedEvent'
-          response.reasoning_summary_part.added: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartAddedEvent'
-          response.reasoning_summary_text.delta: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDeltaEvent'
-          response.reasoning_text.delta: '#/components/schemas/OpenAI.ResponseReasoningTextDeltaEvent'
-          response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
-          response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
-          response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
-          response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
-          response.image_generation_call.generating: '#/components/schemas/OpenAI.ResponseImageGenCallGeneratingEvent'
-          response.image_generation_call.in_progress: '#/components/schemas/OpenAI.ResponseImageGenCallInProgressEvent'
-          response.image_generation_call.partial_image: '#/components/schemas/OpenAI.ResponseImageGenCallPartialImageEvent'
-          response.mcp_call_arguments.delta: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDeltaEvent'
-          response.mcp_call.failed: '#/components/schemas/OpenAI.ResponseMCPCallFailedEvent'
-          response.mcp_call.in_progress: '#/components/schemas/OpenAI.ResponseMCPCallInProgressEvent'
-          response.mcp_list_tools.failed: '#/components/schemas/OpenAI.ResponseMCPListToolsFailedEvent'
-          response.mcp_list_tools.in_progress: '#/components/schemas/OpenAI.ResponseMCPListToolsInProgressEvent'
-          response.output_text.annotation.added: '#/components/schemas/OpenAI.ResponseOutputTextAnnotationAddedEvent'
-          response.queued: '#/components/schemas/OpenAI.ResponseQueuedEvent'
-          response.custom_tool_call_input.delta: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDeltaEvent'
-          response.audio.done: '#/components/schemas/OpenAI.ResponseAudioDoneEvent'
-          response.audio.transcript.done: '#/components/schemas/OpenAI.ResponseAudioTranscriptDoneEvent'
-          response.code_interpreter_call_code.done: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCodeDoneEvent'
-          response.code_interpreter_call.completed: '#/components/schemas/OpenAI.ResponseCodeInterpreterCallCompletedEvent'
-          response.completed: '#/components/schemas/OpenAI.ResponseCompletedEvent'
-          response.content_part.done: '#/components/schemas/OpenAI.ResponseContentPartDoneEvent'
-          response.file_search_call.completed: '#/components/schemas/OpenAI.ResponseFileSearchCallCompletedEvent'
-          response.function_call_arguments.done: '#/components/schemas/OpenAI.ResponseFunctionCallArgumentsDoneEvent'
-          response.output_item.done: '#/components/schemas/OpenAI.ResponseOutputItemDoneEvent'
-          response.reasoning_summary_part.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryPartDoneEvent'
-          response.reasoning_summary_text.done: '#/components/schemas/OpenAI.ResponseReasoningSummaryTextDoneEvent'
-          response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
-          response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
-          response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
-          response.image_generation_call.completed: '#/components/schemas/OpenAI.ResponseImageGenCallCompletedEvent'
-          response.mcp_call_arguments.done: '#/components/schemas/OpenAI.ResponseMCPCallArgumentsDoneEvent'
-          response.mcp_call.completed: '#/components/schemas/OpenAI.ResponseMCPCallCompletedEvent'
-          response.mcp_list_tools.completed: '#/components/schemas/OpenAI.ResponseMCPListToolsCompletedEvent'
-          response.custom_tool_call_input.done: '#/components/schemas/OpenAI.ResponseCustomToolCallInputDoneEvent'
-          response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-    OpenAI.ResponseStreamEventType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - response.audio.delta
-            - response.audio.done
-            - response.audio.transcript.delta
-            - response.audio.transcript.done
-            - response.code_interpreter_call_code.delta
-            - response.code_interpreter_call_code.done
-            - response.code_interpreter_call.completed
-            - response.code_interpreter_call.in_progress
-            - response.code_interpreter_call.interpreting
-            - response.completed
-            - response.content_part.added
-            - response.content_part.done
-            - response.created
-            - error
-            - response.file_search_call.completed
-            - response.file_search_call.in_progress
-            - response.file_search_call.searching
-            - response.function_call_arguments.delta
-            - response.function_call_arguments.done
-            - response.in_progress
-            - response.failed
-            - response.incomplete
-            - response.output_item.added
-            - response.output_item.done
-            - response.reasoning_summary_part.added
-            - response.reasoning_summary_part.done
-            - response.reasoning_summary_text.delta
-            - response.reasoning_summary_text.done
-            - response.reasoning_text.delta
-            - response.reasoning_text.done
-            - response.refusal.delta
-            - response.refusal.done
-            - response.output_text.delta
-            - response.output_text.done
-            - response.web_search_call.completed
-            - response.web_search_call.in_progress
-            - response.web_search_call.searching
-            - response.image_generation_call.completed
-            - response.image_generation_call.generating
-            - response.image_generation_call.in_progress
-            - response.image_generation_call.partial_image
-            - response.mcp_call_arguments.delta
-            - response.mcp_call_arguments.done
-            - response.mcp_call.completed
-            - response.mcp_call.failed
-            - response.mcp_call.in_progress
-            - response.mcp_list_tools.completed
-            - response.mcp_list_tools.failed
-            - response.mcp_list_tools.in_progress
-            - response.output_text.annotation.added
-            - response.queued
-            - response.custom_tool_call_input.delta
-            - response.custom_tool_call_input.done
     OpenAI.ResponseStreamOptions:
       type: object
       properties:
@@ -36392,8 +34727,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when there is an additional text delta.
       x-oaiMeta:
         name: response.output_text.delta
@@ -36447,8 +34780,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.ResponseLogProb'
           description: The log probabilities of the tokens in the delta.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when text content is finalized.
       x-oaiMeta:
         name: response.output_text.done
@@ -36545,8 +34876,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is completed.
       x-oaiMeta:
         name: response.web_search_call.completed
@@ -36583,8 +34912,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is initiated.
       x-oaiMeta:
         name: response.web_search_call.in_progress
@@ -36621,8 +34948,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The sequence number of the web search call being processed.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a web search call is executing.
       x-oaiMeta:
         name: response.web_search_call.searching
@@ -36645,6 +34970,7 @@ components:
             - screenshot
           description: Specifies the event type. For a screenshot action, this property is always set to `screenshot`.
           x-stainless-const: true
+          default: screenshot
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A screenshot action.
@@ -36664,6 +34990,7 @@ components:
             - scroll
           description: Specifies the event type. For a scroll action, this property is always set to `scroll`.
           x-stainless-const: true
+          default: scroll
         x:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
@@ -36680,21 +35007,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.integer'
           description: The vertical scroll distance.
-        keys:
-          anyOf:
-            - type: array
-              items:
-                type: string
-            - type: 'null'
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A scroll action.
       title: Scroll
-    OpenAI.SearchContentType:
-      type: string
-      enum:
-        - text
-        - image
     OpenAI.SearchContextSize:
       type: string
       enum:
@@ -36718,13 +35034,6 @@ components:
         - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ServiceTierEnum:
-      type: string
-      enum:
-        - auto
-        - default
-        - flex
-        - priority
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -36737,6 +35046,7 @@ components:
             - skill_reference
           description: References a skill created with the /v1/skills endpoint.
           x-stainless-const: true
+          default: skill_reference
         skill_id:
           type: string
           minLength: 1
@@ -36758,6 +35068,7 @@ components:
             - apply_patch
           description: The tool to call. Always `apply_patch`.
           x-stainless-const: true
+          default: apply_patch
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the apply_patch tool when executing a tool call.
@@ -36773,6 +35084,7 @@ components:
             - shell
           description: The tool to call. Always `shell`.
           x-stainless-const: true
+          default: shell
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: Forces the model to call the shell tool when a tool call is required.
@@ -36789,6 +35101,7 @@ components:
             - summary_text
           description: The type of the object. Always `summary_text`.
           x-stainless-const: true
+          default: summary_text
         text:
           type: string
           description: A summary of the reasoning output from the model so far.
@@ -36807,6 +35120,7 @@ components:
           enum:
             - text
           x-stainless-const: true
+          default: text
         text:
           type: string
       allOf:
@@ -36950,9 +35264,6 @@ components:
           custom: '#/components/schemas/OpenAI.CustomToolParam'
           web_search_preview: '#/components/schemas/OpenAI.WebSearchPreviewTool'
           apply_patch: '#/components/schemas/OpenAI.ApplyPatchToolParam'
-          computer: '#/components/schemas/OpenAI.ComputerTool'
-          namespace: '#/components/schemas/OpenAI.NamespaceToolParam'
-          tool_search: '#/components/schemas/OpenAI.ToolSearchToolParam'
       description: A tool that can be used to generate a response.
     OpenAI.ToolChoiceAllowed:
       type: object
@@ -37005,34 +35316,6 @@ components:
           type: string
           enum:
             - code_interpreter
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputer:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
-      description: |-
-        Indicates that the model should use a built-in tool to generate a response.
-        [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolChoiceComputerUse:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - computer_use
       allOf:
         - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
       description: |-
@@ -37176,8 +35459,6 @@ components:
           web_search_preview_2025_03_11: '#/components/schemas/OpenAI.ToolChoiceWebSearchPreview20250311'
           image_generation: '#/components/schemas/OpenAI.ToolChoiceImageGeneration'
           code_interpreter: '#/components/schemas/OpenAI.ToolChoiceCodeInterpreter'
-          computer: '#/components/schemas/OpenAI.ToolChoiceComputer'
-          computer_use: '#/components/schemas/OpenAI.ToolChoiceComputerUse'
       description: |-
         How the model should select which tool (or tools) to use when generating
         a response. See the `tools` parameter to see how to specify which tools
@@ -37199,8 +35480,6 @@ components:
             - web_search_preview_2025_03_11
             - image_generation
             - code_interpreter
-            - computer
-            - computer_use
     OpenAI.ToolChoiceWebSearchPreview:
       type: object
       required:
@@ -37229,38 +35508,6 @@ components:
       description: |-
         Indicates that the model should use a built-in tool to generate a response.
         [Learn more about built-in tools](https://platform.openai.com/docs/guides/tools).
-    OpenAI.ToolSearchExecutionType:
-      type: string
-      enum:
-        - server
-        - client
-    OpenAI.ToolSearchToolParam:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - tool_search
-          description: The type of the tool. Always `tool_search`.
-          x-stainless-const: true
-        execution:
-          allOf:
-            - $ref: '#/components/schemas/OpenAI.ToolSearchExecutionType'
-          description: Whether tool search is executed by the server or by the client.
-        description:
-          anyOf:
-            - type: string
-            - type: 'null'
-        parameters:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.EmptyModelParam'
-            - type: 'null'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.Tool'
-      description: Hosted or BYOT tool search configuration for deferred tools.
-      title: Tool search tool
     OpenAI.ToolType:
       anyOf:
         - type: string
@@ -37268,7 +35515,6 @@ components:
           enum:
             - function
             - file_search
-            - computer
             - computer_use_preview
             - web_search
             - mcp
@@ -37277,8 +35523,6 @@ components:
             - local_shell
             - shell
             - custom
-            - namespace
-            - tool_search
             - web_search_preview
             - apply_patch
             - a2a_preview
@@ -37346,6 +35590,7 @@ components:
             - type
           description: Specifies the event type. For a type action, this property is always set to `type`.
           x-stainless-const: true
+          default: type
         text:
           type: string
           description: The text to type.
@@ -37380,6 +35625,7 @@ components:
             - url_citation
           description: The type of the URL citation. Always `url_citation`.
           x-stainless-const: true
+          default: url_citation
         url:
           type: string
           format: uri
@@ -37436,6 +35682,7 @@ components:
             - wait
           description: Specifies the event type. For a wait action, this property is always set to `wait`.
           x-stainless-const: true
+          default: wait
       allOf:
         - $ref: '#/components/schemas/OpenAI.ComputerAction'
       description: A wait action.
@@ -37485,6 +35732,7 @@ components:
       type: object
       required:
         - type
+        - query
       properties:
         type:
           type: string
@@ -37494,7 +35742,7 @@ components:
           x-stainless-const: true
         query:
           type: string
-          description: The search query.
+          description: '[DEPRECATED] The search query.'
           deprecated: true
         queries:
           type: array
@@ -37523,7 +35771,6 @@ components:
           x-stainless-const: true
         url:
           type: string
-          format: uri
     OpenAI.WebSearchApproximateLocation:
       type: object
       required:
@@ -37565,6 +35812,7 @@ components:
             - web_search_preview
           description: The type of the web search tool. One of `web_search_preview` or `web_search_preview_2025_03_11`.
           x-stainless-const: true
+          default: web_search_preview
         user_location:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ApproximateLocation'
@@ -37573,10 +35821,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.SearchContextSize'
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
-        search_content_types:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.SearchContentType'
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: This tool searches the web for relevant results to use in a response. Learn more about the [web search tool](https://platform.openai.com/docs/guides/tools-web-search).
@@ -37591,6 +35835,7 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+          default: web_search
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -37607,6 +35852,12 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -39746,6 +37997,12 @@ components:
           enum:
             - sharepoint_grounding_preview
           description: The object type, which is always 'sharepoint_grounding_preview'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -40442,12 +38699,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/ToolboxToolType'
           description: The type of tool.
-        name:
-          type: string
-          description: Optional user-defined name for this tool or configuration.
-        description:
-          type: string
-          description: Optional user-defined description for this tool or configuration.
         tool_configs:
           type: object
           unevaluatedProperties:
@@ -41034,6 +39285,12 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -41076,6 +39333,12 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.
@@ -41092,6 +39355,12 @@ components:
         project_connection_id:
           type: string
           description: The ID of the WorkIQ project connection.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A WorkIQ tool stored in a toolbox.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -13021,9 +13021,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: An agent implementing the A2A protocol.
@@ -13060,9 +13062,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An A2A tool stored in a toolbox.
@@ -14493,9 +14497,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -14580,9 +14586,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -15072,9 +15080,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         bing_custom_search_preview:
           allOf:
             - $ref: '#/components/schemas/BingCustomSearchToolParameters'
@@ -15196,9 +15206,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -15322,9 +15334,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -15345,9 +15359,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         browser_automation_preview:
           allOf:
             - $ref: '#/components/schemas/BrowserAutomationToolParameters'
@@ -15438,9 +15454,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -15635,9 +15653,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -19322,9 +19342,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A FabricIQ server-side tool.
@@ -19358,9 +19380,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A FabricIQ tool stored in a toolbox.
@@ -19454,9 +19478,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -20540,9 +20566,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20579,9 +20607,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         memory_store_name:
           type: string
           description: The name of the memory store to use.
@@ -20944,9 +20974,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         fabric_dataagent_preview:
           allOf:
             - $ref: '#/components/schemas/FabricDataAgentToolParameters'
@@ -21704,9 +21736,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         container:
           anyOf:
             - type: string
@@ -24789,9 +24823,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -25784,9 +25820,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -26410,9 +26448,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -30662,9 +30702,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -35855,9 +35897,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -37255,9 +37299,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -38000,9 +38046,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         sharepoint_grounding_preview:
           allOf:
             - $ref: '#/components/schemas/SharepointGroundingToolParameters'
@@ -39288,9 +39336,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -39336,9 +39386,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A WorkIQ server-side tool.
@@ -39358,9 +39410,11 @@ components:
         name:
           type: string
           description: Optional user-defined name for this tool or configuration.
+          deprecated: true
         description:
           type: string
           description: Optional user-defined description for this tool or configuration.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A WorkIQ tool stored in a toolbox.

--- a/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/toolboxes/models.tsp
@@ -38,21 +38,6 @@ alias ToolConfigExtension = {
 };
 
 /**
- * Optional name and description fields for tool definitions and nested tool configurations.
- */
-alias ToolNameAndDescriptionExtension = {
-  /**
-   * Optional user-defined name for this tool or configuration.
-   */
-  name?: string;
-
-  /**
-   * Optional user-defined description for this tool or configuration.
-   */
-  description?: string;
-};
-
-/**
  * Spreads `Source`, changing the selected properties to optional.
  */
 model WithFieldsOptional<Source, Keys extends string> {
@@ -64,7 +49,7 @@ model WithFieldsOptional<Source, Keys extends string> {
  * Spreads tool-specific fields from `Source`, excluding fields owned by `ToolboxTool`.
  */
 alias ToolFields<Source> = {
-  ...OmitProperties<Source, "name" | "description" | "type">;
+  ...OmitProperties<Source, "type">;
 };
 
 alias ToolboxCodeInterpreterToolType = "code_interpreter";
@@ -108,7 +93,6 @@ model ToolboxTool {
    */
   type: ToolboxToolType;
 
-  ...ToolNameAndDescriptionExtension;
   ...ToolConfigExtension;
 }
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -132,11 +132,13 @@ namespace Azure.AI.Projects {
     /**
      * Optional user-defined name for this tool or configuration.
      */
+    #deprecated "Optional user-defined name for this tool or configuration is deprecated."
     name?: string;
 
     /**
      * Optional user-defined description for this tool or configuration.
      */
+    #deprecated "Optional user-defined description for this tool or configuration is deprecated."
     description?: string;
   };
 

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -60,11 +60,53 @@ namespace Azure.AI.Projects {
   @@copyProperties(
     OpenAI.WebSearchTool,
     {
+      ...ToolNameAndDescriptionExtension,
+
       /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
        * resource attached to the tool.
        */
       custom_search_configuration?: WebSearchConfiguration,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.CodeInterpreterTool,
+    {
+      ...ToolNameAndDescriptionExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.ImageGenTool,
+    {
+      ...ToolNameAndDescriptionExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.LocalShellToolParam,
+    {
+      ...ToolNameAndDescriptionExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.FunctionShellToolParam,
+    {
+      ...ToolNameAndDescriptionExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.FileSearchTool,
+    {
+      ...ToolNameAndDescriptionExtension,
     }
   );
 
@@ -84,6 +126,21 @@ namespace Azure.AI.Projects {
   }
 
   /**
+   * Optional name and description fields for tool definitions and nested tool configurations.
+   */
+  alias ToolNameAndDescriptionExtension = {
+    /**
+     * Optional user-defined name for this tool or configuration.
+     */
+    name?: string;
+
+    /**
+     * Optional user-defined description for this tool or configuration.
+     */
+    description?: string;
+  };
+
+  /**
    * The input definition information for a bing grounding search tool as used to configure an agent.
    */
   model BingGroundingTool extends OpenAI.Tool {
@@ -91,6 +148,8 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'bing_grounding'.
      */
     type: "bing_grounding";
+
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -119,6 +178,8 @@ namespace Azure.AI.Projects {
      */
     type: "fabric_dataagent_preview";
 
+    ...ToolNameAndDescriptionExtension;
+
     /**
      * The fabric data agent tool parameters.
      */
@@ -146,6 +207,8 @@ namespace Azure.AI.Projects {
      */
     type: "sharepoint_grounding_preview";
 
+    ...ToolNameAndDescriptionExtension;
+
     /**
      * The sharepoint grounding tool parameters.
      */
@@ -160,6 +223,8 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'azure_ai_search'.
      */
     type: "azure_ai_search";
+
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The azure ai search index resource.
@@ -265,6 +330,8 @@ namespace Azure.AI.Projects {
      */
     type: "bing_custom_search_preview";
 
+    ...ToolNameAndDescriptionExtension;
+
     /**
      * The bing custom search tool parameters.
      */
@@ -279,6 +346,8 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'browser_automation_preview'.
      */
     type: "browser_automation_preview";
+
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The Browser Automation Tool parameters.
@@ -668,6 +737,8 @@ namespace Azure.AI.Projects {
      */
     type: "capture_structured_outputs";
 
+    ...ToolNameAndDescriptionExtension;
+
     /**
      * The structured outputs to capture from the model.
      */
@@ -706,6 +777,8 @@ namespace Azure.AI.Projects {
      * specified by the caller (anonymous fetch).
      */
     send_credentials_for_agent_card?: boolean = false;
+
+    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -722,6 +795,7 @@ namespace Azure.AI.Projects {
      */
     project_connection_id: string;
 
+    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -755,6 +829,7 @@ namespace Azure.AI.Projects {
     #suppress "@azure-tools/typespec-azure-core/no-unnamed-union" "Matching OpenAI MCP tool pattern."
     require_approval?: OpenAI.MCPToolRequireApproval | string | null = "always";
 
+    ...ToolNameAndDescriptionExtension;
   }
 
   /**
@@ -765,6 +840,8 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search_preview";
+
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.
@@ -798,6 +875,8 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `memory_search_preview`.
      */
     type: "memory_search";
+
+    ...ToolNameAndDescriptionExtension;
 
     /**
      * The name of the memory store to use.


### PR DESCRIPTION
## Summary
This PR reverts the `ToolNameAndDescriptionExtension` (https://github.com/Azure/azure-rest-api-specs/pull/44091) move into toolbox surface so name/description behavior returns to tool-model ownership, while preserving browser automation toolbox support.


## What Changed
1. Marked `ToolNameAndDescriptionExtension.name` and `.description` as **deprecated** in models.tsp.
2. Kept `ToolNameAndDescriptionExtension` usage on tool models so existing consumers can still build against the current surface.
3. Preserved browser automation toolbox support in models.tsp.
4. Regenerated the Foundry OpenAPI outputs under `openapi3/` from TypeSpec.

## Validation
1. Ran `npx tsp compile . --config tspconfig.yaml` in the Foundry project.
2. Compilation completed successfully.

