### PR TITLE
Add csharp customizations for MachineLearningServices migration

### DIFF
--- a/specification/machinelearningservices/MachineLearningServices.Management/ComponentVersion.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/ComponentVersion.tsp
@@ -11,6 +11,8 @@ using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 
 namespace Microsoft.MachineLearningServices;
+
+// cspell:ignore Learnin
 /**
  * Azure Resource Manager resource envelope.
  */

--- a/specification/machinelearningservices/MachineLearningServices.Management/ComponentVersion.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/ComponentVersion.tsp
@@ -56,7 +56,7 @@ interface ComponentVersionOps
         version: string,
       },
       ErrorResponse,
-      "MachineLearningRegistryComponentVersion"
+      "MachineLearninRegistryComponentVersion"
     > {}
 
 @armResourceOperations

--- a/specification/machinelearningservices/MachineLearningServices.Management/OutboundRuleBasicResource.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/OutboundRuleBasicResource.tsp
@@ -5,7 +5,6 @@ import "@typespec/rest";
 import "@typespec/versioning";
 import "./models.tsp";
 import "./Workspace.tsp";
-import "./ManagedNetworkSettingsPropertiesBasicResource.tsp";
 
 using TypeSpec.Rest;
 using Azure.ResourceManager;
@@ -25,28 +24,6 @@ model OutboundRuleBasicResource
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
   >;
 }
-
-@removed(Versions.v2025_12_01)
-@added(Versions.v2026_01_15_preview)
-@removed(Versions.v2026_03_01)
-@added(Versions.v2026_03_15_preview)
-@parentResource(ManagedNetworkSettingsPropertiesBasicResource)
-model ManagedNetworkOutboundRuleBasicResource
-  is Azure.ResourceManager.ProxyResource<OutboundRule, false> {
-  ...ResourceNameParameter<
-    Resource = ManagedNetworkOutboundRuleBasicResource,
-    KeyName = "ruleName",
-    SegmentName = "outboundRules",
-    NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
-  >;
-}
-
-@removed(Versions.v2025_12_01)
-@added(Versions.v2026_01_15_preview)
-@removed(Versions.v2026_03_01)
-@added(Versions.v2026_03_15_preview)
-model ManagedNetworkOutboundRuleListResult
-  is Azure.Core.Page<ManagedNetworkOutboundRuleBasicResource>;
 
 @armResourceOperations
 interface OutboundRuleBasicResourceOps
@@ -164,14 +141,14 @@ interface OutboundRuleBasicResourceOperationGroup {
    * The GET API for retrieveing a single outbound rule of the managed network associated with the machine learning workspace.
    */
   @summary("The GET API for retrieveing a single outbound rule of the managed network associated with the machine learning workspace.")
-  get is OutboundRuleBasicResourceOperationGroupOps.Read<ManagedNetworkOutboundRuleBasicResource>;
+  get is OutboundRuleBasicResourceOperationGroupOps.Read<OutboundRuleBasicResource>;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "Existing API returns additional response codes"
   createOrUpdate is OutboundRuleBasicResourceOperationGroupOps.CreateOrUpdateAsync<
-    ManagedNetworkOutboundRuleBasicResource,
+    OutboundRuleBasicResource,
     Response =
-      | ArmResourceUpdatedResponse<ManagedNetworkOutboundRuleBasicResource>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = ManagedNetworkOutboundRuleBasicResource>> &
+      | ArmResourceUpdatedResponse<OutboundRuleBasicResource>
+      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = OutboundRuleBasicResource>> &
           Azure.Core.Foundations.RetryAfterHeader)
   >;
 
