### PR TITLE
Fix MachineLearningServices SDK folder

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/tspconfig.yaml
+++ b/specification/machinelearningservices/MachineLearningServices.Management/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/ml"
+    default: "sdk/machinelearningservices"
 emit:
   - "@azure-tools/typespec-autorest"
 options:

--- a/specification/machinelearningservices/MachineLearningServices.Management/tspconfig.yaml
+++ b/specification/machinelearningservices/MachineLearningServices.Management/tspconfig.yaml
@@ -1,6 +1,6 @@
 parameters:
   "service-dir":
-    default: "sdk/machinelearningservices"
+    default: "sdk/ml"
 emit:
   - "@azure-tools/typespec-autorest"
 options:
@@ -46,7 +46,7 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     enable-wire-path-attribute: true
     namespace: "Azure.ResourceManager.MachineLearning"
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    emitter-output-dir: "{output-dir}/sdk/machinelearningservices/{namespace}"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Summary
- update the MachineLearningServices.Management C# management emitter output path to use sdk/machinelearningservices
- keep the shared service-dir default as sdk/ml so other emitters continue using their existing SDK folders

## Validation
- tsp compile --no-emit --warn-as-error specification/machinelearningservices/MachineLearningServices.Management/main.tsp