### PR TITLE
Fix: deprecate name, description, and tool_configs on GA tool classes

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18521,6 +18521,24 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -18647,6 +18665,14 @@
             "enum": [
               "azure_ai_search"
             ]
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -19189,6 +19215,14 @@
             ],
             "description": "The object type, which is always 'browser_automation'."
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "azure_function": {
             "allOf": [
               {
@@ -19574,6 +19608,24 @@
             ],
             "description": "The object type, which is always 'bing_grounding'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "bing_grounding": {
             "allOf": [
               {
@@ -19940,6 +19992,24 @@
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "outputs": {
             "allOf": [
               {
@@ -20191,6 +20261,14 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -24374,6 +24452,14 @@
               }
             ]
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "vector_store_ids": {
             "type": "array",
             "items": {
@@ -25616,6 +25702,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -27567,6 +27661,24 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "container": {
             "anyOf": [
@@ -32460,6 +32572,24 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -34002,6 +34132,24 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -34717,6 +34865,24 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -42067,6 +42233,24 @@
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -42279,6 +42463,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -50182,6 +50374,24 @@
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -50453,6 +50663,14 @@
             ],
             "description": "The object type, which is always 'openapi'."
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "openapi": {
             "allOf": [
               {
@@ -50572,6 +50790,14 @@
             "enum": [
               "openapi"
             ]
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "openapi": {
             "allOf": [
@@ -55124,6 +55350,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -18523,12 +18523,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -18536,7 +18536,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_ai_search": {
@@ -18671,7 +18671,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_ai_search": {
@@ -19220,7 +19220,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_function": {
@@ -19610,12 +19610,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -19623,7 +19623,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "bing_grounding": {
@@ -19994,12 +19994,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -20007,7 +20007,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "outputs": {
@@ -20267,7 +20267,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -24457,7 +24457,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "vector_store_ids": {
@@ -25708,7 +25708,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -27664,12 +27664,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -27677,7 +27677,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "container": {
@@ -32575,12 +32575,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -32588,7 +32588,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -34135,12 +34135,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -34148,7 +34148,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -34868,12 +34868,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -34881,7 +34881,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -42236,12 +42236,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -42249,7 +42249,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -42469,7 +42469,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -50376,12 +50376,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -50389,7 +50389,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "custom_search_configuration": {
@@ -50668,7 +50668,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "openapi": {
@@ -50796,7 +50796,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "openapi": {
@@ -55356,7 +55356,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "custom_search_configuration": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12199,6 +12199,23 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12280,6 +12297,15 @@ components:
           type: string
           enum:
             - azure_ai_search
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -12628,6 +12654,15 @@ components:
           enum:
             - azure_function
           description: The object type, which is always 'browser_automation'.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_function:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
@@ -12884,6 +12919,23 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -13108,6 +13160,23 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -13299,6 +13368,15 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -16370,6 +16448,15 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -17193,6 +17280,15 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An MCP tool stored in a toolbox.
@@ -18494,6 +18590,23 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         container:
           anyOf:
             - type: string
@@ -21790,6 +21903,23 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -22802,6 +22932,23 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -23413,6 +23560,23 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -28385,6 +28549,23 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -28536,6 +28717,15 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -34457,6 +34647,23 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -34638,6 +34845,15 @@ components:
           enum:
             - openapi
           description: The object type, which is always 'openapi'.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -34713,6 +34929,15 @@ components:
           type: string
           enum:
             - openapi
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -37751,6 +37976,15 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -12201,20 +12201,17 @@ components:
           description: The object type, which is always 'azure_ai_search'.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_ai_search:
           allOf:
@@ -12301,10 +12298,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_ai_search:
           allOf:
@@ -12658,10 +12652,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_function:
           allOf:
@@ -12921,20 +12912,17 @@ components:
           description: The object type, which is always 'bing_grounding'.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         bing_grounding:
           allOf:
@@ -13162,20 +13150,17 @@ components:
           description: The type of the tool. Always `capture_structured_outputs`.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         outputs:
           allOf:
@@ -13372,10 +13357,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
@@ -16452,10 +16434,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         vector_store_ids:
           type: array
@@ -17284,10 +17263,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
@@ -18592,20 +18568,17 @@ components:
           x-stainless-const: true
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         container:
           anyOf:
@@ -21905,20 +21878,17 @@ components:
             - type: 'null'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -22934,20 +22904,17 @@ components:
             - type: 'null'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -23562,20 +23529,17 @@ components:
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -28551,20 +28515,17 @@ components:
           x-stainless-const: true
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -28721,10 +28682,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -34649,20 +34607,17 @@ components:
           default: medium
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         custom_search_configuration:
           allOf:
@@ -34849,10 +34804,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         openapi:
           allOf:
@@ -34933,10 +34885,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         openapi:
           allOf:
@@ -37980,10 +37929,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         custom_search_configuration:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -21946,12 +21946,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -21959,7 +21959,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_ai_search": {
@@ -22094,7 +22094,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_ai_search": {
@@ -22643,7 +22643,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "azure_function": {
@@ -23033,12 +23033,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -23046,7 +23046,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "bing_grounding": {
@@ -23417,12 +23417,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -23430,7 +23430,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "outputs": {
@@ -23690,7 +23690,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -28938,7 +28938,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "vector_store_ids": {
@@ -30262,7 +30262,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -32310,12 +32310,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -32323,7 +32323,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "container": {
@@ -37221,12 +37221,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -37234,7 +37234,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -38781,12 +38781,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -38794,7 +38794,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -39514,12 +39514,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -39527,7 +39527,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -46882,12 +46882,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -46895,7 +46895,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -47115,7 +47115,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           }
         },
@@ -55047,12 +55047,12 @@
           },
           "name": {
             "type": "string",
-            "description": "Optional user-defined name for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "description": {
             "type": "string",
-            "description": "Optional user-defined description for this tool or configuration.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "tool_configs": {
@@ -55060,7 +55060,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "custom_search_configuration": {
@@ -55339,7 +55339,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "openapi": {
@@ -55467,7 +55467,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "openapi": {
@@ -60226,7 +60226,7 @@
             "unevaluatedProperties": {
               "$ref": "#/components/schemas/ToolConfig"
             },
-            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "description": "Deprecated. This property is deprecated and will be removed in a future version.",
             "deprecated": true
           },
           "custom_search_configuration": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -21944,6 +21944,24 @@
             ],
             "description": "The object type, which is always 'azure_ai_search'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "azure_ai_search": {
             "allOf": [
               {
@@ -22070,6 +22088,14 @@
             "enum": [
               "azure_ai_search"
             ]
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "azure_ai_search": {
             "allOf": [
@@ -22612,6 +22638,14 @@
             ],
             "description": "The object type, which is always 'browser_automation'."
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "azure_function": {
             "allOf": [
               {
@@ -22997,6 +23031,24 @@
             ],
             "description": "The object type, which is always 'bing_grounding'."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "bing_grounding": {
             "allOf": [
               {
@@ -23363,6 +23415,24 @@
             ],
             "description": "The type of the tool. Always `capture_structured_outputs`."
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "outputs": {
             "allOf": [
               {
@@ -23614,6 +23684,14 @@
               }
             ],
             "description": "The code interpreter container. Can be a container ID or an object that\nspecifies uploaded file IDs to make available to your code, along with an\noptional `memory_limit` setting.\nIf not provided, the service assumes auto."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -28855,6 +28933,14 @@
               }
             ]
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "vector_store_ids": {
             "type": "array",
             "items": {
@@ -30170,6 +30256,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -32213,6 +32307,24 @@
             ],
             "description": "The type of the code interpreter tool. Always `code_interpreter`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "container": {
             "anyOf": [
@@ -37106,6 +37218,24 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -38648,6 +38778,24 @@
                 "type": "null"
               }
             ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -39363,6 +39511,24 @@
               }
             ],
             "description": "Whether to generate a new image or edit an existing image. Default: `auto`."
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -46713,6 +46879,24 @@
             ],
             "description": "The type of the local shell tool. Always `local_shell`.",
             "x-stainless-const": true
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -46925,6 +47109,14 @@
           "project_connection_id": {
             "type": "string",
             "description": "The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server."
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           }
         },
         "allOf": [
@@ -54853,6 +55045,24 @@
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
           },
+          "name": {
+            "type": "string",
+            "description": "Optional user-defined name for this tool or configuration.",
+            "deprecated": true
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional user-defined description for this tool or configuration.",
+            "deprecated": true
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "custom_search_configuration": {
             "allOf": [
               {
@@ -55124,6 +55334,14 @@
             ],
             "description": "The object type, which is always 'openapi'."
           },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
+          },
           "openapi": {
             "allOf": [
               {
@@ -55243,6 +55461,14 @@
             "enum": [
               "openapi"
             ]
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "openapi": {
             "allOf": [
@@ -59994,6 +60220,14 @@
             ],
             "description": "High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.",
             "default": "medium"
+          },
+          "tool_configs": {
+            "type": "object",
+            "unevaluatedProperties": {
+              "$ref": "#/components/schemas/ToolConfig"
+            },
+            "description": "Per-tool configuration map. Keys are tool names or `*` (catch-all default).\nResolution order: exact tool name match takes priority over `*`.\nUnknown tool names are silently ignored at runtime.",
+            "deprecated": true
           },
           "custom_search_configuration": {
             "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14488,6 +14488,23 @@ components:
           enum:
             - azure_ai_search
           description: The object type, which is always 'azure_ai_search'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -14569,6 +14586,15 @@ components:
           type: string
           enum:
             - azure_ai_search
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_ai_search:
           allOf:
             - $ref: '#/components/schemas/AzureAISearchToolResource'
@@ -14917,6 +14943,15 @@ components:
           enum:
             - azure_function
           description: The object type, which is always 'browser_automation'.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         azure_function:
           allOf:
             - $ref: '#/components/schemas/AzureFunctionDefinition'
@@ -15173,6 +15208,23 @@ components:
           enum:
             - bing_grounding
           description: The object type, which is always 'bing_grounding'.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         bing_grounding:
           allOf:
             - $ref: '#/components/schemas/BingGroundingSearchToolParameters'
@@ -15397,6 +15449,23 @@ components:
           enum:
             - capture_structured_outputs
           description: The type of the tool. Always `capture_structured_outputs`.
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         outputs:
           allOf:
             - $ref: '#/components/schemas/StructuredOutputDefinition'
@@ -15588,6 +15657,15 @@ components:
             specifies uploaded file IDs to make available to your code, along with an
             optional `memory_limit` setting.
             If not provided, the service assumes auto.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: A code interpreter tool stored in a toolbox.
@@ -19390,6 +19468,15 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         vector_store_ids:
           type: array
           items:
@@ -20259,6 +20346,15 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
       description: An MCP tool stored in a toolbox.
@@ -21624,6 +21720,23 @@ components:
             - code_interpreter
           description: The type of the code interpreter tool. Always `code_interpreter`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         container:
           anyOf:
             - type: string
@@ -24920,6 +25033,23 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.Filters'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that searches for relevant content from uploaded files. Learn more about the [file search tool](https://platform.openai.com/docs/guides/tools-file-search).
@@ -25932,6 +26062,23 @@ components:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.FunctionShellToolParamEnvironment'
             - type: 'null'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands.
@@ -26543,6 +26690,23 @@ components:
           allOf:
             - $ref: '#/components/schemas/OpenAI.ImageGenActionEnum'
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that generates images using the GPT image models.
@@ -31515,6 +31679,23 @@ components:
             - local_shell
           description: The type of the local shell tool. Always `local_shell`.
           x-stainless-const: true
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: A tool that allows the model to execute shell commands in a local environment.
@@ -31666,6 +31847,15 @@ components:
         project_connection_id:
           type: string
           description: The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
       description: |-
@@ -37607,6 +37797,23 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        name:
+          type: string
+          description: Optional user-defined name for this tool or configuration.
+          deprecated: true
+        description:
+          type: string
+          description: Optional user-defined description for this tool or configuration.
+          deprecated: true
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'
@@ -37788,6 +37995,15 @@ components:
           enum:
             - openapi
           description: The object type, which is always 'openapi'.
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -37863,6 +38079,15 @@ components:
           type: string
           enum:
             - openapi
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         openapi:
           allOf:
             - $ref: '#/components/schemas/OpenApiFunctionDefinition'
@@ -41034,6 +41259,15 @@ components:
             - high
           description: High level guidance for the amount of context window space to use for the search. One of `low`, `medium`, or `high`. `medium` is the default.
           default: medium
+        tool_configs:
+          type: object
+          unevaluatedProperties:
+            $ref: '#/components/schemas/ToolConfig'
+          description: |-
+            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+            Resolution order: exact tool name match takes priority over `*`.
+            Unknown tool names are silently ignored at runtime.
+          deprecated: true
         custom_search_configuration:
           allOf:
             - $ref: '#/components/schemas/WebSearchConfiguration'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -14490,20 +14490,17 @@ components:
           description: The object type, which is always 'azure_ai_search'.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_ai_search:
           allOf:
@@ -14590,10 +14587,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_ai_search:
           allOf:
@@ -14947,10 +14941,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         azure_function:
           allOf:
@@ -15210,20 +15201,17 @@ components:
           description: The object type, which is always 'bing_grounding'.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         bing_grounding:
           allOf:
@@ -15451,20 +15439,17 @@ components:
           description: The type of the tool. Always `capture_structured_outputs`.
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         outputs:
           allOf:
@@ -15661,10 +15646,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
@@ -19472,10 +19454,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         vector_store_ids:
           type: array
@@ -20350,10 +20329,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/ToolboxTool'
@@ -21722,20 +21698,17 @@ components:
           x-stainless-const: true
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         container:
           anyOf:
@@ -25035,20 +25008,17 @@ components:
             - type: 'null'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -26064,20 +26034,17 @@ components:
             - type: 'null'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -26692,20 +26659,17 @@ components:
           description: 'Whether to generate a new image or edit an existing image. Default: `auto`.'
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -31681,20 +31645,17 @@ components:
           x-stainless-const: true
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -31851,10 +31812,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
       allOf:
         - $ref: '#/components/schemas/OpenAI.Tool'
@@ -37799,20 +37757,17 @@ components:
           default: medium
         name:
           type: string
-          description: Optional user-defined name for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         description:
           type: string
-          description: Optional user-defined description for this tool or configuration.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         tool_configs:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         custom_search_configuration:
           allOf:
@@ -37999,10 +37954,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         openapi:
           allOf:
@@ -38083,10 +38035,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         openapi:
           allOf:
@@ -41263,10 +41212,7 @@ components:
           type: object
           unevaluatedProperties:
             $ref: '#/components/schemas/ToolConfig'
-          description: |-
-            Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-            Resolution order: exact tool name match takes priority over `*`.
-            Unknown tool names are silently ignored at runtime.
+          description: Deprecated. This property is deprecated and will be removed in a future version.
           deprecated: true
         custom_search_configuration:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -45,6 +45,38 @@ namespace Azure.AI.Projects {
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyVariants(OpenAI.IncludeEnum, Azure.AI.Projects._AgentIncludable);
 
+  /**
+   * Deprecated name and description fields retained for SDK backward compatibility.
+   * These fields now live on ToolboxTool and should not be used on tool definitions.
+   */
+  alias DeprecatedToolNameAndDescriptionExtension = {
+    /**
+     * Optional user-defined name for this tool or configuration.
+     */
+    #deprecated "Use name on ToolboxTool instead."
+    name?: string;
+
+    /**
+     * Optional user-defined description for this tool or configuration.
+     */
+    #deprecated "Use description on ToolboxTool instead."
+    description?: string;
+  };
+
+  /**
+   * Deprecated tool_configs field retained for SDK backward compatibility.
+   * This field now lives on ToolboxTool and should not be used on tool definitions.
+   */
+  alias DeprecatedToolConfigExtension = {
+    /**
+     * Per-tool configuration map. Keys are tool names or `*` (catch-all default).
+     * Resolution order: exact tool name match takes priority over `*`.
+     * Unknown tool names are silently ignored at runtime.
+     */
+    #deprecated "Use tool_configs on ToolboxTool instead."
+    tool_configs?: Record<ToolConfig>;
+  };
+
   #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
   @@copyProperties(
     OpenAI.MCPTool,
@@ -53,6 +85,8 @@ namespace Azure.AI.Projects {
        * The connection ID in the project for the MCP server. The connection stores authentication and other connection details needed to connect to the MCP server.
        */
       project_connection_id?: string,
+
+      ...DeprecatedToolConfigExtension,
     }
   );
 
@@ -60,11 +94,59 @@ namespace Azure.AI.Projects {
   @@copyProperties(
     OpenAI.WebSearchTool,
     {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
+
       /**
        * The project connections attached to this tool. There can be a maximum of 1 connection
        * resource attached to the tool.
        */
       custom_search_configuration?: WebSearchConfiguration,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.CodeInterpreterTool,
+    {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.ImageGenTool,
+    {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.LocalShellToolParam,
+    {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.FunctionShellToolParam,
+    {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
+    }
+  );
+
+  #suppress "@azure-tools/typespec-azure-core/experimental-feature" "Using experimental feature"
+  @@copyProperties(
+    OpenAI.FileSearchTool,
+    {
+      ...DeprecatedToolNameAndDescriptionExtension,
+      ...DeprecatedToolConfigExtension,
     }
   );
 
@@ -91,6 +173,9 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'bing_grounding'.
      */
     type: "bing_grounding";
+
+    ...DeprecatedToolNameAndDescriptionExtension;
+    ...DeprecatedToolConfigExtension;
 
     /**
      * The bing grounding search tool parameters.
@@ -160,6 +245,9 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'azure_ai_search'.
      */
     type: "azure_ai_search";
+
+    ...DeprecatedToolNameAndDescriptionExtension;
+    ...DeprecatedToolConfigExtension;
 
     /**
      * The azure ai search index resource.
@@ -250,6 +338,8 @@ namespace Azure.AI.Projects {
      */
     type: "openapi";
 
+    ...DeprecatedToolConfigExtension;
+
     /**
      * The openapi function definition.
      */
@@ -314,6 +404,8 @@ namespace Azure.AI.Projects {
      * The object type, which is always 'browser_automation'.
      */
     type: "azure_function";
+
+    ...DeprecatedToolConfigExtension;
 
     /**
      * The Azure Function Tool definition.
@@ -667,6 +759,9 @@ namespace Azure.AI.Projects {
      * The type of the tool. Always `capture_structured_outputs`.
      */
     type: "capture_structured_outputs";
+
+    ...DeprecatedToolNameAndDescriptionExtension;
+    ...DeprecatedToolConfigExtension;
 
     /**
      * The structured outputs to capture from the model.

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -50,13 +50,13 @@ namespace Azure.AI.Projects {
    */
   alias DeprecatedToolNameAndDescriptionExtension = {
     /**
-     * Optional user-defined name for this tool or configuration.
+     * Deprecated. This property is deprecated and will be removed in a future version.
      */
     #deprecated "This property is deprecated and will be removed in a future version."
     name?: string;
 
     /**
-     * Optional user-defined description for this tool or configuration.
+     * Deprecated. This property is deprecated and will be removed in a future version.
      */
     #deprecated "This property is deprecated and will be removed in a future version."
     description?: string;
@@ -67,9 +67,7 @@ namespace Azure.AI.Projects {
    */
   alias DeprecatedToolConfigExtension = {
     /**
-     * Per-tool configuration map. Keys are tool names or `*` (catch-all default).
-     * Resolution order: exact tool name match takes priority over `*`.
-     * Unknown tool names are silently ignored at runtime.
+     * Deprecated. This property is deprecated and will be removed in a future version.
      */
     #deprecated "This property is deprecated and will be removed in a future version."
     tool_configs?: Record<ToolConfig>;

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -47,25 +47,23 @@ namespace Azure.AI.Projects {
 
   /**
    * Deprecated name and description fields retained for SDK backward compatibility.
-   * These fields now live on ToolboxTool and should not be used on tool definitions.
    */
   alias DeprecatedToolNameAndDescriptionExtension = {
     /**
      * Optional user-defined name for this tool or configuration.
      */
-    #deprecated "Use name on ToolboxTool instead."
+    #deprecated "This property is deprecated and will be removed in a future version."
     name?: string;
 
     /**
      * Optional user-defined description for this tool or configuration.
      */
-    #deprecated "Use description on ToolboxTool instead."
+    #deprecated "This property is deprecated and will be removed in a future version."
     description?: string;
   };
 
   /**
    * Deprecated tool_configs field retained for SDK backward compatibility.
-   * This field now lives on ToolboxTool and should not be used on tool definitions.
    */
   alias DeprecatedToolConfigExtension = {
     /**
@@ -73,7 +71,7 @@ namespace Azure.AI.Projects {
      * Resolution order: exact tool name match takes priority over `*`.
      * Unknown tool names are silently ignored at runtime.
      */
-    #deprecated "Use tool_configs on ToolboxTool instead."
+    #deprecated "This property is deprecated and will be removed in a future version."
     tool_configs?: Record<ToolConfig>;
   };
 


### PR DESCRIPTION
## Summary
Restores `name`, `description`, and `tool_configs` fields on General Availability tool definitions with `#deprecated` directive, preventing SDK breaking changes while preserving the intended migration to `ToolboxTool`.

## Why
PR #43467 removed these fields from tool classes and moved them exclusively to `ToolboxTool`. This introduces a breaking change for existing SDK consumers (Python, C#, Java) who rely on setting `name`, `description`, or `tool_configs` directly on tool objects like `CodeInterpreterTool`, `WebSearchTool`, etc.

Instead of removing outright, these fields are now deprecated—maintaining backward compatibility while signaling the migration path to `ToolboxTool`.

## What changed
- Added `DeprecatedToolNameAndDescriptionExtension` and `DeprecatedToolConfigExtension` aliases in `tools/models.tsp` with `#deprecated` directives  
- Re-applied deprecated fields to all GA tools via `@@copyProperties` (OpenAI tools) and direct spread (Azure tools)  
- Regenerated OpenAPI output files  

## Affected GA tools

| Tool                          | name / description | tool_configs |
|-------------------------------|--------------------|--------------|
| OpenAI.WebSearchTool          | ✅                 | ✅           |
| OpenAI.CodeInterpreterTool    | ✅                 | ✅           |
| OpenAI.ImageGenTool           | ✅                 | ✅           |
| OpenAI.FileSearchTool         | ✅                 | ✅           |
| OpenAI.LocalShellToolParam    | ✅                 | ✅           |
| OpenAI.FunctionShellToolParam | ✅                 | ✅           |
| BingGroundingTool             | ✅                 | ✅           |
| AzureAISearchTool             | ✅                 | ✅           |
| CaptureStructuredOutputsTool  | ✅                 | ✅           |
| OpenAI.MCPTool                | —                  | ✅           |
| AzureFunctionTool             | —                  | ✅           |
| OpenApiTool                   | —                  | ✅           |

## Validation
- `npx tsp compile .` succeeds with no errors  
- Generated OpenAPI output shows `deprecated: true` on all affected fields  
- `ToolboxTool` retains non-deprecated versions of these fields (intended home)