@@ -179,15 +156,15 @@ interface OutboundRuleBasicResourceOperationGroup {
    * The DELETE API for deleting a single outbound rule of the managed network associated with the machine learning workspace.
    */
   @summary("The DELETE API for deleting a single outbound rule of the managed network associated with the machine learning workspace.")
-  delete is OutboundRuleBasicResourceOperationGroupOps.DeleteWithoutOkAsync<ManagedNetworkOutboundRuleBasicResource>;
+  delete is OutboundRuleBasicResourceOperationGroupOps.DeleteWithoutOkAsync<OutboundRuleBasicResource>;
 
   /**
    * The GET API for retrieveing the list of outbound rules of the managed network associated with the machine learning workspace.
    */
   @summary("The GET API for retrieveing the list of outbound rules of the managed network associated with the machine learning workspace.")
   list is OutboundRuleBasicResourceOperationGroupOps.List<
-    ManagedNetworkOutboundRuleBasicResource,
-    Response = ManagedNetworkOutboundRuleListResult
+    OutboundRuleBasicResource,
+    Response = OutboundRuleListResult
   >;
 }
 
@@ -197,14 +174,6 @@ interface OutboundRuleBasicResourceOperationGroup {
 );
 @@doc(
   OutboundRuleBasicResource.properties,
-  "Outbound Rule for the managed network of a machine learning workspace."
-);
-@@doc(
-  ManagedNetworkOutboundRuleBasicResource.name,
-  "Name of the workspace managed network outbound rule"
-);
-@@doc(
-  ManagedNetworkOutboundRuleBasicResource.properties,
   "Outbound Rule for the managed network of a machine learning workspace."
 );
 @@doc(

--- a/specification/machinelearningservices/MachineLearningServices.Management/OutboundRuleBasicResource.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/OutboundRuleBasicResource.tsp
@@ -5,6 +5,7 @@ import "@typespec/rest";
 import "@typespec/versioning";
 import "./models.tsp";
 import "./Workspace.tsp";
+import "./ManagedNetworkSettingsPropertiesBasicResource.tsp";
 
 using TypeSpec.Rest;
 using Azure.ResourceManager;
@@ -24,6 +25,28 @@ model OutboundRuleBasicResource
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
   >;
 }
+
+@removed(Versions.v2025_12_01)
+@added(Versions.v2026_01_15_preview)
+@removed(Versions.v2026_03_01)
+@added(Versions.v2026_03_15_preview)
+@parentResource(ManagedNetworkSettingsPropertiesBasicResource)
+model ManagedNetworkOutboundRuleBasicResource
+  is Azure.ResourceManager.ProxyResource<OutboundRule, false> {
+  ...ResourceNameParameter<
+    Resource = ManagedNetworkOutboundRuleBasicResource,
+    KeyName = "ruleName",
+    SegmentName = "outboundRules",
+    NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+  >;
+}
+
+@removed(Versions.v2025_12_01)
+@added(Versions.v2026_01_15_preview)
+@removed(Versions.v2026_03_01)
+@added(Versions.v2026_03_15_preview)
+model ManagedNetworkOutboundRuleListResult
+  is Azure.Core.Page<ManagedNetworkOutboundRuleBasicResource>;
 
 @armResourceOperations
 interface OutboundRuleBasicResourceOps
@@ -128,7 +151,7 @@ interface OutboundRuleBasicResourceOperationGroupOps
         ruleName: string,
       },
       ErrorResponse,
-      "MachineLearningOutboundRuleBasic"
+      "ManagedNetworkOutboundRuleBasic"
     > {}
 
 @removed(Versions.v2025_12_01)
