### PR TITLE
Add retentionPeriodInDays and gracePeriodInDays to SoftDeletePolicy (2026-03-03)

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/Gallery_Create_SoftDeletionEnabled.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/examples/2026-03-03/galleryExamples/Gallery_Create_SoftDeletionEnabled.json
@@ -9,7 +9,9 @@
       "properties": {
         "description": "This is the gallery description.",
         "softDeletePolicy": {
-          "isSoftDeleteEnabled": true
+          "isSoftDeleteEnabled": true,
+          "retentionPeriodInDays": 7,
+          "gracePeriodInDays": 30
         }
       }
     }
@@ -25,7 +27,9 @@
           },
           "provisioningState": "Updating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",
@@ -42,7 +46,9 @@
           },
           "provisioningState": "Creating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",
@@ -59,7 +65,9 @@
           },
           "provisioningState": "Updating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -546,7 +546,7 @@ model SoftDeletePolicy {
   retentionPeriodInDays?: int32;
 
   /**
-   * The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unconsumable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted.
+   * The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unusable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted.
    */
   @added(Versions.v2026_03_03)
   gracePeriodInDays?: int32;

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/ComputeGallery/models.tsp
@@ -538,6 +538,18 @@ model SoftDeletePolicy {
    * Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time.
    */
   isSoftDeleteEnabled?: boolean;
+
+  /**
+   * The retention period in days for a soft-deleted resource. After this period elapses, the soft-deleted gallery image version transitions to a simulated hard-deleted state.
+   */
+  @added(Versions.v2026_03_03)
+  retentionPeriodInDays?: int32;
+
+  /**
+   * The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unconsumable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted.
+   */
+  @added(Versions.v2026_03_03)
+  gracePeriodInDays?: int32;
 }
 
 /**

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -7672,6 +7672,16 @@
         "isSoftDeleteEnabled": {
           "type": "boolean",
           "description": "Enables soft-deletion for resources in this gallery, allowing them to be recovered within retention time."
+        },
+        "retentionPeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The retention period in days for a soft-deleted resource. After this period elapses, the soft-deleted gallery image version transitions to a simulated hard-deleted state."
+        },
+        "gracePeriodInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unconsumable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted."
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/GalleryRP.json
@@ -7681,7 +7681,7 @@
         "gracePeriodInDays": {
           "type": "integer",
           "format": "int32",
-          "description": "The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unconsumable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted."
+          "description": "The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unusable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted."
         }
       }
     },

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/Gallery_Create_SoftDeletionEnabled.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/stable/2026-03-03/examples/galleryExamples/Gallery_Create_SoftDeletionEnabled.json
@@ -9,7 +9,9 @@
       "properties": {
         "description": "This is the gallery description.",
         "softDeletePolicy": {
-          "isSoftDeleteEnabled": true
+          "isSoftDeleteEnabled": true,
+          "retentionPeriodInDays": 7,
+          "gracePeriodInDays": 30
         }
       }
     }
@@ -25,7 +27,9 @@
           },
           "provisioningState": "Updating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",
@@ -42,7 +46,9 @@
           },
           "provisioningState": "Creating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",
@@ -59,7 +65,9 @@
           },
           "provisioningState": "Updating",
           "softDeletePolicy": {
-            "isSoftDeleteEnabled": true
+            "isSoftDeleteEnabled": true,
+            "retentionPeriodInDays": 7,
+            "gracePeriodInDays": 30
           }
         },
         "location": "West US",


### PR DESCRIPTION
## Summary

Adds two new optional properties to the `SoftDeletePolicy` model in the Compute Gallery (`Microsoft.Compute`) API, introduced in api-version **2026-03-03**:

- `retentionPeriodInDays` (`int32`, optional) — The retention period in days for a soft-deleted resource. After this period elapses, the soft-deleted gallery image version transitions to a simulated hard-deleted state.
- `gracePeriodInDays` (`int32`, optional) — The grace period in days for a simulated hard-deleted resource. During this period the gallery image version is unusable but can still be recovered if required. After this period elapses, the gallery image version is permanently (hard) deleted.

Both fields are gated with `@added(Versions.v2026_03_03)`, so they only appear in the `2026-03-03` contract and do not alter previously published api-versions. This follows the same pattern used for the existing `isSoftDeleteEnabled` baseline property and for the fields added in PR #42518.

Field descriptions are sourced from the corresponding `SoftDeletePolicy` model in the CAPS service repository (`Compute-CPlat-PIR`).

## Changes

- `ComputeGallery/models.tsp` — added the two properties (source of truth).
- `stable/2026-03-03/GalleryRP.json` — regenerated swagger.
- `Gallery_Create_SoftDeletionEnabled.json` (source + generated `stable` copies) — updated example to demonstrate the new fields.

The swagger and stable example are emitter-generated via `tsp compile`. Compilation passes.
