### PR TITLE
Pin CSharp API versions for Compute SDK

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/client.tsp
@@ -1179,7 +1179,7 @@ model VMSizePropertiesWithAdditionalProperties {
 );
 @@clientName(
   VMScaleSetLifecycleHookEventState,
-  "VmScaleSetLifecycleHookEventState",
+  "VirtualMachineScaleSetLifecycleHookEventState",
   "csharp"
 );
 @@clientName(
@@ -1189,7 +1189,7 @@ model VMSizePropertiesWithAdditionalProperties {
 );
 @@clientName(
   VMScaleSetLifecycleHookEventProperties,
-  "VmScaleSetLifecycleHookEventProperties",
+  "VirtualMachineScaleSetLifecycleHookEventProperties",
   "csharp"
 );
 @@clientName(
@@ -1204,10 +1204,25 @@ model VMSizePropertiesWithAdditionalProperties {
 );
 @@clientName(
   VMScaleSetLifecycleHookEventType,
-  "VmScaleSetLifecycleHookEventType",
+  "VirtualMachineScaleSetLifecycleHookEventType",
   "csharp"
 );
-@@clientName(LifecycleHook.type, "VmScaleSetLifecycleHookEventType", "csharp");
+@@clientName(LifecycleHook, "VirtualMachineScaleSetLifecycleHook", "csharp");
+@@clientName(
+  LifecycleHookAction,
+  "VirtualMachineScaleSetLifecycleHookAction",
+  "csharp"
+);
+@@clientName(
+  LifecycleHookActionState,
+  "VirtualMachineScaleSetLifecycleHookActionState",
+  "csharp"
+);
+@@clientName(
+  LifecycleHook.type,
+  "VirtualMachineScaleSetLifecycleHookEventType",
+  "csharp"
+);
 @@clientName(
   VMScaleSetLifecycleHookEventUpdate,
   "VirtualMachineScaleSetLifecycleHookEventPatch",

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -13,6 +13,11 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.Compute"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    api-version:
+      Compute: "2025-11-01"
+      ComputeDisk: "2025-01-02"
+      ComputeGallery: "2025-03-03"
+      ComputeSku: "2021-07-01"
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"


### PR DESCRIPTION
Adds CSharp-specific API-version selection for the Compute TypeSpec package:

- Compute: 2025-11-01
- ComputeDisk: 2025-01-02
- ComputeGallery: 2025-03-03
- ComputeSku: 2021-07-01

This is used by the Azure.ResourceManager.Compute SDK regeneration.