@@ -141,14 +164,14 @@ interface OutboundRuleBasicResourceOperationGroup {
    * The GET API for retrieveing a single outbound rule of the managed network associated with the machine learning workspace.
    */
   @summary("The GET API for retrieveing a single outbound rule of the managed network associated with the machine learning workspace.")
-  get is OutboundRuleBasicResourceOperationGroupOps.Read<OutboundRuleBasicResource>;
+  get is OutboundRuleBasicResourceOperationGroupOps.Read<ManagedNetworkOutboundRuleBasicResource>;
 
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "Existing API returns additional response codes"
   createOrUpdate is OutboundRuleBasicResourceOperationGroupOps.CreateOrUpdateAsync<
-    OutboundRuleBasicResource,
+    ManagedNetworkOutboundRuleBasicResource,
     Response =
-      | ArmResourceUpdatedResponse<OutboundRuleBasicResource>
-      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = OutboundRuleBasicResource>> &
+      | ArmResourceUpdatedResponse<ManagedNetworkOutboundRuleBasicResource>
+      | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = ManagedNetworkOutboundRuleBasicResource>> &
           Azure.Core.Foundations.RetryAfterHeader)
   >;
 
@@ -156,15 +179,15 @@ interface OutboundRuleBasicResourceOperationGroup {
    * The DELETE API for deleting a single outbound rule of the managed network associated with the machine learning workspace.
    */
   @summary("The DELETE API for deleting a single outbound rule of the managed network associated with the machine learning workspace.")
-  delete is OutboundRuleBasicResourceOperationGroupOps.DeleteWithoutOkAsync<OutboundRuleBasicResource>;
+  delete is OutboundRuleBasicResourceOperationGroupOps.DeleteWithoutOkAsync<ManagedNetworkOutboundRuleBasicResource>;
 
   /**
    * The GET API for retrieveing the list of outbound rules of the managed network associated with the machine learning workspace.
    */
   @summary("The GET API for retrieveing the list of outbound rules of the managed network associated with the machine learning workspace.")
   list is OutboundRuleBasicResourceOperationGroupOps.List<
-    OutboundRuleBasicResource,
-    Response = OutboundRuleListResult
+    ManagedNetworkOutboundRuleBasicResource,
+    Response = ManagedNetworkOutboundRuleListResult
   >;
 }
 
@@ -174,6 +197,14 @@ interface OutboundRuleBasicResourceOperationGroup {
 );
 @@doc(
   OutboundRuleBasicResource.properties,
+  "Outbound Rule for the managed network of a machine learning workspace."
+);
+@@doc(
+  ManagedNetworkOutboundRuleBasicResource.name,
+  "Name of the workspace managed network outbound rule"
+);
+@@doc(
+  ManagedNetworkOutboundRuleBasicResource.properties,
   "Outbound Rule for the managed network of a machine learning workspace."
 );
 @@doc(

--- a/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
@@ -713,17 +713,6 @@ using Microsoft.MachineLearningServices;
 @@clientName(Caching, "MachineLearningCachingType", "csharp");
 @@access(EncryptionKeyVaultUpdateProperties, Access.public, "csharp");
 @@access(TriggerType, Access.public, "csharp");
-@@access(ComputePowerAction, Access.public, "csharp");
-@@access(ProvisioningStatus, Access.public, "csharp");
-@@access(ComputeWeekDay, Access.public, "csharp");
-@@access(Cron, Access.public, "csharp");
-@@access(Password, Access.public, "csharp");
-@@access(Recurrence, Access.public, "csharp");
-@@access(RecurrenceFrequency, Access.public, "csharp");
-@@access(ComputeRecurrenceSchedule, Access.public, "csharp");
-@@access(ScheduleBase, Access.public, "csharp");
-@@access(ScheduleProvisioningState, Access.public, "csharp");
-@@access(ScheduleStatus, Access.public, "csharp");
 @@access(PrivateEndpointResource.subnetArmId, Access.internal, "csharp");
 @@clientName(
   Azure.ResourceManager.CommonTypes.ErrorResponse,

--- a/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
@@ -713,7 +713,23 @@ using Microsoft.MachineLearningServices;
 @@clientName(Caching, "MachineLearningCachingType", "csharp");
 @@access(EncryptionKeyVaultUpdateProperties, Access.public, "csharp");
 @@access(TriggerType, Access.public, "csharp");
+@@access(ComputePowerAction, Access.public, "csharp");
+@@access(ProvisioningStatus, Access.public, "csharp");
+@@access(ComputeWeekDay, Access.public, "csharp");
+@@access(Cron, Access.public, "csharp");
+@@access(Password, Access.public, "csharp");
+@@access(Recurrence, Access.public, "csharp");
+@@access(RecurrenceFrequency, Access.public, "csharp");
+@@access(ComputeRecurrenceSchedule, Access.public, "csharp");
+@@access(ScheduleBase, Access.public, "csharp");
+@@access(ScheduleProvisioningState, Access.public, "csharp");
+@@access(ScheduleStatus, Access.public, "csharp");
 @@access(PrivateEndpointResource.subnetArmId, Access.internal, "csharp");
+// Preserve the GA C# hierarchy where outbound rules are direct workspace children.
+@@access(OutboundRuleBasicResourceOperationGroup.get, Access.internal, "csharp");
+@@access(OutboundRuleBasicResourceOperationGroup.createOrUpdate, Access.internal, "csharp");
+@@access(OutboundRuleBasicResourceOperationGroup.delete, Access.internal, "csharp");
+@@access(OutboundRuleBasicResourceOperationGroup.list, Access.internal, "csharp");
 @@clientName(
   Azure.ResourceManager.CommonTypes.ErrorResponse,
   "MachineLearningError",
@@ -724,6 +740,7 @@ using Microsoft.MachineLearningServices;
   "MachineLearningDataVersionProperties",
   "csharp"
 );
+@@clientName(DataVersionBase, "MachineLearningDataVersion", "csharp");
 @@clientName(JobBaseProperties, "MachineLearningJobProperties", "csharp");
 @@clientName(
   PartialMinimalTrackedResource,
@@ -1348,7 +1365,7 @@ using Microsoft.MachineLearningServices;
 @@clientName(OrderString, "MachineLearningOrderString", "csharp");
 @@clientName(
   OutboundRuleBasicResource,
-  "MachineLearningOutboundRuleBasicResource",
+  "MachineLearningOutboundRuleBasic",
   "csharp"
 );
 @@clientName(OutputDeliveryMode, "MachineLearningOutputDeliveryMode", "csharp");

--- a/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
+++ b/specification/machinelearningservices/MachineLearningServices.Management/client.tsp
@@ -725,11 +725,6 @@ using Microsoft.MachineLearningServices;
 @@access(ScheduleProvisioningState, Access.public, "csharp");
 @@access(ScheduleStatus, Access.public, "csharp");
 @@access(PrivateEndpointResource.subnetArmId, Access.internal, "csharp");
-// Preserve the GA C# hierarchy where outbound rules are direct workspace children.
-@@access(OutboundRuleBasicResourceOperationGroup.get, Access.internal, "csharp");
-@@access(OutboundRuleBasicResourceOperationGroup.createOrUpdate, Access.internal, "csharp");
-@@access(OutboundRuleBasicResourceOperationGroup.delete, Access.internal, "csharp");
-@@access(OutboundRuleBasicResourceOperationGroup.list, Access.internal, "csharp");
 @@clientName(
   Azure.ResourceManager.CommonTypes.ErrorResponse,
   "MachineLearningError",


### PR DESCRIPTION
Adds C#-scoped TypeSpec customizations needed by Azure.ResourceManager.MachineLearning after the latest spec update.

## Summary
- Preserve the GA workspace-level outbound rule SDK hierarchy while keeping managed-network outbound rules distinct for C# generation.
- Restore the shipped registry component version typo name for C# compatibility.
- Restore public access and C# names for legacy schedule/data compatibility types used by the SDK.

## SDK PR
Azure/azure-sdk-for-net#60253 uses this spec commit for regeneration.

## Validation
- Resource hierarchy gate is clean in the SDK PR.
- Azure.ResourceManager.MachineLearning builds with ApiCompat clean in the SDK PR.